### PR TITLE
remove errors/warnings from top-level

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -891,6 +891,9 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
 
 <h3>Internal changes ⚙️</h3>
 
+* Add new `pennylane.errors` module for custom errors.
+  [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
+
 * Clean up logic in `qml.drawer.tape_text`
   [(#7133)](https://github.com/PennyLaneAI/pennylane/pull/7133)
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -174,23 +174,6 @@ from pennylane.liealg import lie_closure, structure_constants, center
 default_config = Configuration("config.toml")
 
 
-# TODO: Remove this when Catalyst and Lightning PR is merged
-class DeviceError(Exception):
-    """Exception raised when it encounters an illegal operation in the quantum circuit."""
-
-
-class QuantumFunctionError(Exception):
-    """Exception raised when an illegal operation is defined in a quantum function."""
-
-
-class PennyLaneDeprecationWarning(UserWarning):
-    """Warning raised when a PennyLane feature is being deprecated."""
-
-
-class ExperimentalWarning(UserWarning):
-    """Warning raised to indicate experimental/non-stable feature or support."""
-
-
 def __getattr__(name):
 
     if name == "plugin_devices":

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -174,22 +174,6 @@ from pennylane.liealg import lie_closure, structure_constants, center
 default_config = Configuration("config.toml")
 
 
-class DeviceError(Exception):
-    """Exception raised when it encounters an illegal operation in the quantum circuit."""
-
-
-class QuantumFunctionError(Exception):
-    """Exception raised when an illegal operation is defined in a quantum function."""
-
-
-class PennyLaneDeprecationWarning(UserWarning):
-    """Warning raised when a PennyLane feature is being deprecated."""
-
-
-class ExperimentalWarning(UserWarning):
-    """Warning raised to indicate experimental/non-stable feature or support."""
-
-
 def __getattr__(name):
 
     if name == "plugin_devices":

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -174,6 +174,23 @@ from pennylane.liealg import lie_closure, structure_constants, center
 default_config = Configuration("config.toml")
 
 
+# TODO: Remove this when Catalyst and Lightning PR is merged
+class DeviceError(Exception):
+    """Exception raised when it encounters an illegal operation in the quantum circuit."""
+
+
+class QuantumFunctionError(Exception):
+    """Exception raised when an illegal operation is defined in a quantum function."""
+
+
+class PennyLaneDeprecationWarning(UserWarning):
+    """Warning raised when a PennyLane feature is being deprecated."""
+
+
+class ExperimentalWarning(UserWarning):
+    """Warning raised to indicate experimental/non-stable feature or support."""
+
+
 def __getattr__(name):
 
     if name == "plugin_devices":

--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -25,6 +25,7 @@ from functools import lru_cache
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     ExpectationMP,
     MeasurementProcess,
@@ -141,7 +142,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 "The analytic argument has been replaced by shots=None. "
                 "Please use shots=None instead of analytic=True."
             )
-            raise qml.DeviceError(msg)
+            raise pennylane.errors.DeviceError(msg)
 
         if not isinstance(wires, Iterable):
             # interpret wires as the number of consecutive wires
@@ -269,7 +270,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
         elif isinstance(shots, int):
             # device is in sampling mode (unbatched)
             if shots < 1:
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"The specified number of shots needs to be at least 1. Got {shots}."
                 )
 
@@ -283,7 +284,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
             self._raw_shot_sequence = shots
 
         else:
-            raise qml.DeviceError(
+            raise pennylane.errors.DeviceError(
                 "Shots must be a single non-negative integer or a sequence of non-negative integers."
             )
 
@@ -478,10 +479,12 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                     results.append(list(self.probability(wires=obs.wires).values()))
 
                 elif isinstance(mp, StateMP):
-                    raise qml.QuantumFunctionError("Returning the state is not supported")
+                    raise pennylane.errors.QuantumFunctionError(
+                        "Returning the state is not supported"
+                    )
 
                 else:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         f"Unsupported return type specified for observable {obs.name}"
                     )
 
@@ -983,7 +986,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
             if isinstance(o, MidMeasureMP) and not self.capabilities().get(
                 "supports_mid_measure", False
             ):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Mid-circuit measurements are not natively supported on device {self.short_name}. "
                     "Apply the @qml.defer_measurements decorator to your quantum function to "
                     "simulate the application of mid-circuit measurements on this device."
@@ -993,7 +996,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 raise ValueError(f"Postselection is not supported on the {self.name} device.")
 
             if not self.stopping_condition(o):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Gate {operation_name} not supported on device {self.short_name}"
                 )
 
@@ -1007,7 +1010,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
 
                 supports_prod = self.supports_observable(o.name)
                 if not supports_prod:
-                    raise qml.DeviceError(
+                    raise pennylane.errors.DeviceError(
                         f"Observable Prod not supported on device {self.short_name}"
                     )
 
@@ -1015,7 +1018,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 if isinstance(simplified_op, qml.ops.Prod):
                     for i in o.simplify().operands:
                         if not self.supports_observable(i.name):
-                            raise qml.DeviceError(
+                            raise pennylane.errors.DeviceError(
                                 f"Observable {i.name} not supported on device {self.short_name}"
                             )
 
@@ -1023,7 +1026,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 observable_name = o.name
 
                 if not self.supports_observable(observable_name):
-                    raise qml.DeviceError(
+                    raise pennylane.errors.DeviceError(
                         f"Observable {observable_name} not supported on device {self.short_name}"
                     )
 

--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -25,7 +25,6 @@ from functools import lru_cache
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import (
     ExpectationMP,
     MeasurementProcess,
@@ -142,7 +141,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 "The analytic argument has been replaced by shots=None. "
                 "Please use shots=None instead of analytic=True."
             )
-            raise pennylane.errors.DeviceError(msg)
+            raise qml.DeviceError(msg)
 
         if not isinstance(wires, Iterable):
             # interpret wires as the number of consecutive wires
@@ -270,7 +269,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
         elif isinstance(shots, int):
             # device is in sampling mode (unbatched)
             if shots < 1:
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"The specified number of shots needs to be at least 1. Got {shots}."
                 )
 
@@ -284,7 +283,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
             self._raw_shot_sequence = shots
 
         else:
-            raise pennylane.errors.DeviceError(
+            raise qml.DeviceError(
                 "Shots must be a single non-negative integer or a sequence of non-negative integers."
             )
 
@@ -479,12 +478,10 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                     results.append(list(self.probability(wires=obs.wires).values()))
 
                 elif isinstance(mp, StateMP):
-                    raise pennylane.errors.QuantumFunctionError(
-                        "Returning the state is not supported"
-                    )
+                    raise qml.QuantumFunctionError("Returning the state is not supported")
 
                 else:
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         f"Unsupported return type specified for observable {obs.name}"
                     )
 
@@ -986,7 +983,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
             if isinstance(o, MidMeasureMP) and not self.capabilities().get(
                 "supports_mid_measure", False
             ):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Mid-circuit measurements are not natively supported on device {self.short_name}. "
                     "Apply the @qml.defer_measurements decorator to your quantum function to "
                     "simulate the application of mid-circuit measurements on this device."
@@ -996,7 +993,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 raise ValueError(f"Postselection is not supported on the {self.name} device.")
 
             if not self.stopping_condition(o):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Gate {operation_name} not supported on device {self.short_name}"
                 )
 
@@ -1010,7 +1007,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
 
                 supports_prod = self.supports_observable(o.name)
                 if not supports_prod:
-                    raise pennylane.errors.DeviceError(
+                    raise qml.DeviceError(
                         f"Observable Prod not supported on device {self.short_name}"
                     )
 
@@ -1018,7 +1015,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 if isinstance(simplified_op, qml.ops.Prod):
                     for i in o.simplify().operands:
                         if not self.supports_observable(i.name):
-                            raise pennylane.errors.DeviceError(
+                            raise qml.DeviceError(
                                 f"Observable {i.name} not supported on device {self.short_name}"
                             )
 
@@ -1026,7 +1023,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
                 observable_name = o.name
 
                 if not self.supports_observable(observable_name):
-                    raise pennylane.errors.DeviceError(
+                    raise qml.DeviceError(
                         f"Observable {observable_name} not supported on device {self.short_name}"
                     )
 

--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -31,7 +31,6 @@ from typing import Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math import multiply as qmlmul
 from pennylane.math import sum as qmlsum
 from pennylane.measurements import (
@@ -185,11 +184,9 @@ class QubitDevice(Device):
         super().__init__(wires=wires, shots=shots, analytic=analytic)
 
         if "float" not in str(r_dtype):
-            raise pennylane.errors.DeviceError("Real datatype must be a floating point type.")
+            raise qml.DeviceError("Real datatype must be a floating point type.")
         if "complex" not in str(c_dtype):
-            raise pennylane.errors.DeviceError(
-                "Complex datatype must be a complex floating point type."
-            )
+            raise qml.DeviceError("Complex datatype must be a complex floating point type.")
 
         self.C_DTYPE = c_dtype
         self.R_DTYPE = r_dtype
@@ -680,7 +677,7 @@ class QubitDevice(Device):
                     self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         "The state or density matrix cannot be returned in combination "
                         "with other return types"
                     )
@@ -700,7 +697,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, VnEntropyMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         "Returning the Von Neumann entropy is not supported when using custom wire labels"
                     )
 
@@ -720,7 +717,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, MutualInfoMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         "Returning the mutual information is not supported when using custom wire labels"
                     )
 
@@ -741,7 +738,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ClassicalShadowMP):
                 if len(measurements) > 1:
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -749,7 +746,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ShadowExpvalMP):
                 if len(measurements) > 1:
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -763,7 +760,7 @@ class QubitDevice(Device):
 
             else:
                 name = obs.name if isinstance(obs, qml.operation.Operator) else type(obs).__name__
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     f"Unsupported return type specified for observable {name}"
                 )
 
@@ -815,16 +812,14 @@ class QubitDevice(Device):
             array or tensor: the state or the density matrix of the device
         """
         if not self.capabilities().get("returns_state"):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The current device is not capable of returning the state"
             )
 
         state = getattr(self, "state", None)
 
         if state is None:
-            raise pennylane.errors.QuantumFunctionError(
-                "The state is not available in the current device"
-            )
+            raise qml.QuantumFunctionError("The state is not available in the current device")
 
         if wires:
             density_matrix = self.density_matrix(wires)
@@ -868,7 +863,7 @@ class QubitDevice(Device):
             array[int]: the sampled basis states
         """
         if self.shots is None:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The number of shots has to be explicitly set on the device "
                 "when using sample-based measurements."
             )
@@ -1009,7 +1004,7 @@ class QubitDevice(Device):
         try:
             state = self.density_matrix(wires=self.wires)
         except (
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             NotImplementedError,
         ) as e:  # pragma: no cover
             raise NotImplementedError(
@@ -1039,7 +1034,7 @@ class QubitDevice(Device):
         try:
             state = self.density_matrix(wires=self.wires)
         except (
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             NotImplementedError,
         ) as e:  # pragma: no cover
             raise NotImplementedError(
@@ -1654,7 +1649,7 @@ class QubitDevice(Device):
                 or contains a multi-parameter operation aside from :class:`~.Rot`
         """
         if tape.batch_size is not None:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Parameter broadcasting is not supported with adjoint differentiation"
             )
 
@@ -1665,18 +1660,18 @@ class QubitDevice(Device):
 
         for m in tape.measurements:
             if not isinstance(m, ExpectationMP):
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Adjoint differentiation method does not support"
                     f" measurement {m.__class__.__name__}"
                 )
 
             if not m.obs.has_matrix:
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Adjoint differentiation method does not support Hamiltonian observables."
                 )
 
         if self.shot_vector is not None:
-            raise pennylane.errors.QuantumFunctionError("Adjoint does not support shot vectors.")
+            raise qml.QuantumFunctionError("Adjoint does not support shot vectors.")
 
         if self.shots is not None:
             warnings.warn(
@@ -1703,7 +1698,7 @@ class QubitDevice(Device):
         for op in reversed(tape.operations):
             if op.num_params > 1:
                 if not isinstance(op, qml.Rot):
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         f"The {op.name} operation is not supported using "
                         'the "adjoint" differentiation method'
                     )

--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -31,6 +31,7 @@ from typing import Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import multiply as qmlmul
 from pennylane.math import sum as qmlsum
 from pennylane.measurements import (
@@ -184,9 +185,11 @@ class QubitDevice(Device):
         super().__init__(wires=wires, shots=shots, analytic=analytic)
 
         if "float" not in str(r_dtype):
-            raise qml.DeviceError("Real datatype must be a floating point type.")
+            raise pennylane.errors.DeviceError("Real datatype must be a floating point type.")
         if "complex" not in str(c_dtype):
-            raise qml.DeviceError("Complex datatype must be a complex floating point type.")
+            raise pennylane.errors.DeviceError(
+                "Complex datatype must be a complex floating point type."
+            )
 
         self.C_DTYPE = c_dtype
         self.R_DTYPE = r_dtype
@@ -677,7 +680,7 @@ class QubitDevice(Device):
                     self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "The state or density matrix cannot be returned in combination "
                         "with other return types"
                     )
@@ -697,7 +700,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, VnEntropyMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Returning the Von Neumann entropy is not supported when using custom wire labels"
                     )
 
@@ -717,7 +720,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, MutualInfoMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Returning the mutual information is not supported when using custom wire labels"
                     )
 
@@ -738,7 +741,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ClassicalShadowMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -746,7 +749,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ShadowExpvalMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -760,7 +763,7 @@ class QubitDevice(Device):
 
             else:
                 name = obs.name if isinstance(obs, qml.operation.Operator) else type(obs).__name__
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     f"Unsupported return type specified for observable {name}"
                 )
 
@@ -812,14 +815,16 @@ class QubitDevice(Device):
             array or tensor: the state or the density matrix of the device
         """
         if not self.capabilities().get("returns_state"):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The current device is not capable of returning the state"
             )
 
         state = getattr(self, "state", None)
 
         if state is None:
-            raise qml.QuantumFunctionError("The state is not available in the current device")
+            raise pennylane.errors.QuantumFunctionError(
+                "The state is not available in the current device"
+            )
 
         if wires:
             density_matrix = self.density_matrix(wires)
@@ -863,7 +868,7 @@ class QubitDevice(Device):
             array[int]: the sampled basis states
         """
         if self.shots is None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The number of shots has to be explicitly set on the device "
                 "when using sample-based measurements."
             )
@@ -1004,7 +1009,7 @@ class QubitDevice(Device):
         try:
             state = self.density_matrix(wires=self.wires)
         except (
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             NotImplementedError,
         ) as e:  # pragma: no cover
             raise NotImplementedError(
@@ -1034,7 +1039,7 @@ class QubitDevice(Device):
         try:
             state = self.density_matrix(wires=self.wires)
         except (
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             NotImplementedError,
         ) as e:  # pragma: no cover
             raise NotImplementedError(
@@ -1649,7 +1654,7 @@ class QubitDevice(Device):
                 or contains a multi-parameter operation aside from :class:`~.Rot`
         """
         if tape.batch_size is not None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Parameter broadcasting is not supported with adjoint differentiation"
             )
 
@@ -1660,18 +1665,18 @@ class QubitDevice(Device):
 
         for m in tape.measurements:
             if not isinstance(m, ExpectationMP):
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Adjoint differentiation method does not support"
                     f" measurement {m.__class__.__name__}"
                 )
 
             if not m.obs.has_matrix:
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Adjoint differentiation method does not support Hamiltonian observables."
                 )
 
         if self.shot_vector is not None:
-            raise qml.QuantumFunctionError("Adjoint does not support shot vectors.")
+            raise pennylane.errors.QuantumFunctionError("Adjoint does not support shot vectors.")
 
         if self.shots is not None:
             warnings.warn(
@@ -1698,7 +1703,7 @@ class QubitDevice(Device):
         for op in reversed(tape.operations):
             if op.num_params > 1:
                 if not isinstance(op, qml.Rot):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         f"The {op.name} operation is not supported using "
                         'the "adjoint" differentiation method'
                     )

--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -31,6 +31,7 @@ from typing import Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import multiply as qmlmul
 from pennylane.math import sum as qmlsum
 from pennylane.measurements import (
@@ -184,9 +185,11 @@ class QubitDevice(Device):
         super().__init__(wires=wires, shots=shots, analytic=analytic)
 
         if "float" not in str(r_dtype):
-            raise qml.DeviceError("Real datatype must be a floating point type.")
+            raise pennylane.errors.DeviceError("Real datatype must be a floating point type.")
         if "complex" not in str(c_dtype):
-            raise qml.DeviceError("Complex datatype must be a complex floating point type.")
+            raise pennylane.errors.DeviceError(
+                "Complex datatype must be a complex floating point type."
+            )
 
         self.C_DTYPE = c_dtype
         self.R_DTYPE = r_dtype
@@ -677,7 +680,7 @@ class QubitDevice(Device):
                     self.apply([qml.adjoint(g, lazy=False) for g in reversed(diagonalizing_gates)])
             elif isinstance(m, StateMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "The state or density matrix cannot be returned in combination "
                         "with other return types"
                     )
@@ -697,7 +700,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, VnEntropyMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Returning the Von Neumann entropy is not supported when using custom wire labels"
                     )
 
@@ -717,7 +720,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, MutualInfoMP):
                 if self.wires.labels != tuple(range(self.num_wires)):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Returning the mutual information is not supported when using custom wire labels"
                     )
 
@@ -738,7 +741,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ClassicalShadowMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -746,7 +749,7 @@ class QubitDevice(Device):
 
             elif isinstance(m, ShadowExpvalMP):
                 if len(measurements) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         "Classical shadows cannot be returned in combination "
                         "with other return types"
                     )
@@ -760,7 +763,7 @@ class QubitDevice(Device):
 
             else:
                 name = obs.name if isinstance(obs, qml.operation.Operator) else type(obs).__name__
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     f"Unsupported return type specified for observable {name}"
                 )
 
@@ -812,14 +815,16 @@ class QubitDevice(Device):
             array or tensor: the state or the density matrix of the device
         """
         if not self.capabilities().get("returns_state"):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The current device is not capable of returning the state"
             )
 
         state = getattr(self, "state", None)
 
         if state is None:
-            raise qml.QuantumFunctionError("The state is not available in the current device")
+            raise pennylane.errors.QuantumFunctionError(
+                "The state is not available in the current device"
+            )
 
         if wires:
             density_matrix = self.density_matrix(wires)
@@ -863,7 +868,7 @@ class QubitDevice(Device):
             array[int]: the sampled basis states
         """
         if self.shots is None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The number of shots has to be explicitly set on the device "
                 "when using sample-based measurements."
             )
@@ -1003,7 +1008,10 @@ class QubitDevice(Device):
         """
         try:
             state = self.density_matrix(wires=self.wires)
-        except (qml.QuantumFunctionError, NotImplementedError) as e:  # pragma: no cover
+        except (
+            pennylane.errors.QuantumFunctionError,
+            NotImplementedError,
+        ) as e:  # pragma: no cover
             raise NotImplementedError(
                 f"Cannot compute the Von Neumman entropy with device {self.name} that is not capable of returning the "
                 f"state. "
@@ -1030,7 +1038,10 @@ class QubitDevice(Device):
         """
         try:
             state = self.density_matrix(wires=self.wires)
-        except (qml.QuantumFunctionError, NotImplementedError) as e:  # pragma: no cover
+        except (
+            pennylane.errors.QuantumFunctionError,
+            NotImplementedError,
+        ) as e:  # pragma: no cover
             raise NotImplementedError(
                 f"Cannot compute the mutual information with device {self.name} that is not capable of returning the "
                 f"state. "
@@ -1643,7 +1654,7 @@ class QubitDevice(Device):
                 or contains a multi-parameter operation aside from :class:`~.Rot`
         """
         if tape.batch_size is not None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Parameter broadcasting is not supported with adjoint differentiation"
             )
 
@@ -1654,18 +1665,18 @@ class QubitDevice(Device):
 
         for m in tape.measurements:
             if not isinstance(m, ExpectationMP):
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Adjoint differentiation method does not support"
                     f" measurement {m.__class__.__name__}"
                 )
 
             if not m.obs.has_matrix:
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Adjoint differentiation method does not support Hamiltonian observables."
                 )
 
         if self.shot_vector is not None:
-            raise qml.QuantumFunctionError("Adjoint does not support shot vectors.")
+            raise pennylane.errors.QuantumFunctionError("Adjoint does not support shot vectors.")
 
         if self.shots is not None:
             warnings.warn(
@@ -1692,7 +1703,7 @@ class QubitDevice(Device):
         for op in reversed(tape.operations):
             if op.num_params > 1:
                 if not isinstance(op, qml.Rot):
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         f"The {op.name} operation is not supported using "
                         'the "adjoint" differentiation method'
                     )

--- a/pennylane/devices/_qutrit_device.py
+++ b/pennylane/devices/_qutrit_device.py
@@ -23,7 +23,6 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 from pennylane.wires import Wires
 
@@ -160,7 +159,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for DensityMatrix return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.reduced_dm()`), so it needs to be updated before DensityMatrix can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Unsupported return type specified for observable density matrix"
         )
 
@@ -180,7 +179,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for VnEntropy return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.vn_entropy()`), so it needs to be updated before VnEntropy can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Unsupported return type specified for observable Von Neumann entropy"
         )
 
@@ -204,7 +203,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for MutualInfo return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.mutual_info()`), so it needs to be updated before MutualInfo can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Unsupported return type specified for observable mutual information"
         )
 
@@ -224,7 +223,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
             QuantumFunctionError: Classical shadow is currently unsupported on :class:`~.QutritDevice`
         """
         # TODO: Add support for ClassicalShadowMP
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Qutrit devices don't support classical shadow measurements."
         )
 
@@ -244,7 +243,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
             QuantumFunctionError: Shadow Expectation values are currently unsupported on :class:`~.QutritDevice`
         """
         # TODO: Add support for ShadowExpvalMP
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Qutrit devices don't support shadow expectation value measurements."
         )
 

--- a/pennylane/devices/_qutrit_device.py
+++ b/pennylane/devices/_qutrit_device.py
@@ -23,6 +23,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 from pennylane.wires import Wires
 
@@ -159,7 +160,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for DensityMatrix return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.reduced_dm()`), so it needs to be updated before DensityMatrix can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Unsupported return type specified for observable density matrix"
         )
 
@@ -179,7 +180,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for VnEntropy return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.vn_entropy()`), so it needs to be updated before VnEntropy can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Unsupported return type specified for observable Von Neumann entropy"
         )
 
@@ -203,7 +204,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
         # TODO: Add support for MutualInfo return type. Currently, qml.math is hard coded to calculate this for qubit
         # states (see `qml.math.mutual_info()`), so it needs to be updated before MutualInfo can be supported for qutrits.
         # For now, if a user tries to request this return type, an error will be raised.
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Unsupported return type specified for observable mutual information"
         )
 
@@ -223,7 +224,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
             QuantumFunctionError: Classical shadow is currently unsupported on :class:`~.QutritDevice`
         """
         # TODO: Add support for ClassicalShadowMP
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Qutrit devices don't support classical shadow measurements."
         )
 
@@ -243,7 +244,7 @@ class QutritDevice(QubitDevice):  # pylint: disable=too-many-public-methods
             QuantumFunctionError: Shadow Expectation values are currently unsupported on :class:`~.QutritDevice`
         """
         # TODO: Add support for ShadowExpvalMP
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Qutrit devices don't support shadow expectation value measurements."
         )
 

--- a/pennylane/devices/capabilities.py
+++ b/pennylane/devices/capabilities.py
@@ -23,7 +23,6 @@ from typing import Callable, Optional, Union
 import tomlkit as toml
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 
 ALL_SUPPORTED_SCHEMAS = [3]
@@ -442,7 +441,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
         return  # no need to validate if requested deferred or if no method is requested.
 
     if mcm_method == "one-shot" and not shots_present:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             'The "one-shot" MCM method is only supported with finite shots.'
         )
 
@@ -450,7 +449,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
         # If the device does not declare its supported mcm methods through capabilities,
         # simply check that the requested mcm method is something we recognize.
         if mcm_method not in ("deferred", "one-shot", "tree-traversal"):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 f'Requested MCM method "{mcm_method}" unsupported by the device. Supported methods '
                 f'are: "deferred", "one-shot", and "tree-traversal".'
             )
@@ -460,7 +459,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
 
         supported_methods = capabilities.supported_mcm_methods + ["deferred"]
         supported_method_strings = [f'"{m}"' for m in supported_methods]
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f'Requested MCM method "{mcm_method}" unsupported by the device. Supported methods '
             f"are: {', '.join(supported_method_strings)}."
         )

--- a/pennylane/devices/capabilities.py
+++ b/pennylane/devices/capabilities.py
@@ -23,6 +23,7 @@ from typing import Callable, Optional, Union
 import tomlkit as toml
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 
 ALL_SUPPORTED_SCHEMAS = [3]
@@ -441,7 +442,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
         return  # no need to validate if requested deferred or if no method is requested.
 
     if mcm_method == "one-shot" and not shots_present:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             'The "one-shot" MCM method is only supported with finite shots.'
         )
 
@@ -449,7 +450,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
         # If the device does not declare its supported mcm methods through capabilities,
         # simply check that the requested mcm method is something we recognize.
         if mcm_method not in ("deferred", "one-shot", "tree-traversal"):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 f'Requested MCM method "{mcm_method}" unsupported by the device. Supported methods '
                 f'are: "deferred", "one-shot", and "tree-traversal".'
             )
@@ -459,7 +460,7 @@ def validate_mcm_method(capabilities: DeviceCapabilities, mcm_method: str, shots
 
         supported_methods = capabilities.supported_mcm_methods + ["deferred"]
         supported_method_strings = [f'"{m}"' for m in supported_methods]
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f'Requested MCM method "{mcm_method}" unsupported by the device. Supported methods '
             f"are: {', '.join(supported_method_strings)}."
         )

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -24,6 +24,7 @@ from typing import Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -122,7 +123,7 @@ def observable_stopping_condition(obs: qml.operation.Operator) -> bool:
 def _validate_channels(tape, name="device"):
     """Validates the channels for a circuit."""
     if not tape.shots and any(isinstance(op, qml.operation.Channel) for op in tape.operations):
-        raise qml.DeviceError(f"Channel not supported on {name} without finite shots.")
+        raise pennylane.errors.DeviceError(f"Channel not supported on {name} without finite shots.")
 
     return (tape,), null_postprocessing
 
@@ -133,7 +134,7 @@ def _pl_op_to_stim(op):
         stim_op = _OPERATIONS_MAP[op.name]
         stim_tg = map(str, op.wires)
     except KeyError as e:
-        raise qml.DeviceError(
+        raise pennylane.errors.DeviceError(
             f"Operator {op} not supported with default.clifford and does not provide a decomposition."
         ) from e
 
@@ -627,7 +628,7 @@ class DefaultClifford(Device):
             measurement_func = self._analytical_measurement_map.get(type(meas), None)
 
             if measurement_func is None:  # pragma: no cover
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Snapshots of {type(meas)} are not yet supported on default.clifford."
                 )
 
@@ -696,7 +697,7 @@ class DefaultClifford(Device):
                 )[0]
                 # Check if the rotation was permissible
                 if len(samples) > 1:
-                    raise qml.QuantumFunctionError(
+                    raise pennylane.errors.QuantumFunctionError(
                         f"Observable {meas_op.name} is not supported for rotating probabilities on {self.name}."
                     )
                 # Process the result from samples

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -24,7 +24,6 @@ from typing import Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -123,7 +122,7 @@ def observable_stopping_condition(obs: qml.operation.Operator) -> bool:
 def _validate_channels(tape, name="device"):
     """Validates the channels for a circuit."""
     if not tape.shots and any(isinstance(op, qml.operation.Channel) for op in tape.operations):
-        raise pennylane.errors.DeviceError(f"Channel not supported on {name} without finite shots.")
+        raise qml.DeviceError(f"Channel not supported on {name} without finite shots.")
 
     return (tape,), null_postprocessing
 
@@ -134,7 +133,7 @@ def _pl_op_to_stim(op):
         stim_op = _OPERATIONS_MAP[op.name]
         stim_tg = map(str, op.wires)
     except KeyError as e:
-        raise pennylane.errors.DeviceError(
+        raise qml.DeviceError(
             f"Operator {op} not supported with default.clifford and does not provide a decomposition."
         ) from e
 
@@ -628,7 +627,7 @@ class DefaultClifford(Device):
             measurement_func = self._analytical_measurement_map.get(type(meas), None)
 
             if measurement_func is None:  # pragma: no cover
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Snapshots of {type(meas)} are not yet supported on default.clifford."
                 )
 
@@ -697,7 +696,7 @@ class DefaultClifford(Device):
                 )[0]
                 # Check if the rotation was permissible
                 if len(samples) > 1:
-                    raise pennylane.errors.QuantumFunctionError(
+                    raise qml.QuantumFunctionError(
                         f"Observable {meas_op.name} is not supported for rotating probabilities on {self.name}."
                     )
                 # Process the result from samples

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -30,7 +30,6 @@ import numpy as np
 from scipy.special import factorial as fac
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops import Identity
 
 from .._version import __version__
@@ -896,9 +895,7 @@ class DefaultGaussian(Device):
     # pylint: disable=arguments-differ
     def execute(self, operations, observables):
         if len(observables) > 1:
-            raise pennylane.errors.QuantumFunctionError(
-                "Default gaussian only support single measurements."
-            )
+            raise qml.QuantumFunctionError("Default gaussian only support single measurements.")
         return super().execute(operations, observables)
 
     def batch_execute(self, circuits):

--- a/pennylane/devices/default_gaussian.py
+++ b/pennylane/devices/default_gaussian.py
@@ -30,6 +30,7 @@ import numpy as np
 from scipy.special import factorial as fac
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops import Identity
 
 from .._version import __version__
@@ -895,7 +896,9 @@ class DefaultGaussian(Device):
     # pylint: disable=arguments-differ
     def execute(self, operations, observables):
         if len(observables) > 1:
-            raise qml.QuantumFunctionError("Default gaussian only support single measurements.")
+            raise pennylane.errors.QuantumFunctionError(
+                "Default gaussian only support single measurements."
+            )
         return super().execute(operations, observables)
 
     def batch_execute(self, circuits):

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -24,6 +24,7 @@ import logging
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import get_canonical_interface_name
 from pennylane.logging import debug_logger, debug_logger_init
 
@@ -311,7 +312,7 @@ class DefaultMixed(Device):
 
         for option in execution_config.device_options:
             if option not in self._device_options:
-                raise qml.DeviceError(f"device option {option} not present on {self}")
+                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
 
         for option in self._device_options:
             if option not in updated_values["device_options"]:

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -25,6 +25,7 @@ import numpy as np
 
 import pennylane as qml
 
+import pennylane.errors
 from pennylane.math import get_canonical_interface_name
 from pennylane.logging import debug_logger, debug_logger_init
 
@@ -312,7 +313,7 @@ class DefaultMixed(Device):
 
         for option in execution_config.device_options:
             if option not in self._device_options:
-                raise qml.DeviceError(f"device option {option} not present on {self}")
+                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
 
         for option in self._device_options:
             if option not in updated_values["device_options"]:

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -24,7 +24,7 @@ import logging
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
+
 from pennylane.math import get_canonical_interface_name
 from pennylane.logging import debug_logger, debug_logger_init
 
@@ -312,7 +312,7 @@ class DefaultMixed(Device):
 
         for option in execution_config.device_options:
             if option not in self._device_options:
-                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
+                raise qml.DeviceError(f"device option {option} not present on {self}")
 
         for option in self._device_options:
             if option not in updated_values["device_options"]:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -26,6 +26,7 @@ from typing import Optional, Sequence, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.measurements import ClassicalShadowMP, ShadowExpvalMP
 from pennylane.measurements.mid_measure import MidMeasureMP
@@ -189,7 +190,7 @@ def adjoint_state_measurements(
         return (tape,), null_postprocessing
 
     if any(len(m.diagonalizing_gates()) > 0 for m in tape.measurements):
-        raise qml.DeviceError(
+        raise pennylane.errors.DeviceError(
             "adjoint diff supports either all expectation values or only measurements without observables."
         )
 
@@ -239,7 +240,11 @@ def _supports_adjoint(circuit, device_wires, device_name):
 
     try:
         prog((circuit,))
-    except (qml.operation.DecompositionUndefinedError, qml.DeviceError, AttributeError):
+    except (
+        qml.operation.DecompositionUndefinedError,
+        pennylane.errors.DeviceError,
+        AttributeError,
+    ):
         return False
     return True
 
@@ -628,11 +633,13 @@ class DefaultQubit(Device):
 
         for option, value in execution_config.device_options.items():
             if option not in self._device_options:
-                raise qml.DeviceError(f"device option {option} not present on {self}")
+                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
 
             if qml.capture.enabled():
                 if option == "max_workers" and value is not None:
-                    raise qml.DeviceError("Cannot set 'max_workers' if program capture is enabled.")
+                    raise pennylane.errors.DeviceError(
+                        "Cannot set 'max_workers' if program capture is enabled."
+                    )
 
         gradient_method = execution_config.gradient_method
         if execution_config.gradient_method == "best":
@@ -665,7 +672,7 @@ class DefaultQubit(Device):
                 "single-branch-statistics",
                 None,
             ):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"mcm_method='{mcm_method}' is not supported with default.qubit "
                     "when program capture is enabled."
                 )
@@ -986,9 +993,9 @@ class DefaultQubit(Device):
         from .qubit.dq_interpreter import DefaultQubitInterpreter
 
         if self.wires is None:
-            raise qml.DeviceError("Device wires are required for jaxpr execution.")
+            raise pennylane.errors.DeviceError("Device wires are required for jaxpr execution.")
         if self.shots.has_partitioned_shots:
-            raise qml.DeviceError("Shot vectors are unsupported with jaxpr execution.")
+            raise pennylane.errors.DeviceError("Shot vectors are unsupported with jaxpr execution.")
         if self._prng_key is not None:
             key = self.get_prng_keys()[0]
         else:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -26,7 +26,6 @@ from typing import Optional, Sequence, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.measurements import ClassicalShadowMP, ShadowExpvalMP
 from pennylane.measurements.mid_measure import MidMeasureMP
@@ -190,7 +189,7 @@ def adjoint_state_measurements(
         return (tape,), null_postprocessing
 
     if any(len(m.diagonalizing_gates()) > 0 for m in tape.measurements):
-        raise pennylane.errors.DeviceError(
+        raise qml.DeviceError(
             "adjoint diff supports either all expectation values or only measurements without observables."
         )
 
@@ -242,7 +241,7 @@ def _supports_adjoint(circuit, device_wires, device_name):
         prog((circuit,))
     except (
         qml.operation.DecompositionUndefinedError,
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         AttributeError,
     ):
         return False
@@ -633,13 +632,11 @@ class DefaultQubit(Device):
 
         for option, value in execution_config.device_options.items():
             if option not in self._device_options:
-                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
+                raise qml.DeviceError(f"device option {option} not present on {self}")
 
             if qml.capture.enabled():
                 if option == "max_workers" and value is not None:
-                    raise pennylane.errors.DeviceError(
-                        "Cannot set 'max_workers' if program capture is enabled."
-                    )
+                    raise qml.DeviceError("Cannot set 'max_workers' if program capture is enabled.")
 
         gradient_method = execution_config.gradient_method
         if execution_config.gradient_method == "best":
@@ -672,7 +669,7 @@ class DefaultQubit(Device):
                 "single-branch-statistics",
                 None,
             ):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"mcm_method='{mcm_method}' is not supported with default.qubit "
                     "when program capture is enabled."
                 )
@@ -993,9 +990,9 @@ class DefaultQubit(Device):
         from .qubit.dq_interpreter import DefaultQubitInterpreter
 
         if self.wires is None:
-            raise pennylane.errors.DeviceError("Device wires are required for jaxpr execution.")
+            raise qml.DeviceError("Device wires are required for jaxpr execution.")
         if self.shots.has_partitioned_shots:
-            raise pennylane.errors.DeviceError("Shot vectors are unsupported with jaxpr execution.")
+            raise qml.DeviceError("Shot vectors are unsupported with jaxpr execution.")
         if self._prng_key is not None:
             key = self.get_prng_keys()[0]
         else:

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -26,6 +26,7 @@ from typing import Optional, Sequence, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.measurements import ClassicalShadowMP, ShadowExpvalMP
 from pennylane.measurements.mid_measure import MidMeasureMP
@@ -189,7 +190,7 @@ def adjoint_state_measurements(
         return (tape,), null_postprocessing
 
     if any(len(m.diagonalizing_gates()) > 0 for m in tape.measurements):
-        raise qml.DeviceError(
+        raise pennylane.errors.DeviceError(
             "adjoint diff supports either all expectation values or only measurements without observables."
         )
 
@@ -241,7 +242,7 @@ def _supports_adjoint(circuit, device_wires, device_name):
         prog((circuit,))
     except (
         qml.operation.DecompositionUndefinedError,
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         AttributeError,
     ):
         return False
@@ -632,11 +633,13 @@ class DefaultQubit(Device):
 
         for option, value in execution_config.device_options.items():
             if option not in self._device_options:
-                raise qml.DeviceError(f"device option {option} not present on {self}")
+                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
 
             if qml.capture.enabled():
                 if option == "max_workers" and value is not None:
-                    raise qml.DeviceError("Cannot set 'max_workers' if program capture is enabled.")
+                    raise pennylane.errors.DeviceError(
+                        "Cannot set 'max_workers' if program capture is enabled."
+                    )
 
         gradient_method = execution_config.gradient_method
         if execution_config.gradient_method == "best":
@@ -669,7 +672,7 @@ class DefaultQubit(Device):
                 "single-branch-statistics",
                 None,
             ):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"mcm_method='{mcm_method}' is not supported with default.qubit "
                     "when program capture is enabled."
                 )
@@ -990,9 +993,9 @@ class DefaultQubit(Device):
         from .qubit.dq_interpreter import DefaultQubitInterpreter
 
         if self.wires is None:
-            raise qml.DeviceError("Device wires are required for jaxpr execution.")
+            raise pennylane.errors.DeviceError("Device wires are required for jaxpr execution.")
         if self.shots.has_partitioned_shots:
-            raise qml.DeviceError("Shot vectors are unsupported with jaxpr execution.")
+            raise pennylane.errors.DeviceError("Shot vectors are unsupported with jaxpr execution.")
         if self._prng_key is not None:
             key = self.get_prng_keys()[0]
         else:

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -24,6 +24,7 @@ import logging
 import numpy as np
 
 import pennylane as qml  # pylint: disable=unused-import
+import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.wires import WireError
 
@@ -211,7 +212,7 @@ class DefaultQutrit(QutritDevice):
         # be added later.
         for i, operation in enumerate(operations):  # pylint: disable=unused-variable
             if i > 0 and isinstance(operation, qml.QutritBasisState):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Operation {operation.name} cannot be used after other operations have already been applied "
                     f"on a {self.short_name} device."
                 )

--- a/pennylane/devices/default_qutrit.py
+++ b/pennylane/devices/default_qutrit.py
@@ -24,7 +24,6 @@ import logging
 import numpy as np
 
 import pennylane as qml  # pylint: disable=unused-import
-import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.wires import WireError
 
@@ -212,7 +211,7 @@ class DefaultQutrit(QutritDevice):
         # be added later.
         for i, operation in enumerate(operations):  # pylint: disable=unused-variable
             if i > 0 and isinstance(operation, qml.QutritBasisState):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Operation {operation.name} cannot be used after other operations have already been applied "
                     f"on a {self.short_name} device."
                 )

--- a/pennylane/devices/default_qutrit_mixed.py
+++ b/pennylane/devices/default_qutrit_mixed.py
@@ -23,7 +23,6 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.ops import _qutrit__channel__ops__ as channels
 from pennylane.tape import QuantumScript, QuantumScriptOrBatch
@@ -126,18 +125,14 @@ def get_readout_errors(readout_relaxation_probs, readout_misclassification_probs
             with qml.queuing.QueuingManager.stop_recording():
                 qml.QutritAmplitudeDamping(*readout_relaxation_probs, wires=0)
         except Exception as e:
-            raise pennylane.errors.DeviceError(
-                "Applying damping readout error results in error:\n" + str(e)
-            )
+            raise qml.DeviceError("Applying damping readout error results in error:\n" + str(e))
         measure_funcs.append(partial(qml.QutritAmplitudeDamping, *readout_relaxation_probs))
     if readout_misclassification_probs is not None:
         try:
             with qml.queuing.QueuingManager.stop_recording():
                 qml.TritFlip(*readout_misclassification_probs, wires=0)
         except Exception as e:
-            raise pennylane.errors.DeviceError(
-                "Applying trit flip readout error results in error:\n" + str(e)
-            )
+            raise qml.DeviceError("Applying trit flip readout error results in error:\n" + str(e))
         measure_funcs.append(partial(qml.TritFlip, *readout_misclassification_probs))
 
     return None if len(measure_funcs) == 0 else measure_funcs
@@ -323,7 +318,7 @@ class DefaultQutritMixed(Device):
         updated_values = {}
         for option in execution_config.device_options:
             if option not in self._device_options:
-                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
+                raise qml.DeviceError(f"device option {option} not present on {self}")
 
         if execution_config.gradient_method == "best":
             updated_values["gradient_method"] = "backprop"

--- a/pennylane/devices/default_qutrit_mixed.py
+++ b/pennylane/devices/default_qutrit_mixed.py
@@ -23,6 +23,7 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.ops import _qutrit__channel__ops__ as channels
 from pennylane.tape import QuantumScript, QuantumScriptOrBatch
@@ -125,14 +126,18 @@ def get_readout_errors(readout_relaxation_probs, readout_misclassification_probs
             with qml.queuing.QueuingManager.stop_recording():
                 qml.QutritAmplitudeDamping(*readout_relaxation_probs, wires=0)
         except Exception as e:
-            raise qml.DeviceError("Applying damping readout error results in error:\n" + str(e))
+            raise pennylane.errors.DeviceError(
+                "Applying damping readout error results in error:\n" + str(e)
+            )
         measure_funcs.append(partial(qml.QutritAmplitudeDamping, *readout_relaxation_probs))
     if readout_misclassification_probs is not None:
         try:
             with qml.queuing.QueuingManager.stop_recording():
                 qml.TritFlip(*readout_misclassification_probs, wires=0)
         except Exception as e:
-            raise qml.DeviceError("Applying trit flip readout error results in error:\n" + str(e))
+            raise pennylane.errors.DeviceError(
+                "Applying trit flip readout error results in error:\n" + str(e)
+            )
         measure_funcs.append(partial(qml.TritFlip, *readout_misclassification_probs))
 
     return None if len(measure_funcs) == 0 else measure_funcs
@@ -318,7 +323,7 @@ class DefaultQutritMixed(Device):
         updated_values = {}
         for option in execution_config.device_options:
             if option not in self._device_options:
-                raise qml.DeviceError(f"device option {option} not present on {self}")
+                raise pennylane.errors.DeviceError(f"device option {option} not present on {self}")
 
         if execution_config.gradient_method == "best":
             updated_values["gradient_method"] = "backprop"

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -26,7 +26,6 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -434,7 +433,7 @@ class DefaultTensor(Device):
 
         shots = kwargs.pop("shots", None)
         if shots is not None:
-            raise pennylane.errors.DeviceError(
+            raise qml.DeviceError(
                 "default.tensor only supports analytic simulations with shots=None."
             )
 
@@ -603,7 +602,7 @@ class DefaultTensor(Device):
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
         if config.mcm_config.mcm_method not in {None, "deferred"}:
-            raise pennylane.errors.DeviceError(
+            raise qml.DeviceError(
                 f"{self.name} only supports the deferred measurement principle, not {config.mcm_config.mcm_method}"
             )
 

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -26,6 +26,7 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -433,7 +434,7 @@ class DefaultTensor(Device):
 
         shots = kwargs.pop("shots", None)
         if shots is not None:
-            raise qml.DeviceError(
+            raise pennylane.errors.DeviceError(
                 "default.tensor only supports analytic simulations with shots=None."
             )
 
@@ -602,7 +603,7 @@ class DefaultTensor(Device):
                 new_device_options[option] = getattr(self, f"_{option}", None)
 
         if config.mcm_config.mcm_method not in {None, "deferred"}:
-            raise qml.DeviceError(
+            raise pennylane.errors.DeviceError(
                 f"{self.name} only supports the deferred measurement principle, not {config.mcm_config.mcm_method}"
             )
 

--- a/pennylane/devices/device_constructor.py
+++ b/pennylane/devices/device_constructor.py
@@ -21,7 +21,6 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 import pennylane as qml
-import pennylane.errors
 
 
 def _get_device_entrypoints():
@@ -255,7 +254,7 @@ def device(name, *args, **kwargs):
             required_versions = _safe_specifier_set(plugin_device_class.pennylane_requires)
             current_version = Version(qml.version())
             if current_version not in required_versions:
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"The {name} plugin requires PennyLane versions {required_versions}, "
                     f"however PennyLane version {qml.version()} is installed."
                 )
@@ -282,6 +281,6 @@ def device(name, *args, **kwargs):
 
         return dev
 
-    raise pennylane.errors.DeviceError(
+    raise qml.DeviceError(
         f"Device {name} does not exist. Make sure the required plugin is installed."
     )

--- a/pennylane/devices/device_constructor.py
+++ b/pennylane/devices/device_constructor.py
@@ -21,6 +21,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 import pennylane as qml
+import pennylane.errors
 
 
 def _get_device_entrypoints():
@@ -254,7 +255,7 @@ def device(name, *args, **kwargs):
             required_versions = _safe_specifier_set(plugin_device_class.pennylane_requires)
             current_version = Version(qml.version())
             if current_version not in required_versions:
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"The {name} plugin requires PennyLane versions {required_versions}, "
                     f"however PennyLane version {qml.version()} is installed."
                 )
@@ -281,6 +282,6 @@ def device(name, *args, **kwargs):
 
         return dev
 
-    raise qml.DeviceError(
+    raise pennylane.errors.DeviceError(
         f"Device {name} does not exist. Make sure the required plugin is installed."
     )

--- a/pennylane/devices/legacy_facade.py
+++ b/pennylane/devices/legacy_facade.py
@@ -22,6 +22,7 @@ from copy import copy, deepcopy
 from dataclasses import replace
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import get_canonical_interface_name
 from pennylane.measurements import MidMeasureMP, Shots
 from pennylane.transforms.core.transform_program import TransformProgram
@@ -242,7 +243,7 @@ class LegacyDeviceFacade(Device):
     def _setup_backprop_config(self, execution_config):
         tape = qml.tape.QuantumScript()
         if not self._validate_backprop_method(tape):
-            raise qml.DeviceError("device does not support backprop.")
+            raise pennylane.errors.DeviceError("device does not support backprop.")
         if execution_config.use_device_gradient is None:
             return replace(execution_config, use_device_gradient=True)
         return execution_config
@@ -250,7 +251,7 @@ class LegacyDeviceFacade(Device):
     def _setup_adjoint_config(self, execution_config):
         tape = qml.tape.QuantumScript([], [])
         if not self._validate_adjoint_method(tape):
-            raise qml.DeviceError("device does not support device derivatives")
+            raise pennylane.errors.DeviceError("device does not support device derivatives")
         updated_values = {
             "gradient_keyword_arguments": {"use_device_state": True, "method": "adjoint_jacobian"}
         }
@@ -265,7 +266,7 @@ class LegacyDeviceFacade(Device):
         tape = qml.tape.QuantumScript([], [])
 
         if not self._validate_device_method(tape):
-            raise qml.DeviceError("device does not support device derivatives")
+            raise pennylane.errors.DeviceError("device does not support device derivatives")
 
         updated_values = {}
         if execution_config.use_device_gradient is None:
@@ -354,7 +355,11 @@ class LegacyDeviceFacade(Device):
         _add_adjoint_transforms(program, name=f"{self.name} + adjoint")
         try:
             program((tape,))
-        except (qml.operation.DecompositionUndefinedError, qml.DeviceError, AttributeError):
+        except (
+            qml.operation.DecompositionUndefinedError,
+            pennylane.errors.DeviceError,
+            AttributeError,
+        ):
             return False
         return True
 

--- a/pennylane/devices/legacy_facade.py
+++ b/pennylane/devices/legacy_facade.py
@@ -22,7 +22,6 @@ from copy import copy, deepcopy
 from dataclasses import replace
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math import get_canonical_interface_name
 from pennylane.measurements import MidMeasureMP, Shots
 from pennylane.transforms.core.transform_program import TransformProgram
@@ -243,7 +242,7 @@ class LegacyDeviceFacade(Device):
     def _setup_backprop_config(self, execution_config):
         tape = qml.tape.QuantumScript()
         if not self._validate_backprop_method(tape):
-            raise pennylane.errors.DeviceError("device does not support backprop.")
+            raise qml.DeviceError("device does not support backprop.")
         if execution_config.use_device_gradient is None:
             return replace(execution_config, use_device_gradient=True)
         return execution_config
@@ -251,7 +250,7 @@ class LegacyDeviceFacade(Device):
     def _setup_adjoint_config(self, execution_config):
         tape = qml.tape.QuantumScript([], [])
         if not self._validate_adjoint_method(tape):
-            raise pennylane.errors.DeviceError("device does not support device derivatives")
+            raise qml.DeviceError("device does not support device derivatives")
         updated_values = {
             "gradient_keyword_arguments": {"use_device_state": True, "method": "adjoint_jacobian"}
         }
@@ -266,7 +265,7 @@ class LegacyDeviceFacade(Device):
         tape = qml.tape.QuantumScript([], [])
 
         if not self._validate_device_method(tape):
-            raise pennylane.errors.DeviceError("device does not support device derivatives")
+            raise qml.DeviceError("device does not support device derivatives")
 
         updated_values = {}
         if execution_config.use_device_gradient is None:
@@ -357,7 +356,7 @@ class LegacyDeviceFacade(Device):
             program((tape,))
         except (
             qml.operation.DecompositionUndefinedError,
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             AttributeError,
         ):
             return False

--- a/pennylane/devices/legacy_facade.py
+++ b/pennylane/devices/legacy_facade.py
@@ -22,6 +22,7 @@ from copy import copy, deepcopy
 from dataclasses import replace
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import get_canonical_interface_name
 from pennylane.measurements import MidMeasureMP, Shots
 from pennylane.transforms.core.transform_program import TransformProgram
@@ -242,7 +243,7 @@ class LegacyDeviceFacade(Device):
     def _setup_backprop_config(self, execution_config):
         tape = qml.tape.QuantumScript()
         if not self._validate_backprop_method(tape):
-            raise qml.DeviceError("device does not support backprop.")
+            raise pennylane.errors.DeviceError("device does not support backprop.")
         if execution_config.use_device_gradient is None:
             return replace(execution_config, use_device_gradient=True)
         return execution_config
@@ -250,7 +251,7 @@ class LegacyDeviceFacade(Device):
     def _setup_adjoint_config(self, execution_config):
         tape = qml.tape.QuantumScript([], [])
         if not self._validate_adjoint_method(tape):
-            raise qml.DeviceError("device does not support device derivatives")
+            raise pennylane.errors.DeviceError("device does not support device derivatives")
         updated_values = {
             "gradient_keyword_arguments": {"use_device_state": True, "method": "adjoint_jacobian"}
         }
@@ -265,7 +266,7 @@ class LegacyDeviceFacade(Device):
         tape = qml.tape.QuantumScript([], [])
 
         if not self._validate_device_method(tape):
-            raise qml.DeviceError("device does not support device derivatives")
+            raise pennylane.errors.DeviceError("device does not support device derivatives")
 
         updated_values = {}
         if execution_config.use_device_gradient is None:
@@ -356,7 +357,7 @@ class LegacyDeviceFacade(Device):
             program((tape,))
         except (
             qml.operation.DecompositionUndefinedError,
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             AttributeError,
         ):
             return False

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -24,7 +24,6 @@ from itertools import chain
 from typing import Optional, Type
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import Snapshot, transform
 from pennylane.measurements import SampleMeasurement, StateMeasurement
 from pennylane.operation import StatePrepBase
@@ -53,7 +52,7 @@ def _operator_decomposition_gen(  # pylint: disable = too-many-positional-argume
 ) -> Generator[qml.operation.Operator, None, None]:
     """A generator that yields the next operation that is accepted."""
     if error is None:
-        error = pennylane.errors.DeviceError
+        error = qml.DeviceError
 
     max_depth_reached = False
     if max_expansion is not None and max_expansion <= current_depth:
@@ -104,7 +103,7 @@ def no_sampling(
     adjoint and backprop validation.
     """
     if tape.shots:
-        raise pennylane.errors.DeviceError(f"Finite shots are not supported with {name}")
+        raise qml.DeviceError(f"Finite shots are not supported with {name}")
     return (tape,), null_postprocessing
 
 
@@ -253,7 +252,7 @@ def validate_multiprocessing_workers(
             )
 
         if device._debugger and device._debugger.active:
-            raise pennylane.errors.DeviceError(
+            raise qml.DeviceError(
                 "Debugging with ``Snapshots`` is not available with multiprocessing."
             )
 
@@ -278,7 +277,7 @@ def validate_adjoint_trainable_params(
 
     for op in tape.operations[: tape.num_preps]:
         if qml.operation.is_trainable(op):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Differentiating with respect to the input parameters of state-prep operations "
                 "is not supported with the adjoint differentiation method."
             )
@@ -380,7 +379,7 @@ def decompose(  # pylint: disable = too-many-positional-arguments
     """
 
     if error is None:
-        error = pennylane.errors.DeviceError
+        error = qml.DeviceError
 
     if decomposer is None:
 
@@ -460,7 +459,7 @@ def validate_observables(
 
     for m in tape.measurements:
         if m.obs is not None and not stopping_condition(m.obs):
-            raise pennylane.errors.DeviceError(f"Observable {repr(m.obs)} not supported on {name}")
+            raise qml.DeviceError(f"Observable {repr(m.obs)} not supported on {name}")
 
     return (tape,), null_postprocessing
 
@@ -524,14 +523,12 @@ def validate_measurements(
     if shots.total_shots is not None:
         for m in chain(snapshot_measurements, tape.measurements):
             if not sample_measurements(m):
-                raise pennylane.errors.DeviceError(
-                    f"Measurement {m} not accepted with finite shots on {name}"
-                )
+                raise qml.DeviceError(f"Measurement {m} not accepted with finite shots on {name}")
 
     else:
         for m in chain(snapshot_measurements, tape.measurements):
             if not analytic_measurements(m):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Measurement {m} not accepted for analytic simulation on {name}."
                 )
 

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -24,6 +24,7 @@ from itertools import chain
 from typing import Optional, Type
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import Snapshot, transform
 from pennylane.measurements import SampleMeasurement, StateMeasurement
 from pennylane.operation import StatePrepBase
@@ -52,7 +53,7 @@ def _operator_decomposition_gen(  # pylint: disable = too-many-positional-argume
 ) -> Generator[qml.operation.Operator, None, None]:
     """A generator that yields the next operation that is accepted."""
     if error is None:
-        error = qml.DeviceError
+        error = pennylane.errors.DeviceError
 
     max_depth_reached = False
     if max_expansion is not None and max_expansion <= current_depth:
@@ -103,7 +104,7 @@ def no_sampling(
     adjoint and backprop validation.
     """
     if tape.shots:
-        raise qml.DeviceError(f"Finite shots are not supported with {name}")
+        raise pennylane.errors.DeviceError(f"Finite shots are not supported with {name}")
     return (tape,), null_postprocessing
 
 
@@ -252,7 +253,7 @@ def validate_multiprocessing_workers(
             )
 
         if device._debugger and device._debugger.active:
-            raise qml.DeviceError(
+            raise pennylane.errors.DeviceError(
                 "Debugging with ``Snapshots`` is not available with multiprocessing."
             )
 
@@ -277,7 +278,7 @@ def validate_adjoint_trainable_params(
 
     for op in tape.operations[: tape.num_preps]:
         if qml.operation.is_trainable(op):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Differentiating with respect to the input parameters of state-prep operations "
                 "is not supported with the adjoint differentiation method."
             )
@@ -379,7 +380,7 @@ def decompose(  # pylint: disable = too-many-positional-arguments
     """
 
     if error is None:
-        error = qml.DeviceError
+        error = pennylane.errors.DeviceError
 
     if decomposer is None:
 
@@ -459,7 +460,7 @@ def validate_observables(
 
     for m in tape.measurements:
         if m.obs is not None and not stopping_condition(m.obs):
-            raise qml.DeviceError(f"Observable {repr(m.obs)} not supported on {name}")
+            raise pennylane.errors.DeviceError(f"Observable {repr(m.obs)} not supported on {name}")
 
     return (tape,), null_postprocessing
 
@@ -523,12 +524,14 @@ def validate_measurements(
     if shots.total_shots is not None:
         for m in chain(snapshot_measurements, tape.measurements):
             if not sample_measurements(m):
-                raise qml.DeviceError(f"Measurement {m} not accepted with finite shots on {name}")
+                raise pennylane.errors.DeviceError(
+                    f"Measurement {m} not accepted with finite shots on {name}"
+                )
 
     else:
         for m in chain(snapshot_measurements, tape.measurements):
             if not analytic_measurements(m):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Measurement {m} not accepted for analytic simulation on {name}."
                 )
 

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -20,7 +20,6 @@ import pytest
 from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
 
 import pennylane as qml
-import pennylane.errors
 
 # ==========================================================
 # pytest fixtures
@@ -121,7 +120,7 @@ def fixture_device(device_kwargs):
 
         try:
             dev = qml.device(**device_kwargs)
-        except pennylane.errors.DeviceError:
+        except qml.DeviceError:
             dev_name = device_kwargs["name"]
             # exit the tests if the device cannot be created
             pytest.exit(
@@ -279,7 +278,7 @@ def pytest_runtest_makereport(item, call):
             # Exclude failing test cases for unsupported operations/observables
             # and those using not implemented features
             if (
-                call.excinfo.type == pennylane.errors.DeviceError
+                call.excinfo.type == qml.DeviceError
                 and "supported" in str(call.excinfo.value)
                 or call.excinfo.type == NotImplementedError
             ):

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
 
 import pennylane as qml
+import pennylane.errors
 
 # ==========================================================
 # pytest fixtures
@@ -120,7 +121,7 @@ def fixture_device(device_kwargs):
 
         try:
             dev = qml.device(**device_kwargs)
-        except qml.DeviceError:
+        except pennylane.errors.DeviceError:
             dev_name = device_kwargs["name"]
             # exit the tests if the device cannot be created
             pytest.exit(
@@ -278,7 +279,7 @@ def pytest_runtest_makereport(item, call):
             # Exclude failing test cases for unsupported operations/observables
             # and those using not implemented features
             if (
-                call.excinfo.type == qml.DeviceError
+                call.excinfo.type == pennylane.errors.DeviceError
                 and "supported" in str(call.excinfo.value)
                 or call.excinfo.type == NotImplementedError
             ):

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -29,7 +29,6 @@ from flaky import flaky
 from scipy.linalg import block_diag
 
 import pennylane as qml
-import pennylane.errors
 
 pytestmark = pytest.mark.skip_unsupported
 
@@ -369,7 +368,7 @@ class TestSupportedGates:
                 tape = qml.tape.QuantumScript([ops[operation]])
                 try:
                     prog((tape,))
-                except pennylane.errors.DeviceError:
+                except qml.DeviceError:
                     pytest.skip("operation not supported on the device")
 
         @qml.qnode(dev)

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -29,6 +29,7 @@ from flaky import flaky
 from scipy.linalg import block_diag
 
 import pennylane as qml
+import pennylane.errors
 
 pytestmark = pytest.mark.skip_unsupported
 
@@ -368,7 +369,7 @@ class TestSupportedGates:
                 tape = qml.tape.QuantumScript([ops[operation]])
                 try:
                     prog((tape,))
-                except qml.DeviceError:
+                except pennylane.errors.DeviceError:
                     pytest.skip("operation not supported on the device")
 
         @qml.qnode(dev)

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -18,6 +18,7 @@ from flaky import flaky
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.measurements import (
     ClassicalShadowMP,
@@ -1731,7 +1732,7 @@ class TestSampleMeasurement:
             qml.X(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        with pytest.raises((ValueError, qml.DeviceError)):
+        with pytest.raises((ValueError, pennylane.errors.DeviceError)):
             circuit()
 
     def test_method_overriden_by_device(self, device):
@@ -1813,7 +1814,7 @@ class TestStateMeasurement:
                 match="MyMeasurement with finite shots; the returned state information is analytic",
             )
             if isinstance(dev, qml.devices.LegacyDevice)
-            else pytest.raises(qml.DeviceError, match="not accepted with finite shots")
+            else pytest.raises(pennylane.errors.DeviceError, match="not accepted with finite shots")
         ):
             circuit()
 
@@ -1854,7 +1855,7 @@ class TestCustomMeasurement:
             tape = qml.tape.QuantumScript([], [MyMeasurement()])
             try:
                 dev.preprocess_transforms()((tape,))
-            except qml.DeviceError:
+            except pennylane.errors.DeviceError:
                 pytest.xfail("Device does not support custom measurement transforms.")
 
         @qml.qnode(dev)

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -18,7 +18,6 @@ from flaky import flaky
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.measurements import (
     ClassicalShadowMP,
@@ -1732,7 +1731,7 @@ class TestSampleMeasurement:
             qml.X(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
-        with pytest.raises((ValueError, pennylane.errors.DeviceError)):
+        with pytest.raises((ValueError, qml.DeviceError)):
             circuit()
 
     def test_method_overriden_by_device(self, device):
@@ -1814,7 +1813,7 @@ class TestStateMeasurement:
                 match="MyMeasurement with finite shots; the returned state information is analytic",
             )
             if isinstance(dev, qml.devices.LegacyDevice)
-            else pytest.raises(pennylane.errors.DeviceError, match="not accepted with finite shots")
+            else pytest.raises(qml.DeviceError, match="not accepted with finite shots")
         ):
             circuit()
 
@@ -1855,7 +1854,7 @@ class TestCustomMeasurement:
             tape = qml.tape.QuantumScript([], [MyMeasurement()])
             try:
                 dev.preprocess_transforms()((tape,))
-            except pennylane.errors.DeviceError:
+            except qml.DeviceError:
                 pytest.xfail("Device does not support custom measurement transforms.")
 
         @qml.qnode(dev)

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -16,7 +16,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as pnp
 
 from .conftest import get_legacy_capabilities
@@ -220,7 +219,7 @@ class TestCapabilities:
         if cap["supports_tensor_observables"]:
             circuit()
         else:
-            with pytest.raises(pennylane.errors.QuantumFunctionError):
+            with pytest.raises(qml.QuantumFunctionError):
                 circuit()
 
     def test_returns_state(self, device_kwargs):
@@ -239,7 +238,7 @@ class TestCapabilities:
         if not cap.get("returns_state"):
             # If the device is not defined to return state then the
             # access_state method should raise
-            with pytest.raises(pennylane.errors.QuantumFunctionError):
+            with pytest.raises(qml.QuantumFunctionError):
                 dev.access_state()
 
             try:

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -16,6 +16,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as pnp
 
 from .conftest import get_legacy_capabilities
@@ -219,7 +220,7 @@ class TestCapabilities:
         if cap["supports_tensor_observables"]:
             circuit()
         else:
-            with pytest.raises(qml.QuantumFunctionError):
+            with pytest.raises(pennylane.errors.QuantumFunctionError):
                 circuit()
 
     def test_returns_state(self, device_kwargs):
@@ -238,7 +239,7 @@ class TestCapabilities:
         if not cap.get("returns_state"):
             # If the device is not defined to return state then the
             # access_state method should raise
-            with pytest.raises(qml.QuantumFunctionError):
+            with pytest.raises(pennylane.errors.QuantumFunctionError):
                 dev.access_state()
 
             try:

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -26,6 +26,7 @@ import pytest
 from scipy.stats import norm
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import math
 
 pytestmark = pytest.mark.skip_unsupported
@@ -41,7 +42,7 @@ def check_op_supported(op, dev):
         tape = qml.tape.QuantumScript([op])
         try:
             prog((tape,))
-        except qml.DeviceError:
+        except pennylane.errors.DeviceError:
             pytest.skip("operation not supported on the device")
 
 

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -26,7 +26,6 @@ import pytest
 from scipy.stats import norm
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import math
 
 pytestmark = pytest.mark.skip_unsupported
@@ -42,7 +41,7 @@ def check_op_supported(op, dev):
         tape = qml.tape.QuantumScript([op])
         try:
             prog((tape,))
-        except pennylane.errors.DeviceError:
+        except qml.DeviceError:
             pytest.skip("operation not supported on the device")
 
 

--- a/pennylane/errors/__init__.py
+++ b/pennylane/errors/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2018-2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains all the custom exceptions and warnings used in PennyLane.
+"""
+
+
+class DeviceError(Exception):
+    """Exception raised when it encounters an illegal operation in the quantum circuit."""
+
+
+class QuantumFunctionError(Exception):
+    """Exception raised when an illegal operation is defined in a quantum function."""
+
+
+class PennyLaneDeprecationWarning(UserWarning):
+    """Warning raised when a PennyLane feature is being deprecated."""
+
+
+class ExperimentalWarning(UserWarning):
+    """Warning raised to indicate experimental/non-stable feature or support."""

--- a/pennylane/ftqc/__init__.py
+++ b/pennylane/ftqc/__init__.py
@@ -25,7 +25,7 @@ Modules
     :toctree: api
 
 """
-from pennylane.errors import ExperimentalWarning
+from pennylane import ExperimentalWarning
 from .parametric_midmeasure import (
     ParametricMidMeasureMP,
     XMidMeasureMP,

--- a/pennylane/ftqc/__init__.py
+++ b/pennylane/ftqc/__init__.py
@@ -25,7 +25,7 @@ Modules
     :toctree: api
 
 """
-from pennylane import ExperimentalWarning
+from pennylane.errors import ExperimentalWarning
 from .parametric_midmeasure import (
     ParametricMidMeasureMP,
     XMidMeasureMP,

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -22,6 +22,7 @@ from typing import Iterable, Optional, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.drawer.tape_mpl import _add_operation_to_drawer
 from pennylane.measurements.mid_measure import MeasurementValue, MidMeasureMP, measure
 from pennylane.wires import Wires
@@ -260,7 +261,7 @@ def _measure_impl(
     """Concrete implementation of qml.measure"""
     wires = Wires(wires)
     if len(wires) > 1:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Only a single qubit can be measured in the middle of the circuit"
         )
 

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -22,7 +22,6 @@ from typing import Iterable, Optional, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.drawer.tape_mpl import _add_operation_to_drawer
 from pennylane.measurements.mid_measure import MeasurementValue, MidMeasureMP, measure
 from pennylane.wires import Wires
@@ -261,7 +260,7 @@ def _measure_impl(
     """Concrete implementation of qml.measure"""
     wires = Wires(wires)
     if len(wires) > 1:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Only a single qubit can be measured in the middle of the circuit"
         )
 

--- a/pennylane/gradients/hamiltonian_grad.py
+++ b/pennylane/gradients/hamiltonian_grad.py
@@ -16,6 +16,7 @@
 import warnings
 
 import pennylane as qml
+import pennylane.errors
 
 
 def hamiltonian_grad(tape, idx):
@@ -33,7 +34,7 @@ def hamiltonian_grad(tape, idx):
     warnings.warn(
         "The 'hamiltonian_grad' function is deprecated and will be removed in v0.42. "
         "This gradient recipe is not required for the new operator arithmetic system.",
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
     )
 
     op, m_pos, p_idx = tape.get_operation(idx)

--- a/pennylane/gradients/hamiltonian_grad.py
+++ b/pennylane/gradients/hamiltonian_grad.py
@@ -16,7 +16,6 @@
 import warnings
 
 import pennylane as qml
-import pennylane.errors
 
 
 def hamiltonian_grad(tape, idx):
@@ -34,7 +33,7 @@ def hamiltonian_grad(tape, idx):
     warnings.warn(
         "The 'hamiltonian_grad' function is deprecated and will be removed in v0.42. "
         "This gradient recipe is not required for the new operator arithmetic system.",
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
     )
 
     op, m_pos, p_idx = tape.get_operation(idx)

--- a/pennylane/labs/tests/conftest.py
+++ b/pennylane/labs/tests/conftest.py
@@ -20,7 +20,6 @@ import pytest
 from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
 
 import pennylane as qml
-import pennylane.errors
 
 # ==========================================================
 # pytest fixtures
@@ -120,7 +119,7 @@ def fixture_device(device_kwargs):
 
         try:
             dev = qml.device(**device_kwargs)
-        except pennylane.errors.DeviceError:
+        except qml.DeviceError:
             dev_name = device_kwargs["name"]
             # exit the tests if the device cannot be created
             pytest.exit(
@@ -258,7 +257,7 @@ def pytest_runtest_makereport(item, call):
             # Exclude failing test cases for unsupported operations/observables
             # and those using not implemented features
             if (
-                call.excinfo.type == pennylane.errors.DeviceError
+                call.excinfo.type == qml.DeviceError
                 and "supported" in str(call.excinfo.value)
                 or call.excinfo.type == NotImplementedError
             ):

--- a/pennylane/labs/tests/conftest.py
+++ b/pennylane/labs/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from _pytest.runner import pytest_runtest_makereport as orig_pytest_runtest_makereport
 
 import pennylane as qml
+import pennylane.errors
 
 # ==========================================================
 # pytest fixtures
@@ -119,7 +120,7 @@ def fixture_device(device_kwargs):
 
         try:
             dev = qml.device(**device_kwargs)
-        except qml.DeviceError:
+        except pennylane.errors.DeviceError:
             dev_name = device_kwargs["name"]
             # exit the tests if the device cannot be created
             pytest.exit(
@@ -257,7 +258,7 @@ def pytest_runtest_makereport(item, call):
             # Exclude failing test cases for unsupported operations/observables
             # and those using not implemented features
             if (
-                call.excinfo.type == qml.DeviceError
+                call.excinfo.type == pennylane.errors.DeviceError
                 and "supported" in str(call.excinfo.value)
                 or call.excinfo.type == NotImplementedError
             ):

--- a/pennylane/math/fidelity.py
+++ b/pennylane/math/fidelity.py
@@ -23,6 +23,7 @@ import autograd
 import autoray as ar
 
 import pennylane as qml
+import pennylane.errors
 
 from .quantum import _check_density_matrix, _check_state_vector
 from .utils import cast
@@ -77,7 +78,9 @@ def fidelity_statevector(state0, state1, check_state=False, c_dtype="complex128"
         _check_state_vector(state1)
 
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
+        raise pennylane.errors.QuantumFunctionError(
+            "The two states must have the same number of wires."
+        )
 
     batched0 = len(qml.math.shape(state0)) > 1
     batched1 = len(qml.math.shape(state1)) > 1
@@ -148,7 +151,9 @@ def fidelity(state0, state1, check_state=False, c_dtype="complex128"):
         _check_density_matrix(state1)
 
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
+        raise pennylane.errors.QuantumFunctionError(
+            "The two states must have the same number of wires."
+        )
 
     batch_size0 = qml.math.shape(state0)[0] if qml.math.ndim(state0) > 2 else None
     batch_size1 = qml.math.shape(state1)[0] if qml.math.ndim(state1) > 2 else None

--- a/pennylane/math/fidelity.py
+++ b/pennylane/math/fidelity.py
@@ -23,7 +23,6 @@ import autograd
 import autoray as ar
 
 import pennylane as qml
-import pennylane.errors
 
 from .quantum import _check_density_matrix, _check_state_vector
 from .utils import cast
@@ -78,9 +77,7 @@ def fidelity_statevector(state0, state1, check_state=False, c_dtype="complex128"
         _check_state_vector(state1)
 
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise pennylane.errors.QuantumFunctionError(
-            "The two states must have the same number of wires."
-        )
+        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
 
     batched0 = len(qml.math.shape(state0)) > 1
     batched1 = len(qml.math.shape(state1)) > 1
@@ -151,9 +148,7 @@ def fidelity(state0, state1, check_state=False, c_dtype="complex128"):
         _check_density_matrix(state1)
 
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise pennylane.errors.QuantumFunctionError(
-            "The two states must have the same number of wires."
-        )
+        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
 
     batch_size0 = qml.math.shape(state0)[0] if qml.math.ndim(state0) > 2 else None
     batch_size1 = qml.math.shape(state1)[0] if qml.math.ndim(state1) > 2 else None

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -25,6 +25,7 @@ from numpy import float64, sqrt  # pylint:disable=wrong-import-order
 from scipy.sparse import csc_matrix, issparse
 
 import pennylane as qml
+import pennylane.errors
 
 from . import single_dispatch  # pylint:disable=unused-import
 from .interface_utils import get_interface
@@ -862,7 +863,7 @@ def expectation_value(
         _check_hermitian_operator(operator_matrix)
 
     if qml.math.shape(operator_matrix)[-1] != qml.math.shape(state_vector)[-1]:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "The operator and the state vector must have the same number of wires."
         )
 
@@ -1215,7 +1216,9 @@ def relative_entropy(state0, state1, base=None, check_state=False, c_dtype="comp
 
     # Compare the number of wires on both subsystems
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
+        raise pennylane.errors.QuantumFunctionError(
+            "The two states must have the same number of wires."
+        )
 
     return _compute_relative_entropy(state0, state1, base=base)
 
@@ -1512,7 +1515,9 @@ def trace_distance(state0, state1, check_state=False, c_dtype="complex128"):
         _check_density_matrix(state1)
 
     if state0.shape[-1] != state1.shape[-1]:
-        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
+        raise pennylane.errors.QuantumFunctionError(
+            "The two states must have the same number of wires."
+        )
 
     if len(state0.shape) == len(state1.shape) == 3 and state0.shape[0] != state1.shape[0]:
         raise ValueError(

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -25,7 +25,6 @@ from numpy import float64, sqrt  # pylint:disable=wrong-import-order
 from scipy.sparse import csc_matrix, issparse
 
 import pennylane as qml
-import pennylane.errors
 
 from . import single_dispatch  # pylint:disable=unused-import
 from .interface_utils import get_interface
@@ -863,7 +862,7 @@ def expectation_value(
         _check_hermitian_operator(operator_matrix)
 
     if qml.math.shape(operator_matrix)[-1] != qml.math.shape(state_vector)[-1]:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "The operator and the state vector must have the same number of wires."
         )
 
@@ -1216,9 +1215,7 @@ def relative_entropy(state0, state1, base=None, check_state=False, c_dtype="comp
 
     # Compare the number of wires on both subsystems
     if qml.math.shape(state0)[-1] != qml.math.shape(state1)[-1]:
-        raise pennylane.errors.QuantumFunctionError(
-            "The two states must have the same number of wires."
-        )
+        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
 
     return _compute_relative_entropy(state0, state1, base=base)
 
@@ -1515,9 +1512,7 @@ def trace_distance(state0, state1, check_state=False, c_dtype="complex128"):
         _check_density_matrix(state1)
 
     if state0.shape[-1] != state1.shape[-1]:
-        raise pennylane.errors.QuantumFunctionError(
-            "The two states must have the same number of wires."
-        )
+        raise qml.QuantumFunctionError("The two states must have the same number of wires.")
 
     if len(state0.shape) == len(state1.shape) == 3 and state0.shape[0] != state1.shape[0]:
         raise ValueError(

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -20,7 +20,6 @@ from typing import Optional
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.wires import Wires
 
@@ -144,7 +143,7 @@ def counts(
             or (isinstance(o, MeasurementValue) and len(o.measurements) == 1)
             for o in op
         ):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Only sequences of single MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -20,6 +20,7 @@ from typing import Optional
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.wires import Wires
 
@@ -143,7 +144,7 @@ def counts(
             or (isinstance(o, MeasurementValue) and len(o.measurements) == 1)
             for o in op
         ):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Only sequences of single MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -24,6 +24,7 @@ from enum import Enum
 from typing import Optional, Union
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math.utils import is_abstract
 from pennylane.operation import DecompositionUndefinedError, EigvalsUndefinedError, Operator
 from pennylane.pytrees import register_pytree
@@ -275,7 +276,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
         warnings.warn(
             "MeasurementProcess property return_type is deprecated and will be removed in version 0.42. "
             "Instead, please use isinstance for type checking directly.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         return self._shortname
 
@@ -290,7 +291,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
             QuantumFunctionError: the return type of the measurement process is
                 unrecognized and cannot deduce the numeric type
         """
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"The numeric type of the measurement {self.__class__.__name__} is not defined."
         )
 
@@ -319,7 +320,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
         ()
 
         """
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"The shape of the measurement {self.__class__.__name__} is not defined"
         )
 

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -24,7 +24,6 @@ from enum import Enum
 from typing import Optional, Union
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math.utils import is_abstract
 from pennylane.operation import DecompositionUndefinedError, EigvalsUndefinedError, Operator
 from pennylane.pytrees import register_pytree
@@ -276,7 +275,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
         warnings.warn(
             "MeasurementProcess property return_type is deprecated and will be removed in version 0.42. "
             "Instead, please use isinstance for type checking directly.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         return self._shortname
 
@@ -291,7 +290,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
             QuantumFunctionError: the return type of the measurement process is
                 unrecognized and cannot deduce the numeric type
         """
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"The numeric type of the measurement {self.__class__.__name__} is not defined."
         )
 
@@ -320,7 +319,7 @@ class MeasurementProcess(ABC, metaclass=qml.capture.ABCCaptureMeta):
         ()
 
         """
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"The shape of the measurement {self.__class__.__name__} is not defined"
         )
 

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -20,6 +20,7 @@ from functools import lru_cache
 from typing import Generic, Optional, TypeVar, Union
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.wires import Wires
 
 from .measurements import MeasurementProcess, MidMeasure
@@ -222,7 +223,7 @@ def _measure_impl(
     """Concrete implementation of qml.measure"""
     wires = Wires(wires)
     if len(wires) > 1:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Only a single qubit can be measured in the middle of the circuit"
         )
 

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -20,7 +20,6 @@ from functools import lru_cache
 from typing import Generic, Optional, TypeVar, Union
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.wires import Wires
 
 from .measurements import MeasurementProcess, MidMeasure
@@ -223,7 +222,7 @@ def _measure_impl(
     """Concrete implementation of qml.measure"""
     wires = Wires(wires)
     if len(wires) > 1:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Only a single qubit can be measured in the middle of the circuit"
         )
 

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -20,7 +20,6 @@ from copy import copy
 from typing import Optional
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.wires import Wires
 
 from .measurements import MutualInfo, StateMeasurement
@@ -84,7 +83,7 @@ def mutual_info(wires0, wires1, log_base=None):
     if not any(qml.math.is_abstract(w) for w in wires0 + wires1) and [
         wire for wire in wires0 if wire in wires1
     ]:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "Subsystems for computing mutual information must not overlap."
         )
     return MutualInfoMP(wires=(wires0, wires1), log_base=log_base)

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -20,6 +20,7 @@ from copy import copy
 from typing import Optional
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.wires import Wires
 
 from .measurements import MutualInfo, StateMeasurement
@@ -83,7 +84,7 @@ def mutual_info(wires0, wires1, log_base=None):
     if not any(qml.math.is_abstract(w) for w in wires0 + wires1) and [
         wire for wire in wires0 if wire in wires1
     ]:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "Subsystems for computing mutual information must not overlap."
         )
     return MutualInfoMP(wires=(wires0, wires1), log_base=log_base)

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -20,6 +20,7 @@ from typing import Optional
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
@@ -108,7 +109,7 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
         if not qml.math.is_abstract(op[0]) and not all(
             isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in op
         ):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Only sequences of single MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."
@@ -117,16 +118,18 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
         return ProbabilityMP(obs=op)
 
     if isinstance(op, qml.ops.LinearCombination):
-        raise qml.QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
+        raise pennylane.errors.QuantumFunctionError(
+            "Hamiltonians are not supported for rotating probabilities."
+        )
 
     if op is not None and not qml.math.is_abstract(op) and not op.has_diagonalizing_gates:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
         )
 
     if wires is not None:
         if op is not None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Cannot specify the wires to probs if an observable is "
                 "provided. The wires for probs will be determined directly from the observable."
             )

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -20,7 +20,6 @@ from typing import Optional
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
@@ -109,7 +108,7 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
         if not qml.math.is_abstract(op[0]) and not all(
             isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in op
         ):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Only sequences of single MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."
@@ -118,18 +117,16 @@ def probs(wires=None, op=None) -> "ProbabilityMP":
         return ProbabilityMP(obs=op)
 
     if isinstance(op, qml.ops.LinearCombination):
-        raise pennylane.errors.QuantumFunctionError(
-            "Hamiltonians are not supported for rotating probabilities."
-        )
+        raise qml.QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
 
     if op is not None and not qml.math.is_abstract(op) and not op.has_diagonalizing_gates:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
         )
 
     if wires is not None:
         if op is not None:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Cannot specify the wires to probs if an observable is "
                 "provided. The wires for probs will be determined directly from the observable."
             )

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -20,7 +20,6 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.wires import Wires
 
@@ -168,7 +167,7 @@ class SampleMP(SampleMeasurement):
             if not all(
                 isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in obs
             ) and not all(qml.math.is_abstract(o) for o in obs):
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Only sequences of single MeasurementValues can be passed with the op "
                     "argument. MeasurementValues manipulated using arithmetic operators cannot be "
                     "used when collecting statistics for a sequence of mid-circuit measurements."

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -20,6 +20,7 @@ from typing import Optional, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.wires import Wires
 
@@ -167,7 +168,7 @@ class SampleMP(SampleMeasurement):
             if not all(
                 isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in obs
             ) and not all(qml.math.is_abstract(o) for o in obs):
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Only sequences of single MeasurementValues can be passed with the op "
                     "argument. MeasurementValues manipulated using arithmetic operators cannot be "
                     "used when collecting statistics for a sequence of mid-circuit measurements."

--- a/pennylane/ops/functions/generator.py
+++ b/pennylane/ops/functions/generator.py
@@ -21,6 +21,7 @@ import warnings
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops import LinearCombination, Prod, SProd, Sum
 
 
@@ -97,7 +98,7 @@ def _generator_backcompatibility(op):
         "The Operator.generator property is deprecated. Please update the operator so that "
         "\n\t1. Operator.generator() is a method, and"
         "\n\t2. Operator.generator() returns an Operator instance representing the operator.",
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
     )
     gen = op.generator
 
@@ -195,7 +196,7 @@ def generator(op: qml.operation.Operator, format="prefactor"):
             gen = _generator_backcompatibility(gen_op)
 
         if not gen.is_hermitian:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 f"Generator {gen.name} of operation {gen_op.name} is not hermitian"
             )
 

--- a/pennylane/ops/functions/generator.py
+++ b/pennylane/ops/functions/generator.py
@@ -21,7 +21,6 @@ import warnings
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops import LinearCombination, Prod, SProd, Sum
 
 
@@ -98,7 +97,7 @@ def _generator_backcompatibility(op):
         "The Operator.generator property is deprecated. Please update the operator so that "
         "\n\t1. Operator.generator() is a method, and"
         "\n\t2. Operator.generator() returns an Operator instance representing the operator.",
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
     )
     gen = op.generator
 
@@ -196,7 +195,7 @@ def generator(op: qml.operation.Operator, format="prefactor"):
             gen = _generator_backcompatibility(gen_op)
 
         if not gen.is_hermitian:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 f"Generator {gen.name} of operation {gen_op.name} is not hermitian"
             )
 

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -18,6 +18,7 @@ Defines `is_commuting`, an function for determining if two functions commute.
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops.op_math import Prod, SProd, Sum
 
 
@@ -160,7 +161,7 @@ def _check_opmath_operations(operation1, operation2):
             continue
 
         if isinstance(op, (SProd, Prod, Sum)):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 f"Operation {op} currently not supported. Prod, Sprod, and Sum instances must have a valid Pauli representation."
             )
 
@@ -342,12 +343,12 @@ def is_commuting(operation1, operation2):
     if operation1.name in unsupported_operations or isinstance(
         operation1, (qml.operation.CVOperation, qml.operation.Channel)
     ):
-        raise qml.QuantumFunctionError(f"Operation {operation1.name} not supported.")
+        raise pennylane.errors.QuantumFunctionError(f"Operation {operation1.name} not supported.")
 
     if operation2.name in unsupported_operations or isinstance(
         operation2, (qml.operation.CVOperation, qml.operation.Channel)
     ):
-        raise qml.QuantumFunctionError(f"Operation {operation2.name} not supported.")
+        raise pennylane.errors.QuantumFunctionError(f"Operation {operation2.name} not supported.")
 
     if operation1.pauli_rep is not None and operation2.pauli_rep is not None:
         return _pword_is_commuting(operation1, operation2)

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -18,7 +18,6 @@ Defines `is_commuting`, an function for determining if two functions commute.
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops.op_math import Prod, SProd, Sum
 
 
@@ -161,7 +160,7 @@ def _check_opmath_operations(operation1, operation2):
             continue
 
         if isinstance(op, (SProd, Prod, Sum)):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 f"Operation {op} currently not supported. Prod, Sprod, and Sum instances must have a valid Pauli representation."
             )
 
@@ -343,12 +342,12 @@ def is_commuting(operation1, operation2):
     if operation1.name in unsupported_operations or isinstance(
         operation1, (qml.operation.CVOperation, qml.operation.Channel)
     ):
-        raise pennylane.errors.QuantumFunctionError(f"Operation {operation1.name} not supported.")
+        raise qml.QuantumFunctionError(f"Operation {operation1.name} not supported.")
 
     if operation2.name in unsupported_operations or isinstance(
         operation2, (qml.operation.CVOperation, qml.operation.Channel)
     ):
-        raise pennylane.errors.QuantumFunctionError(f"Operation {operation2.name} not supported.")
+        raise qml.QuantumFunctionError(f"Operation {operation2.name} not supported.")
 
     if operation1.pauli_rep is not None and operation2.pauli_rep is not None:
         return _pword_is_commuting(operation1, operation2)

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -24,7 +24,6 @@ import numpy as np
 from scipy.linalg import block_diag
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.operation import AnyWires, Wires
 from pennylane.ops.qubit.parametric_ops_single_qubit import stack_last
@@ -42,7 +41,7 @@ def _deprecate_control_wires(control_wires):
         warnings.warn(
             "The control_wires input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
             "Please note that the second positional arg of your input is going to be the new wires, following wires=controlled_wires+target_wires, where target_wires is the optional arg wires in the legacy interface.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
 
 
@@ -152,7 +151,7 @@ class ControlledQubitUnitary(ControlledOp):
             warnings.warn(
                 "QubitUnitary input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
                 "Instead, please use a full matrix as input, or try qml.ctrl for controlled QubitUnitary.",
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
             )
             base = base.matrix()
 
@@ -186,7 +185,7 @@ class ControlledQubitUnitary(ControlledOp):
             warnings.warn(
                 "QubitUnitary input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
                 "Instead, please use a full matrix as input, or try qml.ctrl for controlled QubitUnitary.",
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
             )
             base = base.matrix()
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy.linalg import block_diag
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.operation import AnyWires, Wires
 from pennylane.ops.qubit.parametric_ops_single_qubit import stack_last
@@ -41,7 +42,7 @@ def _deprecate_control_wires(control_wires):
         warnings.warn(
             "The control_wires input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
             "Please note that the second positional arg of your input is going to be the new wires, following wires=controlled_wires+target_wires, where target_wires is the optional arg wires in the legacy interface.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
 
 
@@ -151,7 +152,7 @@ class ControlledQubitUnitary(ControlledOp):
             warnings.warn(
                 "QubitUnitary input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
                 "Instead, please use a full matrix as input, or try qml.ctrl for controlled QubitUnitary.",
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
             )
             base = base.matrix()
 
@@ -185,7 +186,7 @@ class ControlledQubitUnitary(ControlledOp):
             warnings.warn(
                 "QubitUnitary input to ControlledQubitUnitary is deprecated and will be removed in v0.42. "
                 "Instead, please use a full matrix as input, or try qml.ctrl for controlled QubitUnitary.",
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
             )
             base = base.matrix()
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -25,6 +25,7 @@ from typing import Union
 from scipy.sparse import kron as sparse_kron
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import math
 from pennylane.operation import Operator
 from pennylane.ops.op_math.pow import Pow
@@ -261,7 +262,7 @@ class Prod(CompositeOp):
         warnings.warn(
             "Accessing the terms of a tensor product operator via op.obs is deprecated and will be removed "
             "in Pennylane v0.42. Instead, please use op.operands.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         return self.operands
 
@@ -489,7 +490,7 @@ class Prod(CompositeOp):
         .. seealso:: :attr:`~Prod.ops`, :class:`~Prod.pauli_rep`"""
         warnings.warn(
             "Prod.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         coeffs, _ = self.terms()
         return coeffs
@@ -504,7 +505,7 @@ class Prod(CompositeOp):
         .. seealso:: :attr:`~Prod.coeffs`, :class:`~Prod.pauli_rep`"""
         warnings.warn(
             "Prod.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         _, ops = self.terms()
         return ops

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -25,7 +25,6 @@ from typing import Union
 from scipy.sparse import kron as sparse_kron
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import math
 from pennylane.operation import Operator
 from pennylane.ops.op_math.pow import Pow
@@ -262,7 +261,7 @@ class Prod(CompositeOp):
         warnings.warn(
             "Accessing the terms of a tensor product operator via op.obs is deprecated and will be removed "
             "in Pennylane v0.42. Instead, please use op.operands.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         return self.operands
 
@@ -490,7 +489,7 @@ class Prod(CompositeOp):
         .. seealso:: :attr:`~Prod.ops`, :class:`~Prod.pauli_rep`"""
         warnings.warn(
             "Prod.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         coeffs, _ = self.terms()
         return coeffs
@@ -505,7 +504,7 @@ class Prod(CompositeOp):
         .. seealso:: :attr:`~Prod.coeffs`, :class:`~Prod.pauli_rep`"""
         warnings.warn(
             "Prod.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         _, ops = self.terms()
         return ops

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -24,6 +24,7 @@ from collections.abc import Iterable
 from copy import copy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import math
 from pennylane.operation import Operator
 from pennylane.queuing import QueuingManager
@@ -540,7 +541,7 @@ class Sum(CompositeOp):
         .. seealso:: :attr:`~Sum.ops`, :class:`~Sum.pauli_rep`"""
         warnings.warn(
             "Sum.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         coeffs, _ = self.terms()
         return coeffs
@@ -555,7 +556,7 @@ class Sum(CompositeOp):
         .. seealso:: :attr:`~Sum.coeffs`, :class:`~Sum.pauli_rep`"""
         warnings.warn(
             "Sum.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         _, ops = self.terms()
         return ops

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -24,7 +24,6 @@ from collections.abc import Iterable
 from copy import copy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import math
 from pennylane.operation import Operator
 from pennylane.queuing import QueuingManager
@@ -541,7 +540,7 @@ class Sum(CompositeOp):
         .. seealso:: :attr:`~Sum.ops`, :class:`~Sum.pauli_rep`"""
         warnings.warn(
             "Sum.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         coeffs, _ = self.terms()
         return coeffs
@@ -556,7 +555,7 @@ class Sum(CompositeOp):
         .. seealso:: :attr:`~Sum.coeffs`, :class:`~Sum.pauli_rep`"""
         warnings.warn(
             "Sum.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         _, ops = self.terms()
         return ops

--- a/pennylane/pauli/dla/center.py
+++ b/pennylane/pauli/dla/center.py
@@ -16,7 +16,6 @@ import warnings
 from typing import Union
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 
@@ -124,6 +123,6 @@ def center(
     warnings.warn(
         "Calling center via qml.pauli.center is deprecated. center has moved to pennylane.liealg. "
         "Please call center from top level as qml.center or from the liealg module via qml.liealg.center.",
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
     )
     return qml.center(g, pauli)

--- a/pennylane/pauli/dla/center.py
+++ b/pennylane/pauli/dla/center.py
@@ -16,6 +16,7 @@ import warnings
 from typing import Union
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 
@@ -123,6 +124,6 @@ def center(
     warnings.warn(
         "Calling center via qml.pauli.center is deprecated. center has moved to pennylane.liealg. "
         "Please call center from top level as qml.center or from the liealg module via qml.liealg.center.",
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
     )
     return qml.center(g, pauli)

--- a/pennylane/pauli/dla/lie_closure.py
+++ b/pennylane/pauli/dla/lie_closure.py
@@ -19,7 +19,6 @@ from typing import Iterable, Union
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.typing import TensorLike
 
@@ -138,7 +137,7 @@ def lie_closure(
     warnings.warn(
         "Calling lie_closure via qml.pauli.lie_closure is deprecated. lie_closure has moved to pennylane.liealg. "
         "Please call lie_closure from top level as qml.lie_closure or from the liealg module via qml.liealg.lie_closure.",
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
     )
 
     return qml.lie_closure(

--- a/pennylane/pauli/dla/lie_closure.py
+++ b/pennylane/pauli/dla/lie_closure.py
@@ -19,6 +19,7 @@ from typing import Iterable, Union
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.typing import TensorLike
 
@@ -137,7 +138,7 @@ def lie_closure(
     warnings.warn(
         "Calling lie_closure via qml.pauli.lie_closure is deprecated. lie_closure has moved to pennylane.liealg. "
         "Please call lie_closure from top level as qml.lie_closure or from the liealg module via qml.liealg.lie_closure.",
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
     )
 
     return qml.lie_closure(

--- a/pennylane/pauli/dla/structure_constants.py
+++ b/pennylane/pauli/dla/structure_constants.py
@@ -16,6 +16,7 @@ import warnings
 from typing import Union
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.typing import TensorLike
 
@@ -180,7 +181,7 @@ def structure_constants(
     warnings.warn(
         "Calling structure_constants via qml.pauli.structure_constants is deprecated. structure_constants has moved to pennylane.liealg. "
         "Please call structure_constants from top level as qml.structure_constants or from the liealg module via qml.liealg.structure_constants.",
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
     )
 
     return qml.structure_constants(g, pauli=pauli, matrix=matrix, is_orthogonal=is_orthogonal)

--- a/pennylane/pauli/dla/structure_constants.py
+++ b/pennylane/pauli/dla/structure_constants.py
@@ -16,7 +16,6 @@ import warnings
 from typing import Union
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.typing import TensorLike
 
@@ -181,7 +180,7 @@ def structure_constants(
     warnings.warn(
         "Calling structure_constants via qml.pauli.structure_constants is deprecated. structure_constants has moved to pennylane.liealg. "
         "Please call structure_constants from top level as qml.structure_constants or from the liealg module via qml.liealg.structure_constants.",
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
     )
 
     return qml.structure_constants(g, pauli=pauli, matrix=matrix, is_orthogonal=is_orthogonal)

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -20,7 +20,7 @@ from typing import Optional, Text
 
 from packaging.version import Version
 
-from pennylane import PennyLaneDeprecationWarning
+from pennylane.errors import PennyLaneDeprecationWarning
 
 try:
     import tensorflow as tf

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -20,7 +20,7 @@ from typing import Optional, Text
 
 from packaging.version import Version
 
-from pennylane.errors import PennyLaneDeprecationWarning
+import pennylane as qml
 
 try:
     import tensorflow as tf
@@ -316,7 +316,7 @@ class KerasLayer(Layer):
     ):
         warnings.warn(
             "The 'KerasLayer' class is deprecated and will be removed in v0.42. ",
-            PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         # pylint: disable=too-many-arguments
         if not CORRECT_TF_VERSION:

--- a/pennylane/qnn/keras.py
+++ b/pennylane/qnn/keras.py
@@ -20,7 +20,7 @@ from typing import Optional, Text
 
 from packaging.version import Version
 
-import pennylane as qml
+import pennylane.errors as qml
 
 try:
     import tensorflow as tf

--- a/pennylane/tape/__init__.py
+++ b/pennylane/tape/__init__.py
@@ -18,7 +18,7 @@ validates quantum operations and measurements.
 
 from .operation_recorder import OperationRecorder
 from .qscript import QuantumScript, QuantumScriptBatch, QuantumScriptOrBatch, make_qscript
-from .tape import QuantumTape, QuantumTapeBatch, TapeError, expand_tape_state_prep
+from .tape import QuantumTape, QuantumTapeBatch, expand_tape_state_prep
 
 
 # pylint: disable=import-outside-toplevel

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from threading import RLock
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import CountsMP, MeasurementProcess, ProbabilityMP, SampleMP
 from pennylane.operation import DecompositionUndefinedError, Operator, StatePrepBase
 from pennylane.pytrees import register_pytree
@@ -85,7 +86,9 @@ def _validate_computational_basis_sampling(tape):
             if obs.obs is not None and not qml.pauli.utils.are_pauli_words_qwc(
                 [obs.obs, pauliz_for_cb_obs]
             ):
-                raise qml.QuantumFunctionError(_err_msg_for_some_meas_not_qwc(measurements))
+                raise pennylane.errors.QuantumFunctionError(
+                    _err_msg_for_some_meas_not_qwc(measurements)
+                )
 
 
 def rotations_and_diagonal_measurements(tape):
@@ -100,7 +103,7 @@ def rotations_and_diagonal_measurements(tape):
             rotations, diag_obs = qml.pauli.diagonalize_qwc_pauli_words(tape.obs_sharing_wires)
         except (TypeError, ValueError) as e:
             if any(isinstance(m, (ProbabilityMP, SampleMP, CountsMP)) for m in tape.measurements):
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Only observables that are qubit-wise commuting "
                     "Pauli words can be returned on the same wire.\n"
                     "Try removing all probability, sample and counts measurements "
@@ -108,7 +111,9 @@ def rotations_and_diagonal_measurements(tape):
                     "for each non-commuting observable."
                 ) from e
 
-            raise qml.QuantumFunctionError(_err_msg_for_some_meas_not_qwc(tape.measurements)) from e
+            raise pennylane.errors.QuantumFunctionError(
+                _err_msg_for_some_meas_not_qwc(tape.measurements)
+            ) from e
 
         measurements = copy.copy(tape.measurements)
 

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -20,7 +20,6 @@ from collections.abc import Sequence
 from threading import RLock
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import CountsMP, MeasurementProcess, ProbabilityMP, SampleMP
 from pennylane.operation import DecompositionUndefinedError, Operator, StatePrepBase
 from pennylane.pytrees import register_pytree
@@ -86,9 +85,7 @@ def _validate_computational_basis_sampling(tape):
             if obs.obs is not None and not qml.pauli.utils.are_pauli_words_qwc(
                 [obs.obs, pauliz_for_cb_obs]
             ):
-                raise pennylane.errors.QuantumFunctionError(
-                    _err_msg_for_some_meas_not_qwc(measurements)
-                )
+                raise qml.QuantumFunctionError(_err_msg_for_some_meas_not_qwc(measurements))
 
 
 def rotations_and_diagonal_measurements(tape):
@@ -103,7 +100,7 @@ def rotations_and_diagonal_measurements(tape):
             rotations, diag_obs = qml.pauli.diagonalize_qwc_pauli_words(tape.obs_sharing_wires)
         except (TypeError, ValueError) as e:
             if any(isinstance(m, (ProbabilityMP, SampleMP, CountsMP)) for m in tape.measurements):
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Only observables that are qubit-wise commuting "
                     "Pauli words can be returned on the same wire.\n"
                     "Try removing all probability, sample and counts measurements "
@@ -111,9 +108,7 @@ def rotations_and_diagonal_measurements(tape):
                     "for each non-commuting observable."
                 ) from e
 
-            raise pennylane.errors.QuantumFunctionError(
-                _err_msg_for_some_meas_not_qwc(tape.measurements)
-            ) from e
+            raise qml.QuantumFunctionError(_err_msg_for_some_meas_not_qwc(tape.measurements)) from e
 
         measurements = copy.copy(tape.measurements)
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -16,6 +16,7 @@ This submodule contains the templates for the Hilbert-Schmidt tests.
 """
 # pylint: disable-msg=too-many-arguments
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import AnyWires, Operation
 
 
@@ -122,13 +123,15 @@ class HilbertSchmidt(Operation):
         self._num_params = len(params)
 
         if not isinstance(u_tape, qml.tape.QuantumScript):
-            raise qml.QuantumFunctionError("The argument u_tape must be a QuantumTape.")
+            raise pennylane.errors.QuantumFunctionError(
+                "The argument u_tape must be a QuantumTape."
+            )
 
         u_wires = u_tape.wires
         self.hyperparameters["u_tape"] = u_tape
 
         if not callable(v_function):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The argument v_function must be a callable quantum function."
             )
 
@@ -139,14 +142,18 @@ class HilbertSchmidt(Operation):
         self.hyperparameters["v_wires"] = qml.wires.Wires(v_wires)
 
         if len(u_wires) != len(v_wires):
-            raise qml.QuantumFunctionError("U and V must have the same number of wires.")
+            raise pennylane.errors.QuantumFunctionError(
+                "U and V must have the same number of wires."
+            )
 
         if not qml.wires.Wires(v_wires).contains_wires(v_tape.wires):
-            raise qml.QuantumFunctionError("All wires in v_tape must be in v_wires.")
+            raise pennylane.errors.QuantumFunctionError("All wires in v_tape must be in v_wires.")
 
         # Intersection of wires
         if len(qml.wires.Wires.shared_wires([u_tape.wires, v_tape.wires])) != 0:
-            raise qml.QuantumFunctionError("u_tape and v_tape must act on distinct wires.")
+            raise pennylane.errors.QuantumFunctionError(
+                "u_tape and v_tape must act on distinct wires."
+            )
 
         wires = qml.wires.Wires(u_wires + v_wires)
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -16,7 +16,6 @@ This submodule contains the templates for the Hilbert-Schmidt tests.
 """
 # pylint: disable-msg=too-many-arguments
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import AnyWires, Operation
 
 
@@ -123,15 +122,13 @@ class HilbertSchmidt(Operation):
         self._num_params = len(params)
 
         if not isinstance(u_tape, qml.tape.QuantumScript):
-            raise pennylane.errors.QuantumFunctionError(
-                "The argument u_tape must be a QuantumTape."
-            )
+            raise qml.QuantumFunctionError("The argument u_tape must be a QuantumTape.")
 
         u_wires = u_tape.wires
         self.hyperparameters["u_tape"] = u_tape
 
         if not callable(v_function):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The argument v_function must be a callable quantum function."
             )
 
@@ -142,18 +139,14 @@ class HilbertSchmidt(Operation):
         self.hyperparameters["v_wires"] = qml.wires.Wires(v_wires)
 
         if len(u_wires) != len(v_wires):
-            raise pennylane.errors.QuantumFunctionError(
-                "U and V must have the same number of wires."
-            )
+            raise qml.QuantumFunctionError("U and V must have the same number of wires.")
 
         if not qml.wires.Wires(v_wires).contains_wires(v_tape.wires):
-            raise pennylane.errors.QuantumFunctionError("All wires in v_tape must be in v_wires.")
+            raise qml.QuantumFunctionError("All wires in v_tape must be in v_wires.")
 
         # Intersection of wires
         if len(qml.wires.Wires.shared_wires([u_tape.wires, v_tape.wires])) != 0:
-            raise pennylane.errors.QuantumFunctionError(
-                "u_tape and v_tape must act on distinct wires."
-            )
+            raise qml.QuantumFunctionError("u_tape and v_tape must act on distinct wires.")
 
         wires = qml.wires.Wires(u_wires + v_wires)
 

--- a/pennylane/templates/subroutines/qdrift.py
+++ b/pennylane/templates/subroutines/qdrift.py
@@ -15,7 +15,6 @@
 import copy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math import requires_grad, unwrap
 from pennylane.operation import Operation
 from pennylane.ops import LinearCombination, Sum
@@ -208,7 +207,7 @@ class QDrift(Operation):
             )
 
         if any(requires_grad(coeff) for coeff in coeffs):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The QDrift template currently doesn't support differentiation through the "
                 "coefficients of the input Hamiltonian."
             )

--- a/pennylane/templates/subroutines/qdrift.py
+++ b/pennylane/templates/subroutines/qdrift.py
@@ -15,6 +15,7 @@
 import copy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import requires_grad, unwrap
 from pennylane.operation import Operation
 from pennylane.ops import LinearCombination, Sum
@@ -207,7 +208,7 @@ class QDrift(Operation):
             )
 
         if any(requires_grad(coeff) for coeff in coeffs):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The QDrift template currently doesn't support differentiation through the "
                 "coefficients of the input Hamiltonian."
             )

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -18,6 +18,7 @@ Contains the QuantumPhaseEstimation template.
 import copy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import AnyWires, Operator
 from pennylane.queuing import QueuingManager
 from pennylane.resource.error import ErrorOperation, SpectralNormError
@@ -162,14 +163,14 @@ class QuantumPhaseEstimation(ErrorOperation):
         if isinstance(unitary, Operator):
             # If the unitary is expressed in terms of operators, do not provide target wires
             if target_wires is not None:
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "The unitary is expressed as an operator, which already has target wires "
                     "defined, do not additionally specify target wires."
                 )
             target_wires = unitary.wires
 
         elif target_wires is None:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Target wires must be specified if the unitary is expressed as a matrix."
             )
 
@@ -179,14 +180,14 @@ class QuantumPhaseEstimation(ErrorOperation):
         # Estimation wires are required, but kept as an optional argument so that it can be
         # placed after target_wires for backwards compatibility.
         if estimation_wires is None:
-            raise qml.QuantumFunctionError("No estimation wires specified.")
+            raise pennylane.errors.QuantumFunctionError("No estimation wires specified.")
 
         target_wires = qml.wires.Wires(target_wires)
         estimation_wires = qml.wires.Wires(estimation_wires)
         wires = target_wires + estimation_wires
 
         if any(wire in target_wires for wire in estimation_wires):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The target wires and estimation wires must not overlap."
             )
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -18,7 +18,6 @@ Contains the QuantumPhaseEstimation template.
 import copy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import AnyWires, Operator
 from pennylane.queuing import QueuingManager
 from pennylane.resource.error import ErrorOperation, SpectralNormError
@@ -163,14 +162,14 @@ class QuantumPhaseEstimation(ErrorOperation):
         if isinstance(unitary, Operator):
             # If the unitary is expressed in terms of operators, do not provide target wires
             if target_wires is not None:
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "The unitary is expressed as an operator, which already has target wires "
                     "defined, do not additionally specify target wires."
                 )
             target_wires = unitary.wires
 
         elif target_wires is None:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Target wires must be specified if the unitary is expressed as a matrix."
             )
 
@@ -180,14 +179,14 @@ class QuantumPhaseEstimation(ErrorOperation):
         # Estimation wires are required, but kept as an optional argument so that it can be
         # placed after target_wires for backwards compatibility.
         if estimation_wires is None:
-            raise pennylane.errors.QuantumFunctionError("No estimation wires specified.")
+            raise qml.QuantumFunctionError("No estimation wires specified.")
 
         target_wires = qml.wires.Wires(target_wires)
         estimation_wires = qml.wires.Wires(estimation_wires)
         wires = target_wires + estimation_wires
 
         if any(wire in target_wires for wire in estimation_wires):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The target wires and estimation wires must not overlap."
             )
 

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -19,6 +19,7 @@ from functools import partial
 from warnings import warn
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops import __all__ as all_ops
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch
@@ -174,7 +175,7 @@ def compile(
     if pipeline is None:
         warn(
             "Specifying pipeline=None is now deprecated. Please specify a sequence of transforms",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         pipeline = default_pipeline
     else:

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -19,7 +19,6 @@ from functools import partial
 from warnings import warn
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops import __all__ as all_ops
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch
@@ -175,7 +174,7 @@ def compile(
     if pipeline is None:
         warn(
             "Specifying pipeline=None is now deprecated. Please specify a sequence of transforms",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         pipeline = default_pipeline
     else:

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import Optional, overload
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.tape import QuantumScriptBatch
 from pennylane.typing import BatchPostprocessingFn, PostprocessingFn, ResultBatch
 
@@ -41,19 +42,19 @@ def _get_interface(qnode, args, kwargs) -> str:
 
 
 def _numpy_jac(*_, **__) -> qml.typing.TensorLike:
-    raise qml.QuantumFunctionError("No trainable parameters.")
+    raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
 
 
 def _autograd_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args) and argnums is None:
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     return qml.jacobian(classical_function, argnum=argnums)(*args, **kwargs)
 
 
 # pylint: disable=import-outside-toplevel, unused-argument
 def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     import tensorflow as tf
 
     with tf.GradientTape() as tape:
@@ -64,7 +65,7 @@ def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLi
 # pylint: disable=import-outside-toplevel, unused-argument
 def _torch_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     from torch.autograd.functional import jacobian
 
     return jacobian(partial(classical_function, **kwargs), args)
@@ -76,7 +77,7 @@ def _jax_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorL
 
     if argnums is None:
         if not isinstance(args[0], jax.numpy.ndarray):
-            raise qml.QuantumFunctionError("No trainable parameters.")
+            raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
         argnums = 0
     return jax.jacobian(classical_function, argnums=argnums)(*args, **kwargs)
 
@@ -519,7 +520,7 @@ class TransformProgram:
 
         interface = _get_interface(qnode, args, kwargs)
         if interface == "jax" and "argnum" in self[index].kwargs:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "argnum does not work with the Jax interface. You should use argnums instead."
             )
 

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -20,7 +20,6 @@ from functools import partial
 from typing import Optional, overload
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.tape import QuantumScriptBatch
 from pennylane.typing import BatchPostprocessingFn, PostprocessingFn, ResultBatch
 
@@ -42,19 +41,19 @@ def _get_interface(qnode, args, kwargs) -> str:
 
 
 def _numpy_jac(*_, **__) -> qml.typing.TensorLike:
-    raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
+    raise qml.QuantumFunctionError("No trainable parameters.")
 
 
 def _autograd_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args) and argnums is None:
-        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
+        raise qml.QuantumFunctionError("No trainable parameters.")
     return qml.jacobian(classical_function, argnum=argnums)(*args, **kwargs)
 
 
 # pylint: disable=import-outside-toplevel, unused-argument
 def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
+        raise qml.QuantumFunctionError("No trainable parameters.")
     import tensorflow as tf
 
     with tf.GradientTape() as tape:
@@ -65,7 +64,7 @@ def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLi
 # pylint: disable=import-outside-toplevel, unused-argument
 def _torch_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
+        raise qml.QuantumFunctionError("No trainable parameters.")
     from torch.autograd.functional import jacobian
 
     return jacobian(partial(classical_function, **kwargs), args)
@@ -77,7 +76,7 @@ def _jax_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorL
 
     if argnums is None:
         if not isinstance(args[0], jax.numpy.ndarray):
-            raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
+            raise qml.QuantumFunctionError("No trainable parameters.")
         argnums = 0
     return jax.jacobian(classical_function, argnums=argnums)(*args, **kwargs)
 
@@ -520,7 +519,7 @@ class TransformProgram:
 
         interface = _get_interface(qnode, args, kwargs)
         if interface == "jax" and "argnum" in self[index].kwargs:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "argnum does not work with the Jax interface. You should use argnums instead."
             )
 

--- a/pennylane/transforms/core/transform_program.py
+++ b/pennylane/transforms/core/transform_program.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import Optional, overload
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.tape import QuantumScriptBatch
 from pennylane.typing import BatchPostprocessingFn, PostprocessingFn, ResultBatch
 
@@ -41,19 +42,19 @@ def _get_interface(qnode, args, kwargs) -> str:
 
 
 def _numpy_jac(*_, **__) -> qml.typing.TensorLike:
-    raise qml.QuantumFunctionError("No trainable parameters.")
+    raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
 
 
 def _autograd_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args) and argnums is None:
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     return qml.jacobian(classical_function, argnum=argnums)(*args, **kwargs)
 
 
 # pylint: disable=import-outside-toplevel, unused-argument
 def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     import tensorflow as tf
 
     with tf.GradientTape() as tape:
@@ -64,7 +65,7 @@ def _tf_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLi
 # pylint: disable=import-outside-toplevel, unused-argument
 def _torch_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorLike:
     if not qml.math.get_trainable_indices(args):
-        raise qml.QuantumFunctionError("No trainable parameters.")
+        raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
     from torch.autograd.functional import jacobian
 
     return jacobian(partial(classical_function, **kwargs), args)
@@ -76,7 +77,7 @@ def _jax_jac(classical_function, argnums, *args, **kwargs) -> qml.typing.TensorL
 
     if argnums is None:
         if not isinstance(args[0], jax.numpy.ndarray):
-            raise qml.QuantumFunctionError("No trainable parameters.")
+            raise pennylane.errors.QuantumFunctionError("No trainable parameters.")
         argnums = 0
     return jax.jacobian(classical_function, argnums=argnums)(*args, **kwargs)
 
@@ -284,8 +285,10 @@ class TransformProgram:
 
     @overload
     def __getitem__(self, idx: int) -> "TransformContainer": ...
+
     @overload
     def __getitem__(self, idx: slice) -> "TransformProgram": ...
+
     def __getitem__(self, idx):
         """(TransformContainer, List[TransformContainer]): Return the indexed transform container from underlying
         transform program"""
@@ -517,7 +520,7 @@ class TransformProgram:
 
         interface = _get_interface(qnode, args, kwargs)
         if interface == "jax" and "argnum" in self[index].kwargs:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "argnum does not work with the Jax interface. You should use argnums instead."
             )
 
@@ -633,10 +636,12 @@ class TransformProgram:
     def __call__(
         self, jaxpr: "jax.core.Jaxpr", consts: Sequence, *args
     ) -> "jax.core.ClosedJaxpr": ...
+
     @overload
     def __call__(
         self, tapes: QuantumScriptBatch
     ) -> tuple[QuantumScriptBatch, BatchPostprocessingFn]: ...
+
     def __call__(self, *args, **kwargs):
         if type(args[0]).__name__ == "Jaxpr":
             return self.__call_jaxpr(*args, **kwargs)

--- a/pennylane/transforms/diagonalize_measurements.py
+++ b/pennylane/transforms/diagonalize_measurements.py
@@ -17,7 +17,6 @@ from copy import copy
 from functools import singledispatch
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops import CompositeOp, LinearCombination, SymbolicOp
 from pennylane.pauli import diagonalize_qwc_pauli_words
 from pennylane.tape.tape import (
@@ -179,7 +178,7 @@ def diagonalize_measurements(tape, supported_base_obs=_default_supported_obs, to
             diagonalizing_gates, new_measurements = _diagonalize_all_pauli_obs(
                 tape, to_eigvals=to_eigvals
             )
-        except pennylane.errors.QuantumFunctionError:
+        except qml.QuantumFunctionError:
             # the pauli_rep based method sometimes fails unnecessarily -
             # if it fails, fall back on the less efficient method (which may also fail)
             diagonalizing_gates, new_measurements = _diagonalize_subset_of_pauli_obs(

--- a/pennylane/transforms/diagonalize_measurements.py
+++ b/pennylane/transforms/diagonalize_measurements.py
@@ -17,6 +17,7 @@ from copy import copy
 from functools import singledispatch
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops import CompositeOp, LinearCombination, SymbolicOp
 from pennylane.pauli import diagonalize_qwc_pauli_words
 from pennylane.tape.tape import (
@@ -178,7 +179,7 @@ def diagonalize_measurements(tape, supported_base_obs=_default_supported_obs, to
             diagonalizing_gates, new_measurements = _diagonalize_all_pauli_obs(
                 tape, to_eigvals=to_eigvals
             )
-        except qml.QuantumFunctionError:
+        except pennylane.errors.QuantumFunctionError:
             # the pauli_rep based method sometimes fails unnecessarily -
             # if it fails, fall back on the less efficient method (which may also fail)
             diagonalizing_gates, new_measurements = _diagonalize_subset_of_pauli_obs(

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -24,6 +24,7 @@ from collections.abc import Sequence
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     CountsMP,
     ExpectationMP,
@@ -107,7 +108,9 @@ def dynamic_one_shot(tape: QuantumScript, **kwargs) -> tuple[QuantumScriptBatch,
     _ = kwargs.get("device", None)
 
     if not tape.shots:
-        raise qml.QuantumFunctionError("dynamic_one_shot is only supported with finite shots.")
+        raise pennylane.errors.QuantumFunctionError(
+            "dynamic_one_shot is only supported with finite shots."
+        )
 
     samples_present = any(isinstance(mp, SampleMP) for mp in tape.measurements)
     postselect_present = any(op.postselect is not None for op in tape.operations if is_mcm(op))

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -24,7 +24,6 @@ from collections.abc import Sequence
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import (
     CountsMP,
     ExpectationMP,
@@ -108,9 +107,7 @@ def dynamic_one_shot(tape: QuantumScript, **kwargs) -> tuple[QuantumScriptBatch,
     _ = kwargs.get("device", None)
 
     if not tape.shots:
-        raise pennylane.errors.QuantumFunctionError(
-            "dynamic_one_shot is only supported with finite shots."
-        )
+        raise qml.QuantumFunctionError("dynamic_one_shot is only supported with finite shots.")
 
     samples_present = any(isinstance(mp, SampleMP) for mp in tape.measurements)
     postselect_present = any(op.postselect is not None for op in tape.operations if is_mcm(op))

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -18,7 +18,6 @@ from functools import lru_cache, partial
 from typing import Sequence
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import AmplitudeEmbedding
 from pennylane.math import flatten, reshape
 from pennylane.queuing import QueuingManager
@@ -82,7 +81,7 @@ def _get_plxpr_merge_amplitude_embedding():  # pylint: disable=missing-docstring
                 return
 
             if len(self.state["visited_wires"].intersection(set(op.wires))) > 0:
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     "qml.AmplitudeEmbedding cannot be applied on wires already used by other operations."
                 )
 
@@ -352,7 +351,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
 
         # Check the qubits have not been used.
         if len(visited_wires.intersection(wires_set)) > 0:
-            raise pennylane.errors.DeviceError(
+            raise qml.DeviceError(
                 f"Operation {current_gate.name} cannot be used after other Operation applied in the same qubit "
             )
         input_wires.append(current_gate.wires)

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -18,6 +18,7 @@ from functools import lru_cache, partial
 from typing import Sequence
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import AmplitudeEmbedding
 from pennylane.math import flatten, reshape
 from pennylane.queuing import QueuingManager
@@ -81,7 +82,7 @@ def _get_plxpr_merge_amplitude_embedding():  # pylint: disable=missing-docstring
                 return
 
             if len(self.state["visited_wires"].intersection(set(op.wires))) > 0:
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     "qml.AmplitudeEmbedding cannot be applied on wires already used by other operations."
                 )
 
@@ -351,7 +352,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
 
         # Check the qubits have not been used.
         if len(visited_wires.intersection(wires_set)) > 0:
-            raise qml.DeviceError(
+            raise pennylane.errors.DeviceError(
                 f"Operation {current_gate.name} cannot be used after other Operation applied in the same qubit "
             )
         input_wires.append(current_gate.wires)

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import adjoint
 from pennylane.ops.qubit.attributes import symmetric_over_all_wires
 from pennylane.tape import QuantumScript, QuantumScriptBatch
@@ -205,21 +206,23 @@ def pattern_matching_optimization(
     for pattern in pattern_tapes:
         # Check the validity of the pattern
         if not isinstance(pattern, QuantumScript):
-            raise qml.QuantumFunctionError("The pattern is not a valid quantum tape.")
+            raise pennylane.errors.QuantumFunctionError("The pattern is not a valid quantum tape.")
 
         # Check that it does not contain a measurement.
         if pattern.measurements:
-            raise qml.QuantumFunctionError("The pattern contains measurements.")
+            raise pennylane.errors.QuantumFunctionError("The pattern contains measurements.")
 
         # Verify that the pattern is implementing the identity
         if not np.allclose(
             qml.matrix(pattern, wire_order=pattern.wires), np.eye(2**pattern.num_wires)
         ):
-            raise qml.QuantumFunctionError("Pattern is not valid, it does not implement identity.")
+            raise pennylane.errors.QuantumFunctionError(
+                "Pattern is not valid, it does not implement identity."
+            )
 
         # Verify that the pattern has less qubits or same number of qubits
         if tape.num_wires < pattern.num_wires:
-            raise qml.QuantumFunctionError("Circuit has less qubits than the pattern.")
+            raise pennylane.errors.QuantumFunctionError("Circuit has less qubits than the pattern.")
 
         # Construct Dag representation of the circuit and the pattern.
         circuit_dag = commutation_dag(tape)

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -21,7 +21,6 @@ from collections import OrderedDict
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import adjoint
 from pennylane.ops.qubit.attributes import symmetric_over_all_wires
 from pennylane.tape import QuantumScript, QuantumScriptBatch
@@ -206,23 +205,21 @@ def pattern_matching_optimization(
     for pattern in pattern_tapes:
         # Check the validity of the pattern
         if not isinstance(pattern, QuantumScript):
-            raise pennylane.errors.QuantumFunctionError("The pattern is not a valid quantum tape.")
+            raise qml.QuantumFunctionError("The pattern is not a valid quantum tape.")
 
         # Check that it does not contain a measurement.
         if pattern.measurements:
-            raise pennylane.errors.QuantumFunctionError("The pattern contains measurements.")
+            raise qml.QuantumFunctionError("The pattern contains measurements.")
 
         # Verify that the pattern is implementing the identity
         if not np.allclose(
             qml.matrix(pattern, wire_order=pattern.wires), np.eye(2**pattern.num_wires)
         ):
-            raise pennylane.errors.QuantumFunctionError(
-                "Pattern is not valid, it does not implement identity."
-            )
+            raise qml.QuantumFunctionError("Pattern is not valid, it does not implement identity.")
 
         # Verify that the pattern has less qubits or same number of qubits
         if tape.num_wires < pattern.num_wires:
-            raise pennylane.errors.QuantumFunctionError("Circuit has less qubits than the pattern.")
+            raise qml.QuantumFunctionError("Circuit has less qubits than the pattern.")
 
         # Construct Dag representation of the circuit and the pattern.
         circuit_dag = commutation_dag(tape)

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -18,6 +18,7 @@ import contextlib
 import warnings
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import (
     gen_is_multi_term_hamiltonian,
     has_gen,
@@ -486,7 +487,7 @@ def set_decomposition(custom_decomps, dev):
             warnings.filterwarnings(
                 action="ignore",
                 message=r"max_expansion argument is deprecated",
-                category=qml.PennyLaneDeprecationWarning,
+                category=pennylane.errors.PennyLaneDeprecationWarning,
             )
             original_preprocess = dev.preprocess
             new_preprocess = _create_decomp_preprocessing(custom_decomps, dev)

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -18,7 +18,6 @@ import contextlib
 import warnings
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import (
     gen_is_multi_term_hamiltonian,
     has_gen,
@@ -487,7 +486,7 @@ def set_decomposition(custom_decomps, dev):
             warnings.filterwarnings(
                 action="ignore",
                 message=r"max_expansion argument is deprecated",
-                category=pennylane.errors.PennyLaneDeprecationWarning,
+                category=qml.PennyLaneDeprecationWarning,
             )
             original_preprocess = dev.preprocess
             new_preprocess = _create_decomp_preprocessing(custom_decomps, dev)

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -21,7 +21,6 @@ from functools import partial
 import numpy as np
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import TransformError, transform
@@ -376,7 +375,7 @@ def _add_operations_to_graph(tape, graph, gate_types, q_mapper, c_mapper):
         # Check that the gate is compatible with PyZX
         name = op.name
         if name not in gate_types:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "The expansion of the quantum tape failed, PyZX does not support", name
             )
 
@@ -490,14 +489,14 @@ def from_zx(graph, decompose_phases=True):
 
             # The graph is not diagram like.
             if len(neighbors) != 1:
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Graph doesn't seem circuit like: multiple parents. Try to use the PyZX function `extract_circuit`."
                 )
 
             neighbor_0 = neighbors[0]
 
             if qubits[neighbor_0] != qubit_1:
-                raise pennylane.errors.QuantumFunctionError(
+                raise qml.QuantumFunctionError(
                     "Cross qubit connections, the graph is not circuit-like."
                 )
 
@@ -572,7 +571,7 @@ def _add_two_qubit_gates(graph, vertex, neighbor, type_1, type_2, qubit_1, qubit
     """Return the list of two qubit gates giveeen the vertex and its neighbor."""
     if type_1 == type_2:
         if graph.edge_type(graph.edge(vertex, neighbor)) != EdgeType.HADAMARD:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Two green or respectively two red nodes connected by a simple edge does not have a "
                 "circuit representation."
             )
@@ -587,7 +586,7 @@ def _add_two_qubit_gates(graph, vertex, neighbor, type_1, type_2, qubit_1, qubit
         return [op_1, op_2, op_3]
 
     if graph.edge_type(graph.edge(vertex, neighbor)) != EdgeType.SIMPLE:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "A green and red node connected by a Hadamard edge does not have a circuit representation."
         )
     # Type1 is always of type Z therefore the qubits are already ordered.

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -21,6 +21,7 @@ from functools import partial
 import numpy as np
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.operation import Operator
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import TransformError, transform
@@ -375,7 +376,7 @@ def _add_operations_to_graph(tape, graph, gate_types, q_mapper, c_mapper):
         # Check that the gate is compatible with PyZX
         name = op.name
         if name not in gate_types:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "The expansion of the quantum tape failed, PyZX does not support", name
             )
 
@@ -489,14 +490,14 @@ def from_zx(graph, decompose_phases=True):
 
             # The graph is not diagram like.
             if len(neighbors) != 1:
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Graph doesn't seem circuit like: multiple parents. Try to use the PyZX function `extract_circuit`."
                 )
 
             neighbor_0 = neighbors[0]
 
             if qubits[neighbor_0] != qubit_1:
-                raise qml.QuantumFunctionError(
+                raise pennylane.errors.QuantumFunctionError(
                     "Cross qubit connections, the graph is not circuit-like."
                 )
 
@@ -571,7 +572,7 @@ def _add_two_qubit_gates(graph, vertex, neighbor, type_1, type_2, qubit_1, qubit
     """Return the list of two qubit gates giveeen the vertex and its neighbor."""
     if type_1 == type_2:
         if graph.edge_type(graph.edge(vertex, neighbor)) != EdgeType.HADAMARD:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Two green or respectively two red nodes connected by a simple edge does not have a "
                 "circuit representation."
             )
@@ -586,7 +587,7 @@ def _add_two_qubit_gates(graph, vertex, neighbor, type_1, type_2, qubit_1, qubit
         return [op_1, op_2, op_3]
 
     if graph.edge_type(graph.edge(vertex, neighbor)) != EdgeType.SIMPLE:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "A green and red node connected by a Hadamard edge does not have a circuit representation."
         )
     # Type1 is always of type Z therefore the qubits are already ordered.

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -24,6 +24,7 @@ from warnings import warn
 from cachetools import Cache
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import Interface, InterfaceLike
 from pennylane.tape import QuantumScriptBatch
 from pennylane.transforms.core import TransformDispatcher, TransformProgram
@@ -170,7 +171,7 @@ def execute(
             "The config argument has been deprecated and will be removed in v0.42. "
             "The provided config argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
 
     if inner_transform != "unset":
@@ -178,13 +179,13 @@ def execute(
             "The inner_transform argument has been deprecated and will be removed in v0.42. "
             "The provided inner_transform argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
 
     if mcm_config != "unset":
         warn(
             "The mcm_config argument is deprecated and will be removed in v0.42, use mcm_method and postselect_mode instead.",
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
         )
         mcm_method = mcm_config.mcm_method
         postselect_mode = mcm_config.postselect_mode

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -24,7 +24,6 @@ from warnings import warn
 from cachetools import Cache
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math import Interface, InterfaceLike
 from pennylane.tape import QuantumScriptBatch
 from pennylane.transforms.core import TransformDispatcher, TransformProgram
@@ -171,7 +170,7 @@ def execute(
             "The config argument has been deprecated and will be removed in v0.42. "
             "The provided config argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
 
     if inner_transform != "unset":
@@ -179,13 +178,13 @@ def execute(
             "The inner_transform argument has been deprecated and will be removed in v0.42. "
             "The provided inner_transform argument will be ignored. "
             "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
 
     if mcm_config != "unset":
         warn(
             "The mcm_config argument is deprecated and will be removed in v0.42, use mcm_method and postselect_mode instead.",
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
         )
         mcm_method = mcm_config.mcm_method
         postselect_mode = mcm_config.postselect_mode

--- a/pennylane/workflow/jacobian_products.py
+++ b/pennylane/workflow/jacobian_products.py
@@ -24,7 +24,6 @@ import numpy as np
 from cachetools import LRUCache
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.tape import QuantumScriptBatch
 from pennylane.typing import ResultBatch, TensorLike
 
@@ -217,18 +216,18 @@ class NoGradients(JacobianProductCalculator):
     error_msg = "Derivatives cannot be calculated with diff_method=None"
 
     def compute_jacobian(self, tapes: QuantumScriptBatch) -> tuple:
-        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
+        raise qml.QuantumFunctionError(NoGradients.error_msg)
 
     def compute_vjp(self, tapes: QuantumScriptBatch, dy: Sequence[Sequence[TensorLike]]) -> tuple:
-        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
+        raise qml.QuantumFunctionError(NoGradients.error_msg)
 
     def execute_and_compute_jvp(
         self, tapes: QuantumScriptBatch, tangents: Sequence[Sequence[TensorLike]]
     ) -> tuple[ResultBatch, tuple]:
-        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
+        raise qml.QuantumFunctionError(NoGradients.error_msg)
 
     def execute_and_compute_jacobian(self, tapes: QuantumScriptBatch) -> tuple[ResultBatch, tuple]:
-        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
+        raise qml.QuantumFunctionError(NoGradients.error_msg)
 
 
 class TransformJacobianProducts(JacobianProductCalculator):

--- a/pennylane/workflow/jacobian_products.py
+++ b/pennylane/workflow/jacobian_products.py
@@ -24,6 +24,7 @@ import numpy as np
 from cachetools import LRUCache
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.tape import QuantumScriptBatch
 from pennylane.typing import ResultBatch, TensorLike
 
@@ -216,18 +217,18 @@ class NoGradients(JacobianProductCalculator):
     error_msg = "Derivatives cannot be calculated with diff_method=None"
 
     def compute_jacobian(self, tapes: QuantumScriptBatch) -> tuple:
-        raise qml.QuantumFunctionError(NoGradients.error_msg)
+        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
 
     def compute_vjp(self, tapes: QuantumScriptBatch, dy: Sequence[Sequence[TensorLike]]) -> tuple:
-        raise qml.QuantumFunctionError(NoGradients.error_msg)
+        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
 
     def execute_and_compute_jvp(
         self, tapes: QuantumScriptBatch, tangents: Sequence[Sequence[TensorLike]]
     ) -> tuple[ResultBatch, tuple]:
-        raise qml.QuantumFunctionError(NoGradients.error_msg)
+        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
 
     def execute_and_compute_jacobian(self, tapes: QuantumScriptBatch) -> tuple[ResultBatch, tuple]:
-        raise qml.QuantumFunctionError(NoGradients.error_msg)
+        raise pennylane.errors.QuantumFunctionError(NoGradients.error_msg)
 
 
 class TransformJacobianProducts(JacobianProductCalculator):

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -25,7 +25,6 @@ from typing import Literal, Optional, Union, get_args
 from cachetools import Cache, LRUCache
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.debugging import pldb_device_manager
 from pennylane.logging import debug_logger
 from pennylane.math import Interface, SupportedInterfaceUserInput, get_canonical_interface_name
@@ -166,7 +165,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
     if not measurement_processes or not all(
         isinstance(m, qml.measurements.MeasurementProcess) for m in measurement_processes
     ):
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "A quantum function must return either a single measurement, "
             "or a nonempty sequence of measurements."
         )
@@ -174,7 +173,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
     terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
 
     if any(ret is not m for ret, m in zip(measurement_processes, terminal_measurements)):
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             "All measurements must be returned in the order they are measured."
         )
 
@@ -191,7 +190,7 @@ def _validate_diff_method(
     if device.supports_derivatives(config):
         return
     if diff_method in {"backprop", "adjoint", "device"}:  # device-only derivatives
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"Device {device} does not support {diff_method} with requested circuit."
         )
     if isinstance(diff_method, str) and diff_method in tuple(get_args(SupportedDiffMethods)):
@@ -199,7 +198,7 @@ def _validate_diff_method(
     if isinstance(diff_method, TransformDispatcher):
         return
 
-    raise pennylane.errors.QuantumFunctionError(
+    raise qml.QuantumFunctionError(
         f"Differentiation method {diff_method} not recognized. Allowed "
         f"options are {tuple(get_args(SupportedDiffMethods))}."
     )
@@ -568,7 +567,7 @@ class QNode:
             )
 
         if not isinstance(device, (qml.devices.LegacyDevice, qml.devices.Device)):
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 "Invalid device. Device must be a valid PennyLane device."
             )
 
@@ -581,7 +580,7 @@ class QNode:
                 warnings.warn(
                     f"Specifying gradient keyword arguments {list(kwargs.keys())} as additional kwargs has been deprecated and will be removed in v0.42. \
                     Instead, please specify these arguments through the `gradient_kwargs` dictionary argument.",
-                    pennylane.errors.PennyLaneDeprecationWarning,
+                    qml.PennyLaneDeprecationWarning,
                 )
             gradient_kwargs |= kwargs
         _validate_gradient_kwargs(gradient_kwargs)
@@ -786,7 +785,7 @@ class QNode:
             return new_config.gradient_method, {}, device
 
         if diff_method in {"backprop", "adjoint", "device"}:  # device-only derivatives
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 f"Device {device} does not support {diff_method} with requested circuit."
             )
 
@@ -813,7 +812,7 @@ class QNode:
         if isinstance(diff_method, qml.transforms.core.TransformDispatcher):
             return diff_method, {}, device
 
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"Differentiation method {diff_method} not recognized. Allowed "
             f"options are {tuple(get_args(SupportedDiffMethods))}."
         )

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -25,6 +25,7 @@ from typing import Literal, Optional, Union, get_args
 from cachetools import Cache, LRUCache
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.debugging import pldb_device_manager
 from pennylane.logging import debug_logger
 from pennylane.math import Interface, SupportedInterfaceUserInput, get_canonical_interface_name
@@ -165,7 +166,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
     if not measurement_processes or not all(
         isinstance(m, qml.measurements.MeasurementProcess) for m in measurement_processes
     ):
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "A quantum function must return either a single measurement, "
             "or a nonempty sequence of measurements."
         )
@@ -173,7 +174,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
     terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
 
     if any(ret is not m for ret, m in zip(measurement_processes, terminal_measurements)):
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             "All measurements must be returned in the order they are measured."
         )
 
@@ -190,7 +191,7 @@ def _validate_diff_method(
     if device.supports_derivatives(config):
         return
     if diff_method in {"backprop", "adjoint", "device"}:  # device-only derivatives
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"Device {device} does not support {diff_method} with requested circuit."
         )
     if isinstance(diff_method, str) and diff_method in tuple(get_args(SupportedDiffMethods)):
@@ -198,7 +199,7 @@ def _validate_diff_method(
     if isinstance(diff_method, TransformDispatcher):
         return
 
-    raise qml.QuantumFunctionError(
+    raise pennylane.errors.QuantumFunctionError(
         f"Differentiation method {diff_method} not recognized. Allowed "
         f"options are {tuple(get_args(SupportedDiffMethods))}."
     )
@@ -567,7 +568,7 @@ class QNode:
             )
 
         if not isinstance(device, (qml.devices.LegacyDevice, qml.devices.Device)):
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 "Invalid device. Device must be a valid PennyLane device."
             )
 
@@ -580,7 +581,7 @@ class QNode:
                 warnings.warn(
                     f"Specifying gradient keyword arguments {list(kwargs.keys())} as additional kwargs has been deprecated and will be removed in v0.42. \
                     Instead, please specify these arguments through the `gradient_kwargs` dictionary argument.",
-                    qml.PennyLaneDeprecationWarning,
+                    pennylane.errors.PennyLaneDeprecationWarning,
                 )
             gradient_kwargs |= kwargs
         _validate_gradient_kwargs(gradient_kwargs)
@@ -785,7 +786,7 @@ class QNode:
             return new_config.gradient_method, {}, device
 
         if diff_method in {"backprop", "adjoint", "device"}:  # device-only derivatives
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 f"Device {device} does not support {diff_method} with requested circuit."
             )
 
@@ -812,7 +813,7 @@ class QNode:
         if isinstance(diff_method, qml.transforms.core.TransformDispatcher):
             return diff_method, {}, device
 
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"Differentiation method {diff_method} not recognized. Allowed "
             f"options are {tuple(get_args(SupportedDiffMethods))}."
         )

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -22,6 +22,7 @@ from warnings import warn
 from packaging.version import Version
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.logging import debug_logger
 from pennylane.math import Interface, get_canonical_interface_name, get_interface
 from pennylane.tape import QuantumScriptBatch
@@ -54,7 +55,7 @@ def _use_tensorflow_autograph():
     try:  # pragma: no cover
         import tensorflow as tf
     except ImportError as e:  # pragma: no cover
-        raise qml.QuantumFunctionError(  # pragma: no cover
+        raise pennylane.errors.QuantumFunctionError(  # pragma: no cover
             "tensorflow not found. Please install the latest "  # pragma: no cover
             "version of tensorflow supported by Pennylane "  # pragma: no cover
             "to enable the 'tensorflow' interface."  # pragma: no cover
@@ -111,7 +112,7 @@ def _resolve_interface(interface: Union[str, Interface], tapes: QuantumScriptBat
         try:  # pragma: no cover
             import jax
         except ImportError as e:  # pragma: no cover
-            raise qml.QuantumFunctionError(  # pragma: no cover
+            raise pennylane.errors.QuantumFunctionError(  # pragma: no cover
                 "jax not found. Please install the latest "  # pragma: no cover
                 "version of jax to enable the 'jax' interface."  # pragma: no cover
             ) from e  # pragma: no cover
@@ -189,7 +190,7 @@ def _resolve_diff_method(
         return new_config
 
     if diff_method in {"backprop", "adjoint", "device"}:
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"Device {device} does not support {diff_method} with requested circuit."
         )
 
@@ -211,7 +212,7 @@ def _resolve_diff_method(
         elif isinstance(diff_method, TransformDispatcher):
             updated_values["gradient_method"] = diff_method
         else:
-            raise qml.QuantumFunctionError(
+            raise pennylane.errors.QuantumFunctionError(
                 f"Differentiation method {diff_method} not recognized. Allowed "
                 f"options are {tuple(get_args(SupportedDiffMethods))}."
             )
@@ -256,7 +257,7 @@ def _resolve_execution_config(
     if execution_config.use_device_jacobian_product and not device.supports_vjp(
         execution_config, tapes[0]
     ):
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"device_vjp=True is not supported for device {device},"
             f" diff_method {execution_config.gradient_method},"
             " and the provided circuit."

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -22,7 +22,6 @@ from warnings import warn
 from packaging.version import Version
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.logging import debug_logger
 from pennylane.math import Interface, get_canonical_interface_name, get_interface
 from pennylane.tape import QuantumScriptBatch
@@ -55,7 +54,7 @@ def _use_tensorflow_autograph():
     try:  # pragma: no cover
         import tensorflow as tf
     except ImportError as e:  # pragma: no cover
-        raise pennylane.errors.QuantumFunctionError(  # pragma: no cover
+        raise qml.QuantumFunctionError(  # pragma: no cover
             "tensorflow not found. Please install the latest "  # pragma: no cover
             "version of tensorflow supported by Pennylane "  # pragma: no cover
             "to enable the 'tensorflow' interface."  # pragma: no cover
@@ -112,7 +111,7 @@ def _resolve_interface(interface: Union[str, Interface], tapes: QuantumScriptBat
         try:  # pragma: no cover
             import jax
         except ImportError as e:  # pragma: no cover
-            raise pennylane.errors.QuantumFunctionError(  # pragma: no cover
+            raise qml.QuantumFunctionError(  # pragma: no cover
                 "jax not found. Please install the latest "  # pragma: no cover
                 "version of jax to enable the 'jax' interface."  # pragma: no cover
             ) from e  # pragma: no cover
@@ -190,7 +189,7 @@ def _resolve_diff_method(
         return new_config
 
     if diff_method in {"backprop", "adjoint", "device"}:
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"Device {device} does not support {diff_method} with requested circuit."
         )
 
@@ -212,7 +211,7 @@ def _resolve_diff_method(
         elif isinstance(diff_method, TransformDispatcher):
             updated_values["gradient_method"] = diff_method
         else:
-            raise pennylane.errors.QuantumFunctionError(
+            raise qml.QuantumFunctionError(
                 f"Differentiation method {diff_method} not recognized. Allowed "
                 f"options are {tuple(get_args(SupportedDiffMethods))}."
             )
@@ -257,7 +256,7 @@ def _resolve_execution_config(
     if execution_config.use_device_jacobian_product and not device.supports_vjp(
         execution_config, tapes[0]
     ):
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"device_vjp=True is not supported for device {device},"
             f" diff_method {execution_config.gradient_method},"
             " and the provided circuit."

--- a/pennylane/workflow/run.py
+++ b/pennylane/workflow/run.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import Callable
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.math import Interface
 from pennylane.tape import QuantumScriptBatch
 from pennylane.transforms.core import TransformProgram
@@ -218,7 +219,7 @@ def _get_ml_boundary_execute(
                 from .interfaces.jax import jax_jvp_execute as ml_boundary
 
     except ImportError as e:  # pragma: no cover
-        raise qml.QuantumFunctionError(
+        raise pennylane.errors.QuantumFunctionError(
             f"{interface} not found. Please install the latest "
             f"version of {interface} to enable the '{interface}' interface."
         ) from e

--- a/pennylane/workflow/run.py
+++ b/pennylane/workflow/run.py
@@ -20,7 +20,6 @@ from functools import partial
 from typing import Callable
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.math import Interface
 from pennylane.tape import QuantumScriptBatch
 from pennylane.transforms.core import TransformProgram
@@ -219,7 +218,7 @@ def _get_ml_boundary_execute(
                 from .interfaces.jax import jax_jvp_execute as ml_boundary
 
     except ImportError as e:  # pragma: no cover
-        raise pennylane.errors.QuantumFunctionError(
+        raise qml.QuantumFunctionError(
             f"{interface} not found. Please install the latest "
             f"version of {interface} to enable the '{interface}' interface."
         ) from e

--- a/tests/capture/transforms/test_capture_merge_amplitude_embedding.py
+++ b/tests/capture/transforms/test_capture_merge_amplitude_embedding.py
@@ -16,7 +16,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 
 jax = pytest.importorskip("jax")
 
@@ -63,7 +62,7 @@ class TestRepeatedQubitDeviceErrors:
             return qml.expval(qml.Z(0))
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)()
@@ -77,7 +76,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=wire)
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)(1)
@@ -92,7 +91,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=1)
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)()
@@ -110,7 +109,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.ctrl(ctrl_fn, [2, 3])()
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)()
@@ -128,7 +127,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=1)
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)()
@@ -155,7 +154,7 @@ class TestRepeatedQubitDeviceErrors:
             cond_f()
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -182,7 +181,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=collision_wire)
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -211,7 +210,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=collision_wire)
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -244,7 +243,7 @@ class TestRepeatedQubitDeviceErrors:
             cond_f()  # Also contains wires 0
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             args = (3,)

--- a/tests/capture/transforms/test_capture_merge_amplitude_embedding.py
+++ b/tests/capture/transforms/test_capture_merge_amplitude_embedding.py
@@ -16,6 +16,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 
 jax = pytest.importorskip("jax")
 
@@ -62,7 +63,7 @@ class TestRepeatedQubitDeviceErrors:
             return qml.expval(qml.Z(0))
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)()
@@ -76,7 +77,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=wire)
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)(1)
@@ -91,7 +92,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=1)
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(qfunc)()
@@ -109,7 +110,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.ctrl(ctrl_fn, [2, 3])()
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)()
@@ -127,7 +128,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=1)
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)()
@@ -154,7 +155,7 @@ class TestRepeatedQubitDeviceErrors:
             cond_f()
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -181,7 +182,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=collision_wire)
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -210,7 +211,7 @@ class TestRepeatedQubitDeviceErrors:
             qml.AmplitudeEmbedding(jax.numpy.array([0.0, 1.0]), wires=collision_wire)
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             jax.make_jaxpr(f)(3)
@@ -243,7 +244,7 @@ class TestRepeatedQubitDeviceErrors:
             cond_f()  # Also contains wires 0
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="qml.AmplitudeEmbedding cannot be applied on wires already used by other operations.",
         ):
             args = (3,)

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -21,6 +21,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.capture import CaptureError
 
 pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
@@ -496,7 +497,9 @@ class TestDifferentiation:
             def execute(self, *_, **__):
                 return 0
 
-        with pytest.raises(qml.QuantumFunctionError, match="does not support backprop"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="does not support backprop"
+        ):
 
             @qml.qnode(DummyDev(wires=2), diff_method="backprop")
             def _(x):

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -21,7 +21,6 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.capture import CaptureError
 
 pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
@@ -497,9 +496,7 @@ class TestDifferentiation:
             def execute(self, *_, **__):
                 return 0
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="does not support backprop"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="does not support backprop"):
 
             @qml.qnode(DummyDev(wires=2), diff_method="backprop")
             def _(x):

--- a/tests/default_qubit_legacy.py
+++ b/tests/default_qubit_legacy.py
@@ -26,7 +26,6 @@ import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import BasisState, Snapshot, StatePrep
 from pennylane._version import __version__
 from pennylane.devices._qubit_device import QubitDevice
@@ -280,7 +279,7 @@ class DefaultQubitLegacy(QubitDevice):
         # apply the circuit operations
         for i, operation in enumerate(operations):
             if i > 0 and isinstance(operation, (StatePrep, BasisState)):
-                raise pennylane.errors.DeviceError(
+                raise qml.DeviceError(
                     f"Operation {operation.name} cannot be used after other Operations have already been applied "
                     f"on a {self.short_name} device."
                 )

--- a/tests/default_qubit_legacy.py
+++ b/tests/default_qubit_legacy.py
@@ -26,6 +26,7 @@ import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import BasisState, Snapshot, StatePrep
 from pennylane._version import __version__
 from pennylane.devices._qubit_device import QubitDevice
@@ -279,7 +280,7 @@ class DefaultQubitLegacy(QubitDevice):
         # apply the circuit operations
         for i, operation in enumerate(operations):
             if i > 0 and isinstance(operation, (StatePrep, BasisState)):
-                raise qml.DeviceError(
+                raise pennylane.errors.DeviceError(
                     f"Operation {operation.name} cannot be used after other Operations have already been applied "
                     f"on a {self.short_name} device."
                 )

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import DefaultQubit, ExecutionConfig
 
 max_workers_list = [
@@ -75,7 +76,7 @@ def test_snapshot_multiprocessing_qnode():
         return qml.expval(qml.PauliX(0) + qml.PauliY(0))
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match="Debugging with ``Snapshots`` is not available with multiprocessing.",
     ):
         qml.snapshots(circuit)()

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import DefaultQubit, ExecutionConfig
 
 max_workers_list = [
@@ -76,7 +75,7 @@ def test_snapshot_multiprocessing_qnode():
         return qml.expval(qml.PauliX(0) + qml.PauliY(0))
 
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match="Debugging with ``Snapshots`` is not available with multiprocessing.",
     ):
         qml.snapshots(circuit)()

--- a/tests/devices/default_qubit/test_default_qubit_plxpr.py
+++ b/tests/devices/default_qubit/test_default_qubit_plxpr.py
@@ -16,6 +16,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig, MCMConfig
 
 jax = pytest.importorskip("jax")
@@ -30,7 +31,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(device_options={"foo": "bar"})
 
-        with pytest.raises(qml.DeviceError, match="device option foo not present"):
+        with pytest.raises(pennylane.errors.DeviceError, match="device option foo not present"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_max_workers(self):
@@ -38,7 +39,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(device_options={"max_workers": "1"})
 
-        with pytest.raises(qml.DeviceError, match="Cannot set 'max_workers'"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Cannot set 'max_workers'"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_best_gradient_method(self):
@@ -64,7 +65,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(mcm_config=MCMConfig(mcm_method="foo"))
 
-        with pytest.raises(qml.DeviceError, match="mcm_method='foo' is not supported"):
+        with pytest.raises(pennylane.errors.DeviceError, match="mcm_method='foo' is not supported"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_default_mcm_config(self):
@@ -129,7 +130,7 @@ class TestExecution:
         jaxpr = jax.make_jaxpr(lambda x: x + 1)(0.1)
         dev = qml.device("default.qubit")
 
-        with pytest.raises(qml.DeviceError, match="Device wires are required."):
+        with pytest.raises(pennylane.errors.DeviceError, match="Device wires are required."):
             dev.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.2)
 
     def test_no_partitioned_shots(self):
@@ -139,7 +140,7 @@ class TestExecution:
         dev = qml.device("default.qubit", wires=1, shots=(100, 100))
 
         with pytest.raises(
-            qml.DeviceError, match="Shot vectors are unsupported with jaxpr execution."
+            pennylane.errors.DeviceError, match="Shot vectors are unsupported with jaxpr execution."
         ):
             dev.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.2)
 

--- a/tests/devices/default_qubit/test_default_qubit_plxpr.py
+++ b/tests/devices/default_qubit/test_default_qubit_plxpr.py
@@ -16,7 +16,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import ExecutionConfig, MCMConfig
 
 jax = pytest.importorskip("jax")
@@ -31,7 +30,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(device_options={"foo": "bar"})
 
-        with pytest.raises(pennylane.errors.DeviceError, match="device option foo not present"):
+        with pytest.raises(qml.DeviceError, match="device option foo not present"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_max_workers(self):
@@ -39,7 +38,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(device_options={"max_workers": "1"})
 
-        with pytest.raises(pennylane.errors.DeviceError, match="Cannot set 'max_workers'"):
+        with pytest.raises(qml.DeviceError, match="Cannot set 'max_workers'"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_best_gradient_method(self):
@@ -65,7 +64,7 @@ class TestPreprocess:
         dev = qml.device("default.qubit", wires=1)
         config = ExecutionConfig(mcm_config=MCMConfig(mcm_method="foo"))
 
-        with pytest.raises(pennylane.errors.DeviceError, match="mcm_method='foo' is not supported"):
+        with pytest.raises(qml.DeviceError, match="mcm_method='foo' is not supported"):
             _ = dev.preprocess(execution_config=config)
 
     def test_execution_config_default_mcm_config(self):
@@ -130,7 +129,7 @@ class TestExecution:
         jaxpr = jax.make_jaxpr(lambda x: x + 1)(0.1)
         dev = qml.device("default.qubit")
 
-        with pytest.raises(pennylane.errors.DeviceError, match="Device wires are required."):
+        with pytest.raises(qml.DeviceError, match="Device wires are required."):
             dev.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.2)
 
     def test_no_partitioned_shots(self):
@@ -140,7 +139,7 @@ class TestExecution:
         dev = qml.device("default.qubit", wires=1, shots=(100, 100))
 
         with pytest.raises(
-            pennylane.errors.DeviceError, match="Shot vectors are unsupported with jaxpr execution."
+            qml.DeviceError, match="Shot vectors are unsupported with jaxpr execution."
         ):
             dev.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.2)
 

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -18,6 +18,7 @@ import pytest
 import scipy as sp
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import DefaultQubit, ExecutionConfig
 from pennylane.devices.default_qubit import stopping_condition
@@ -97,7 +98,7 @@ class TestConfigSetup:
     def test_error_if_device_option_not_available(self):
         """Test that an error is raised if a device option is requested but not a valid option."""
         config = qml.devices.ExecutionConfig(device_options={"bla": "val"})
-        with pytest.raises(qml.DeviceError, match="device option bla"):
+        with pytest.raises(pennylane.errors.DeviceError, match="device option bla"):
             qml.device("default.qubit").preprocess(config)
 
     def test_choose_best_gradient_method(self):
@@ -399,7 +400,7 @@ class TestPreprocessing:
         program = device.preprocess_transforms()
 
         if not supported:
-            with pytest.raises(qml.DeviceError):
+            with pytest.raises(pennylane.errors.DeviceError):
                 program([tape])
         else:
             program([tape])
@@ -630,7 +631,7 @@ class TestPreprocessingIntegration:
         ]
 
         program = qml.device("default.qubit").preprocess_transforms()
-        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(
@@ -651,7 +652,7 @@ class TestPreprocessingIntegration:
         execution_config = qml.devices.ExecutionConfig(gradient_method="adjoint")
 
         program = qml.device("default.qubit").preprocess_transforms(execution_config)
-        with pytest.raises(qml.DeviceError, match=message):
+        with pytest.raises(pennylane.errors.DeviceError, match=message):
             program([qs])
 
     def test_preprocess_tape_for_adjoint(self):
@@ -805,7 +806,7 @@ class TestAdjointDiffTapeValidation:
         program = qml.device("default.qubit").preprocess_transforms(execution_config)
 
         msg = "Finite shots are not supported with"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             program((tape,))
 
     def test_non_diagonal_non_expval(self):
@@ -820,7 +821,7 @@ class TestAdjointDiffTapeValidation:
         )
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match=r"adjoint diff supports either all expectation values or only measurements without observables",
         ):
             program((qs,))

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -18,7 +18,6 @@ import pytest
 import scipy as sp
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import DefaultQubit, ExecutionConfig
 from pennylane.devices.default_qubit import stopping_condition
@@ -98,7 +97,7 @@ class TestConfigSetup:
     def test_error_if_device_option_not_available(self):
         """Test that an error is raised if a device option is requested but not a valid option."""
         config = qml.devices.ExecutionConfig(device_options={"bla": "val"})
-        with pytest.raises(pennylane.errors.DeviceError, match="device option bla"):
+        with pytest.raises(qml.DeviceError, match="device option bla"):
             qml.device("default.qubit").preprocess(config)
 
     def test_choose_best_gradient_method(self):
@@ -400,7 +399,7 @@ class TestPreprocessing:
         program = device.preprocess_transforms()
 
         if not supported:
-            with pytest.raises(pennylane.errors.DeviceError):
+            with pytest.raises(qml.DeviceError):
                 program([tape])
         else:
             program([tape])
@@ -631,7 +630,7 @@ class TestPreprocessingIntegration:
         ]
 
         program = qml.device("default.qubit").preprocess_transforms()
-        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(
@@ -652,7 +651,7 @@ class TestPreprocessingIntegration:
         execution_config = qml.devices.ExecutionConfig(gradient_method="adjoint")
 
         program = qml.device("default.qubit").preprocess_transforms(execution_config)
-        with pytest.raises(pennylane.errors.DeviceError, match=message):
+        with pytest.raises(qml.DeviceError, match=message):
             program([qs])
 
     def test_preprocess_tape_for_adjoint(self):
@@ -806,7 +805,7 @@ class TestAdjointDiffTapeValidation:
         program = qml.device("default.qubit").preprocess_transforms(execution_config)
 
         msg = "Finite shots are not supported with"
-        with pytest.raises(pennylane.errors.DeviceError, match=msg):
+        with pytest.raises(qml.DeviceError, match=msg):
             program((tape,))
 
     def test_non_diagonal_non_expval(self):
@@ -821,7 +820,7 @@ class TestAdjointDiffTapeValidation:
         )
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match=r"adjoint diff supports either all expectation values or only measurements without observables",
         ):
             program((qs,))

--- a/tests/devices/default_tensor/test_default_tensor.py
+++ b/tests/devices/default_tensor/test_default_tensor.py
@@ -24,6 +24,7 @@ from scipy.linalg import expm
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.qchem import givens_decomposition
 from pennylane.typing import TensorLike
 from pennylane.wires import WireError
@@ -283,7 +284,7 @@ def test_passing_shots_None():
 def test_passing_finite_shots_error():
     """Test that an error is raised if finite shots are passed on initialization."""
 
-    with pytest.raises(qml.DeviceError, match=r"only supports analytic simulations"):
+    with pytest.raises(pennylane.errors.DeviceError, match=r"only supports analytic simulations"):
         qml.device("default.tensor", shots=10)
 
 
@@ -538,7 +539,7 @@ class TestMCMs:
         mcm_config = qml.devices.MCMConfig(mcm_method=mcm_method)
         config = qml.devices.ExecutionConfig(mcm_config=mcm_config)
         with pytest.raises(
-            qml.DeviceError, match=r"only supports the deferred measurement principle."
+            pennylane.errors.DeviceError, match=r"only supports the deferred measurement principle."
         ):
             qml.device("default.tensor").preprocess(config)
 

--- a/tests/devices/default_tensor/test_default_tensor.py
+++ b/tests/devices/default_tensor/test_default_tensor.py
@@ -24,7 +24,6 @@ from scipy.linalg import expm
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.qchem import givens_decomposition
 from pennylane.typing import TensorLike
 from pennylane.wires import WireError
@@ -284,7 +283,7 @@ def test_passing_shots_None():
 def test_passing_finite_shots_error():
     """Test that an error is raised if finite shots are passed on initialization."""
 
-    with pytest.raises(pennylane.errors.DeviceError, match=r"only supports analytic simulations"):
+    with pytest.raises(qml.DeviceError, match=r"only supports analytic simulations"):
         qml.device("default.tensor", shots=10)
 
 
@@ -539,7 +538,7 @@ class TestMCMs:
         mcm_config = qml.devices.MCMConfig(mcm_method=mcm_method)
         config = qml.devices.ExecutionConfig(mcm_config=mcm_config)
         with pytest.raises(
-            pennylane.errors.DeviceError, match=r"only supports the deferred measurement principle."
+            qml.DeviceError, match=r"only supports the deferred measurement principle."
         ):
             qml.device("default.tensor").preprocess(config)
 

--- a/tests/devices/qubit_mixed/test_qubit_mixed_preprocessing.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_preprocessing.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.devices.default_mixed import (
     DefaultMixed,
@@ -91,7 +92,7 @@ class TestPreprocessing:
         dev = DefaultMixed()
 
         config = ExecutionConfig(device_options={"invalid_option": "val"})
-        with pytest.raises(qml.DeviceError, match="device option invalid_option"):
+        with pytest.raises(pennylane.errors.DeviceError, match="device option invalid_option"):
             dev.preprocess(config)
 
     def test_chooses_best_gradient_method(self):
@@ -318,7 +319,7 @@ class TestPreprocessing:
         ]
 
         program, _ = DefaultMixed(wires=2).preprocess()
-        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(

--- a/tests/devices/qubit_mixed/test_qubit_mixed_preprocessing.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_preprocessing.py
@@ -22,7 +22,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.devices.default_mixed import (
     DefaultMixed,
@@ -92,7 +91,7 @@ class TestPreprocessing:
         dev = DefaultMixed()
 
         config = ExecutionConfig(device_options={"invalid_option": "val"})
-        with pytest.raises(pennylane.errors.DeviceError, match="device option invalid_option"):
+        with pytest.raises(qml.DeviceError, match="device option invalid_option"):
             dev.preprocess(config)
 
     def test_chooses_best_gradient_method(self):
@@ -319,7 +318,7 @@ class TestPreprocessing:
         ]
 
         program, _ = DefaultMixed(wires=2).preprocess()
-        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_preprocessing.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_preprocessing.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.devices.default_qutrit_mixed import (
     DefaultQutritMixed,
@@ -58,7 +59,7 @@ class TestPreprocessing:
         dev = DefaultQutritMixed()
 
         config = ExecutionConfig(device_options={"bla": "val"})
-        with pytest.raises(qml.DeviceError, match="device option bla"):
+        with pytest.raises(pennylane.errors.DeviceError, match="device option bla"):
             dev.preprocess(config)
 
     def test_chooses_best_gradient_method(self):
@@ -268,7 +269,7 @@ class TestPreprocessingIntegration:
         ]
 
         program = DefaultQutritMixed().preprocess_transforms()
-        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_preprocessing.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_preprocessing.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.devices.default_qutrit_mixed import (
     DefaultQutritMixed,
@@ -59,7 +58,7 @@ class TestPreprocessing:
         dev = DefaultQutritMixed()
 
         config = ExecutionConfig(device_options={"bla": "val"})
-        with pytest.raises(pennylane.errors.DeviceError, match="device option bla"):
+        with pytest.raises(qml.DeviceError, match="device option bla"):
             dev.preprocess(config)
 
     def test_chooses_best_gradient_method(self):
@@ -269,7 +268,7 @@ class TestPreprocessingIntegration:
         ]
 
         program = DefaultQutritMixed().preprocess_transforms()
-        with pytest.raises(pennylane.errors.DeviceError, match="Operator NoMatNoDecompOp"):
+        with pytest.raises(qml.DeviceError, match="Operator NoMatNoDecompOp"):
             program(tapes)
 
     @pytest.mark.parametrize(

--- a/tests/devices/test_default_clifford.py
+++ b/tests/devices/test_default_clifford.py
@@ -22,7 +22,6 @@ import scipy as sp
 from dummy_debugger import Debugger
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices.default_clifford import _pl_op_to_stim
 
 stim = pytest.importorskip("stim")
@@ -639,7 +638,7 @@ def test_meas_error():
         return qml.probs(op=qml.Hermitian(Amat + Amat.conj().T, wires=[0, 1]))
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError,
+        qml.QuantumFunctionError,
         match="Hermitian is not supported for rotating probabilities on default.clifford.",
     ):
         circuit_herm()
@@ -659,7 +658,7 @@ def test_clifford_error(check):
         return qml.state()
 
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match=r"Operator RX\(1.0, wires=\[0\]\) not supported with default.clifford and does not provide a decomposition",
     ):
         circuit()
@@ -675,7 +674,7 @@ def test_meas_error_noisy():
         return qml.expval(qml.PauliZ(0))
 
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match="Channel not supported on default.clifford without finite shots.",
     ):
         circ_1()
@@ -687,7 +686,7 @@ def test_meas_error_noisy():
         return qml.expval(qml.PauliZ(0))
 
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match=r"Operator AmplitudeDamping\(0.2, wires=\[0\]\) not supported with default.clifford",
     ):
         circ_2()

--- a/tests/devices/test_default_clifford.py
+++ b/tests/devices/test_default_clifford.py
@@ -22,6 +22,7 @@ import scipy as sp
 from dummy_debugger import Debugger
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.default_clifford import _pl_op_to_stim
 
 stim = pytest.importorskip("stim")
@@ -638,7 +639,7 @@ def test_meas_error():
         return qml.probs(op=qml.Hermitian(Amat + Amat.conj().T, wires=[0, 1]))
 
     with pytest.raises(
-        qml.QuantumFunctionError,
+        pennylane.errors.QuantumFunctionError,
         match="Hermitian is not supported for rotating probabilities on default.clifford.",
     ):
         circuit_herm()
@@ -658,7 +659,7 @@ def test_clifford_error(check):
         return qml.state()
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match=r"Operator RX\(1.0, wires=\[0\]\) not supported with default.clifford and does not provide a decomposition",
     ):
         circuit()
@@ -674,7 +675,7 @@ def test_meas_error_noisy():
         return qml.expval(qml.PauliZ(0))
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match="Channel not supported on default.clifford without finite shots.",
     ):
         circ_1()
@@ -686,7 +687,7 @@ def test_meas_error_noisy():
         return qml.expval(qml.PauliZ(0))
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match=r"Operator AmplitudeDamping\(0.2, wires=\[0\]\) not supported with default.clifford",
     ):
         circ_2()

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -23,6 +23,7 @@ from scipy.linalg import block_diag
 from scipy.special import factorial as fac
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.default_gaussian import (
     beamsplitter,
     coherent_state,
@@ -112,7 +113,7 @@ def test_analytic_deprecation():
     msg += "Please use shots=None instead of analytic=True."
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match=msg,
     ):
         qml.device("default.gaussian", wires=1, shots=1, analytic=True)
@@ -863,7 +864,7 @@ class TestDefaultGaussianIntegration:
             return qml.sample(qml.QuadX(0)), qml.expval(qml.QuadX(1))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Default gaussian only support single measurements.",
         ):
             circuit()

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -23,7 +23,7 @@ from scipy.linalg import block_diag
 from scipy.special import factorial as fac
 
 import pennylane as qml
-from pennylane import DeviceError
+import pennylane.errors
 from pennylane.devices.default_gaussian import (
     beamsplitter,
     coherent_state,
@@ -39,6 +39,7 @@ from pennylane.devices.default_gaussian import (
     two_mode_squeezing,
     vacuum_state,
 )
+from pennylane.errors import DeviceError
 from pennylane.wires import Wires
 
 U = np.array(
@@ -864,7 +865,7 @@ class TestDefaultGaussianIntegration:
             return qml.sample(qml.QuadX(0)), qml.expval(qml.QuadX(1))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Default gaussian only support single measurements.",
         ):
             circuit()

--- a/tests/devices/test_default_gaussian.py
+++ b/tests/devices/test_default_gaussian.py
@@ -23,7 +23,6 @@ from scipy.linalg import block_diag
 from scipy.special import factorial as fac
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices.default_gaussian import (
     beamsplitter,
     coherent_state,
@@ -39,7 +38,6 @@ from pennylane.devices.default_gaussian import (
     two_mode_squeezing,
     vacuum_state,
 )
-from pennylane.errors import DeviceError
 from pennylane.wires import Wires
 
 U = np.array(
@@ -114,7 +112,7 @@ def test_analytic_deprecation():
     msg += "Please use shots=None instead of analytic=True."
 
     with pytest.raises(
-        DeviceError,
+        qml.DeviceError,
         match=msg,
     ):
         qml.device("default.gaussian", wires=1, shots=1, analytic=True)
@@ -865,7 +863,7 @@ class TestDefaultGaussianIntegration:
             return qml.sample(qml.QuadX(0)), qml.expval(qml.QuadX(1))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Default gaussian only support single measurements.",
         ):
             circuit()

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -22,6 +22,7 @@ from gate_data import GELL_MANN, OMEGA, TADD, TCLOCK, TSHIFT, TSWAP
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.wires import WireError, Wires
 
@@ -42,16 +43,18 @@ def test_analytic_deprecation():
     msg = "The analytic argument has been replaced by shots=None. "
     msg += "Please use shots=None instead of analytic=True."
 
-    with pytest.raises(qml.DeviceError, match=msg):
+    with pytest.raises(pennylane.errors.DeviceError, match=msg):
         qml.device("default.qutrit", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
-    with pytest.raises(qml.DeviceError, match="Real datatype must be a floating point type."):
+    with pytest.raises(
+        pennylane.errors.DeviceError, match="Real datatype must be a floating point type."
+    ):
         qml.device("default.qutrit", wires=1, r_dtype=np.complex128)
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match="Complex datatype must be a complex floating point type.",
     ):
         qml.device("default.qutrit", wires=1, c_dtype=np.float64)
@@ -421,7 +424,7 @@ class TestApply:
             qutrit_device_2_wires.apply([qml.QutritBasisState(np.array([0, 1]), wires=[0])])
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="Operation QutritBasisState cannot be used after other operations have already been applied "
             "on a default.qutrit device.",
         ):

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -22,7 +22,6 @@ from gate_data import GELL_MANN, OMEGA, TADD, TCLOCK, TSHIFT, TSWAP
 from scipy.stats import unitary_group
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.wires import WireError, Wires
 
@@ -43,18 +42,16 @@ def test_analytic_deprecation():
     msg = "The analytic argument has been replaced by shots=None. "
     msg += "Please use shots=None instead of analytic=True."
 
-    with pytest.raises(pennylane.errors.DeviceError, match=msg):
+    with pytest.raises(qml.DeviceError, match=msg):
         qml.device("default.qutrit", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
-    with pytest.raises(
-        pennylane.errors.DeviceError, match="Real datatype must be a floating point type."
-    ):
+    with pytest.raises(qml.DeviceError, match="Real datatype must be a floating point type."):
         qml.device("default.qutrit", wires=1, r_dtype=np.complex128)
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match="Complex datatype must be a complex floating point type.",
     ):
         qml.device("default.qutrit", wires=1, c_dtype=np.float64)
@@ -424,7 +421,7 @@ class TestApply:
             qutrit_device_2_wires.apply([qml.QutritBasisState(np.array([0, 1]), wires=[0])])
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="Operation QutritBasisState cannot be used after other operations have already been applied "
             "on a default.qutrit device.",
         ):

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -22,6 +22,7 @@ from gate_data import GELL_MANN, OMEGA, TADD, TCLOCK, TSHIFT, TSWAP
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.wires import WireError, Wires
 
@@ -42,16 +43,19 @@ def test_analytic_deprecation():
     msg = "The analytic argument has been replaced by shots=None. "
     msg += "Please use shots=None instead of analytic=True."
 
-    with pytest.raises(qml.DeviceError, match=msg):
+    with pytest.raises(pennylane.errors.DeviceError, match=msg):
         qml.device("default.qutrit", wires=1, shots=1, analytic=True)
 
 
 def test_dtype_errors():
     """Test that if an incorrect dtype is provided to the device then an error is raised."""
-    with pytest.raises(qml.DeviceError, match="Real datatype must be a floating point type."):
+    with pytest.raises(
+        pennylane.errors.DeviceError, match="Real datatype must be a floating point type."
+    ):
         qml.device("default.qutrit", wires=1, r_dtype=np.complex128)
     with pytest.raises(
-        qml.DeviceError, match="Complex datatype must be a complex floating point type."
+        pennylane.errors.DeviceError,
+        match="Complex datatype must be a complex floating point type.",
     ):
         qml.device("default.qutrit", wires=1, c_dtype=np.float64)
 
@@ -420,7 +424,7 @@ class TestApply:
             qutrit_device_2_wires.apply([qml.QutritBasisState(np.array([0, 1]), wires=[0])])
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="Operation QutritBasisState cannot be used after other operations have already been applied "
             "on a default.qutrit device.",
         ):

--- a/tests/devices/test_default_qutrit_mixed.py
+++ b/tests/devices/test_default_qutrit_mixed.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import math
 from pennylane import numpy as qnp
 from pennylane.devices import DefaultQutritMixed, ExecutionConfig
@@ -1591,7 +1592,7 @@ class TestReadoutError:
     )
     def test_measurement_error_validation(self, relaxations, misclassifications, num_wires):
         """Ensure error is raised for wrong number of arguments inputted in readout errors."""
-        with pytest.raises(qml.DeviceError, match="results in error:"):
+        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed",
                 wires=num_wires,
@@ -1601,11 +1602,11 @@ class TestReadoutError:
 
     def test_prob_type(self, num_wires):
         """Tests that an error is raised for wrong data type in readout errors"""
-        with pytest.raises(qml.DeviceError, match="results in error:"):
+        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed", wires=num_wires, readout_relaxation_probs=[0.1, 0.2, "0.3"]
             )
-        with pytest.raises(qml.DeviceError, match="results in error:"):
+        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed",
                 wires=num_wires,

--- a/tests/devices/test_default_qutrit_mixed.py
+++ b/tests/devices/test_default_qutrit_mixed.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import math
 from pennylane import numpy as qnp
 from pennylane.devices import DefaultQutritMixed, ExecutionConfig
@@ -1592,7 +1591,7 @@ class TestReadoutError:
     )
     def test_measurement_error_validation(self, relaxations, misclassifications, num_wires):
         """Ensure error is raised for wrong number of arguments inputted in readout errors."""
-        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
+        with pytest.raises(qml.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed",
                 wires=num_wires,
@@ -1602,11 +1601,11 @@ class TestReadoutError:
 
     def test_prob_type(self, num_wires):
         """Tests that an error is raised for wrong data type in readout errors"""
-        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
+        with pytest.raises(qml.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed", wires=num_wires, readout_relaxation_probs=[0.1, 0.2, "0.3"]
             )
-        with pytest.raises(pennylane.errors.DeviceError, match="results in error:"):
+        with pytest.raises(qml.DeviceError, match="results in error:"):
             qml.device(
                 "default.qutrit.mixed",
                 wires=num_wires,

--- a/tests/devices/test_device_api.py
+++ b/tests/devices/test_device_api.py
@@ -19,7 +19,6 @@ from typing import Optional, Union
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig, MCMConfig
 from pennylane.devices.capabilities import (
     DeviceCapabilities,
@@ -203,7 +202,7 @@ class TestSetupExecutionConfig:
         initial_config = ExecutionConfig(mcm_config=mcm_config)
 
         if expected_error is not None:
-            with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error):
+            with pytest.raises(qml.QuantumFunctionError, match=expected_error):
                 dev.setup_execution_config(initial_config, tape)
             return
 
@@ -232,7 +231,7 @@ class TestSetupExecutionConfig:
         tape = QuantumScript([qml.measurements.MidMeasureMP(0)], [], shots=shots)
         initial_config = ExecutionConfig(mcm_config=mcm_config)
         if expected_error:
-            with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error):
+            with pytest.raises(qml.QuantumFunctionError, match=expected_error):
                 dev.setup_execution_config(initial_config, tape)
         else:
             final_config = dev.setup_execution_config(initial_config, tape)
@@ -470,15 +469,13 @@ class TestPreprocessTransforms:
         _, __ = program((valid_tape,))
 
         invalid_tape = QuantumScript([], [qml.var(qml.PauliZ(0))], shots=shots)
-        with pytest.raises(
-            pennylane.errors.DeviceError, match=r"Measurement var\(Z\(0\)\) not accepted"
-        ):
+        with pytest.raises(qml.DeviceError, match=r"Measurement var\(Z\(0\)\) not accepted"):
             _, __ = program((invalid_tape,))
 
         invalid_tape = QuantumScript(
             [], [qml.expval(qml.Hermitian([[1.0, 0], [0, 1.0]], 0))], shots=shots
         )
-        with pytest.raises(pennylane.errors.DeviceError, match=r"Observable Hermitian"):
+        with pytest.raises(qml.DeviceError, match=r"Observable Hermitian"):
             _, __ = program((invalid_tape,))
 
         shots_only_meas_tape = QuantumScript([], [qml.counts()], shots=shots)
@@ -491,20 +488,20 @@ class TestPreprocessTransforms:
             _, __ = program((shots_only_meas_tape,))
             _, __ = program((shots_only_obs_tape,))
 
-            with pytest.raises(pennylane.errors.DeviceError, match=r"Measurement .* not accepted"):
+            with pytest.raises(qml.DeviceError, match=r"Measurement .* not accepted"):
                 _, __ = program((analytic_only_meas_tape,))
 
-            with pytest.raises(pennylane.errors.DeviceError, match=r"Observable .* not supported"):
+            with pytest.raises(qml.DeviceError, match=r"Observable .* not supported"):
                 _, __ = program((analytic_only_obs_tape,))
 
         else:
             _, __ = program((analytic_only_meas_tape,))
             _, __ = program((analytic_only_obs_tape,))
 
-            with pytest.raises(pennylane.errors.DeviceError, match=r"Measurement .* not accepted"):
+            with pytest.raises(qml.DeviceError, match=r"Measurement .* not accepted"):
                 _, __ = program((shots_only_meas_tape,))
 
-            with pytest.raises(pennylane.errors.DeviceError, match=r"Observable .* not supported"):
+            with pytest.raises(qml.DeviceError, match=r"Observable .* not supported"):
                 _, __ = program((shots_only_obs_tape,))
 
     @pytest.mark.usefixtures("create_temporary_toml_file")

--- a/tests/devices/test_device_api.py
+++ b/tests/devices/test_device_api.py
@@ -19,6 +19,7 @@ from typing import Optional, Union
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig, MCMConfig
 from pennylane.devices.capabilities import (
     DeviceCapabilities,
@@ -202,7 +203,7 @@ class TestSetupExecutionConfig:
         initial_config = ExecutionConfig(mcm_config=mcm_config)
 
         if expected_error is not None:
-            with pytest.raises(qml.QuantumFunctionError, match=expected_error):
+            with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error):
                 dev.setup_execution_config(initial_config, tape)
             return
 
@@ -231,7 +232,7 @@ class TestSetupExecutionConfig:
         tape = QuantumScript([qml.measurements.MidMeasureMP(0)], [], shots=shots)
         initial_config = ExecutionConfig(mcm_config=mcm_config)
         if expected_error:
-            with pytest.raises(qml.QuantumFunctionError, match=expected_error):
+            with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error):
                 dev.setup_execution_config(initial_config, tape)
         else:
             final_config = dev.setup_execution_config(initial_config, tape)
@@ -469,13 +470,15 @@ class TestPreprocessTransforms:
         _, __ = program((valid_tape,))
 
         invalid_tape = QuantumScript([], [qml.var(qml.PauliZ(0))], shots=shots)
-        with pytest.raises(qml.DeviceError, match=r"Measurement var\(Z\(0\)\) not accepted"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match=r"Measurement var\(Z\(0\)\) not accepted"
+        ):
             _, __ = program((invalid_tape,))
 
         invalid_tape = QuantumScript(
             [], [qml.expval(qml.Hermitian([[1.0, 0], [0, 1.0]], 0))], shots=shots
         )
-        with pytest.raises(qml.DeviceError, match=r"Observable Hermitian"):
+        with pytest.raises(pennylane.errors.DeviceError, match=r"Observable Hermitian"):
             _, __ = program((invalid_tape,))
 
         shots_only_meas_tape = QuantumScript([], [qml.counts()], shots=shots)
@@ -488,20 +491,20 @@ class TestPreprocessTransforms:
             _, __ = program((shots_only_meas_tape,))
             _, __ = program((shots_only_obs_tape,))
 
-            with pytest.raises(qml.DeviceError, match=r"Measurement .* not accepted"):
+            with pytest.raises(pennylane.errors.DeviceError, match=r"Measurement .* not accepted"):
                 _, __ = program((analytic_only_meas_tape,))
 
-            with pytest.raises(qml.DeviceError, match=r"Observable .* not supported"):
+            with pytest.raises(pennylane.errors.DeviceError, match=r"Observable .* not supported"):
                 _, __ = program((analytic_only_obs_tape,))
 
         else:
             _, __ = program((analytic_only_meas_tape,))
             _, __ = program((analytic_only_obs_tape,))
 
-            with pytest.raises(qml.DeviceError, match=r"Measurement .* not accepted"):
+            with pytest.raises(pennylane.errors.DeviceError, match=r"Measurement .* not accepted"):
                 _, __ = program((shots_only_meas_tape,))
 
-            with pytest.raises(qml.DeviceError, match=r"Observable .* not supported"):
+            with pytest.raises(pennylane.errors.DeviceError, match=r"Observable .* not supported"):
                 _, __ = program((shots_only_obs_tape,))
 
     @pytest.mark.usefixtures("create_temporary_toml_file")

--- a/tests/devices/test_legacy_device.py
+++ b/tests/devices/test_legacy_device.py
@@ -23,6 +23,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import LegacyDevice as Device
 from pennylane.wires import Wires
 
@@ -359,7 +360,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             qml.expval(qml.PauliZ(0) @ (qml.PauliX(1) @ qml.PauliY(2)))
         ]
 
-        with pytest.raises(qml.DeviceError, match="Observable PauliY not supported"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Observable PauliY not supported"):
             dev.check_validity(queue, unsupported_nested_observables)
 
     def test_check_validity_on_prod_support(self, mock_device_supporting_paulis):
@@ -375,7 +376,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         observables = [qml.expval(qml.PauliZ(0) @ qml.PauliX(1))]
 
         # mock device does not support Tensor product
-        with pytest.raises(qml.DeviceError, match="Observable Prod not supported"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Observable Prod not supported"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_queue(self, mock_device_supporting_paulis):
@@ -390,7 +391,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.PauliZ(0))]
 
-        with pytest.raises(qml.DeviceError, match="Gate RX not supported on device"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Gate RX not supported on device"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_observable(self, mock_device_supporting_paulis):
@@ -405,7 +406,9 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.Hadamard(0))]
 
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_projector_as_operation(self, mock_device_supporting_paulis):
@@ -430,7 +433,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
     def test_args(self, mock_device):
         """Test that the device requires correct arguments"""
         with pytest.raises(
-            qml.DeviceError, match="specified number of shots needs to be at least 1"
+            pennylane.errors.DeviceError, match="specified number of shots needs to be at least 1"
         ):
             Device(mock_device, shots=0)
 
@@ -544,7 +547,9 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         tape = qml.tape.QuantumScript.from_queue(q)
         # Raises an error for device that doesn't support mid-circuit measurements natively
-        with pytest.raises(qml.DeviceError, match="Mid-circuit measurements are not natively"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Mid-circuit measurements are not natively"
+        ):
             dev.check_validity(tape.operations, tape.observables)
 
     @pytest.mark.parametrize(
@@ -623,7 +628,8 @@ class TestOperations:
         dev = mock_device()
 
         with pytest.raises(
-            qml.DeviceError, match="The specified number of shots needs to be at least 1"
+            pennylane.errors.DeviceError,
+            match="The specified number of shots needs to be at least 1",
         ):
             dev.shots = shots
 
@@ -713,7 +719,9 @@ class TestOperations:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev.execute(queue, observables)
 
     def test_execute_obs_probs(self, mock_device_supporting_paulis):
@@ -828,7 +836,9 @@ class TestObservables:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.execute(queue, observables)
 
     def test_unsupported_observable_return_type_raise_error(
@@ -843,7 +853,8 @@ class TestObservables:
         observables = [qml.counts(op=qml.PauliZ(0))]
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Unsupported return type specified for observable"
+            pennylane.errors.QuantumFunctionError,
+            match="Unsupported return type specified for observable",
         ):
             dev.execute(queue, observables)
 
@@ -899,7 +910,7 @@ class TestDeviceInit:
     def test_no_device(self):
         """Test that an exception is raised for a device that doesn't exist"""
 
-        with pytest.raises(qml.DeviceError, match="Device None does not exist"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Device None does not exist"):
             qml.device("None", wires=0)
 
     def test_outdated_API(self, monkeypatch):
@@ -907,7 +918,9 @@ class TestDeviceInit:
 
         with monkeypatch.context() as m:
             m.setattr(qml, "version", lambda: "0.0.1")
-            with pytest.raises(qml.DeviceError, match="plugin requires PennyLane versions"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="plugin requires PennyLane versions"
+            ):
                 qml.device("default.qutrit", wires=0)
 
     def test_plugin_devices_from_devices_triggers_getattr(self, mocker):
@@ -960,7 +973,9 @@ class TestDeviceInit:
             assert not qml.plugin_devices
 
             # since there are no entry points, there will be no plugin devices
-            with pytest.raises(qml.DeviceError, match="Device default.qubit does not exist"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="Device default.qubit does not exist"
+            ):
                 qml.device("default.qubit", wires=0)
 
         # outside of the context, entrypoints will now be found automatically

--- a/tests/devices/test_legacy_device.py
+++ b/tests/devices/test_legacy_device.py
@@ -23,6 +23,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import LegacyDevice as Device
 from pennylane.wires import Wires
 
@@ -359,7 +360,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             qml.expval(qml.PauliZ(0) @ (qml.PauliX(1) @ qml.PauliY(2)))
         ]
 
-        with pytest.raises(qml.DeviceError, match="Observable PauliY not supported"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Observable PauliY not supported"):
             dev.check_validity(queue, unsupported_nested_observables)
 
     def test_check_validity_on_prod_support(self, mock_device_supporting_paulis):
@@ -375,7 +376,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         observables = [qml.expval(qml.PauliZ(0) @ qml.PauliX(1))]
 
         # mock device does not support Tensor product
-        with pytest.raises(qml.DeviceError, match="Observable Prod not supported"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Observable Prod not supported"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_queue(self, mock_device_supporting_paulis):
@@ -390,7 +391,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.PauliZ(0))]
 
-        with pytest.raises(qml.DeviceError, match="Gate RX not supported on device"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Gate RX not supported on device"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_observable(self, mock_device_supporting_paulis):
@@ -405,7 +406,9 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.Hadamard(0))]
 
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_projector_as_operation(self, mock_device_supporting_paulis):
@@ -430,7 +433,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
     def test_args(self, mock_device):
         """Test that the device requires correct arguments"""
         with pytest.raises(
-            qml.DeviceError, match="specified number of shots needs to be at least 1"
+            pennylane.errors.DeviceError, match="specified number of shots needs to be at least 1"
         ):
             Device(mock_device, shots=0)
 
@@ -544,7 +547,9 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         tape = qml.tape.QuantumScript.from_queue(q)
         # Raises an error for device that doesn't support mid-circuit measurements natively
-        with pytest.raises(qml.DeviceError, match="Mid-circuit measurements are not natively"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Mid-circuit measurements are not natively"
+        ):
             dev.check_validity(tape.operations, tape.observables)
 
     @pytest.mark.parametrize(
@@ -623,7 +628,7 @@ class TestOperations:
         dev = mock_device()
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="The specified number of shots needs to be at least 1",
         ):
             dev.shots = shots
@@ -714,7 +719,9 @@ class TestOperations:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev.execute(queue, observables)
 
     def test_execute_obs_probs(self, mock_device_supporting_paulis):
@@ -829,7 +836,9 @@ class TestObservables:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.execute(queue, observables)
 
     def test_unsupported_observable_return_type_raise_error(
@@ -844,7 +853,7 @@ class TestObservables:
         observables = [qml.counts(op=qml.PauliZ(0))]
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Unsupported return type specified for observable",
         ):
             dev.execute(queue, observables)
@@ -901,7 +910,7 @@ class TestDeviceInit:
     def test_no_device(self):
         """Test that an exception is raised for a device that doesn't exist"""
 
-        with pytest.raises(qml.DeviceError, match="Device None does not exist"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Device None does not exist"):
             qml.device("None", wires=0)
 
     def test_outdated_API(self, monkeypatch):
@@ -909,7 +918,9 @@ class TestDeviceInit:
 
         with monkeypatch.context() as m:
             m.setattr(qml, "version", lambda: "0.0.1")
-            with pytest.raises(qml.DeviceError, match="plugin requires PennyLane versions"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="plugin requires PennyLane versions"
+            ):
                 qml.device("default.qutrit", wires=0)
 
     def test_plugin_devices_from_devices_triggers_getattr(self, mocker):
@@ -962,7 +973,9 @@ class TestDeviceInit:
             assert not qml.plugin_devices
 
             # since there are no entry points, there will be no plugin devices
-            with pytest.raises(qml.DeviceError, match="Device default.qubit does not exist"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="Device default.qubit does not exist"
+            ):
                 qml.device("default.qubit", wires=0)
 
         # outside of the context, entrypoints will now be found automatically

--- a/tests/devices/test_legacy_device.py
+++ b/tests/devices/test_legacy_device.py
@@ -23,7 +23,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import LegacyDevice as Device
 from pennylane.wires import Wires
 
@@ -360,7 +359,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             qml.expval(qml.PauliZ(0) @ (qml.PauliX(1) @ qml.PauliY(2)))
         ]
 
-        with pytest.raises(pennylane.errors.DeviceError, match="Observable PauliY not supported"):
+        with pytest.raises(qml.DeviceError, match="Observable PauliY not supported"):
             dev.check_validity(queue, unsupported_nested_observables)
 
     def test_check_validity_on_prod_support(self, mock_device_supporting_paulis):
@@ -376,7 +375,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
         observables = [qml.expval(qml.PauliZ(0) @ qml.PauliX(1))]
 
         # mock device does not support Tensor product
-        with pytest.raises(pennylane.errors.DeviceError, match="Observable Prod not supported"):
+        with pytest.raises(qml.DeviceError, match="Observable Prod not supported"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_queue(self, mock_device_supporting_paulis):
@@ -391,7 +390,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.PauliZ(0))]
 
-        with pytest.raises(pennylane.errors.DeviceError, match="Gate RX not supported on device"):
+        with pytest.raises(qml.DeviceError, match="Gate RX not supported on device"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_invalid_observable(self, mock_device_supporting_paulis):
@@ -406,9 +405,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         observables = [qml.expval(qml.Hadamard(0))]
 
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
             dev.check_validity(queue, observables)
 
     def test_check_validity_on_projector_as_operation(self, mock_device_supporting_paulis):
@@ -433,7 +430,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
     def test_args(self, mock_device):
         """Test that the device requires correct arguments"""
         with pytest.raises(
-            pennylane.errors.DeviceError, match="specified number of shots needs to be at least 1"
+            qml.DeviceError, match="specified number of shots needs to be at least 1"
         ):
             Device(mock_device, shots=0)
 
@@ -547,9 +544,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
 
         tape = qml.tape.QuantumScript.from_queue(q)
         # Raises an error for device that doesn't support mid-circuit measurements natively
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Mid-circuit measurements are not natively"
-        ):
+        with pytest.raises(qml.DeviceError, match="Mid-circuit measurements are not natively"):
             dev.check_validity(tape.operations, tape.observables)
 
     @pytest.mark.parametrize(
@@ -628,7 +623,7 @@ class TestOperations:
         dev = mock_device()
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="The specified number of shots needs to be at least 1",
         ):
             dev.shots = shots
@@ -719,9 +714,7 @@ class TestOperations:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
             dev.execute(queue, observables)
 
     def test_execute_obs_probs(self, mock_device_supporting_paulis):
@@ -836,9 +829,7 @@ class TestObservables:
             qml.sample(qml.PauliZ(2)),
         ]
 
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
             dev.execute(queue, observables)
 
     def test_unsupported_observable_return_type_raise_error(
@@ -853,7 +844,7 @@ class TestObservables:
         observables = [qml.counts(op=qml.PauliZ(0))]
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Unsupported return type specified for observable",
         ):
             dev.execute(queue, observables)
@@ -910,7 +901,7 @@ class TestDeviceInit:
     def test_no_device(self):
         """Test that an exception is raised for a device that doesn't exist"""
 
-        with pytest.raises(pennylane.errors.DeviceError, match="Device None does not exist"):
+        with pytest.raises(qml.DeviceError, match="Device None does not exist"):
             qml.device("None", wires=0)
 
     def test_outdated_API(self, monkeypatch):
@@ -918,9 +909,7 @@ class TestDeviceInit:
 
         with monkeypatch.context() as m:
             m.setattr(qml, "version", lambda: "0.0.1")
-            with pytest.raises(
-                pennylane.errors.DeviceError, match="plugin requires PennyLane versions"
-            ):
+            with pytest.raises(qml.DeviceError, match="plugin requires PennyLane versions"):
                 qml.device("default.qutrit", wires=0)
 
     def test_plugin_devices_from_devices_triggers_getattr(self, mocker):
@@ -973,9 +962,7 @@ class TestDeviceInit:
             assert not qml.plugin_devices
 
             # since there are no entry points, there will be no plugin devices
-            with pytest.raises(
-                pennylane.errors.DeviceError, match="Device default.qubit does not exist"
-            ):
+            with pytest.raises(qml.DeviceError, match="Device default.qubit does not exist"):
                 qml.device("default.qubit", wires=0)
 
         # outside of the context, entrypoints will now be found automatically

--- a/tests/devices/test_legacy_facade.py
+++ b/tests/devices/test_legacy_facade.py
@@ -22,6 +22,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.devices.legacy_facade import (
     LegacyDeviceFacade,
@@ -292,13 +293,13 @@ class TestGradientSupport:
         assert not dev.supports_derivatives(ExecutionConfig(gradient_method="device"))
         assert not dev.supports_derivatives(ExecutionConfig(gradient_method="param_shift"))
 
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="device"))
 
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="adjoint"))
 
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="backprop"))
 
     def test_adjoint_support(self):

--- a/tests/devices/test_legacy_facade.py
+++ b/tests/devices/test_legacy_facade.py
@@ -22,7 +22,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.devices.legacy_facade import (
     LegacyDeviceFacade,
@@ -293,13 +292,13 @@ class TestGradientSupport:
         assert not dev.supports_derivatives(ExecutionConfig(gradient_method="device"))
         assert not dev.supports_derivatives(ExecutionConfig(gradient_method="param_shift"))
 
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="device"))
 
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="adjoint"))
 
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             dev.preprocess(ExecutionConfig(gradient_method="backprop"))
 
     def test_adjoint_support(self):

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -18,7 +18,6 @@ import pytest
 from flaky import flaky
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -54,7 +53,7 @@ def test_no_backprop_auto_interface():
         """Simple quantum function."""
         return qml.expval(qml.PauliZ(0))
 
-    with pytest.raises(pennylane.errors.QuantumFunctionError, match="does not support backprop"):
+    with pytest.raises(qml.QuantumFunctionError, match="does not support backprop"):
         qml.QNode(circuit, dev, diff_method="backprop")
 
 
@@ -67,7 +66,7 @@ def test_finite_shots_adjoint():
         """Simple quantum function."""
         return qml.expval(qml.PauliZ(0))
 
-    with pytest.raises(pennylane.errors.QuantumFunctionError, match="does not support adjoint"):
+    with pytest.raises(qml.QuantumFunctionError, match="does not support adjoint"):
         qml.QNode(circuit, dev, diff_method="adjoint")()
 
 

--- a/tests/devices/test_lightning_qubit.py
+++ b/tests/devices/test_lightning_qubit.py
@@ -18,6 +18,7 @@ import pytest
 from flaky import flaky
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -53,7 +54,7 @@ def test_no_backprop_auto_interface():
         """Simple quantum function."""
         return qml.expval(qml.PauliZ(0))
 
-    with pytest.raises(qml.QuantumFunctionError, match="does not support backprop"):
+    with pytest.raises(pennylane.errors.QuantumFunctionError, match="does not support backprop"):
         qml.QNode(circuit, dev, diff_method="backprop")
 
 
@@ -66,7 +67,7 @@ def test_finite_shots_adjoint():
         """Simple quantum function."""
         return qml.expval(qml.PauliZ(0))
 
-    with pytest.raises(qml.QuantumFunctionError, match="does not support adjoint"):
+    with pytest.raises(pennylane.errors.QuantumFunctionError, match="does not support adjoint"):
         qml.QNode(circuit, dev, diff_method="adjoint")()
 
 

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -17,7 +17,6 @@ import warnings
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices.preprocess import (
     _operator_decomposition_gen,
     decompose,
@@ -123,7 +122,7 @@ class TestPrivateHelpers:
     def test_error_from_unsupported_operation(self):
         """Test that a device error is raised if the operator cant be decomposed and doesn't have a matrix."""
         op = NoMatNoDecompOp("a")
-        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported with abc and does"):
+        with pytest.raises(qml.DeviceError, match=r"not supported with abc and does"):
             tuple(
                 _operator_decomposition_gen(
                     op, lambda op: op.has_matrix, self.decomposer, name="abc"
@@ -139,9 +138,7 @@ def test_no_sampling():
     assert batch[0] is tape1
 
     tape2 = qml.tape.QuantumScript(shots=2)
-    with pytest.raises(
-        pennylane.errors.DeviceError, match="Finite shots are not supported with abc"
-    ):
+    with pytest.raises(qml.DeviceError, match="Finite shots are not supported with abc"):
         no_sampling(tape2, name="abc")
 
 
@@ -163,9 +160,7 @@ def test_validate_adjoint_trainable_params_obs_warning():
 def test_validate_adjoint_trainable_params_state_prep_error():
     """Tests error raised for validate_adjoint_trainable_params with trainable state-preps."""
     tape = qml.tape.QuantumScript([qml.StatePrep(qml.numpy.array([1.0, 0.0]), wires=[0])])
-    with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="Differentiating with respect to"
-    ):
+    with pytest.raises(qml.QuantumFunctionError, match="Differentiating with respect to"):
         validate_adjoint_trainable_params(tape)
 
 
@@ -244,7 +239,7 @@ class TestDecomposeValidation:
         """Test that expand_fn throws an error when an operation does not define a matrix or decomposition."""
 
         tape = QuantumScript(ops=[NoMatNoDecompOp(0)], measurements=[qml.expval(qml.Hadamard(0))])
-        with pytest.raises(pennylane.errors.DeviceError, match="not supported with abc"):
+        with pytest.raises(qml.DeviceError, match="not supported with abc"):
             decompose(tape, lambda op: op.has_matrix, name="abc")
 
     def test_decompose(self):
@@ -258,9 +253,7 @@ class TestDecomposeValidation:
         """Test that a device error is raised if decomposition enters an infinite loop."""
 
         qs = qml.tape.QuantumScript([InfiniteOp(1.23, 0)])
-        with pytest.raises(
-            pennylane.errors.DeviceError, match=r"Reached recursion limit trying to decompose"
-        ):
+        with pytest.raises(qml.DeviceError, match=r"Reached recursion limit trying to decompose"):
             decompose(qs, lambda obj: obj.has_matrix)
 
     @pytest.mark.parametrize(
@@ -290,7 +283,7 @@ class TestValidateObservables:
         tape = QuantumScript(
             ops=[qml.PauliX(0)], measurements=[qml.expval(qml.GellMann(wires=0, index=1))]
         )
-        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported on abc"):
+        with pytest.raises(qml.DeviceError, match=r"not supported on abc"):
             validate_observables(tape, lambda obs: obs.name == "PauliX", name="abc")
 
     def test_invalid_tensor_observable(self):
@@ -299,7 +292,7 @@ class TestValidateObservables:
             ops=[qml.PauliX(0), qml.PauliY(1)],
             measurements=[qml.expval(qml.PauliX(0) @ qml.GellMann(wires=1, index=2))],
         )
-        with pytest.raises(pennylane.errors.DeviceError, match="not supported on device"):
+        with pytest.raises(qml.DeviceError, match="not supported on device"):
             validate_observables(tape, lambda obj: obj.name == "PauliX")
 
 
@@ -350,7 +343,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=None)
 
         msg = "not accepted for analytic simulation on device"
-        with pytest.raises(pennylane.errors.DeviceError, match=msg):
+        with pytest.raises(qml.DeviceError, match=msg):
             validate_measurements(tape)
 
     @pytest.mark.parametrize(
@@ -366,7 +359,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=100)
 
         msg = "not accepted with finite shots on device"
-        with pytest.raises(pennylane.errors.DeviceError, match=msg):
+        with pytest.raises(qml.DeviceError, match=msg):
             validate_measurements(tape, lambda obj: True)
 
 
@@ -498,7 +491,7 @@ class TestMidCircuitMeasurements:
         tape = QuantumScript([qml.measurements.MidMeasureMP(0)], [], shots=shots)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="dynamic_one_shot is only supported with finite shots.",
         ):
             _, _ = mid_circuit_measurements(tape, dev, mcm_config)

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -17,6 +17,7 @@ import warnings
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.preprocess import (
     _operator_decomposition_gen,
     decompose,
@@ -122,7 +123,7 @@ class TestPrivateHelpers:
     def test_error_from_unsupported_operation(self):
         """Test that a device error is raised if the operator cant be decomposed and doesn't have a matrix."""
         op = NoMatNoDecompOp("a")
-        with pytest.raises(qml.DeviceError, match=r"not supported with abc and does"):
+        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported with abc and does"):
             tuple(
                 _operator_decomposition_gen(
                     op, lambda op: op.has_matrix, self.decomposer, name="abc"
@@ -138,7 +139,9 @@ def test_no_sampling():
     assert batch[0] is tape1
 
     tape2 = qml.tape.QuantumScript(shots=2)
-    with pytest.raises(qml.DeviceError, match="Finite shots are not supported with abc"):
+    with pytest.raises(
+        pennylane.errors.DeviceError, match="Finite shots are not supported with abc"
+    ):
         no_sampling(tape2, name="abc")
 
 
@@ -160,7 +163,9 @@ def test_validate_adjoint_trainable_params_obs_warning():
 def test_validate_adjoint_trainable_params_state_prep_error():
     """Tests error raised for validate_adjoint_trainable_params with trainable state-preps."""
     tape = qml.tape.QuantumScript([qml.StatePrep(qml.numpy.array([1.0, 0.0]), wires=[0])])
-    with pytest.raises(qml.QuantumFunctionError, match="Differentiating with respect to"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Differentiating with respect to"
+    ):
         validate_adjoint_trainable_params(tape)
 
 
@@ -239,7 +244,7 @@ class TestDecomposeValidation:
         """Test that expand_fn throws an error when an operation does not define a matrix or decomposition."""
 
         tape = QuantumScript(ops=[NoMatNoDecompOp(0)], measurements=[qml.expval(qml.Hadamard(0))])
-        with pytest.raises(qml.DeviceError, match="not supported with abc"):
+        with pytest.raises(pennylane.errors.DeviceError, match="not supported with abc"):
             decompose(tape, lambda op: op.has_matrix, name="abc")
 
     def test_decompose(self):
@@ -253,7 +258,9 @@ class TestDecomposeValidation:
         """Test that a device error is raised if decomposition enters an infinite loop."""
 
         qs = qml.tape.QuantumScript([InfiniteOp(1.23, 0)])
-        with pytest.raises(qml.DeviceError, match=r"Reached recursion limit trying to decompose"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match=r"Reached recursion limit trying to decompose"
+        ):
             decompose(qs, lambda obj: obj.has_matrix)
 
     @pytest.mark.parametrize(
@@ -283,7 +290,7 @@ class TestValidateObservables:
         tape = QuantumScript(
             ops=[qml.PauliX(0)], measurements=[qml.expval(qml.GellMann(wires=0, index=1))]
         )
-        with pytest.raises(qml.DeviceError, match=r"not supported on abc"):
+        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported on abc"):
             validate_observables(tape, lambda obs: obs.name == "PauliX", name="abc")
 
     def test_invalid_tensor_observable(self):
@@ -292,7 +299,7 @@ class TestValidateObservables:
             ops=[qml.PauliX(0), qml.PauliY(1)],
             measurements=[qml.expval(qml.PauliX(0) @ qml.GellMann(wires=1, index=2))],
         )
-        with pytest.raises(qml.DeviceError, match="not supported on device"):
+        with pytest.raises(pennylane.errors.DeviceError, match="not supported on device"):
             validate_observables(tape, lambda obj: obj.name == "PauliX")
 
 
@@ -343,7 +350,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=None)
 
         msg = "not accepted for analytic simulation on device"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             validate_measurements(tape)
 
     @pytest.mark.parametrize(
@@ -359,7 +366,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=100)
 
         msg = "not accepted with finite shots on device"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             validate_measurements(tape, lambda obj: True)
 
 
@@ -491,7 +498,7 @@ class TestMidCircuitMeasurements:
         tape = QuantumScript([qml.measurements.MidMeasureMP(0)], [], shots=shots)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="dynamic_one_shot is only supported with finite shots.",
         ):
             _, _ = mid_circuit_measurements(tape, dev, mcm_config)

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -17,6 +17,7 @@ import warnings
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.preprocess import (
     _operator_decomposition_gen,
     decompose,
@@ -122,7 +123,7 @@ class TestPrivateHelpers:
     def test_error_from_unsupported_operation(self):
         """Test that a device error is raised if the operator cant be decomposed and doesn't have a matrix."""
         op = NoMatNoDecompOp("a")
-        with pytest.raises(qml.DeviceError, match=r"not supported with abc and does"):
+        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported with abc and does"):
             tuple(
                 _operator_decomposition_gen(
                     op, lambda op: op.has_matrix, self.decomposer, name="abc"
@@ -138,7 +139,9 @@ def test_no_sampling():
     assert batch[0] is tape1
 
     tape2 = qml.tape.QuantumScript(shots=2)
-    with pytest.raises(qml.DeviceError, match="Finite shots are not supported with abc"):
+    with pytest.raises(
+        pennylane.errors.DeviceError, match="Finite shots are not supported with abc"
+    ):
         no_sampling(tape2, name="abc")
 
 
@@ -160,7 +163,9 @@ def test_validate_adjoint_trainable_params_obs_warning():
 def test_validate_adjoint_trainable_params_state_prep_error():
     """Tests error raised for validate_adjoint_trainable_params with trainable state-preps."""
     tape = qml.tape.QuantumScript([qml.StatePrep(qml.numpy.array([1.0, 0.0]), wires=[0])])
-    with pytest.raises(qml.QuantumFunctionError, match="Differentiating with respect to"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Differentiating with respect to"
+    ):
         validate_adjoint_trainable_params(tape)
 
 
@@ -239,7 +244,7 @@ class TestDecomposeValidation:
         """Test that expand_fn throws an error when an operation does not define a matrix or decomposition."""
 
         tape = QuantumScript(ops=[NoMatNoDecompOp(0)], measurements=[qml.expval(qml.Hadamard(0))])
-        with pytest.raises(qml.DeviceError, match="not supported with abc"):
+        with pytest.raises(pennylane.errors.DeviceError, match="not supported with abc"):
             decompose(tape, lambda op: op.has_matrix, name="abc")
 
     def test_decompose(self):
@@ -253,7 +258,9 @@ class TestDecomposeValidation:
         """Test that a device error is raised if decomposition enters an infinite loop."""
 
         qs = qml.tape.QuantumScript([InfiniteOp(1.23, 0)])
-        with pytest.raises(qml.DeviceError, match=r"Reached recursion limit trying to decompose"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match=r"Reached recursion limit trying to decompose"
+        ):
             decompose(qs, lambda obj: obj.has_matrix)
 
     @pytest.mark.parametrize(
@@ -283,7 +290,7 @@ class TestValidateObservables:
         tape = QuantumScript(
             ops=[qml.PauliX(0)], measurements=[qml.expval(qml.GellMann(wires=0, index=1))]
         )
-        with pytest.raises(qml.DeviceError, match=r"not supported on abc"):
+        with pytest.raises(pennylane.errors.DeviceError, match=r"not supported on abc"):
             validate_observables(tape, lambda obs: obs.name == "PauliX", name="abc")
 
     def test_invalid_tensor_observable(self):
@@ -292,7 +299,7 @@ class TestValidateObservables:
             ops=[qml.PauliX(0), qml.PauliY(1)],
             measurements=[qml.expval(qml.PauliX(0) @ qml.GellMann(wires=1, index=2))],
         )
-        with pytest.raises(qml.DeviceError, match="not supported on device"):
+        with pytest.raises(pennylane.errors.DeviceError, match="not supported on device"):
             validate_observables(tape, lambda obj: obj.name == "PauliX")
 
 
@@ -343,7 +350,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=None)
 
         msg = "not accepted for analytic simulation on device"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             validate_measurements(tape)
 
     @pytest.mark.parametrize(
@@ -359,7 +366,7 @@ class TestValidateMeasurements:
         tape = QuantumScript([], measurements, shots=100)
 
         msg = "not accepted with finite shots on device"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             validate_measurements(tape, lambda obj: True)
 
 
@@ -491,7 +498,8 @@ class TestMidCircuitMeasurements:
         tape = QuantumScript([qml.measurements.MidMeasureMP(0)], [], shots=shots)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="dynamic_one_shot is only supported with finite shots."
+            pennylane.errors.QuantumFunctionError,
+            match="dynamic_one_shot is only supported with finite shots.",
         ):
             _, _ = mid_circuit_measurements(tape, dev, mcm_config)
 

--- a/tests/devices/test_qubit_device.py
+++ b/tests/devices/test_qubit_device.py
@@ -22,7 +22,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice
 from pennylane.measurements import (
@@ -240,9 +239,7 @@ class TestOperations:
             qml.var(qml.PauliZ(1))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -304,9 +301,7 @@ class TestObservables:
             qml.sample(qml.PauliZ(2))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -327,7 +322,7 @@ class TestObservables:
         with monkeypatch.context() as m:
             m.setattr(QubitDevice, "apply", lambda self, x, **kwargs: None)
             with pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match="Unsupported return type specified for observable",
             ):
                 dev = mock_qubit_device_with_paulis_and_methods()
@@ -379,7 +374,7 @@ class TestExtractStatistics:
         dev = mock_qubit_device_extract_stats()
         delattr(dev.__class__, "state")
         _match = "The state is not available in the current"
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=_match):
+        with pytest.raises(qml.QuantumFunctionError, match=_match):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", [None])
@@ -391,7 +386,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
         dev = mock_qubit_device_extract_stats()
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", ["not None"])
@@ -405,7 +400,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev = mock_qubit_device_extract_stats()
             dev.statistics(qscript)
 
@@ -434,9 +429,7 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.classical_shadow(wires=0), qml.state()])
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be returned"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be returned"):
             dev.statistics(tape)
 
     def test_no_shadow_expval_with_other_meas(self, mock_qubit_device_extract_stats):
@@ -446,9 +439,7 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.shadow_expval(qml.X(0)), qml.state()])
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be"):
             dev.statistics(tape)
 
 
@@ -503,7 +494,7 @@ class TestSampleBasisStates:
         state_probs = [0.1, 0.2, 0.3, 0.4]
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1692,15 +1683,11 @@ def test_no_adjoint_jacobian_errors():
 
     dev = DummyQubitDevice(wires=0)
 
-    with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="Parameter broadcasting is not supported"
-    ):
+    with pytest.raises(qml.QuantumFunctionError, match="Parameter broadcasting is not supported"):
         dev.adjoint_jacobian(tape)
 
     dev.shots = (10, 10)  # pylint: disable=attribute-defined-outside-init
 
     tape2 = qml.tape.QuantumScript([qml.RX(0.1, 0)], [qml.expval(qml.Z(0))])
-    with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="Adjoint does not support shot vector"
-    ):
+    with pytest.raises(qml.QuantumFunctionError, match="Adjoint does not support shot vector"):
         dev.adjoint_jacobian(tape2)

--- a/tests/devices/test_qubit_device.py
+++ b/tests/devices/test_qubit_device.py
@@ -22,6 +22,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice
 from pennylane.measurements import (
@@ -239,7 +240,9 @@ class TestOperations:
             qml.var(qml.PauliZ(1))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -301,7 +304,9 @@ class TestObservables:
             qml.sample(qml.PauliZ(2))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -322,7 +327,8 @@ class TestObservables:
         with monkeypatch.context() as m:
             m.setattr(QubitDevice, "apply", lambda self, x, **kwargs: None)
             with pytest.raises(
-                qml.QuantumFunctionError, match="Unsupported return type specified for observable"
+                pennylane.errors.QuantumFunctionError,
+                match="Unsupported return type specified for observable",
             ):
                 dev = mock_qubit_device_with_paulis_and_methods()
                 dev.execute(tape)
@@ -373,7 +379,7 @@ class TestExtractStatistics:
         dev = mock_qubit_device_extract_stats()
         delattr(dev.__class__, "state")
         _match = "The state is not available in the current"
-        with pytest.raises(qml.QuantumFunctionError, match=_match):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=_match):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", [None])
@@ -385,7 +391,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
         dev = mock_qubit_device_extract_stats()
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", ["not None"])
@@ -399,7 +405,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev = mock_qubit_device_extract_stats()
             dev.statistics(qscript)
 
@@ -428,7 +434,9 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.classical_shadow(wires=0), qml.state()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be returned"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be returned"
+        ):
             dev.statistics(tape)
 
     def test_no_shadow_expval_with_other_meas(self, mock_qubit_device_extract_stats):
@@ -438,7 +446,9 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.shadow_expval(qml.X(0)), qml.state()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be"
+        ):
             dev.statistics(tape)
 
 
@@ -493,7 +503,7 @@ class TestSampleBasisStates:
         state_probs = [0.1, 0.2, 0.3, 0.4]
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1682,11 +1692,15 @@ def test_no_adjoint_jacobian_errors():
 
     dev = DummyQubitDevice(wires=0)
 
-    with pytest.raises(qml.QuantumFunctionError, match="Parameter broadcasting is not supported"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Parameter broadcasting is not supported"
+    ):
         dev.adjoint_jacobian(tape)
 
     dev.shots = (10, 10)  # pylint: disable=attribute-defined-outside-init
 
     tape2 = qml.tape.QuantumScript([qml.RX(0.1, 0)], [qml.expval(qml.Z(0))])
-    with pytest.raises(qml.QuantumFunctionError, match="Adjoint does not support shot vector"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Adjoint does not support shot vector"
+    ):
         dev.adjoint_jacobian(tape2)

--- a/tests/devices/test_qubit_device.py
+++ b/tests/devices/test_qubit_device.py
@@ -22,6 +22,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice
 from pennylane.measurements import (
@@ -239,7 +240,9 @@ class TestOperations:
             qml.var(qml.PauliZ(1))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -301,7 +304,9 @@ class TestObservables:
             qml.sample(qml.PauliZ(2))
 
         tape = QuantumScript.from_queue(q)
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev = mock_qubit_device_with_paulis_and_methods()
             dev.execute(tape)
 
@@ -322,7 +327,7 @@ class TestObservables:
         with monkeypatch.context() as m:
             m.setattr(QubitDevice, "apply", lambda self, x, **kwargs: None)
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="Unsupported return type specified for observable",
             ):
                 dev = mock_qubit_device_with_paulis_and_methods()
@@ -374,7 +379,7 @@ class TestExtractStatistics:
         dev = mock_qubit_device_extract_stats()
         delattr(dev.__class__, "state")
         _match = "The state is not available in the current"
-        with pytest.raises(qml.QuantumFunctionError, match=_match):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=_match):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", [None])
@@ -386,7 +391,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
         dev = mock_qubit_device_extract_stats()
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     @pytest.mark.parametrize("returntype", ["not None"])
@@ -400,7 +405,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev = mock_qubit_device_extract_stats()
             dev.statistics(qscript)
 
@@ -429,7 +434,9 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.classical_shadow(wires=0), qml.state()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be returned"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be returned"
+        ):
             dev.statistics(tape)
 
     def test_no_shadow_expval_with_other_meas(self, mock_qubit_device_extract_stats):
@@ -439,7 +446,9 @@ class TestExtractStatistics:
 
         tape = qml.tape.QuantumScript([], [qml.shadow_expval(qml.X(0)), qml.state()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Classical shadows cannot be"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Classical shadows cannot be"
+        ):
             dev.statistics(tape)
 
 
@@ -494,7 +503,7 @@ class TestSampleBasisStates:
         state_probs = [0.1, 0.2, 0.3, 0.4]
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1683,11 +1692,15 @@ def test_no_adjoint_jacobian_errors():
 
     dev = DummyQubitDevice(wires=0)
 
-    with pytest.raises(qml.QuantumFunctionError, match="Parameter broadcasting is not supported"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Parameter broadcasting is not supported"
+    ):
         dev.adjoint_jacobian(tape)
 
     dev.shots = (10, 10)  # pylint: disable=attribute-defined-outside-init
 
     tape2 = qml.tape.QuantumScript([qml.RX(0.1, 0)], [qml.expval(qml.Z(0))])
-    with pytest.raises(qml.QuantumFunctionError, match="Adjoint does not support shot vector"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="Adjoint does not support shot vector"
+    ):
         dev.adjoint_jacobian(tape2)

--- a/tests/devices/test_qutrit_device.py
+++ b/tests/devices/test_qutrit_device.py
@@ -22,6 +22,7 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice, QutritDevice
 from pennylane.measurements import (
@@ -198,7 +199,9 @@ class TestOperations:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev.execute(tape)
 
     unitaries = [unitary_group.rvs(3, random_state=1967) for _ in range(3)]
@@ -260,7 +263,9 @@ class TestObservables:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.execute(tape)
 
     def test_unsupported_observable_return_type_raise_error(self, mock_qutrit_device, monkeypatch):
@@ -280,7 +285,7 @@ class TestObservables:
             m.setattr(QutritDevice, "apply", lambda self, x, **kwargs: None)
             dev = mock_qutrit_device()
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="Unsupported return type specified for observable",
             ):
                 dev.execute(tape)
@@ -334,7 +339,7 @@ class TestExtractStatistics:
             dev = mock_qutrit_device()
             m.delattr(QubitDevice, "state")
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="The state is not available in the current",
             ):
                 dev.statistics(qscript)
@@ -348,7 +353,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             with monkeypatch.context() as m:
                 dev = mock_qutrit_device_extract_stats()
                 results = dev.statistics(qscript)
@@ -367,7 +372,7 @@ class TestExtractStatistics:
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
         dev = mock_qutrit_device_extract_stats()
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     def test_return_state_with_multiple_observables(self, mock_qutrit_device_extract_stats):
@@ -385,7 +390,7 @@ class TestExtractStatistics:
         dev = mock_qutrit_device_extract_stats()
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination",
         ):
             dev.execute(tape)
@@ -564,7 +569,7 @@ class TestSampleBasisStates:
         state_probs[0] = 0.2
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1038,7 +1043,7 @@ class TestShotList:
 
     def test_invalid_shot_list(self, mock_qutrit_device_shots):
         """Test exception raised if the shot list is the wrong type"""
-        with pytest.raises(qml.DeviceError, match="Shots must be"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Shots must be"):
             mock_qutrit_device_shots(wires=2, shots=0.5)
 
         with pytest.raises(ValueError, match="Shots must be"):
@@ -1209,21 +1214,21 @@ class TestUnimplemented:
         """Test that density_matrix is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.density_matrix(wires=0)
 
     def test_vn_entropy(self, mock_qutrit_device):
         """Test that vn_entropy is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.vn_entropy(wires=0, log_base=3)
 
     def test_mutual_info(self, mock_qutrit_device):
         """Test that mutual_info is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.mutual_info(0, 1, log_base=3)
 
     def test_classical_shadow(self, mock_qutrit_device):
@@ -1232,7 +1237,9 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
+        ):
             dev.classical_shadow(obs, qs)
 
     def test_shadow_expval(self, mock_qutrit_device):
@@ -1241,5 +1248,7 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
+        ):
             dev.shadow_expval(obs, qs)

--- a/tests/devices/test_qutrit_device.py
+++ b/tests/devices/test_qutrit_device.py
@@ -22,7 +22,6 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice, QutritDevice
 from pennylane.measurements import (
@@ -199,9 +198,7 @@ class TestOperations:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
             dev.execute(tape)
 
     unitaries = [unitary_group.rvs(3, random_state=1967) for _ in range(3)]
@@ -263,9 +260,7 @@ class TestObservables:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
-        ):
+        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
             dev.execute(tape)
 
     def test_unsupported_observable_return_type_raise_error(self, mock_qutrit_device, monkeypatch):
@@ -285,7 +280,7 @@ class TestObservables:
             m.setattr(QutritDevice, "apply", lambda self, x, **kwargs: None)
             dev = mock_qutrit_device()
             with pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match="Unsupported return type specified for observable",
             ):
                 dev.execute(tape)
@@ -339,7 +334,7 @@ class TestExtractStatistics:
             dev = mock_qutrit_device()
             m.delattr(QubitDevice, "state")
             with pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match="The state is not available in the current",
             ):
                 dev.statistics(qscript)
@@ -353,7 +348,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             with monkeypatch.context() as m:
                 dev = mock_qutrit_device_extract_stats()
                 results = dev.statistics(qscript)
@@ -372,7 +367,7 @@ class TestExtractStatistics:
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
         dev = mock_qutrit_device_extract_stats()
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     def test_return_state_with_multiple_observables(self, mock_qutrit_device_extract_stats):
@@ -390,7 +385,7 @@ class TestExtractStatistics:
         dev = mock_qutrit_device_extract_stats()
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination",
         ):
             dev.execute(tape)
@@ -569,7 +564,7 @@ class TestSampleBasisStates:
         state_probs[0] = 0.2
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1043,7 +1038,7 @@ class TestShotList:
 
     def test_invalid_shot_list(self, mock_qutrit_device_shots):
         """Test exception raised if the shot list is the wrong type"""
-        with pytest.raises(pennylane.errors.DeviceError, match="Shots must be"):
+        with pytest.raises(qml.DeviceError, match="Shots must be"):
             mock_qutrit_device_shots(wires=2, shots=0.5)
 
         with pytest.raises(ValueError, match="Shots must be"):
@@ -1214,21 +1209,21 @@ class TestUnimplemented:
         """Test that density_matrix is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev.density_matrix(wires=0)
 
     def test_vn_entropy(self, mock_qutrit_device):
         """Test that vn_entropy is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev.vn_entropy(wires=0, log_base=3)
 
     def test_mutual_info(self, mock_qutrit_device):
         """Test that mutual_info is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
             dev.mutual_info(0, 1, log_base=3)
 
     def test_classical_shadow(self, mock_qutrit_device):
@@ -1237,9 +1232,7 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
             dev.classical_shadow(obs, qs)
 
     def test_shadow_expval(self, mock_qutrit_device):
@@ -1248,7 +1241,5 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
             dev.shadow_expval(obs, qs)

--- a/tests/devices/test_qutrit_device.py
+++ b/tests/devices/test_qutrit_device.py
@@ -22,6 +22,7 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.devices import QubitDevice, QutritDevice
 from pennylane.measurements import (
@@ -198,7 +199,9 @@ class TestOperations:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(qml.DeviceError, match="Gate Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Gate Hadamard not supported on device"
+        ):
             dev.execute(tape)
 
     unitaries = [unitary_group.rvs(3, random_state=1967) for _ in range(3)]
@@ -260,7 +263,9 @@ class TestObservables:
 
         tape = QuantumScript(queue, observables)
         dev = mock_qutrit_device()
-        with pytest.raises(qml.DeviceError, match="Observable Hadamard not supported on device"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="Observable Hadamard not supported on device"
+        ):
             dev.execute(tape)
 
     def test_unsupported_observable_return_type_raise_error(self, mock_qutrit_device, monkeypatch):
@@ -280,7 +285,8 @@ class TestObservables:
             m.setattr(QutritDevice, "apply", lambda self, x, **kwargs: None)
             dev = mock_qutrit_device()
             with pytest.raises(
-                qml.QuantumFunctionError, match="Unsupported return type specified for observable"
+                pennylane.errors.QuantumFunctionError,
+                match="Unsupported return type specified for observable",
             ):
                 dev.execute(tape)
 
@@ -333,7 +339,8 @@ class TestExtractStatistics:
             dev = mock_qutrit_device()
             m.delattr(QubitDevice, "state")
             with pytest.raises(
-                qml.QuantumFunctionError, match="The state is not available in the current"
+                pennylane.errors.QuantumFunctionError,
+                match="The state is not available in the current",
             ):
                 dev.statistics(qscript)
 
@@ -346,7 +353,7 @@ class TestExtractStatistics:
 
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             with monkeypatch.context() as m:
                 dev = mock_qutrit_device_extract_stats()
                 results = dev.statistics(qscript)
@@ -365,7 +372,7 @@ class TestExtractStatistics:
         qscript = QuantumScript(measurements=[UnsupportedMeasurement()])
 
         dev = mock_qutrit_device_extract_stats()
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.statistics(qscript)
 
     def test_return_state_with_multiple_observables(self, mock_qutrit_device_extract_stats):
@@ -383,7 +390,7 @@ class TestExtractStatistics:
         dev = mock_qutrit_device_extract_stats()
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination",
         ):
             dev.execute(tape)
@@ -562,7 +569,7 @@ class TestSampleBasisStates:
         state_probs[0] = 0.2
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The number of shots has to be explicitly set on the device",
         ):
             dev.sample_basis_states(number_of_states, state_probs)
@@ -1036,7 +1043,7 @@ class TestShotList:
 
     def test_invalid_shot_list(self, mock_qutrit_device_shots):
         """Test exception raised if the shot list is the wrong type"""
-        with pytest.raises(qml.DeviceError, match="Shots must be"):
+        with pytest.raises(pennylane.errors.DeviceError, match="Shots must be"):
             mock_qutrit_device_shots(wires=2, shots=0.5)
 
         with pytest.raises(ValueError, match="Shots must be"):
@@ -1207,21 +1214,21 @@ class TestUnimplemented:
         """Test that density_matrix is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.density_matrix(wires=0)
 
     def test_vn_entropy(self, mock_qutrit_device):
         """Test that vn_entropy is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.vn_entropy(wires=0, log_base=3)
 
     def test_mutual_info(self, mock_qutrit_device):
         """Test that mutual_info is unimplemented"""
         dev = mock_qutrit_device()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Unsupported return type"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Unsupported return type"):
             dev.mutual_info(0, 1, log_base=3)
 
     def test_classical_shadow(self, mock_qutrit_device):
@@ -1230,7 +1237,9 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
+        ):
             dev.classical_shadow(obs, qs)
 
     def test_shadow_expval(self, mock_qutrit_device):
@@ -1239,5 +1248,7 @@ class TestUnimplemented:
         qs = qml.tape.QuantumScript()
         obs = qml.GellMann(1, 1)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Qutrit devices don't support"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Qutrit devices don't support"
+        ):
             dev.shadow_expval(obs, qs)

--- a/tests/docs/test_supported_confs.py
+++ b/tests/docs/test_supported_confs.py
@@ -27,8 +27,9 @@ QNode without an exception being raised."""
 import pytest
 
 import pennylane as qml
-from pennylane import QuantumFunctionError
+import pennylane.errors
 from pennylane import numpy as np
+from pennylane.errors import QuantumFunctionError
 from pennylane.measurements import Expectation, MutualInfo, Probability, Sample, Variance, VnEntropy
 from pennylane.measurements.measurements import ObservableReturnTypes
 
@@ -275,12 +276,12 @@ class TestSupportedConfs:
         x = get_variable(None, wire_specs)
 
         msg = None
-        error_type = qml.DeviceError
+        error_type = pennylane.errors.DeviceError
         if diff_method == "adjoint" and (shots is not None or return_type is Sample):
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif diff_method == "backprop" and shots:
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif not shots and return_type is Sample:
             msg = "not accepted for analytic simulation"
@@ -347,7 +348,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs, complex=True)
 
         if shots is not None:
-            with pytest.raises(qml.QuantumFunctionError):
+            with pytest.raises(pennylane.errors.QuantumFunctionError):
                 compute_gradient(x, interface, circuit, return_type)
         elif return_type == ObservableReturnTypes.Probability and interface == "tf":
             with pytest.raises(Exception):
@@ -373,7 +374,7 @@ class TestSupportedConfs:
             circuit = get_qnode(interface, "adjoint", return_type, shots, wire_specs)
             x = get_variable(interface, wire_specs)
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="does not support adjoint with requested circuit",
             ):
                 compute_gradient(x, interface, circuit, return_type)
@@ -413,7 +414,9 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, "parameter-shift", return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs, complex=complex)
         if shots is not None and interface != "jax":
-            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="not accepted with finite shots"
+            ):
                 compute_gradient(x, interface, circuit, return_type, complex=complex)
         else:
             if interface == "torch" and return_type == "StateVector":
@@ -437,7 +440,9 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, diff_method, return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs)
         if shots is not None and return_type in (VnEntropy, MutualInfo):
-            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="not accepted with finite shots"
+            ):
                 compute_gradient(x, interface, circuit, return_type)
         else:
             compute_gradient(x, interface, circuit, return_type)
@@ -477,10 +482,10 @@ class TestSupportedConfs:
         """Test sample measurement fails for all interfaces and diff_methods
         when shots=None"""
         if diff_method in {"adjoint"}:
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = "does not support adjoint with requested circuit"
         else:
-            error_type = qml.DeviceError
+            error_type = pennylane.errors.DeviceError
             msg = "not accepted for analytic simulation"
 
         with pytest.raises(error_type, match=msg):
@@ -541,7 +546,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs)
         if return_type in (VnEntropy, MutualInfo):
             if shots and interface != "jax":
-                err_cls = qml.DeviceError
+                err_cls = pennylane.errors.DeviceError
                 msg = "not accepted with finite shots"
             else:
                 err_cls = ValueError

--- a/tests/docs/test_supported_confs.py
+++ b/tests/docs/test_supported_confs.py
@@ -27,9 +27,7 @@ QNode without an exception being raised."""
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
-from pennylane.errors import QuantumFunctionError
 from pennylane.measurements import Expectation, MutualInfo, Probability, Sample, Variance, VnEntropy
 from pennylane.measurements.measurements import ObservableReturnTypes
 
@@ -260,7 +258,7 @@ class TestSupportedConfs:
         """Test diff_method=device raises an error for all interfaces for default.qubit"""
         msg = "does not support device with requested circuit"
 
-        with pytest.raises(QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             get_qnode(interface, "device", return_type, shots, wire_specs)
 
     @pytest.mark.parametrize(
@@ -276,12 +274,12 @@ class TestSupportedConfs:
         x = get_variable(None, wire_specs)
 
         msg = None
-        error_type = pennylane.errors.DeviceError
+        error_type = qml.DeviceError
         if diff_method == "adjoint" and (shots is not None or return_type is Sample):
-            error_type = pennylane.errors.QuantumFunctionError
+            error_type = qml.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif diff_method == "backprop" and shots:
-            error_type = pennylane.errors.QuantumFunctionError
+            error_type = qml.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif not shots and return_type is Sample:
             msg = "not accepted for analytic simulation"
@@ -331,7 +329,7 @@ class TestSupportedConfs:
 
         x = get_variable(None, wire_specs)
         qn = get_qnode(interface, "backprop", return_type, 100, wire_specs)
-        with pytest.raises(QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             qn(x)
 
     @pytest.mark.parametrize("interface", diff_interfaces)
@@ -348,7 +346,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs, complex=True)
 
         if shots is not None:
-            with pytest.raises(pennylane.errors.QuantumFunctionError):
+            with pytest.raises(qml.QuantumFunctionError):
                 compute_gradient(x, interface, circuit, return_type)
         elif return_type == ObservableReturnTypes.Probability and interface == "tf":
             with pytest.raises(Exception):
@@ -374,7 +372,7 @@ class TestSupportedConfs:
             circuit = get_qnode(interface, "adjoint", return_type, shots, wire_specs)
             x = get_variable(interface, wire_specs)
             with pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match="does not support adjoint with requested circuit",
             ):
                 compute_gradient(x, interface, circuit, return_type)
@@ -414,9 +412,7 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, "parameter-shift", return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs, complex=complex)
         if shots is not None and interface != "jax":
-            with pytest.raises(
-                pennylane.errors.DeviceError, match="not accepted with finite shots"
-            ):
+            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
                 compute_gradient(x, interface, circuit, return_type, complex=complex)
         else:
             if interface == "torch" and return_type == "StateVector":
@@ -440,9 +436,7 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, diff_method, return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs)
         if shots is not None and return_type in (VnEntropy, MutualInfo):
-            with pytest.raises(
-                pennylane.errors.DeviceError, match="not accepted with finite shots"
-            ):
+            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
                 compute_gradient(x, interface, circuit, return_type)
         else:
             compute_gradient(x, interface, circuit, return_type)
@@ -482,10 +476,10 @@ class TestSupportedConfs:
         """Test sample measurement fails for all interfaces and diff_methods
         when shots=None"""
         if diff_method in {"adjoint"}:
-            error_type = pennylane.errors.QuantumFunctionError
+            error_type = qml.QuantumFunctionError
             msg = "does not support adjoint with requested circuit"
         else:
-            error_type = pennylane.errors.DeviceError
+            error_type = qml.DeviceError
             msg = "not accepted for analytic simulation"
 
         with pytest.raises(error_type, match=msg):
@@ -546,7 +540,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs)
         if return_type in (VnEntropy, MutualInfo):
             if shots and interface != "jax":
-                err_cls = pennylane.errors.DeviceError
+                err_cls = qml.DeviceError
                 msg = "not accepted with finite shots"
             else:
                 err_cls = ValueError

--- a/tests/docs/test_supported_confs.py
+++ b/tests/docs/test_supported_confs.py
@@ -27,6 +27,7 @@ QNode without an exception being raised."""
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.measurements import Expectation, MutualInfo, Probability, Sample, Variance, VnEntropy
 from pennylane.measurements.measurements import ObservableReturnTypes
@@ -258,7 +259,7 @@ class TestSupportedConfs:
         """Test diff_method=device raises an error for all interfaces for default.qubit"""
         msg = "does not support device with requested circuit"
 
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             get_qnode(interface, "device", return_type, shots, wire_specs)
 
     @pytest.mark.parametrize(
@@ -274,12 +275,12 @@ class TestSupportedConfs:
         x = get_variable(None, wire_specs)
 
         msg = None
-        error_type = qml.DeviceError
+        error_type = pennylane.errors.DeviceError
         if diff_method == "adjoint" and (shots is not None or return_type is Sample):
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif diff_method == "backprop" and shots:
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = f"does not support {diff_method} with requested circuit"
         elif not shots and return_type is Sample:
             msg = "not accepted for analytic simulation"
@@ -329,7 +330,7 @@ class TestSupportedConfs:
 
         x = get_variable(None, wire_specs)
         qn = get_qnode(interface, "backprop", return_type, 100, wire_specs)
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             qn(x)
 
     @pytest.mark.parametrize("interface", diff_interfaces)
@@ -346,7 +347,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs, complex=True)
 
         if shots is not None:
-            with pytest.raises(qml.QuantumFunctionError):
+            with pytest.raises(pennylane.errors.QuantumFunctionError):
                 compute_gradient(x, interface, circuit, return_type)
         elif return_type == ObservableReturnTypes.Probability and interface == "tf":
             with pytest.raises(Exception):
@@ -372,7 +373,7 @@ class TestSupportedConfs:
             circuit = get_qnode(interface, "adjoint", return_type, shots, wire_specs)
             x = get_variable(interface, wire_specs)
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="does not support adjoint with requested circuit",
             ):
                 compute_gradient(x, interface, circuit, return_type)
@@ -412,7 +413,9 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, "parameter-shift", return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs, complex=complex)
         if shots is not None and interface != "jax":
-            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="not accepted with finite shots"
+            ):
                 compute_gradient(x, interface, circuit, return_type, complex=complex)
         else:
             if interface == "torch" and return_type == "StateVector":
@@ -436,7 +439,9 @@ class TestSupportedConfs:
         circuit = get_qnode(interface, diff_method, return_type, shots, wire_specs)
         x = get_variable(interface, wire_specs)
         if shots is not None and return_type in (VnEntropy, MutualInfo):
-            with pytest.raises(qml.DeviceError, match="not accepted with finite shots"):
+            with pytest.raises(
+                pennylane.errors.DeviceError, match="not accepted with finite shots"
+            ):
                 compute_gradient(x, interface, circuit, return_type)
         else:
             compute_gradient(x, interface, circuit, return_type)
@@ -476,10 +481,10 @@ class TestSupportedConfs:
         """Test sample measurement fails for all interfaces and diff_methods
         when shots=None"""
         if diff_method in {"adjoint"}:
-            error_type = qml.QuantumFunctionError
+            error_type = pennylane.errors.QuantumFunctionError
             msg = "does not support adjoint with requested circuit"
         else:
-            error_type = qml.DeviceError
+            error_type = pennylane.errors.DeviceError
             msg = "not accepted for analytic simulation"
 
         with pytest.raises(error_type, match=msg):
@@ -540,7 +545,7 @@ class TestSupportedConfs:
         x = get_variable(interface, wire_specs)
         if return_type in (VnEntropy, MutualInfo):
             if shots and interface != "jax":
-                err_cls = qml.DeviceError
+                err_cls = pennylane.errors.DeviceError
                 msg = "not accepted with finite shots"
             else:
                 err_cls = ValueError

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices.qubit import measure as apply_qubit_measurement
 from pennylane.ftqc import (
     ParametricMidMeasureMP,
@@ -459,7 +458,7 @@ class TestMeasureFunctions:
         """Test that a QuanutmFunctionError is raised if too many wires are passed"""
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only a single qubit can be measured in the middle of the circuit",
         ):
             func([0, 1])

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices.qubit import measure as apply_qubit_measurement
 from pennylane.ftqc import (
     ParametricMidMeasureMP,
@@ -458,7 +459,7 @@ class TestMeasureFunctions:
         """Test that a QuanutmFunctionError is raised if too many wires are passed"""
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only a single qubit can be measured in the middle of the circuit",
         ):
             func([0, 1])

--- a/tests/gradients/core/test_adjoint_diff.py
+++ b/tests/gradients/core/test_adjoint_diff.py
@@ -18,7 +18,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -39,9 +38,7 @@ class TestAdjointJacobian:
             qml.var(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Adjoint differentiation method does"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Adjoint differentiation method does"):
             dev.adjoint_jacobian(tape)
 
     def test_finite_shots_warns(self):
@@ -85,9 +82,7 @@ class TestAdjointJacobian:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="The CRot operation is not"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="The CRot operation is not"):
             dev.adjoint_jacobian(tape)
 
     def test_trainable_hermitian_warns(self):

--- a/tests/gradients/core/test_adjoint_diff.py
+++ b/tests/gradients/core/test_adjoint_diff.py
@@ -18,6 +18,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -38,7 +39,9 @@ class TestAdjointJacobian:
             qml.var(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(qml.QuantumFunctionError, match="Adjoint differentiation method does"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Adjoint differentiation method does"
+        ):
             dev.adjoint_jacobian(tape)
 
     def test_finite_shots_warns(self):
@@ -82,7 +85,9 @@ class TestAdjointJacobian:
             qml.expval(qml.PauliZ(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(qml.QuantumFunctionError, match="The CRot operation is not"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="The CRot operation is not"
+        ):
             dev.adjoint_jacobian(tape)
 
     def test_trainable_hermitian_warns(self):

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -18,6 +18,7 @@ Tests for the gradients.hadamard_gradient module.
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -829,7 +830,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.torch
@@ -845,7 +846,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.tf
@@ -861,7 +862,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.jax
@@ -877,7 +878,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     def test_no_trainable_params_tape(self):
@@ -1220,7 +1221,7 @@ class TestJaxArgnums:
         y = jax.numpy.array(-0.654)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.gradients.hadamard_grad(circuit, argnum=argnums)(x, y)

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -18,7 +18,6 @@ Tests for the gradients.hadamard_gradient module.
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 
@@ -830,7 +829,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.torch
@@ -846,7 +845,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.tf
@@ -862,7 +861,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     @pytest.mark.jax
@@ -878,7 +877,7 @@ class TestHadamardGradEdgeCases:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.hadamard_grad(circuit)(weights)
 
     def test_no_trainable_params_tape(self):
@@ -1221,7 +1220,7 @@ class TestJaxArgnums:
         y = jax.numpy.array(-0.654)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.gradients.hadamard_grad(circuit, argnum=argnums)(x, y)

--- a/tests/gradients/core/test_hamiltonian_gradient.py
+++ b/tests/gradients/core/test_hamiltonian_gradient.py
@@ -15,13 +15,12 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.gradients.hamiltonian_grad import hamiltonian_grad
 
 
 def test_hamiltonian_grad_deprecation():
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         with qml.queuing.AnnotatedQueue() as q:
@@ -49,14 +48,14 @@ def test_behaviour():
     tape = qml.tape.QuantumScript.from_queue(q)
     tape.trainable_params = {2, 3}
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=0)
     res1 = processing_fn(dev.execute(tapes))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=1)

--- a/tests/gradients/core/test_hamiltonian_gradient.py
+++ b/tests/gradients/core/test_hamiltonian_gradient.py
@@ -15,12 +15,13 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.gradients.hamiltonian_grad import hamiltonian_grad
 
 
 def test_hamiltonian_grad_deprecation():
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         with qml.queuing.AnnotatedQueue() as q:
@@ -48,14 +49,14 @@ def test_behaviour():
     tape = qml.tape.QuantumScript.from_queue(q)
     tape.trainable_params = {2, 3}
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=0)
     res1 = processing_fn(dev.execute(tapes))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=1)

--- a/tests/gradients/core/test_hamiltonian_gradient.py
+++ b/tests/gradients/core/test_hamiltonian_gradient.py
@@ -15,12 +15,14 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.gradients.hamiltonian_grad import hamiltonian_grad
 
 
 def test_hamiltonian_grad_deprecation():
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'hamiltonian_grad' function is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning,
+        match="The 'hamiltonian_grad' function is deprecated",
     ):
         with qml.queuing.AnnotatedQueue() as q:
             qml.RY(0.3, wires=0)
@@ -47,13 +49,15 @@ def test_behaviour():
     tape = qml.tape.QuantumScript.from_queue(q)
     tape.trainable_params = {2, 3}
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'hamiltonian_grad' function is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning,
+        match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=0)
     res1 = processing_fn(dev.execute(tapes))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'hamiltonian_grad' function is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning,
+        match="The 'hamiltonian_grad' function is deprecated",
     ):
         tapes, processing_fn = hamiltonian_grad(tape, idx=1)
     res2 = processing_fn(dev.execute(tapes))

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -22,7 +22,6 @@ import pytest
 from scipy.linalg import block_diag
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients.metric_tensor import _get_aux_wire
 
@@ -683,7 +682,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.torch
@@ -701,7 +700,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.tf
@@ -719,7 +718,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.jax
@@ -737,7 +736,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     def test_no_trainable_params_tape(self):
@@ -1052,7 +1051,7 @@ class TestFullMetricTensor:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.metric_tensor(circuit, argnum=range(len(params)), approx=None)(*params)
@@ -1439,7 +1438,7 @@ def test_generator_no_expval(monkeypatch):
             qml.expval(qml.PauliX(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="is not hermitian"):
+        with pytest.raises(qml.QuantumFunctionError, match="is not hermitian"):
             qml.metric_tensor(tape, approx="block-diag")
 
 

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -22,6 +22,7 @@ import pytest
 from scipy.linalg import block_diag
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients.metric_tensor import _get_aux_wire
 
@@ -682,7 +683,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.torch
@@ -700,7 +701,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.tf
@@ -718,7 +719,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     @pytest.mark.jax
@@ -736,7 +737,7 @@ class TestMetricTensor:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.metric_tensor(circuit)(weights)
 
     def test_no_trainable_params_tape(self):
@@ -1051,7 +1052,7 @@ class TestFullMetricTensor:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.metric_tensor(circuit, argnum=range(len(params)), approx=None)(*params)
@@ -1438,7 +1439,7 @@ def test_generator_no_expval(monkeypatch):
             qml.expval(qml.PauliX(0))
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        with pytest.raises(qml.QuantumFunctionError, match="is not hermitian"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="is not hermitian"):
             qml.metric_tensor(tape, approx="block-diag")
 
 

--- a/tests/gradients/finite_diff/test_finite_difference.py
+++ b/tests/gradients/finite_diff/test_finite_difference.py
@@ -20,7 +20,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import finite_diff, finite_diff_coeffs
 from pennylane.operation import AnyWires, Observable
@@ -259,7 +258,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.torch
@@ -275,7 +274,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.tf
@@ -291,7 +290,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.jax
@@ -307,7 +306,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.parametrize("prefactor", [1.0, 2.0])

--- a/tests/gradients/finite_diff/test_finite_difference.py
+++ b/tests/gradients/finite_diff/test_finite_difference.py
@@ -20,6 +20,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import finite_diff, finite_diff_coeffs
 from pennylane.operation import AnyWires, Observable
@@ -258,7 +259,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.torch
@@ -274,7 +275,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.tf
@@ -290,7 +291,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.jax
@@ -306,7 +307,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit)(weights)
 
     @pytest.mark.parametrize("prefactor", [1.0, 2.0])

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -19,6 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import finite_diff
 from pennylane.measurements import Shots
@@ -161,7 +162,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.torch
@@ -177,7 +178,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.tf
@@ -193,7 +194,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.jax
@@ -209,7 +210,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
+++ b/tests/gradients/finite_diff/test_finite_difference_shot_vec.py
@@ -19,7 +19,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import finite_diff
 from pennylane.measurements import Shots
@@ -162,7 +161,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.torch
@@ -178,7 +177,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.tf
@@ -194,7 +193,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     @pytest.mark.jax
@@ -210,7 +209,7 @@ class TestFiniteDiff:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.finite_diff(circuit, h=h_val)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/gradients/finite_diff/test_spsa_gradient.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient.py
@@ -19,6 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.gradients import spsa_grad
 from pennylane.gradients.spsa_gradient import _rademacher_sampler
@@ -322,7 +323,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.torch
@@ -338,7 +339,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.tf
@@ -354,7 +355,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.jax
@@ -370,7 +371,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/gradients/finite_diff/test_spsa_gradient.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient.py
@@ -19,7 +19,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.gradients import spsa_grad
 from pennylane.gradients.spsa_gradient import _rademacher_sampler
@@ -323,7 +322,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.torch
@@ -339,7 +338,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.tf
@@ -355,7 +354,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     @pytest.mark.jax
@@ -371,7 +370,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -22,7 +22,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.gradients import spsa_grad
 from pennylane.measurements import Shots
@@ -186,7 +185,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.torch
@@ -202,7 +201,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.tf
@@ -218,7 +217,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.jax
@@ -234,7 +233,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     def test_all_zero_diff_methods(self, seed):

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -22,6 +22,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.gradients import spsa_grad
 from pennylane.measurements import Shots
@@ -185,7 +186,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.torch
@@ -201,7 +202,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.tf
@@ -217,7 +218,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     @pytest.mark.jax
@@ -233,7 +234,7 @@ class TestSpsaGradient:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             spsa_grad(circuit, h=h_val)(weights)
 
     def test_all_zero_diff_methods(self, seed):

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -18,6 +18,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import (
@@ -3509,7 +3510,7 @@ class TestHamiltonianExpvalGradients:
         dev = qml.device("default.qubit", wires=2)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'hamiltonian_grad' function is deprecated",
         ):
             with pytest.warns(UserWarning, match="Please use qml.gradients.split_to_single_terms"):
@@ -4588,7 +4589,7 @@ class TestJaxArgnums:
         y = jax.numpy.array(-0.654)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.gradients.param_shift(circuit, argnum=argnums)(x, y)

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -18,7 +18,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import (
@@ -3510,7 +3509,7 @@ class TestHamiltonianExpvalGradients:
         dev = qml.device("default.qubit", wires=2)
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'hamiltonian_grad' function is deprecated",
         ):
             with pytest.warns(UserWarning, match="Please use qml.gradients.split_to_single_terms"):
@@ -4589,7 +4588,7 @@ class TestJaxArgnums:
         y = jax.numpy.array(-0.654)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.gradients.param_shift(circuit, argnum=argnums)(x, y)

--- a/tests/gradients/parameter_shift/test_parameter_shift.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift.py
@@ -18,6 +18,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import param_shift
 from pennylane.gradients.parameter_shift import (
@@ -3509,7 +3510,8 @@ class TestHamiltonianExpvalGradients:
         dev = qml.device("default.qubit", wires=2)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'hamiltonian_grad' function is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'hamiltonian_grad' function is deprecated",
         ):
             with pytest.warns(UserWarning, match="Please use qml.gradients.split_to_single_terms"):
                 self.cost_fn(weights, coeffs1, coeffs2, dev, broadcast)
@@ -4587,7 +4589,7 @@ class TestJaxArgnums:
         y = jax.numpy.array(-0.654)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="argnum does not work with the Jax interface. You should use argnums instead.",
         ):
             qml.gradients.param_shift(circuit, argnum=argnums)(x, y)

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -19,7 +19,6 @@ from unittest import mock
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import param_shift_cv
 from pennylane.gradients.gradient_transform import choose_trainable_param_indices
@@ -301,7 +300,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.torch
@@ -318,7 +317,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.tf
@@ -335,7 +334,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.jax
@@ -352,7 +351,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     def test_no_trainable_params_tape(self):

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -19,6 +19,7 @@ from unittest import mock
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients import param_shift_cv
 from pennylane.gradients.gradient_transform import choose_trainable_param_indices
@@ -300,7 +301,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.torch
@@ -317,7 +318,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.tf
@@ -334,7 +335,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     @pytest.mark.jax
@@ -351,7 +352,7 @@ class TestParameterShiftLogic:
             return qml.expval(qml.QuadX(0))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_cv(circuit, dev)(weights)
 
     def test_no_trainable_params_tape(self):

--- a/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
@@ -18,6 +18,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients.parameter_shift_hessian import (
     _collect_recipes,
@@ -1437,7 +1438,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.torch
@@ -1454,7 +1455,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.tf
@@ -1471,7 +1472,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.jax
@@ -1488,7 +1489,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_hessian.py
@@ -18,7 +18,6 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.gradients.parameter_shift_hessian import (
     _collect_recipes,
@@ -1438,7 +1437,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.torch
@@ -1455,7 +1454,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.tf
@@ -1472,7 +1471,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     @pytest.mark.jax
@@ -1489,7 +1488,7 @@ class TestParameterShiftHessianQNode:
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
         weights = [0.1, 0.2]
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters."):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters."):
             qml.gradients.param_shift_hessian(circuit)(weights)
 
     def test_all_zero_diff_methods(self):

--- a/tests/math/test_entropies_math.py
+++ b/tests/math/test_entropies_math.py
@@ -16,7 +16,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -255,7 +254,7 @@ class TestRelativeEntropy:
         """Test that an error is raised when the dimensions do not match"""
         msg = "The two states must have the same number of wires"
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             qml.math.relative_entropy(state0, state1)
 
 

--- a/tests/math/test_entropies_math.py
+++ b/tests/math/test_entropies_math.py
@@ -16,6 +16,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -254,7 +255,7 @@ class TestRelativeEntropy:
         """Test that an error is raised when the dimensions do not match"""
         msg = "The two states must have the same number of wires"
 
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             qml.math.relative_entropy(state0, state1)
 
 

--- a/tests/math/test_expectation_value.py
+++ b/tests/math/test_expectation_value.py
@@ -17,7 +17,6 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -136,7 +135,7 @@ class TestExpectationValueMath:
         ops = np.diag([0, 1, 0, 0])
         state_vectors = [1, 0]
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The operator and the state vector must have the same number of wires.",
         ):
             qml.math.expectation_value(ops, state_vectors, check_state=True, check_operator=True)

--- a/tests/math/test_expectation_value.py
+++ b/tests/math/test_expectation_value.py
@@ -17,6 +17,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -135,7 +136,7 @@ class TestExpectationValueMath:
         ops = np.diag([0, 1, 0, 0])
         state_vectors = [1, 0]
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The operator and the state vector must have the same number of wires.",
         ):
             qml.math.expectation_value(ops, state_vectors, check_state=True, check_operator=True)

--- a/tests/math/test_fidelity_math.py
+++ b/tests/math/test_fidelity_math.py
@@ -17,6 +17,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -144,7 +145,7 @@ class TestFidelityMath:
         state0 = [0, 1, 0, 0]
         state1 = [1, 0]
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.fidelity_statevector(state0, state1, check_state=True)
@@ -154,7 +155,7 @@ class TestFidelityMath:
         state0 = np.diag([0, 1, 0, 0])
         state1 = [[1, 0], [0, 0]]
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.fidelity(state0, state1, check_state=True)

--- a/tests/math/test_fidelity_math.py
+++ b/tests/math/test_fidelity_math.py
@@ -17,7 +17,6 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -145,7 +144,7 @@ class TestFidelityMath:
         state0 = [0, 1, 0, 0]
         state1 = [1, 0]
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.fidelity_statevector(state0, state1, check_state=True)
@@ -155,7 +154,7 @@ class TestFidelityMath:
         state0 = np.diag([0, 1, 0, 0])
         state1 = [[1, 0], [0, 0]]
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.fidelity(state0, state1, check_state=True)

--- a/tests/math/test_fidelity_math.py
+++ b/tests/math/test_fidelity_math.py
@@ -17,6 +17,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -144,7 +145,8 @@ class TestFidelityMath:
         state0 = [0, 1, 0, 0]
         state1 = [1, 0]
         with pytest.raises(
-            qml.QuantumFunctionError, match="The two states must have the same number of wires"
+            pennylane.errors.QuantumFunctionError,
+            match="The two states must have the same number of wires",
         ):
             qml.math.fidelity_statevector(state0, state1, check_state=True)
 
@@ -153,7 +155,8 @@ class TestFidelityMath:
         state0 = np.diag([0, 1, 0, 0])
         state1 = [[1, 0], [0, 0]]
         with pytest.raises(
-            qml.QuantumFunctionError, match="The two states must have the same number of wires"
+            pennylane.errors.QuantumFunctionError,
+            match="The two states must have the same number of wires",
         ):
             qml.math.fidelity(state0, state1, check_state=True)
 

--- a/tests/math/test_trace_distance_math.py
+++ b/tests/math/test_trace_distance_math.py
@@ -17,6 +17,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -262,12 +263,14 @@ class TestTraceDistanceMath:
         state0, state1 = states
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The two states must have the same number of wires"
+            pennylane.errors.QuantumFunctionError,
+            match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state0, state1, check_state=True)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The two states must have the same number of wires"
+            pennylane.errors.QuantumFunctionError,
+            match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state1, state0, check_state=True)
 

--- a/tests/math/test_trace_distance_math.py
+++ b/tests/math/test_trace_distance_math.py
@@ -17,7 +17,6 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -263,13 +262,13 @@ class TestTraceDistanceMath:
         state0, state1 = states
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state0, state1, check_state=True)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state1, state0, check_state=True)

--- a/tests/math/test_trace_distance_math.py
+++ b/tests/math/test_trace_distance_math.py
@@ -17,6 +17,7 @@ import numpy as onp
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 
 pytestmark = pytest.mark.all_interfaces
@@ -262,13 +263,13 @@ class TestTraceDistanceMath:
         state0, state1 = states
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state0, state1, check_state=True)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The two states must have the same number of wires",
         ):
             qml.math.trace_distance(state1, state0, check_state=True)

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -20,6 +20,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.measurements import ClassicalShadowMP
 from pennylane.measurements.classical_shadow import ShadowExpvalMP
@@ -343,7 +344,7 @@ class TestClassicalShadow:
         circuit = get_circuit(wires, None, seed)
 
         msg = "not accepted for analytic simulation on default.qubit"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             circuit()
 
     @pytest.mark.parametrize("shots", shots_list)
@@ -477,7 +478,7 @@ class TestExpvalMeasurement:
         H = qml.PauliZ(0)
 
         msg = "not accepted for analytic simulation on default.qubit"
-        with pytest.raises(qml.DeviceError, match=msg):
+        with pytest.raises(pennylane.errors.DeviceError, match=msg):
             _ = circuit(H, k=10)
 
     def test_multi_measurement_allowed(self, seed):

--- a/tests/measurements/test_classical_shadow.py
+++ b/tests/measurements/test_classical_shadow.py
@@ -20,7 +20,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.measurements import ClassicalShadowMP
 from pennylane.measurements.classical_shadow import ShadowExpvalMP
@@ -344,7 +343,7 @@ class TestClassicalShadow:
         circuit = get_circuit(wires, None, seed)
 
         msg = "not accepted for analytic simulation on default.qubit"
-        with pytest.raises(pennylane.errors.DeviceError, match=msg):
+        with pytest.raises(qml.DeviceError, match=msg):
             circuit()
 
     @pytest.mark.parametrize("shots", shots_list)
@@ -478,7 +477,7 @@ class TestExpvalMeasurement:
         H = qml.PauliZ(0)
 
         msg = "not accepted for analytic simulation on default.qubit"
-        with pytest.raises(pennylane.errors.DeviceError, match=msg):
+        with pytest.raises(qml.DeviceError, match=msg):
             _ = circuit(H, k=10)
 
     def test_multi_measurement_allowed(self, seed):

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import CountsMP
 from pennylane.wires import Wires
 
@@ -254,7 +253,7 @@ class TestProcessSamples:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0, qml.PauliZ(0)])
@@ -267,7 +266,7 @@ class TestProcessSamples:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0 + m1, m2])

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import CountsMP
 from pennylane.wires import Wires
 
@@ -253,7 +254,7 @@ class TestProcessSamples:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0, qml.PauliZ(0)])
@@ -266,7 +267,7 @@ class TestProcessSamples:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0 + m1, m2])

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -95,7 +94,7 @@ def test_none_return_type():
     `None`"""
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="MeasurementProcess property return_type is deprecated",
     ):
 
@@ -572,7 +571,7 @@ class TestSampleMeasurement:
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             circuit()
@@ -620,7 +619,7 @@ class TestStateMeasurement:
             return MyMeasurement()
 
         with pytest.raises(
-            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
+            qml.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit()
 
@@ -693,7 +692,7 @@ class TestMeasurementProcess:
     def test_deprecation_return_type(self):
         """Test that the return_type property is deprecated."""
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="MeasurementProcess property return_type is deprecated",
         ):
             _ = MeasurementProcess().return_type

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -61,7 +62,9 @@ def test_no_measure():
         qml.RX(x, wires=0)
         return qml.PauliY(0)
 
-    with pytest.raises(qml.QuantumFunctionError, match="must return either a single measurement"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+    ):
         _ = circuit(0.65)
 
 
@@ -71,7 +74,7 @@ def test_numeric_type_unrecognized_error():
 
     mp = NotValidMeasurement()
     with pytest.raises(
-        qml.QuantumFunctionError,
+        pennylane.errors.QuantumFunctionError,
         match="The numeric type of the measurement NotValidMeasurement is not defined",
     ):
         _ = mp.numeric_type
@@ -83,7 +86,7 @@ def test_shape_unrecognized_error():
     dev = qml.device("default.qubit", wires=2)
     mp = NotValidMeasurement()
     with pytest.raises(
-        qml.QuantumFunctionError,
+        pennylane.errors.QuantumFunctionError,
         match="The shape of the measurement NotValidMeasurement is not defined",
     ):
         mp.shape(dev, Shots(None))
@@ -94,7 +97,7 @@ def test_none_return_type():
     `None`"""
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="MeasurementProcess property return_type is deprecated",
     ):
 
@@ -571,7 +574,7 @@ class TestSampleMeasurement:
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             circuit()
@@ -619,7 +622,7 @@ class TestStateMeasurement:
             return MyMeasurement()
 
         with pytest.raises(
-            qml.DeviceError, match="not accepted with finite shots on default.qubit"
+            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit()
 
@@ -692,7 +695,7 @@ class TestMeasurementProcess:
     def test_deprecation_return_type(self):
         """Test that the return_type property is deprecated."""
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="MeasurementProcess property return_type is deprecated",
         ):
             _ = MeasurementProcess().return_type
@@ -715,5 +718,5 @@ class TestMeasurementProcess:
         measurement = qml.counts(wires=[0, 1])
         msg = "The shape of the measurement CountsMP is not defined"
 
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             measurement.shape(shots=None, num_device_wires=2)

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -94,7 +95,7 @@ def test_none_return_type():
     `None`"""
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="MeasurementProcess property return_type is deprecated",
     ):
 
@@ -571,7 +572,7 @@ class TestSampleMeasurement:
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
 
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             circuit()
@@ -619,7 +620,7 @@ class TestStateMeasurement:
             return MyMeasurement()
 
         with pytest.raises(
-            qml.DeviceError, match="not accepted with finite shots on default.qubit"
+            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit()
 
@@ -692,7 +693,7 @@ class TestMeasurementProcess:
     def test_deprecation_return_type(self):
         """Test that the return_type property is deprecated."""
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="MeasurementProcess property return_type is deprecated",
         ):
             _ = MeasurementProcess().return_type

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -18,6 +18,7 @@ from itertools import product
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.measurements import MeasurementValue, MidMeasureMP
 from pennylane.wires import Wires
@@ -38,7 +39,7 @@ class TestMeasure:
         """Test that an error is raised if multiple wires are passed to
         measure."""
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only a single qubit can be measured in the middle of the circuit",
         ):
             qml.measure(wires=[0, 1])

--- a/tests/measurements/test_mid_measure.py
+++ b/tests/measurements/test_mid_measure.py
@@ -18,7 +18,6 @@ from itertools import product
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as np
 from pennylane.measurements import MeasurementValue, MidMeasureMP
 from pennylane.wires import Wires
@@ -39,7 +38,7 @@ class TestMeasure:
         """Test that an error is raised if multiple wires are passed to
         measure."""
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only a single qubit can be measured in the middle of the circuit",
         ):
             qml.measure(wires=[0, 1])

--- a/tests/measurements/test_mutual_info.py
+++ b/tests/measurements/test_mutual_info.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements.mutual_info import MutualInfoMP
 from pennylane.wires import Wires
 
@@ -85,7 +86,7 @@ class TestMutualInfoUnitTests:
         wires = qml.wires.Wires(range(2))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Subsystems for computing mutual information must not overlap.",
         ):
             qml.mutual_info(wires0=[0], wires1=[0, 1]).process_density_matrix(dm, wires)
@@ -169,7 +170,7 @@ class TestIntegration:
             return qml.mutual_info(wires0=[0], wires1=[1])
 
         with pytest.raises(
-            qml.DeviceError, match="not accepted with finite shots on default.qubit"
+            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit(0.5)
 
@@ -484,7 +485,7 @@ class TestIntegration:
             return qml.mutual_info(wires0=[0, 1], wires1=[1, 2])
 
         msg = "Subsystems for computing mutual information must not overlap"
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             circuit(params)
 
     @pytest.mark.all_interfaces

--- a/tests/measurements/test_mutual_info.py
+++ b/tests/measurements/test_mutual_info.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements.mutual_info import MutualInfoMP
 from pennylane.wires import Wires
 
@@ -86,7 +85,7 @@ class TestMutualInfoUnitTests:
         wires = qml.wires.Wires(range(2))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Subsystems for computing mutual information must not overlap.",
         ):
             qml.mutual_info(wires0=[0], wires1=[0, 1]).process_density_matrix(dm, wires)
@@ -170,7 +169,7 @@ class TestIntegration:
             return qml.mutual_info(wires0=[0], wires1=[1])
 
         with pytest.raises(
-            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
+            qml.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit(0.5)
 
@@ -485,7 +484,7 @@ class TestIntegration:
             return qml.mutual_info(wires0=[0, 1], wires1=[1, 2])
 
         msg = "Subsystems for computing mutual information must not overlap"
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             circuit(params)
 
     @pytest.mark.all_interfaces

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.measurements import MeasurementProcess, ProbabilityMP
 from pennylane.queuing import AnnotatedQueue
@@ -459,7 +460,7 @@ class TestProbs:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0, qml.PauliZ(0)])
@@ -472,7 +473,7 @@ class TestProbs:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0 + m1, m2])
@@ -777,7 +778,7 @@ class TestProbs:
             return qml.probs(op=H)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Hamiltonians are not supported for rotating probabilities.",
         ):
             circuit()
@@ -798,7 +799,7 @@ class TestProbs:
             return qml.probs(op=operation(0.56, wires=[0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not define diagonalizing gates : cannot be used to rotate the probability",
         ):
             circuit()
@@ -815,7 +816,7 @@ class TestProbs:
             return qml.probs(op=qml.Hermitian(hermitian, wires=0), wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Cannot specify the wires to probs if an observable is "
             "provided. The wires for probs will be determined directly from the observable.",
         ):

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.measurements import MeasurementProcess, ProbabilityMP
 from pennylane.queuing import AnnotatedQueue
@@ -460,7 +459,7 @@ class TestProbs:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0, qml.PauliZ(0)])
@@ -473,7 +472,7 @@ class TestProbs:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0 + m1, m2])
@@ -778,7 +777,7 @@ class TestProbs:
             return qml.probs(op=H)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Hamiltonians are not supported for rotating probabilities.",
         ):
             circuit()
@@ -799,7 +798,7 @@ class TestProbs:
             return qml.probs(op=operation(0.56, wires=[0, 1]))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not define diagonalizing gates : cannot be used to rotate the probability",
         ):
             circuit()
@@ -816,7 +815,7 @@ class TestProbs:
             return qml.probs(op=qml.Hermitian(hermitian, wires=0), wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Cannot specify the wires to probs if an observable is "
             "provided. The wires for probs will be determined directly from the observable.",
         ):

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementShapeError
 from pennylane.operation import EigvalsUndefinedError, Operator
 
@@ -195,7 +196,7 @@ class TestSample:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.sample(op=[m0, qml.PauliZ(0)])
@@ -208,7 +209,7 @@ class TestSample:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.sample(op=[m0 + m1, m2])

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -16,7 +16,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import MeasurementShapeError
 from pennylane.operation import EigvalsUndefinedError, Operator
 
@@ -196,7 +195,7 @@ class TestSample:
         m0 = qml.measure(0)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.sample(op=[m0, qml.PauliZ(0)])
@@ -209,7 +208,7 @@ class TestSample:
         m2 = qml.measure(2)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Only sequences of single MeasurementValues can be passed with the op argument",
         ):
             _ = qml.sample(op=[m0 + m1, m2])

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -18,6 +18,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.math.matrix_manipulation import _permute_dense_matrix
 from pennylane.math.quantum import reduce_dm, reduce_statevector
@@ -378,7 +379,9 @@ class TestState:
 
         with monkeypatch.context() as m:
             m.setattr(DefaultQubitLegacy, "capabilities", lambda *args, **kwargs: capabilities)
-            with pytest.raises(qml.QuantumFunctionError, match="The current device is not capable"):
+            with pytest.raises(
+                pennylane.errors.QuantumFunctionError, match="The current device is not capable"
+            ):
                 func()
 
     def test_state_not_supported(self):
@@ -390,7 +393,9 @@ class TestState:
         def func():
             return state()
 
-        with pytest.raises(qml.QuantumFunctionError, match="Returning the state is not supported"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Returning the state is not supported"
+        ):
             func()
 
     @pytest.mark.parametrize("diff_method", ["best", "finite-diff", "parameter-shift"])
@@ -1007,7 +1012,9 @@ class TestDensityMatrix:
             qml.Hadamard(wires=0)
             return density_matrix(0), expval(qml.PauliZ(1))
 
-        with pytest.raises(qml.QuantumFunctionError, match="cannot be returned in combination"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="cannot be returned in combination"
+        ):
             func()
 
     def test_no_state_capability(self, monkeypatch):
@@ -1024,7 +1031,7 @@ class TestDensityMatrix:
         with monkeypatch.context() as m:
             m.setattr(DefaultQubitLegacy, "capabilities", lambda *args, **kwargs: capabilities)
             with pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match="The current device is not capable" " of returning the state",
             ):
                 func()
@@ -1038,7 +1045,9 @@ class TestDensityMatrix:
         def func():
             return density_matrix(0)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Returning the state is not supported"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Returning the state is not supported"
+        ):
             func()
 
     @pytest.mark.parametrize("wires", [[0, 2], ["a", -1]])

--- a/tests/measurements/test_state.py
+++ b/tests/measurements/test_state.py
@@ -18,7 +18,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as pnp
 from pennylane.math.matrix_manipulation import _permute_dense_matrix
 from pennylane.math.quantum import reduce_dm, reduce_statevector
@@ -379,9 +378,7 @@ class TestState:
 
         with monkeypatch.context() as m:
             m.setattr(DefaultQubitLegacy, "capabilities", lambda *args, **kwargs: capabilities)
-            with pytest.raises(
-                pennylane.errors.QuantumFunctionError, match="The current device is not capable"
-            ):
+            with pytest.raises(qml.QuantumFunctionError, match="The current device is not capable"):
                 func()
 
     def test_state_not_supported(self):
@@ -393,9 +390,7 @@ class TestState:
         def func():
             return state()
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Returning the state is not supported"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Returning the state is not supported"):
             func()
 
     @pytest.mark.parametrize("diff_method", ["best", "finite-diff", "parameter-shift"])
@@ -1012,9 +1007,7 @@ class TestDensityMatrix:
             qml.Hadamard(wires=0)
             return density_matrix(0), expval(qml.PauliZ(1))
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="cannot be returned in combination"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="cannot be returned in combination"):
             func()
 
     def test_no_state_capability(self, monkeypatch):
@@ -1031,7 +1024,7 @@ class TestDensityMatrix:
         with monkeypatch.context() as m:
             m.setattr(DefaultQubitLegacy, "capabilities", lambda *args, **kwargs: capabilities)
             with pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match="The current device is not capable" " of returning the state",
             ):
                 func()
@@ -1045,9 +1038,7 @@ class TestDensityMatrix:
         def func():
             return density_matrix(0)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Returning the state is not supported"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Returning the state is not supported"):
             func()
 
     @pytest.mark.parametrize("wires", [[0, 2], ["a", -1]])

--- a/tests/measurements/test_vn_entropy.py
+++ b/tests/measurements/test_vn_entropy.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements.vn_entropy import VnEntropyMP
 from pennylane.wires import Wires
 
@@ -188,7 +187,7 @@ class TestIntegration:
             return qml.vn_entropy(wires=[0])
 
         with pytest.raises(
-            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
+            qml.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit(0.5)
 

--- a/tests/measurements/test_vn_entropy.py
+++ b/tests/measurements/test_vn_entropy.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements.vn_entropy import VnEntropyMP
 from pennylane.wires import Wires
 
@@ -187,7 +188,7 @@ class TestIntegration:
             return qml.vn_entropy(wires=[0])
 
         with pytest.raises(
-            qml.DeviceError, match="not accepted with finite shots on default.qubit"
+            pennylane.errors.DeviceError, match="not accepted with finite shots on default.qubit"
         ):
             circuit(0.5)
 

--- a/tests/ops/functions/test_generator.py
+++ b/tests/ops/functions/test_generator.py
@@ -22,7 +22,6 @@ import pytest
 from scipy import sparse
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.ops import Prod, SProd, Sum
 
@@ -170,7 +169,7 @@ class TestValidation:
 
         op = SomeOp(0.5, wires=0)
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="is not hermitian"):
+        with pytest.raises(qml.QuantumFunctionError, match="is not hermitian"):
             qml.generator(op)
 
     def test_multi_param_op(self):

--- a/tests/ops/functions/test_generator.py
+++ b/tests/ops/functions/test_generator.py
@@ -22,6 +22,7 @@ import pytest
 from scipy import sparse
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.ops import Prod, SProd, Sum
 
@@ -169,7 +170,7 @@ class TestValidation:
 
         op = SomeOp(0.5, wires=0)
 
-        with pytest.raises(qml.QuantumFunctionError, match="is not hermitian"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="is not hermitian"):
             qml.generator(op)
 
     def test_multi_param_op(self):

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -18,6 +18,7 @@ Unittests for is_commuting
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.ops.functions.is_commuting import _check_mat_commutation, _get_target_name
 
@@ -826,7 +827,7 @@ class TestCommutingFunction:
     )
     def test_non_pauli_word_ops_not_supported(self, pauli_word_1, pauli_word_2):
         """Ensure invalid inputs are handled properly when determining commutativity."""
-        with pytest.raises(qml.QuantumFunctionError):
+        with pytest.raises(pennylane.errors.QuantumFunctionError):
             qml.is_commuting(pauli_word_1, pauli_word_2)
 
     def test_operation_1_not_supported(self):
@@ -834,14 +835,17 @@ class TestCommutingFunction:
         rho = np.zeros((2**1, 2**1), dtype=np.complex128)
         rho[0, 0] = 1
         with pytest.raises(
-            qml.QuantumFunctionError, match="Operation QubitDensityMatrix not supported."
+            pennylane.errors.QuantumFunctionError,
+            match="Operation QubitDensityMatrix not supported.",
         ):
             qml.is_commuting(qml.QubitDensityMatrix(rho, wires=[0]), qml.PauliX(wires=0))
 
     def test_operation_2_not_supported(self):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(qml.QuantumFunctionError, match="Operation PauliRot not supported."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Operation PauliRot not supported."
+        ):
             qml.is_commuting(qml.PauliX(wires=0), qml.PauliRot(1, "X", wires=0))
 
     @pytest.mark.parametrize(
@@ -853,7 +857,9 @@ class TestCommutingFunction:
     def test_composite_arithmetic_ops_not_supported(self, op, name):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(qml.QuantumFunctionError, match=f"Operation {name} not supported."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match=f"Operation {name} not supported."
+        ):
             qml.is_commuting(qml.PauliX(wires=0), op)
 
     def test_non_commuting(self):

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -18,6 +18,7 @@ Unittests for is_commuting
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.ops.functions.is_commuting import _check_mat_commutation, _get_target_name
 
@@ -826,7 +827,7 @@ class TestCommutingFunction:
     )
     def test_non_pauli_word_ops_not_supported(self, pauli_word_1, pauli_word_2):
         """Ensure invalid inputs are handled properly when determining commutativity."""
-        with pytest.raises(qml.QuantumFunctionError):
+        with pytest.raises(pennylane.errors.QuantumFunctionError):
             qml.is_commuting(pauli_word_1, pauli_word_2)
 
     def test_operation_1_not_supported(self):
@@ -834,7 +835,7 @@ class TestCommutingFunction:
         rho = np.zeros((2**1, 2**1), dtype=np.complex128)
         rho[0, 0] = 1
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Operation QubitDensityMatrix not supported.",
         ):
             qml.is_commuting(qml.QubitDensityMatrix(rho, wires=[0]), qml.PauliX(wires=0))
@@ -842,7 +843,9 @@ class TestCommutingFunction:
     def test_operation_2_not_supported(self):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(qml.QuantumFunctionError, match="Operation PauliRot not supported."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Operation PauliRot not supported."
+        ):
             qml.is_commuting(qml.PauliX(wires=0), qml.PauliRot(1, "X", wires=0))
 
     @pytest.mark.parametrize(
@@ -854,7 +857,9 @@ class TestCommutingFunction:
     def test_composite_arithmetic_ops_not_supported(self, op, name):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(qml.QuantumFunctionError, match=f"Operation {name} not supported."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match=f"Operation {name} not supported."
+        ):
             qml.is_commuting(qml.PauliX(wires=0), op)
 
     def test_non_commuting(self):

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -18,7 +18,6 @@ Unittests for is_commuting
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as np
 from pennylane.ops.functions.is_commuting import _check_mat_commutation, _get_target_name
 
@@ -827,7 +826,7 @@ class TestCommutingFunction:
     )
     def test_non_pauli_word_ops_not_supported(self, pauli_word_1, pauli_word_2):
         """Ensure invalid inputs are handled properly when determining commutativity."""
-        with pytest.raises(pennylane.errors.QuantumFunctionError):
+        with pytest.raises(qml.QuantumFunctionError):
             qml.is_commuting(pauli_word_1, pauli_word_2)
 
     def test_operation_1_not_supported(self):
@@ -835,7 +834,7 @@ class TestCommutingFunction:
         rho = np.zeros((2**1, 2**1), dtype=np.complex128)
         rho[0, 0] = 1
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Operation QubitDensityMatrix not supported.",
         ):
             qml.is_commuting(qml.QubitDensityMatrix(rho, wires=[0]), qml.PauliX(wires=0))
@@ -843,9 +842,7 @@ class TestCommutingFunction:
     def test_operation_2_not_supported(self):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Operation PauliRot not supported."
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Operation PauliRot not supported."):
             qml.is_commuting(qml.PauliX(wires=0), qml.PauliRot(1, "X", wires=0))
 
     @pytest.mark.parametrize(
@@ -857,9 +854,7 @@ class TestCommutingFunction:
     def test_composite_arithmetic_ops_not_supported(self, op, name):
         """Test that giving a non supported operation raises an error."""
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match=f"Operation {name} not supported."
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match=f"Operation {name} not supported."):
             qml.is_commuting(qml.PauliX(wires=0), op)
 
     def test_non_commuting(self):

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -23,6 +23,7 @@ from scipy.linalg import fractional_matrix_power
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.ops.qubit.matrix_ops import QubitUnitary
 from pennylane.wires import Wires
 
@@ -85,7 +86,7 @@ class TestControlledQubitUnitary:
         base_op = QubitUnitary(base_op, wires=1)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="QubitUnitary input to ControlledQubitUnitary is deprecated",
         ):
             qml.ControlledQubitUnitary(base_op, wires=[0, 1])
@@ -98,11 +99,11 @@ class TestControlledQubitUnitary:
         base_op = QubitUnitary(base_op, wires=1)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(base_op, wires=[1], control_wires=[0])
@@ -112,11 +113,11 @@ class TestControlledQubitUnitary:
         U = np.array([[0, 1], [1, 0]])
         U = qml.QubitUnitary(U, wires=0)
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(
@@ -127,7 +128,7 @@ class TestControlledQubitUnitary:
         """Test initialization with deprecated control_wires argument"""
         U = np.array([[0, 1], [1, 0]])
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.raises(TypeError, match="Must specify a set of wires"):
@@ -137,11 +138,11 @@ class TestControlledQubitUnitary:
     def test_deprecated_interface_still_available(self, base):
         """Test that the deprecated interface is still available"""
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(base, control_wires=[1, 2, 3])
@@ -193,7 +194,7 @@ class TestControlledQubitUnitary:
     def test_initialization_from_matrix_and_operator(self):
         base_op = QubitUnitary(X, wires=1)
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="QubitUnitary input to ControlledQubitUnitary is deprecated",
         ):
             op1 = qml.ControlledQubitUnitary(X, wires=[0, 2, 1])

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -23,7 +23,6 @@ from scipy.linalg import fractional_matrix_power
 from scipy.stats import unitary_group
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.ops.qubit.matrix_ops import QubitUnitary
 from pennylane.wires import Wires
 
@@ -86,7 +85,7 @@ class TestControlledQubitUnitary:
         base_op = QubitUnitary(base_op, wires=1)
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="QubitUnitary input to ControlledQubitUnitary is deprecated",
         ):
             qml.ControlledQubitUnitary(base_op, wires=[0, 1])
@@ -99,11 +98,11 @@ class TestControlledQubitUnitary:
         base_op = QubitUnitary(base_op, wires=1)
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(base_op, wires=[1], control_wires=[0])
@@ -113,11 +112,11 @@ class TestControlledQubitUnitary:
         U = np.array([[0, 1], [1, 0]])
         U = qml.QubitUnitary(U, wires=0)
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(
@@ -128,7 +127,7 @@ class TestControlledQubitUnitary:
         """Test initialization with deprecated control_wires argument"""
         U = np.array([[0, 1], [1, 0]])
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.raises(TypeError, match="Must specify a set of wires"):
@@ -138,11 +137,11 @@ class TestControlledQubitUnitary:
     def test_deprecated_interface_still_available(self, base):
         """Test that the deprecated interface is still available"""
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The control_wires input to ControlledQubitUnitary is deprecated",
         ):
             with pytest.warns(
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
                 match="QubitUnitary input to ControlledQubitUnitary is deprecated",
             ):
                 qml.ControlledQubitUnitary(base, control_wires=[1, 2, 3])
@@ -194,7 +193,7 @@ class TestControlledQubitUnitary:
     def test_initialization_from_matrix_and_operator(self):
         base_op = QubitUnitary(X, wires=1)
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="QubitUnitary input to ControlledQubitUnitary is deprecated",
         ):
             op1 = qml.ControlledQubitUnitary(X, wires=[0, 2, 1])

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -15,6 +15,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.ops.op_math import Evolution, Exp
 
@@ -204,7 +205,7 @@ class TestEvolution:
         op = Evolution(qml.RX(np.pi / 3, 0), 1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="of operation Evolution is not hermitian"
+            pennylane.errors.QuantumFunctionError, match="of operation Evolution is not hermitian"
         ):
             qml.generator(op)
 

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -15,7 +15,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.ops.op_math import Evolution, Exp
 
@@ -205,7 +204,7 @@ class TestEvolution:
         op = Evolution(qml.RX(np.pi / 3, 0), 1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="of operation Evolution is not hermitian"
+            qml.QuantumFunctionError, match="of operation Evolution is not hermitian"
         ):
             qml.generator(op)
 

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -24,6 +24,7 @@ import pytest
 import scipy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import X, Y, Z
 from pennylane import numpy as pnp
 from pennylane.ops import LinearCombination
@@ -1988,7 +1989,7 @@ class TestLinearCombinationDifferentiation:
 
         grad_fn = qml.grad(circuit)
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="not supported on adjoint",
         ):
             grad_fn(coeffs, param)

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -24,7 +24,6 @@ import pytest
 import scipy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import X, Y, Z
 from pennylane import numpy as pnp
 from pennylane.ops import LinearCombination
@@ -1989,7 +1988,7 @@ class TestLinearCombinationDifferentiation:
 
         grad_fn = qml.grad(circuit)
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="not supported on adjoint",
         ):
             grad_fn(coeffs, param)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as qnp
 from pennylane import math
 from pennylane.operation import AnyWires, MatrixUndefinedError, Operator
@@ -93,14 +94,18 @@ ops_hermitian_status = (  # computed manually
 def test_legacy_ops():
     """Test that PennyLaneDepcreationWarning is raised when Prod.ops is called"""
     H = qml.prod(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.ops is deprecated and"):
+    with pytest.warns(
+        pennylane.errors.PennyLaneDeprecationWarning, match="Prod.ops is deprecated and"
+    ):
         _ = H.ops
 
 
 def test_legacy_coeffs():
     """Test that PennyLaneDepcreationWarning is raised when Prod.coeffs is called"""
     H = qml.prod(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"):
+    with pytest.warns(
+        pennylane.errors.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"
+    ):
         _ = H.coeffs
 
 
@@ -108,7 +113,7 @@ def test_obs_attribute():
     """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
     op = qml.prod(X(0), X(1), X(2))
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="Accessing the terms of a tensor product operator via op.obs is deprecated",
     ):
         obs = op.obs
@@ -1485,7 +1490,7 @@ class TestIntegration:
             qml.PauliX(0)
             return qml.expval(prod_op)
 
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             my_circ()
 
     def test_operation_integration(self):

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as qnp
 from pennylane import math
 from pennylane.operation import AnyWires, MatrixUndefinedError, Operator
@@ -94,18 +93,14 @@ ops_hermitian_status = (  # computed manually
 def test_legacy_ops():
     """Test that PennyLaneDepcreationWarning is raised when Prod.ops is called"""
     H = qml.prod(X(0), X(1))
-    with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="Prod.ops is deprecated and"
-    ):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.ops is deprecated and"):
         _ = H.ops
 
 
 def test_legacy_coeffs():
     """Test that PennyLaneDepcreationWarning is raised when Prod.coeffs is called"""
     H = qml.prod(X(0), X(1))
-    with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"
-    ):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"):
         _ = H.coeffs
 
 
@@ -113,7 +108,7 @@ def test_obs_attribute():
     """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
     op = qml.prod(X(0), X(1), X(2))
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="Accessing the terms of a tensor product operator via op.obs is deprecated",
     ):
         obs = op.obs
@@ -1490,7 +1485,7 @@ class TestIntegration:
             qml.PauliX(0)
             return qml.expval(prod_op)
 
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             my_circ()
 
     def test_operation_integration(self):

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as qnp
 from pennylane import X, Y, Z, math
 from pennylane.operation import AnyWires, MatrixUndefinedError, Operator
@@ -115,14 +116,18 @@ def compare_and_expand_mat(mat1, mat2):
 def test_legacy_ops():
     """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
     H = qml.sum(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.ops is deprecated and"):
+    with pytest.warns(
+        pennylane.errors.PennyLaneDeprecationWarning, match="Sum.ops is deprecated and"
+    ):
         _ = H.ops
 
 
 def test_legacy_coeffs():
     """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
     H = qml.sum(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.coeffs is deprecated and"):
+    with pytest.warns(
+        pennylane.errors.PennyLaneDeprecationWarning, match="Sum.coeffs is deprecated and"
+    ):
         _ = H.coeffs
 
 

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -22,7 +22,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as qnp
 from pennylane import X, Y, Z, math
 from pennylane.operation import AnyWires, MatrixUndefinedError, Operator
@@ -116,18 +115,14 @@ def compare_and_expand_mat(mat1, mat2):
 def test_legacy_ops():
     """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
     H = qml.sum(X(0), X(1))
-    with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="Sum.ops is deprecated and"
-    ):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.ops is deprecated and"):
         _ = H.ops
 
 
 def test_legacy_coeffs():
     """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
     H = qml.sum(X(0), X(1))
-    with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="Sum.coeffs is deprecated and"
-    ):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.coeffs is deprecated and"):
         _ = H.coeffs
 
 

--- a/tests/ops/qubit/test_sparse.py
+++ b/tests/ops/qubit/test_sparse.py
@@ -19,7 +19,6 @@ import pytest
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, lil_matrix
 
 import pennylane as qml
-import pennylane.errors
 
 SPARSEHAMILTONIAN_TEST_MATRIX = np.array(
     [
@@ -219,7 +218,7 @@ class TestSparse:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not support backprop with requested circuit.",
         ):
             qml.grad(circuit, argnum=0)([0.5])

--- a/tests/ops/qubit/test_sparse.py
+++ b/tests/ops/qubit/test_sparse.py
@@ -19,6 +19,7 @@ import pytest
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, lil_matrix
 
 import pennylane as qml
+import pennylane.errors
 
 SPARSEHAMILTONIAN_TEST_MATRIX = np.array(
     [
@@ -218,7 +219,7 @@ class TestSparse:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support backprop with requested circuit.",
         ):
             qml.grad(circuit, argnum=0)([0.5])

--- a/tests/pauli/dla/test_deprecations.py
+++ b/tests/pauli/dla/test_deprecations.py
@@ -17,21 +17,22 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 
 
 def test_lie_closure_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.lie_closure"""
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.lie_closure([qml.X(0)])
 
 
 def test_structure_constants_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.structure_constants"""
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.structure_constants([qml.X(0)])
 
 
 def test_center_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.center"""
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.center([qml.X(0)])

--- a/tests/pauli/dla/test_deprecations.py
+++ b/tests/pauli/dla/test_deprecations.py
@@ -17,22 +17,21 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 
 
 def test_lie_closure_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.lie_closure"""
-    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.lie_closure([qml.X(0)])
 
 
 def test_structure_constants_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.structure_constants"""
-    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.structure_constants([qml.X(0)])
 
 
 def test_center_deprecation_warning():
     """Test deprecation warning when calling qml.pauli.center"""
-    with pytest.warns(pennylane.errors.PennyLaneDeprecationWarning, match="Please call"):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Please call"):
         _ = qml.pauli.center([qml.X(0)])

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -26,7 +26,7 @@ filterwarnings =
     ignore:Casting complex values to real discards the imaginary part:UserWarning:torch.autograd
     ignore:Call to deprecated create function:DeprecationWarning
     ignore:the imp module is deprecated:DeprecationWarning
-    error::pennylane.PennyLaneDeprecationWarning
+    error::pennylane.errors.PennyLaneDeprecationWarning
     # Suppress expected AutoGraphWarnings that arise from the tests
     error:AutoGraph will not transform the function:pennylane.capture.autograph.AutoGraphWarning
 addopts = --benchmark-disable

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -21,6 +21,7 @@ import pytest
 from packaging.version import Version
 
 import pennylane as qml
+import pennylane.errors
 
 KerasLayer = qml.qnn.keras.KerasLayer
 
@@ -53,7 +54,7 @@ def model(get_circuit, n_qubits, output_dim):
     between Dense layers."""
     c, w = get_circuit
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -76,7 +77,7 @@ def model_dm(get_circuit_dm, n_qubits, output_dim):
     """The Keras NN model."""
     c, w = get_circuit_dm
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -148,7 +149,8 @@ def test_bad_tf_version(get_circuit, output_dim, monkeypatch):  # pylint: disabl
         m.setattr(qml.qnn.keras, "CORRECT_TF_VERSION", False)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(ImportError, match="KerasLayer requires TensorFlow version 2"):
                 KerasLayer(c, w, output_dim)
@@ -173,7 +175,8 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="QNode must include an argument with name"):
                 KerasLayer(circuit, weight_shapes, output_dim=1)
@@ -188,7 +191,8 @@ class TestKerasLayer:
         c, w = get_circuit
         w[qml.qnn.keras.KerasLayer._input_arg] = n_qubits  # pylint: disable=protected-access
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
                 ValueError,
@@ -203,7 +207,8 @@ class TestKerasLayer:
         c, w = get_circuit
         del w["w1"]
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
                 ValueError, match="Must specify a shape for every non-input parameter"
@@ -222,7 +227,8 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="Cannot have a variable number of positional"):
                 KerasLayer(circuit, weight_shapes, output_dim=1)
@@ -260,7 +266,8 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
         x = tf.ones((2, n_qubits))
@@ -281,7 +288,8 @@ class TestKerasLayer:
         its first element while an int is left unchanged."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim[0])
         assert layer.output_dim == output_dim[1]
@@ -292,7 +300,8 @@ class TestKerasLayer:
         with values that are tuples."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
         assert layer.weight_shapes == {
@@ -340,7 +349,8 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
         x = tf.ones((2, n_qubits))
@@ -359,7 +369,8 @@ class TestKerasLayer:
         dictionary, i.e., that each value of the dictionary has correct shape and name."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
         layer.build(input_shape=(10, n_qubits))
@@ -401,7 +412,8 @@ class TestKerasLayer:
             m.setattr(tf.keras.layers.Layer, "add_weight", add_weight_dummy)
             c, w = get_circuit
             with pytest.warns(
-                qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+                pennylane.errors.PennyLaneDeprecationWarning,
+                match="The 'KerasLayer' class is deprecated",
             ):
                 layer = KerasLayer(c, w, output_dim, weight_specs=weight_specs)
             layer.build(input_shape=(10, n_qubits))
@@ -419,7 +431,8 @@ class TestKerasLayer:
         output shape is of type tf.TensorShape"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
 
@@ -435,7 +448,8 @@ class TestKerasLayer:
         (batch_size, output_dim) with results that agree with directly calling the QNode"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
         x = tf.ones((batch_size, n_qubits))
@@ -469,7 +483,8 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_shuffled, w, output_dim)
         x = tf.ones((batch_size, n_qubits))
@@ -506,7 +521,8 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_default, w, output_dim)
         x = tf.ones((batch_size, n_qubits))
@@ -530,7 +546,8 @@ class TestKerasLayer:
         """
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
         x = tf.ones((batch_size, middle_dim, n_qubits))
@@ -549,7 +566,8 @@ class TestKerasLayer:
         """Test the __str__ and __repr__ representations"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
 
@@ -562,7 +580,8 @@ class TestKerasLayer:
         taken with respect to the trainable variables"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
         x = tf.ones((1, n_qubits))
@@ -599,7 +618,8 @@ class TestKerasLayer:
         weight_shapes = {"weights": (3, 2, 3)}
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = qml.qnn.KerasLayer(f, weight_shapes, output_dim=2)
 
@@ -619,7 +639,8 @@ class TestKerasLayer:
         """Test that the compute_output_shape method returns the expected shape"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
 
@@ -634,7 +655,8 @@ class TestKerasLayer:
         """Test that the construct method builds the correct tape with correct differentiability"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
 
@@ -663,7 +685,7 @@ def test_invalid_interface_error(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         with pytest.raises(ValueError, match="Invalid interface"):
             _ = KerasLayer(circuit, weight_shapes, output_dim=2)
@@ -685,7 +707,7 @@ def test_qnode_interface_not_mutated(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
     assert (
@@ -741,7 +763,8 @@ class TestKerasLayerIntegration:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit, output_dim)
         model = tf.keras.models.Sequential([clayer, qlayer])
@@ -752,7 +775,8 @@ class TestKerasLayerIntegration:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit, output_dim)
         new_model = tf.keras.models.Sequential([new_clayer, new_qlayer])
@@ -854,7 +878,8 @@ class TestKerasLayerIntegrationDM:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit_dm, output_dim)
         model = tf.keras.models.Sequential([clayer, qlayer])
@@ -865,7 +890,8 @@ class TestKerasLayerIntegrationDM:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+            pennylane.errors.PennyLaneDeprecationWarning,
+            match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit_dm, output_dim)
         new_model = tf.keras.models.Sequential([new_clayer, new_qlayer])
@@ -933,7 +959,7 @@ def test_batch_input_single_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(2,))
     layer.build((None, 2))
@@ -961,7 +987,7 @@ def test_batch_input_multi_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(5,))
     layer.build((None, 4))
@@ -991,7 +1017,7 @@ def test_draw():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1031,7 +1057,7 @@ def test_draw_mpl():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1069,7 +1095,7 @@ def test_specs():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1118,7 +1144,7 @@ def test_save_and_load_preserves_weights(tmpdir):
 
     weight_shapes = {"weights": (n_qubits,)}
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         quantum_layer = qml.qnn.KerasLayer(circuit, weight_shapes, output_dim=2)
 

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -21,7 +21,6 @@ import pytest
 from packaging.version import Version
 
 import pennylane as qml
-import pennylane.errors
 
 KerasLayer = qml.qnn.keras.KerasLayer
 
@@ -54,7 +53,7 @@ def model(get_circuit, n_qubits, output_dim):
     between Dense layers."""
     c, w = get_circuit
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -77,7 +76,7 @@ def model_dm(get_circuit_dm, n_qubits, output_dim):
     """The Keras NN model."""
     c, w = get_circuit_dm
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -149,7 +148,7 @@ def test_bad_tf_version(get_circuit, output_dim, monkeypatch):  # pylint: disabl
         m.setattr(qml.qnn.keras, "CORRECT_TF_VERSION", False)
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(ImportError, match="KerasLayer requires TensorFlow version 2"):
@@ -175,7 +174,7 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="QNode must include an argument with name"):
@@ -191,7 +190,7 @@ class TestKerasLayer:
         c, w = get_circuit
         w[qml.qnn.keras.KerasLayer._input_arg] = n_qubits  # pylint: disable=protected-access
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
@@ -207,7 +206,7 @@ class TestKerasLayer:
         c, w = get_circuit
         del w["w1"]
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
@@ -227,7 +226,7 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="Cannot have a variable number of positional"):
@@ -266,7 +265,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
@@ -288,7 +287,7 @@ class TestKerasLayer:
         its first element while an int is left unchanged."""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim[0])
@@ -300,7 +299,7 @@ class TestKerasLayer:
         with values that are tuples."""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -349,7 +348,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
@@ -369,7 +368,7 @@ class TestKerasLayer:
         dictionary, i.e., that each value of the dictionary has correct shape and name."""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -412,7 +411,7 @@ class TestKerasLayer:
             m.setattr(tf.keras.layers.Layer, "add_weight", add_weight_dummy)
             c, w = get_circuit
             with pytest.warns(
-                pennylane.errors.PennyLaneDeprecationWarning,
+                qml.PennyLaneDeprecationWarning,
                 match="The 'KerasLayer' class is deprecated",
             ):
                 layer = KerasLayer(c, w, output_dim, weight_specs=weight_specs)
@@ -431,7 +430,7 @@ class TestKerasLayer:
         output shape is of type tf.TensorShape"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -448,7 +447,7 @@ class TestKerasLayer:
         (batch_size, output_dim) with results that agree with directly calling the QNode"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -483,7 +482,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_shuffled, w, output_dim)
@@ -521,7 +520,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_default, w, output_dim)
@@ -546,7 +545,7 @@ class TestKerasLayer:
         """
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -566,7 +565,7 @@ class TestKerasLayer:
         """Test the __str__ and __repr__ representations"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -580,7 +579,7 @@ class TestKerasLayer:
         taken with respect to the trainable variables"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -618,7 +617,7 @@ class TestKerasLayer:
         weight_shapes = {"weights": (3, 2, 3)}
 
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = qml.qnn.KerasLayer(f, weight_shapes, output_dim=2)
@@ -639,7 +638,7 @@ class TestKerasLayer:
         """Test that the compute_output_shape method returns the expected shape"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -655,7 +654,7 @@ class TestKerasLayer:
         """Test that the construct method builds the correct tape with correct differentiability"""
         c, w = get_circuit
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -685,7 +684,7 @@ def test_invalid_interface_error(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         with pytest.raises(ValueError, match="Invalid interface"):
             _ = KerasLayer(circuit, weight_shapes, output_dim=2)
@@ -707,7 +706,7 @@ def test_qnode_interface_not_mutated(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
     assert (
@@ -763,7 +762,7 @@ class TestKerasLayerIntegration:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit, output_dim)
@@ -775,7 +774,7 @@ class TestKerasLayerIntegration:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit, output_dim)
@@ -878,7 +877,7 @@ class TestKerasLayerIntegrationDM:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit_dm, output_dim)
@@ -890,7 +889,7 @@ class TestKerasLayerIntegrationDM:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit_dm, output_dim)
@@ -959,7 +958,7 @@ def test_batch_input_single_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(2,))
     layer.build((None, 2))
@@ -987,7 +986,7 @@ def test_batch_input_multi_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(5,))
     layer.build((None, 4))
@@ -1017,7 +1016,7 @@ def test_draw():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1057,7 +1056,7 @@ def test_draw_mpl():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1095,7 +1094,7 @@ def test_specs():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1144,7 +1143,7 @@ def test_save_and_load_preserves_weights(tmpdir):
 
     weight_shapes = {"weights": (n_qubits,)}
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         quantum_layer = qml.qnn.KerasLayer(circuit, weight_shapes, output_dim=2)
 

--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -21,6 +21,7 @@ import pytest
 from packaging.version import Version
 
 import pennylane as qml
+import pennylane.errors
 
 KerasLayer = qml.qnn.keras.KerasLayer
 
@@ -53,7 +54,7 @@ def model(get_circuit, n_qubits, output_dim):
     between Dense layers."""
     c, w = get_circuit
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -76,7 +77,7 @@ def model_dm(get_circuit_dm, n_qubits, output_dim):
     """The Keras NN model."""
     c, w = get_circuit_dm
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer1 = KerasLayer(c, w, output_dim)
         layer2 = KerasLayer(c, w, output_dim)
@@ -148,7 +149,7 @@ def test_bad_tf_version(get_circuit, output_dim, monkeypatch):  # pylint: disabl
         m.setattr(qml.qnn.keras, "CORRECT_TF_VERSION", False)
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(ImportError, match="KerasLayer requires TensorFlow version 2"):
@@ -174,7 +175,7 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="QNode must include an argument with name"):
@@ -190,7 +191,7 @@ class TestKerasLayer:
         c, w = get_circuit
         w[qml.qnn.keras.KerasLayer._input_arg] = n_qubits  # pylint: disable=protected-access
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
@@ -206,7 +207,7 @@ class TestKerasLayer:
         c, w = get_circuit
         del w["w1"]
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(
@@ -226,7 +227,7 @@ class TestKerasLayer:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             with pytest.raises(TypeError, match="Cannot have a variable number of positional"):
@@ -265,7 +266,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
@@ -287,7 +288,7 @@ class TestKerasLayer:
         its first element while an int is left unchanged."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim[0])
@@ -299,7 +300,7 @@ class TestKerasLayer:
         with values that are tuples."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -348,7 +349,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim=output_dim)
@@ -368,7 +369,7 @@ class TestKerasLayer:
         dictionary, i.e., that each value of the dictionary has correct shape and name."""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -411,7 +412,7 @@ class TestKerasLayer:
             m.setattr(tf.keras.layers.Layer, "add_weight", add_weight_dummy)
             c, w = get_circuit
             with pytest.warns(
-                qml.PennyLaneDeprecationWarning,
+                pennylane.errors.PennyLaneDeprecationWarning,
                 match="The 'KerasLayer' class is deprecated",
             ):
                 layer = KerasLayer(c, w, output_dim, weight_specs=weight_specs)
@@ -430,7 +431,7 @@ class TestKerasLayer:
         output shape is of type tf.TensorShape"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -447,7 +448,7 @@ class TestKerasLayer:
         (batch_size, output_dim) with results that agree with directly calling the QNode"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -482,7 +483,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_shuffled, w, output_dim)
@@ -520,7 +521,7 @@ class TestKerasLayer:
             return [qml.expval(qml.PauliZ(i)) for i in range(output_dim)]
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c_default, w, output_dim)
@@ -545,7 +546,7 @@ class TestKerasLayer:
         """
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -565,7 +566,7 @@ class TestKerasLayer:
         """Test the __str__ and __repr__ representations"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -579,7 +580,7 @@ class TestKerasLayer:
         taken with respect to the trainable variables"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -617,7 +618,7 @@ class TestKerasLayer:
         weight_shapes = {"weights": (3, 2, 3)}
 
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = qml.qnn.KerasLayer(f, weight_shapes, output_dim=2)
@@ -638,7 +639,7 @@ class TestKerasLayer:
         """Test that the compute_output_shape method returns the expected shape"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -654,7 +655,7 @@ class TestKerasLayer:
         """Test that the construct method builds the correct tape with correct differentiability"""
         c, w = get_circuit
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             layer = KerasLayer(c, w, output_dim)
@@ -684,7 +685,7 @@ def test_invalid_interface_error(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         with pytest.raises(ValueError, match="Invalid interface"):
             _ = KerasLayer(circuit, weight_shapes, output_dim=2)
@@ -706,7 +707,7 @@ def test_qnode_interface_not_mutated(interface):
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
     assert (
@@ -762,7 +763,7 @@ class TestKerasLayerIntegration:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit, output_dim)
@@ -774,7 +775,7 @@ class TestKerasLayerIntegration:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit, output_dim)
@@ -877,7 +878,7 @@ class TestKerasLayerIntegrationDM:
         method"""
         clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             qlayer = KerasLayer(*get_circuit_dm, output_dim)
@@ -889,7 +890,7 @@ class TestKerasLayerIntegrationDM:
 
         new_clayer = tf.keras.layers.Dense(n_qubits, use_bias=False, input_shape=(n_qubits,))
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The 'KerasLayer' class is deprecated",
         ):
             new_qlayer = KerasLayer(*get_circuit_dm, output_dim)
@@ -958,7 +959,7 @@ def test_batch_input_single_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(2,))
     layer.build((None, 2))
@@ -986,7 +987,7 @@ def test_batch_input_multi_measure(tol):
 
     KerasLayer.set_input_argument("x")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         layer = KerasLayer(circuit, weight_shapes={"weights": (2,)}, output_dim=(5,))
     layer.build((None, 4))
@@ -1016,7 +1017,7 @@ def test_draw():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1056,7 +1057,7 @@ def test_draw_mpl():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1094,7 +1095,7 @@ def test_specs():
         return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1))
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         qlayer = KerasLayer(circuit, weight_shapes, output_dim=2)
 
@@ -1143,7 +1144,7 @@ def test_save_and_load_preserves_weights(tmpdir):
 
     weight_shapes = {"weights": (n_qubits,)}
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning, match="The 'KerasLayer' class is deprecated"
     ):
         quantum_layer = qml.qnn.KerasLayer(circuit, weight_shapes, output_dim=2)
 

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import CircuitGraph
 from pennylane.measurements import (
     ExpectationMP,
@@ -1065,9 +1064,7 @@ class TestExpand:
             qml.expval(qml.PauliX(0))
             ret(op=qml.PauliZ(0))
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [expval, var, probs])
@@ -1081,9 +1078,7 @@ class TestExpand:
             ret(op=qml.PauliX(0))
             qml.sample(wires=wires)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [expval, var, probs])
@@ -1097,9 +1092,7 @@ class TestExpand:
             ret(op=qml.PauliX(0))
             qml.counts(wires=wires)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [sample, counts, probs])
@@ -1120,7 +1113,7 @@ class TestExpand:
             "for each non-commuting observable."
         )
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error_msg):
+        with pytest.raises(qml.QuantumFunctionError, match=expected_error_msg):
             tape.expand(expand_measurements=True)
 
     def test_multiple_expand_no_change_original_tape(self):

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import CircuitGraph
 from pennylane.measurements import (
     ExpectationMP,
@@ -1064,7 +1065,9 @@ class TestExpand:
             qml.expval(qml.PauliX(0))
             ret(op=qml.PauliZ(0))
 
-        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
+        ):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [expval, var, probs])
@@ -1078,7 +1081,9 @@ class TestExpand:
             ret(op=qml.PauliX(0))
             qml.sample(wires=wires)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
+        ):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [expval, var, probs])
@@ -1092,7 +1097,9 @@ class TestExpand:
             ret(op=qml.PauliX(0))
             qml.counts(wires=wires)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Only observables that are qubit-wise"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Only observables that are qubit-wise"
+        ):
             tape.expand(expand_measurements=True)
 
     @pytest.mark.parametrize("ret", [sample, counts, probs])
@@ -1113,7 +1120,7 @@ class TestExpand:
             "for each non-commuting observable."
         )
 
-        with pytest.raises(qml.QuantumFunctionError, match=expected_error_msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=expected_error_msg):
             tape.expand(expand_measurements=True)
 
     def test_multiple_expand_no_change_original_tape(self):

--- a/tests/templates/test_subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/test_subroutines/test_hilbert_schmidt.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 
 # pylint: disable=expression-not-assigned
 
@@ -334,7 +335,7 @@ class TestHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -351,7 +352,8 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="U and V must have the same number of wires."
+            pennylane.errors.QuantumFunctionError,
+            match="U and V must have the same number of wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
 
@@ -365,7 +367,8 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The argument u_tape must be a QuantumTape."
+            pennylane.errors.QuantumFunctionError,
+            match="The argument u_tape must be a QuantumTape.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
 
@@ -381,7 +384,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -397,7 +400,8 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="u_tape and v_tape must act on distinct wires."
+            pennylane.errors.QuantumFunctionError,
+            match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
 
@@ -619,7 +623,7 @@ class TestLocalHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -636,7 +640,8 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="U and V must have the same number of wires."
+            pennylane.errors.QuantumFunctionError,
+            match="U and V must have the same number of wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
 
@@ -650,7 +655,8 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The argument u_tape must be a QuantumTape."
+            pennylane.errors.QuantumFunctionError,
+            match="The argument u_tape must be a QuantumTape.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
 
@@ -666,7 +672,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -682,7 +688,8 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="u_tape and v_tape must act on distinct wires."
+            pennylane.errors.QuantumFunctionError,
+            match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
 

--- a/tests/templates/test_subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/test_subroutines/test_hilbert_schmidt.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 
 # pylint: disable=expression-not-assigned
 
@@ -335,7 +334,7 @@ class TestHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -352,7 +351,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="U and V must have the same number of wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
@@ -367,7 +366,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The argument u_tape must be a QuantumTape.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
@@ -384,7 +383,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -400,7 +399,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
@@ -623,7 +622,7 @@ class TestLocalHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -640,7 +639,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="U and V must have the same number of wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
@@ -655,7 +654,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The argument u_tape must be a QuantumTape.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
@@ -672,7 +671,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -688,7 +687,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)

--- a/tests/templates/test_subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/test_subroutines/test_hilbert_schmidt.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 
 # pylint: disable=expression-not-assigned
 
@@ -334,7 +335,7 @@ class TestHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -351,7 +352,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="U and V must have the same number of wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
@@ -366,7 +367,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument u_tape must be a QuantumTape.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
@@ -383,7 +384,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -399,7 +400,7 @@ class TestHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.HilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)
@@ -622,7 +623,7 @@ class TestLocalHilbertSchmidt:
 
         v_circuit = qml.tape.QuantumScript.from_queue(q_v_circuit)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument v_function must be a callable quantum " "function.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
@@ -639,7 +640,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="U and V must have the same number of wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[2], u_tape=U)
@@ -654,7 +655,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The argument u_tape must be a QuantumTape.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=u_circuit)
@@ -671,7 +672,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=2)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
+            pennylane.errors.QuantumFunctionError, match="All wires in v_tape must be in v_wires."
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[1], u_tape=U)
 
@@ -687,7 +688,7 @@ class TestLocalHilbertSchmidt:
             qml.RZ(params[0], wires=0)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="u_tape and v_tape must act on distinct wires.",
         ):
             qml.LocalHilbertSchmidt([0.1], v_function=v_circuit, v_wires=[0], u_tape=U)

--- a/tests/templates/test_subroutines/test_qdrift.py
+++ b/tests/templates/test_subroutines/test_qdrift.py
@@ -20,7 +20,6 @@ from functools import reduce
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as qnp
 from pennylane.math import allclose, isclose
 from pennylane.templates.subroutines.qdrift import _sample_decomposition
@@ -377,7 +376,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             qml.grad(circ)(time, coeffs)
 
     @pytest.mark.torch
@@ -398,7 +397,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             res_circ = circ(time, coeffs)
             res_circ.backward()
 
@@ -423,7 +422,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             with tf.GradientTape() as tape:
                 result = circ(time, coeffs)
             tape.gradient(result, coeffs)
@@ -447,7 +446,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             jax.grad(circ, argnums=[1])(time, coeffs)
 
     @pytest.mark.autograd

--- a/tests/templates/test_subroutines/test_qdrift.py
+++ b/tests/templates/test_subroutines/test_qdrift.py
@@ -20,6 +20,7 @@ from functools import reduce
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as qnp
 from pennylane.math import allclose, isclose
 from pennylane.templates.subroutines.qdrift import _sample_decomposition
@@ -376,7 +377,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             qml.grad(circ)(time, coeffs)
 
     @pytest.mark.torch
@@ -397,7 +398,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             res_circ = circ(time, coeffs)
             res_circ.backward()
 
@@ -422,7 +423,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             with tf.GradientTape() as tape:
                 result = circ(time, coeffs)
             tape.gradient(result, coeffs)
@@ -446,7 +447,7 @@ class TestIntegration:
             return qml.expval(qml.Hadamard(0))
 
         msg = "The QDrift template currently doesn't support differentiation through the coefficients of the input Hamiltonian."
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             jax.grad(circ, argnums=[1])(time, coeffs)
 
     @pytest.mark.autograd

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -19,7 +19,6 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
-import pennylane.errors
 
 
 def test_standard_validity():
@@ -332,21 +331,21 @@ class TestDecomposition:
         unitary = unitary_group.rvs(4, random_state=1967)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Target wires must be specified if the unitary is expressed as a matrix.",
         ):
             qml.QuantumPhaseEstimation(unitary, estimation_wires=[2, 3])
 
         unitary = qml.RX(3, wires=[0])
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The unitary is expressed as an operator, which already has target wires "
             "defined, do not additionally specify target wires.",
         ):
             qml.QuantumPhaseEstimation(unitary, target_wires=[1], estimation_wires=[2, 3])
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="No estimation wires specified.",
         ):
             qml.QuantumPhaseEstimation(unitary)
@@ -433,9 +432,7 @@ class TestInputs:
         """Tests if a QuantumFunctionError is raised if target_wires and estimation_wires contain a
         common element"""
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="The target wires and estimation wires"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="The target wires and estimation wires"):
             qml.QuantumPhaseEstimation(np.eye(4), target_wires=[0, 1], estimation_wires=[1, 2])
 
     def test_id(self):

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -19,6 +19,7 @@ import pytest
 from scipy.stats import unitary_group
 
 import pennylane as qml
+import pennylane.errors
 
 
 def test_standard_validity():
@@ -331,21 +332,21 @@ class TestDecomposition:
         unitary = unitary_group.rvs(4, random_state=1967)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Target wires must be specified if the unitary is expressed as a matrix.",
         ):
             qml.QuantumPhaseEstimation(unitary, estimation_wires=[2, 3])
 
         unitary = qml.RX(3, wires=[0])
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The unitary is expressed as an operator, which already has target wires "
             "defined, do not additionally specify target wires.",
         ):
             qml.QuantumPhaseEstimation(unitary, target_wires=[1], estimation_wires=[2, 3])
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="No estimation wires specified.",
         ):
             qml.QuantumPhaseEstimation(unitary)
@@ -432,7 +433,9 @@ class TestInputs:
         """Tests if a QuantumFunctionError is raised if target_wires and estimation_wires contain a
         common element"""
 
-        with pytest.raises(qml.QuantumFunctionError, match="The target wires and estimation wires"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="The target wires and estimation wires"
+        ):
             qml.QuantumPhaseEstimation(np.eye(4), target_wires=[0, 1], estimation_wires=[1, 2])
 
     def test_id(self):

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -23,7 +23,6 @@ from flaky import flaky
 from scipy.stats import ttest_ind
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as qnp
 from pennylane.debugging import PLDB, pldb_device_manager
 from pennylane.ops.functions.equal import assert_equal
@@ -151,7 +150,7 @@ class TestSnapshotGeneral:
 
         # Expect a DeviceError to be raised here since no shots has
         # been provided to the snapshot due to the analytical device
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             qml.snapshots(circuit)()
 
     def test_non_StateMP_state_measurements_with_finite_shot_device_fails(self, dev):
@@ -163,7 +162,7 @@ class TestSnapshotGeneral:
 
         # Expect a DeviceError to be raised here since no shots has
         # been provided to the snapshot due to the finite-shot device
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             qml.snapshots(circuit)(shots=200)
 
     def test_StateMP_with_finite_shot_device_passes(self, dev):
@@ -624,12 +623,12 @@ class TestSnapshotUnsupportedQNode:
 
         with (
             pytest.raises(
-                pennylane.errors.DeviceError,
+                qml.DeviceError,
                 match=r"not accepted for analytic simulation on adjoint \+ lightning.qubit",
             )
             if diff_method == "adjoint"
             else pytest.raises(
-                pennylane.errors.QuantumFunctionError,
+                qml.QuantumFunctionError,
                 match=f"does not support {diff_method} with requested circuit",
             )
         ):

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -23,6 +23,7 @@ from flaky import flaky
 from scipy.stats import ttest_ind
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as qnp
 from pennylane.debugging import PLDB, pldb_device_manager
 from pennylane.ops.functions.equal import assert_equal
@@ -150,7 +151,7 @@ class TestSnapshotGeneral:
 
         # Expect a DeviceError to be raised here since no shots has
         # been provided to the snapshot due to the analytical device
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             qml.snapshots(circuit)()
 
     def test_non_StateMP_state_measurements_with_finite_shot_device_fails(self, dev):
@@ -162,7 +163,7 @@ class TestSnapshotGeneral:
 
         # Expect a DeviceError to be raised here since no shots has
         # been provided to the snapshot due to the finite-shot device
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             qml.snapshots(circuit)(shots=200)
 
     def test_StateMP_with_finite_shot_device_passes(self, dev):
@@ -623,12 +624,12 @@ class TestSnapshotUnsupportedQNode:
 
         with (
             pytest.raises(
-                qml.DeviceError,
+                pennylane.errors.DeviceError,
                 match=r"not accepted for analytic simulation on adjoint \+ lightning.qubit",
             )
             if diff_method == "adjoint"
             else pytest.raises(
-                qml.QuantumFunctionError,
+                pennylane.errors.QuantumFunctionError,
                 match=f"does not support {diff_method} with requested circuit",
             )
         ):

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -24,6 +24,7 @@ import pytest
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -42,7 +43,7 @@ def test_additional_kwargs_is_deprecated():
     dev = qml.device("default.qubit", wires=1)
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match=r"Specifying gradient keyword arguments \[\'atol\'\] as additional kwargs has been deprecated",
     ):
         QNode(dummyfunc, dev, atol=1)
@@ -80,7 +81,9 @@ def test_no_measure():
         qml.RX(x, wires=0)
         return qml.PauliY(0)
 
-    with pytest.raises(qml.QuantumFunctionError, match="must return either a single measurement"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+    ):
         _ = circuit(0.65)
 
 
@@ -300,7 +303,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     # pylint: disable=protected-access, too-many-statements
@@ -365,7 +368,8 @@ class TestValidation:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Differentiation method hello not recognized"
+            pennylane.errors.QuantumFunctionError,
+            match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
 
@@ -390,7 +394,7 @@ class TestValidation:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support adjoint with requested circuit",
         ):
             circ(shots=1)
@@ -407,7 +411,8 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="does not support backprop with requested circuit"
+            pennylane.errors.QuantumFunctionError,
+            match="does not support backprop with requested circuit",
         ):
             qml.grad(circuit, argnum=0)([0.5])
 
@@ -607,7 +612,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -620,7 +625,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -633,7 +638,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -652,7 +657,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)
@@ -1186,7 +1191,9 @@ class TestIntegration:
         def circuit():
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(qml.QuantumFunctionError, match="device_vjp=True is not supported"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="device_vjp=True is not supported"
+        ):
             circuit()
 
     @pytest.mark.parametrize(
@@ -1211,7 +1218,7 @@ class TestIntegration:
         res = circuit(x)  # execution works fine
         assert qml.math.allclose(res, np.cos(0.5))
 
-        with pytest.raises(qml.QuantumFunctionError, match="with diff_method=None"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="with diff_method=None"):
             qml.math.grad(circuit)(x)
 
 
@@ -1673,14 +1680,16 @@ class TestGetGradientFn:
     def test_get_gradient_fn_custom_dev_adjoint(self):
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         with pytest.raises(
-            qml.QuantumFunctionError, match=r"Device CustomDevice does not support adjoint"
+            pennylane.errors.QuantumFunctionError,
+            match=r"Device CustomDevice does not support adjoint",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "adjoint")
 
     def test_error_for_backprop_with_custom_device(self):
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         with pytest.raises(
-            qml.QuantumFunctionError, match=r"Device CustomDevice does not support backprop"
+            pennylane.errors.QuantumFunctionError,
+            match=r"Device CustomDevice does not support backprop",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "backprop")
 
@@ -1745,7 +1754,8 @@ class TestGetGradientFn:
     def test_invalid_diff_method(self):
         """Test that an invalid diff method raises an error."""
         with pytest.raises(
-            qml.QuantumFunctionError, match="Differentiation method invalid-method not recognized"
+            pennylane.errors.QuantumFunctionError,
+            match="Differentiation method invalid-method not recognized",
         ):
             QNode.get_gradient_fn(self.dev, None, diff_method="invalid-method")
 
@@ -1847,7 +1857,9 @@ class TestNewDeviceIntegration:
         def circuit():
             return qml.sample(wires=(0, 1))
 
-        with pytest.raises(qml.DeviceError, match="not accepted for analytic simulation"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="not accepted for analytic simulation"
+        ):
             circuit()
 
         results = circuit(shots=10)  # pylint: disable=unexpected-keyword-arg
@@ -2127,7 +2139,7 @@ def test_resets_after_execution_error():
         BadOp(x, wires=0)
         return qml.state()
 
-    with pytest.raises(qml.DeviceError):
+    with pytest.raises(pennylane.errors.DeviceError):
         circuit(qml.numpy.array(0.1))
 
     assert circuit.interface == "auto"

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -24,6 +24,7 @@ import pytest
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -42,7 +43,7 @@ def test_additional_kwargs_is_deprecated():
     dev = qml.device("default.qubit", wires=1)
 
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match=r"Specifying gradient keyword arguments \[\'atol\'\] as additional kwargs has been deprecated",
     ):
         QNode(dummyfunc, dev, atol=1)
@@ -80,7 +81,9 @@ def test_no_measure():
         qml.RX(x, wires=0)
         return qml.PauliY(0)
 
-    with pytest.raises(qml.QuantumFunctionError, match="must return either a single measurement"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+    ):
         _ = circuit(0.65)
 
 
@@ -300,7 +303,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     # pylint: disable=protected-access, too-many-statements
@@ -365,7 +368,7 @@ class TestValidation:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
@@ -391,7 +394,7 @@ class TestValidation:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support adjoint with requested circuit",
         ):
             circ(shots=1)
@@ -408,7 +411,7 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support backprop with requested circuit",
         ):
             qml.grad(circuit, argnum=0)([0.5])
@@ -609,7 +612,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -622,7 +625,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -635,7 +638,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -654,7 +657,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)
@@ -1188,7 +1191,9 @@ class TestIntegration:
         def circuit():
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(qml.QuantumFunctionError, match="device_vjp=True is not supported"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="device_vjp=True is not supported"
+        ):
             circuit()
 
     @pytest.mark.parametrize(
@@ -1213,7 +1218,7 @@ class TestIntegration:
         res = circuit(x)  # execution works fine
         assert qml.math.allclose(res, np.cos(0.5))
 
-        with pytest.raises(qml.QuantumFunctionError, match="with diff_method=None"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="with diff_method=None"):
             qml.math.grad(circuit)(x)
 
 
@@ -1675,7 +1680,7 @@ class TestGetGradientFn:
     def test_get_gradient_fn_custom_dev_adjoint(self):
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match=r"Device CustomDevice does not support adjoint",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "adjoint")
@@ -1683,7 +1688,7 @@ class TestGetGradientFn:
     def test_error_for_backprop_with_custom_device(self):
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match=r"Device CustomDevice does not support backprop",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "backprop")
@@ -1749,7 +1754,7 @@ class TestGetGradientFn:
     def test_invalid_diff_method(self):
         """Test that an invalid diff method raises an error."""
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Differentiation method invalid-method not recognized",
         ):
             QNode.get_gradient_fn(self.dev, None, diff_method="invalid-method")
@@ -1852,7 +1857,9 @@ class TestNewDeviceIntegration:
         def circuit():
             return qml.sample(wires=(0, 1))
 
-        with pytest.raises(qml.DeviceError, match="not accepted for analytic simulation"):
+        with pytest.raises(
+            pennylane.errors.DeviceError, match="not accepted for analytic simulation"
+        ):
             circuit()
 
         results = circuit(shots=10)  # pylint: disable=unexpected-keyword-arg
@@ -2132,7 +2139,7 @@ def test_resets_after_execution_error():
         BadOp(x, wires=0)
         return qml.state()
 
-    with pytest.raises(qml.DeviceError):
+    with pytest.raises(pennylane.errors.DeviceError):
         circuit(qml.numpy.array(0.1))
 
     assert circuit.interface == "auto"

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -24,7 +24,6 @@ import pytest
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -43,7 +42,7 @@ def test_additional_kwargs_is_deprecated():
     dev = qml.device("default.qubit", wires=1)
 
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match=r"Specifying gradient keyword arguments \[\'atol\'\] as additional kwargs has been deprecated",
     ):
         QNode(dummyfunc, dev, atol=1)
@@ -81,9 +80,7 @@ def test_no_measure():
         qml.RX(x, wires=0)
         return qml.PauliY(0)
 
-    with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
-    ):
+    with pytest.raises(qml.QuantumFunctionError, match="must return either a single measurement"):
         _ = circuit(0.65)
 
 
@@ -303,7 +300,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     # pylint: disable=protected-access, too-many-statements
@@ -368,7 +365,7 @@ class TestValidation:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
@@ -394,7 +391,7 @@ class TestValidation:
             return qml.expval(qml.PauliZ(0))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not support adjoint with requested circuit",
         ):
             circ(shots=1)
@@ -411,7 +408,7 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not support backprop with requested circuit",
         ):
             qml.grad(circuit, argnum=0)([0.5])
@@ -612,7 +609,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -625,7 +622,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -638,7 +635,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -657,7 +654,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)
@@ -1191,9 +1188,7 @@ class TestIntegration:
         def circuit():
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="device_vjp=True is not supported"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="device_vjp=True is not supported"):
             circuit()
 
     @pytest.mark.parametrize(
@@ -1218,7 +1213,7 @@ class TestIntegration:
         res = circuit(x)  # execution works fine
         assert qml.math.allclose(res, np.cos(0.5))
 
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="with diff_method=None"):
+        with pytest.raises(qml.QuantumFunctionError, match="with diff_method=None"):
             qml.math.grad(circuit)(x)
 
 
@@ -1680,7 +1675,7 @@ class TestGetGradientFn:
     def test_get_gradient_fn_custom_dev_adjoint(self):
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match=r"Device CustomDevice does not support adjoint",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "adjoint")
@@ -1688,7 +1683,7 @@ class TestGetGradientFn:
     def test_error_for_backprop_with_custom_device(self):
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match=r"Device CustomDevice does not support backprop",
         ):
             QNode.get_gradient_fn(self.dev, "autograd", "backprop")
@@ -1754,7 +1749,7 @@ class TestGetGradientFn:
     def test_invalid_diff_method(self):
         """Test that an invalid diff method raises an error."""
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Differentiation method invalid-method not recognized",
         ):
             QNode.get_gradient_fn(self.dev, None, diff_method="invalid-method")
@@ -1857,9 +1852,7 @@ class TestNewDeviceIntegration:
         def circuit():
             return qml.sample(wires=(0, 1))
 
-        with pytest.raises(
-            pennylane.errors.DeviceError, match="not accepted for analytic simulation"
-        ):
+        with pytest.raises(qml.DeviceError, match="not accepted for analytic simulation"):
             circuit()
 
         results = circuit(shots=10)  # pylint: disable=unexpected-keyword-arg
@@ -2139,7 +2132,7 @@ def test_resets_after_execution_error():
         BadOp(x, wires=0)
         return qml.state()
 
-    with pytest.raises(pennylane.errors.DeviceError):
+    with pytest.raises(qml.DeviceError):
         circuit(qml.numpy.array(0.1))
 
     assert circuit.interface == "auto"

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -24,6 +24,7 @@ from default_qubit_legacy import DefaultQubitLegacy
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -109,7 +110,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     def test_unknown_diff_method_string(self):
@@ -117,7 +118,7 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
@@ -140,7 +141,7 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1, shots=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support adjoint with requested circuit.",
         ):
 
@@ -162,7 +163,7 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="does not support backprop with requested circuit.",
         ):
             qml.grad(circuit, argnum=0)([0.5])
@@ -329,7 +330,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -342,7 +343,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -355,7 +356,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -374,7 +375,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -24,7 +24,6 @@ from default_qubit_legacy import DefaultQubitLegacy
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -110,7 +109,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     def test_unknown_diff_method_string(self):
@@ -118,7 +117,7 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
@@ -141,7 +140,7 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1, shots=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not support adjoint with requested circuit.",
         ):
 
@@ -163,7 +162,7 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="does not support backprop with requested circuit.",
         ):
             qml.grad(circuit, argnum=0)([0.5])
@@ -330,7 +329,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -343,7 +342,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -356,7 +355,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
+            qml.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -375,7 +374,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -24,6 +24,7 @@ from default_qubit_legacy import DefaultQubitLegacy
 from scipy.sparse import csr_matrix
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -109,7 +110,7 @@ class TestValidation:
 
     def test_invalid_device(self):
         """Test that an exception is raised for an invalid device"""
-        with pytest.raises(qml.QuantumFunctionError, match="Invalid device"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="Invalid device"):
             QNode(dummyfunc, None)
 
     def test_unknown_diff_method_string(self):
@@ -117,7 +118,8 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Differentiation method hello not recognized"
+            pennylane.errors.QuantumFunctionError,
+            match="Differentiation method hello not recognized",
         ):
             QNode(dummyfunc, dev, interface="autograd", diff_method="hello")
 
@@ -139,7 +141,8 @@ class TestValidation:
         dev = DefaultQubitLegacy(wires=1, shots=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="does not support adjoint with requested circuit."
+            pennylane.errors.QuantumFunctionError,
+            match="does not support adjoint with requested circuit.",
         ):
 
             @qnode(dev, diff_method="adjoint")
@@ -160,7 +163,8 @@ class TestValidation:
             return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="does not support backprop with requested circuit."
+            pennylane.errors.QuantumFunctionError,
+            match="does not support backprop with requested circuit.",
         ):
             qml.grad(circuit, argnum=0)([0.5])
 
@@ -326,7 +330,7 @@ class TestTapeConstruction:
         qn = QNode(func0, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -339,7 +343,7 @@ class TestTapeConstruction:
         qn = QNode(func2, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -352,7 +356,7 @@ class TestTapeConstruction:
         qn = QNode(func3, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="must return either a single measurement"
+            pennylane.errors.QuantumFunctionError, match="must return either a single measurement"
         ):
             qn(5, 1)
 
@@ -371,7 +375,7 @@ class TestTapeConstruction:
         qn = QNode(func, dev)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="measurements must be returned in the order they are measured",
         ):
             qn(5, 1)

--- a/tests/test_return_types.py
+++ b/tests/test_return_types.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1279,7 +1280,8 @@ class TestDeviceNewUnits:
         tape = qml.tape.QuantumScript.from_queue(q)
         dev = qml.device("default.qubit", wires=3)
         with pytest.raises(
-            qml.DeviceError, match="not accepted for analytic simulation on default.qubit"
+            pennylane.errors.DeviceError,
+            match="not accepted for analytic simulation on default.qubit",
         ):
             program = dev.preprocess_transforms()
             qml.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)

--- a/tests/test_return_types.py
+++ b/tests/test_return_types.py
@@ -18,7 +18,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1280,7 +1279,7 @@ class TestDeviceNewUnits:
         tape = qml.tape.QuantumScript.from_queue(q)
         dev = qml.device("default.qubit", wires=3)
         with pytest.raises(
-            pennylane.errors.DeviceError,
+            qml.DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             program = dev.preprocess_transforms()

--- a/tests/test_return_types.py
+++ b/tests/test_return_types.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1279,7 +1280,7 @@ class TestDeviceNewUnits:
         tape = qml.tape.QuantumScript.from_queue(q)
         dev = qml.device("default.qubit", wires=3)
         with pytest.raises(
-            qml.DeviceError,
+            pennylane.errors.DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             program = dev.preprocess_transforms()

--- a/tests/test_return_types_legacy.py
+++ b/tests/test_return_types_legacy.py
@@ -19,6 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1215,7 +1216,8 @@ class TestQubitDeviceNewUnits:
         dev = DefaultQubitLegacy(wires=3)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Unsupported return type specified for observable"
+            pennylane.errors.QuantumFunctionError,
+            match="Unsupported return type specified for observable",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
 
@@ -1232,7 +1234,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination with other return types",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1248,7 +1250,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Returning the Von Neumann entropy is not supported when using custom wire labels",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1264,5 +1266,5 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         msg = "Returning the mutual information is not supported when using custom wire labels"
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             qml.execute(tapes=[tape], device=dev, diff_method=None)

--- a/tests/test_return_types_legacy.py
+++ b/tests/test_return_types_legacy.py
@@ -19,6 +19,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1215,7 +1216,7 @@ class TestQubitDeviceNewUnits:
         dev = DefaultQubitLegacy(wires=3)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Unsupported return type specified for observable",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1233,7 +1234,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination with other return types",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1249,7 +1250,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Returning the Von Neumann entropy is not supported when using custom wire labels",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1265,5 +1266,5 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         msg = "Returning the mutual information is not supported when using custom wire labels"
-        with pytest.raises(qml.QuantumFunctionError, match=msg):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
             qml.execute(tapes=[tape], device=dev, diff_method=None)

--- a/tests/test_return_types_legacy.py
+++ b/tests/test_return_types_legacy.py
@@ -19,7 +19,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import MeasurementProcess
 
 test_wires = [2, 3, 4]
@@ -1216,7 +1215,7 @@ class TestQubitDeviceNewUnits:
         dev = DefaultQubitLegacy(wires=3)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Unsupported return type specified for observable",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1234,7 +1233,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination with other return types",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1250,7 +1249,7 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Returning the Von Neumann entropy is not supported when using custom wire labels",
         ):
             qml.execute(tapes=[tape], device=dev, diff_method=None)
@@ -1266,5 +1265,5 @@ class TestQubitDeviceNewUnits:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         msg = "Returning the mutual information is not supported when using custom wire labels"
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match=msg):
+        with pytest.raises(qml.QuantumFunctionError, match=msg):
             qml.execute(tapes=[tape], device=dev, diff_method=None)

--- a/tests/transforms/core/test_transform_program.py
+++ b/tests/transforms/core/test_transform_program.py
@@ -18,7 +18,6 @@ import pytest
 import rustworkx as rx
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import (
     TransformContainer,
@@ -613,7 +612,7 @@ class TestClassicalCotransfroms:
         program.set_classical_component(circuit, (arg,), {})
 
         tape = qml.tape.QuantumScript([], [])
-        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters"):
+        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters"):
             program((tape,))
 
 

--- a/tests/transforms/core/test_transform_program.py
+++ b/tests/transforms/core/test_transform_program.py
@@ -18,6 +18,7 @@ import pytest
 import rustworkx as rx
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import (
     TransformContainer,
@@ -612,7 +613,7 @@ class TestClassicalCotransfroms:
         program.set_classical_component(circuit, (arg,), {})
 
         tape = qml.tape.QuantumScript([], [])
-        with pytest.raises(qml.QuantumFunctionError, match="No trainable parameters"):
+        with pytest.raises(pennylane.errors.QuantumFunctionError, match="No trainable parameters"):
             program((tape,))
 
 

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -20,6 +20,7 @@ import pytest
 from test_optimization.utils import compare_operation_lists
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.transforms import unitary_to_rot
 from pennylane.transforms.compile import compile
@@ -54,7 +55,9 @@ def test_deprecation_pipeline_None():
     """Test that specifying `pipeline=None` is deprecated."""
 
     tape = qml.tape.QuantumScript()
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"):
+    with pytest.warns(
+        pennylane.errors.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"
+    ):
         qml.compile(tape, pipeline=None)
 
 

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -20,7 +20,6 @@ import pytest
 from test_optimization.utils import compare_operation_lists
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.transforms import unitary_to_rot
 from pennylane.transforms.compile import compile
@@ -55,9 +54,7 @@ def test_deprecation_pipeline_None():
     """Test that specifying `pipeline=None` is deprecated."""
 
     tape = qml.tape.QuantumScript()
-    with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"
-    ):
+    with pytest.warns(qml.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"):
         qml.compile(tape, pipeline=None)
 
 

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -23,6 +23,7 @@ from functools import partial
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.devices import DefaultQubit
 from pennylane.measurements import MeasurementValue, MidMeasureMP
@@ -111,7 +112,7 @@ def test_postselection_error_with_wrong_device():
         return qml.probs(wires=[0])
 
     with pytest.raises(
-        qml.DeviceError,
+        pennylane.errors.DeviceError,
         match=re.escape(
             "Operator Projector(array([1]), wires=[0]) not supported with default.mixed and does not provide a decomposition."
         ),

--- a/tests/transforms/test_defer_measurements.py
+++ b/tests/transforms/test_defer_measurements.py
@@ -23,7 +23,6 @@ from functools import partial
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as np
 from pennylane.devices import DefaultQubit
 from pennylane.measurements import MeasurementValue, MidMeasureMP
@@ -112,7 +111,7 @@ def test_postselection_error_with_wrong_device():
         return qml.probs(wires=[0])
 
     with pytest.raises(
-        pennylane.errors.DeviceError,
+        qml.DeviceError,
         match=re.escape(
             "Operator Projector(array([1]), wires=[0]) not supported with default.mixed and does not provide a decomposition."
         ),

--- a/tests/transforms/test_dynamic_one_shot.py
+++ b/tests/transforms/test_dynamic_one_shot.py
@@ -20,6 +20,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.measurements import (
     CountsMP,
     ExpectationMP,
@@ -168,7 +169,7 @@ def test_unsupported_shots():
     tape = qml.tape.QuantumScript([MidMeasureMP(0)], [qml.probs(wires=0)], shots=None)
 
     with pytest.raises(
-        qml.QuantumFunctionError,
+        pennylane.errors.QuantumFunctionError,
         match="dynamic_one_shot is only supported with finite shots.",
     ):
         _, _ = qml.dynamic_one_shot(tape)

--- a/tests/transforms/test_dynamic_one_shot.py
+++ b/tests/transforms/test_dynamic_one_shot.py
@@ -20,7 +20,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.measurements import (
     CountsMP,
     ExpectationMP,
@@ -169,7 +168,7 @@ def test_unsupported_shots():
     tape = qml.tape.QuantumScript([MidMeasureMP(0)], [qml.probs(wires=0)], shots=None)
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError,
+        qml.QuantumFunctionError,
         match="dynamic_one_shot is only supported with finite shots.",
     ):
         _, _ = qml.dynamic_one_shot(tape)

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -18,6 +18,7 @@ Unit tests for the optimization transform ``merge_amplitude_embedding``.
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane.transforms.optimization import merge_amplitude_embedding
 
@@ -72,7 +73,7 @@ class TestMergeAmplitudeEmbedding:
         dev = qml.device("default.qubit", wires=2)
         qnode = qml.QNode(transformed_qfunc, dev)
 
-        with pytest.raises(qml.DeviceError, match="applied in the same qubit"):
+        with pytest.raises(pennylane.errors.DeviceError, match="applied in the same qubit"):
             qnode()
 
     def test_decorator(self):

--- a/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
+++ b/tests/transforms/test_optimization/test_merge_amplitude_embedding.py
@@ -18,7 +18,6 @@ Unit tests for the optimization transform ``merge_amplitude_embedding``.
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane.transforms.optimization import merge_amplitude_embedding
 
@@ -73,7 +72,7 @@ class TestMergeAmplitudeEmbedding:
         dev = qml.device("default.qubit", wires=2)
         qnode = qml.QNode(transformed_qfunc, dev)
 
-        with pytest.raises(pennylane.errors.DeviceError, match="applied in the same qubit"):
+        with pytest.raises(qml.DeviceError, match="applied in the same qubit"):
             qnode()
 
     def test_decorator(self):

--- a/tests/transforms/test_optimization/test_pattern_matching.py
+++ b/tests/transforms/test_optimization/test_pattern_matching.py
@@ -19,6 +19,7 @@ Unit tests for the optimization transform ``pattern_matching_optimization``.
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.transforms.commutation_dag import commutation_dag
 from pennylane.transforms.optimization.pattern_matching import (
@@ -837,7 +838,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The pattern is not a valid quantum tape."
+            pennylane.errors.QuantumFunctionError, match="The pattern is not a valid quantum tape."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -864,7 +865,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Pattern is not valid, it does not implement identity.",
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
@@ -886,7 +887,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Circuit has less qubits than the pattern."
+            pennylane.errors.QuantumFunctionError, match="Circuit has less qubits than the pattern."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -917,7 +918,9 @@ class TestPatternMatchingOptimization:
         template = qml.tape.QuantumScript.from_queue(q_template)
         dev = qml.device("default.qubit", wires=10)
 
-        with pytest.raises(qml.QuantumFunctionError, match="The pattern contains measurements."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="The pattern contains measurements."
+        ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
             optimized_qnode()

--- a/tests/transforms/test_optimization/test_pattern_matching.py
+++ b/tests/transforms/test_optimization/test_pattern_matching.py
@@ -19,6 +19,7 @@ Unit tests for the optimization transform ``pattern_matching_optimization``.
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 import pennylane.numpy as np
 from pennylane.transforms.commutation_dag import commutation_dag
 from pennylane.transforms.optimization.pattern_matching import (
@@ -837,7 +838,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="The pattern is not a valid quantum tape."
+            pennylane.errors.QuantumFunctionError, match="The pattern is not a valid quantum tape."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -864,7 +865,8 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Pattern is not valid, it does not implement identity."
+            pennylane.errors.QuantumFunctionError,
+            match="Pattern is not valid, it does not implement identity.",
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -885,7 +887,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="Circuit has less qubits than the pattern."
+            pennylane.errors.QuantumFunctionError, match="Circuit has less qubits than the pattern."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -916,7 +918,9 @@ class TestPatternMatchingOptimization:
         template = qml.tape.QuantumScript.from_queue(q_template)
         dev = qml.device("default.qubit", wires=10)
 
-        with pytest.raises(qml.QuantumFunctionError, match="The pattern contains measurements."):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="The pattern contains measurements."
+        ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
             optimized_qnode()

--- a/tests/transforms/test_optimization/test_pattern_matching.py
+++ b/tests/transforms/test_optimization/test_pattern_matching.py
@@ -19,7 +19,6 @@ Unit tests for the optimization transform ``pattern_matching_optimization``.
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 import pennylane.numpy as np
 from pennylane.transforms.commutation_dag import commutation_dag
 from pennylane.transforms.optimization.pattern_matching import (
@@ -838,7 +837,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="The pattern is not a valid quantum tape."
+            qml.QuantumFunctionError, match="The pattern is not a valid quantum tape."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -865,7 +864,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=10)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Pattern is not valid, it does not implement identity.",
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
@@ -887,7 +886,7 @@ class TestPatternMatchingOptimization:
         dev = qml.device("default.qubit", wires=1)
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Circuit has less qubits than the pattern."
+            qml.QuantumFunctionError, match="Circuit has less qubits than the pattern."
         ):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
@@ -918,9 +917,7 @@ class TestPatternMatchingOptimization:
         template = qml.tape.QuantumScript.from_queue(q_template)
         dev = qml.device("default.qubit", wires=10)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="The pattern contains measurements."
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="The pattern contains measurements."):
             optimized_qfunc = pattern_matching_optimization(circuit, pattern_tapes=[template])
             optimized_qnode = qml.QNode(optimized_qfunc, dev)
             optimized_qnode()

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.tape import QuantumScript
 from pennylane.transforms import TransformError
 
@@ -212,7 +213,9 @@ class TestConvertersZX:
         mat_product /= mat_product[0, 0]
         assert qml.math.allclose(mat_product, I)
 
-        with pytest.raises(qml.QuantumFunctionError, match="Graph doesn't seem circuit like"):
+        with pytest.raises(
+            pennylane.errors.QuantumFunctionError, match="Graph doesn't seem circuit like"
+        ):
             qml.transforms.from_zx(zx_g)
 
     @pytest.mark.parametrize("decompose", decompose_phases)
@@ -469,7 +472,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Cross qubit connections, the graph is not circuit-like.",
         ):
             qml.transforms.from_zx(graph)
@@ -481,7 +484,7 @@ class TestConvertersZX:
 
         qs = QuantumScript(operations, [])
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="The expansion of the quantum tape failed, PyZX does not support",
         ):
             qml.transforms.to_zx(qs)
@@ -534,7 +537,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Two green or respectively two red nodes connected by a ",
         ):
             qml.transforms.from_zx(graph)
@@ -587,7 +590,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="A green and red node connected by a Hadamard edge ",
         ):
             qml.transforms.from_zx(graph)

--- a/tests/transforms/test_zx.py
+++ b/tests/transforms/test_zx.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.tape import QuantumScript
 from pennylane.transforms import TransformError
 
@@ -213,9 +212,7 @@ class TestConvertersZX:
         mat_product /= mat_product[0, 0]
         assert qml.math.allclose(mat_product, I)
 
-        with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="Graph doesn't seem circuit like"
-        ):
+        with pytest.raises(qml.QuantumFunctionError, match="Graph doesn't seem circuit like"):
             qml.transforms.from_zx(zx_g)
 
     @pytest.mark.parametrize("decompose", decompose_phases)
@@ -472,7 +469,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Cross qubit connections, the graph is not circuit-like.",
         ):
             qml.transforms.from_zx(graph)
@@ -484,7 +481,7 @@ class TestConvertersZX:
 
         qs = QuantumScript(operations, [])
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="The expansion of the quantum tape failed, PyZX does not support",
         ):
             qml.transforms.to_zx(qs)
@@ -537,7 +534,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Two green or respectively two red nodes connected by a ",
         ):
             qml.transforms.from_zx(graph)
@@ -590,7 +587,7 @@ class TestConvertersZX:
         graph.set_outputs(tuple(outputs))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="A green and red node connected by a Hadamard edge ",
         ):
             qml.transforms.from_zx(graph)

--- a/tests/workflow/interfaces/execute/test_execute.py
+++ b/tests/workflow/interfaces/execute/test_execute.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import DefaultQubit
 
 
@@ -67,7 +68,7 @@ def test_mcm_config_deprecation(mocker):
 
     with dev.tracker:
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The mcm_config argument is deprecated and will be removed in v0.42, use mcm_method and postselect_mode instead.",
         ):
             spy = mocker.spy(qml.dynamic_one_shot, "_transform")
@@ -85,7 +86,8 @@ def test_config_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The config argument has been deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning,
+        match="The config argument has been deprecated",
     ):
         qml.execute((tape,), dev, config=qml.devices.DefaultExecutionConfig)
 
@@ -96,7 +98,8 @@ def test_inner_transform_program_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning, match="The inner_transform argument has been deprecated"
+        pennylane.errors.PennyLaneDeprecationWarning,
+        match="The inner_transform argument has been deprecated",
     ):
         qml.execute((tape,), dev, inner_transform=qml.transforms.core.TransformProgram())
 

--- a/tests/workflow/interfaces/execute/test_execute.py
+++ b/tests/workflow/interfaces/execute/test_execute.py
@@ -17,7 +17,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import DefaultQubit
 
 
@@ -68,7 +67,7 @@ def test_mcm_config_deprecation(mocker):
 
     with dev.tracker:
         with pytest.warns(
-            pennylane.errors.PennyLaneDeprecationWarning,
+            qml.PennyLaneDeprecationWarning,
             match="The mcm_config argument is deprecated and will be removed in v0.42, use mcm_method and postselect_mode instead.",
         ):
             spy = mocker.spy(qml.dynamic_one_shot, "_transform")
@@ -86,7 +85,7 @@ def test_config_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="The config argument has been deprecated",
     ):
         qml.execute((tape,), dev, config=qml.devices.DefaultExecutionConfig)
@@ -98,7 +97,7 @@ def test_inner_transform_program_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        pennylane.errors.PennyLaneDeprecationWarning,
+        qml.PennyLaneDeprecationWarning,
         match="The inner_transform argument has been deprecated",
     ):
         qml.execute((tape,), dev, inner_transform=qml.transforms.core.TransformProgram())

--- a/tests/workflow/interfaces/execute/test_execute.py
+++ b/tests/workflow/interfaces/execute/test_execute.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import DefaultQubit
 
 
@@ -67,7 +68,7 @@ def test_mcm_config_deprecation(mocker):
 
     with dev.tracker:
         with pytest.warns(
-            qml.PennyLaneDeprecationWarning,
+            pennylane.errors.PennyLaneDeprecationWarning,
             match="The mcm_config argument is deprecated and will be removed in v0.42, use mcm_method and postselect_mode instead.",
         ):
             spy = mocker.spy(qml.dynamic_one_shot, "_transform")
@@ -85,7 +86,7 @@ def test_config_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="The config argument has been deprecated",
     ):
         qml.execute((tape,), dev, config=qml.devices.DefaultExecutionConfig)
@@ -97,7 +98,7 @@ def test_inner_transform_program_deprecation():
     tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
     dev = qml.device("default.qubit")
     with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
+        pennylane.errors.PennyLaneDeprecationWarning,
         match="The inner_transform argument has been deprecated",
     ):
         qml.execute((tape,), dev, inner_transform=qml.transforms.core.TransformProgram())

--- a/tests/workflow/interfaces/legacy_devices_integration/test_execute_legacy.py
+++ b/tests/workflow/interfaces/legacy_devices_integration/test_execute_legacy.py
@@ -19,12 +19,11 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-import pennylane.errors
 
 
 def test_old_interface_no_device_jacobian_products():
     """Test that an error is always raised for the old device interface if device jacobian products are requested."""
     dev = DefaultQubitLegacy(wires=2)
     tape = qml.tape.QuantumScript([qml.RX(1.0, wires=0)], [qml.expval(qml.PauliZ(0))])
-    with pytest.raises(pennylane.errors.QuantumFunctionError):
+    with pytest.raises(qml.QuantumFunctionError):
         qml.execute((tape,), dev, device_vjp=True)

--- a/tests/workflow/interfaces/legacy_devices_integration/test_execute_legacy.py
+++ b/tests/workflow/interfaces/legacy_devices_integration/test_execute_legacy.py
@@ -19,11 +19,12 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+import pennylane.errors
 
 
 def test_old_interface_no_device_jacobian_products():
     """Test that an error is always raised for the old device interface if device jacobian products are requested."""
     dev = DefaultQubitLegacy(wires=2)
     tape = qml.tape.QuantumScript([qml.RX(1.0, wires=0)], [qml.expval(qml.PauliZ(0))])
-    with pytest.raises(qml.QuantumFunctionError):
+    with pytest.raises(pennylane.errors.QuantumFunctionError):
         qml.execute((tape,), dev, device_vjp=True)

--- a/tests/workflow/interfaces/qnode/test_autograd_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_autograd_qnode.py
@@ -21,6 +21,7 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
@@ -459,7 +460,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             res = circuit(a, b)
 
         # execute with shots=100
@@ -1630,7 +1631,7 @@ class TestSample:
             return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliX(1))
 
         with pytest.raises(
-            qml.QuantumFunctionError, match="does not support backprop with requested"
+            pennylane.errors.QuantumFunctionError, match="does not support backprop with requested"
         ):
             circuit(shots=10)
 

--- a/tests/workflow/interfaces/qnode/test_autograd_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_autograd_qnode.py
@@ -21,7 +21,6 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
@@ -460,7 +459,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             res = circuit(a, b)
 
         # execute with shots=100
@@ -1631,7 +1630,7 @@ class TestSample:
             return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliX(1))
 
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError, match="does not support backprop with requested"
+            qml.QuantumFunctionError, match="does not support backprop with requested"
         ):
             circuit(shots=10)
 

--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -21,6 +21,7 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
@@ -825,7 +826,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -21,7 +21,6 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import numpy as np
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
@@ -826,7 +825,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_jax_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_qnode.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -743,7 +744,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_jax_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_qnode.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -744,7 +743,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_tensorflow_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_tensorflow_qnode.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -443,7 +444,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             circuit(weights)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_tensorflow_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_tensorflow_qnode.py
@@ -19,7 +19,6 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -444,7 +443,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             circuit(weights)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_torch_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_torch_qnode.py
@@ -20,6 +20,7 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
+import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -553,7 +554,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(qml.DeviceError):
+        with pytest.raises(pennylane.errors.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/qnode/test_torch_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_torch_qnode.py
@@ -20,7 +20,6 @@ import pytest
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-import pennylane.errors
 from pennylane import qnode
 from pennylane.devices import DefaultQubit
 
@@ -554,7 +553,7 @@ class TestShotsIntegration:
             return qml.sample(wires=(0, 1))
 
         # execute with device default shots (None)
-        with pytest.raises(pennylane.errors.DeviceError):
+        with pytest.raises(qml.DeviceError):
             circuit(a, b)
 
         # execute with shots=100

--- a/tests/workflow/interfaces/test_jacobian_products.py
+++ b/tests/workflow/interfaces/test_jacobian_products.py
@@ -22,6 +22,7 @@ from cachetools import LRUCache
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.workflow.jacobian_products import (
     DeviceDerivatives,
     DeviceJacobianProducts,
@@ -86,22 +87,22 @@ def test_no_gradients():
     jpc = NoGradients()
 
     with pytest.raises(
-        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.compute_jacobian(())
 
     with pytest.raises(
-        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.compute_vjp((), ())
 
     with pytest.raises(
-        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.execute_and_compute_jvp((), ())
 
     with pytest.raises(
-        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.execute_and_compute_jacobian(())
 

--- a/tests/workflow/interfaces/test_jacobian_products.py
+++ b/tests/workflow/interfaces/test_jacobian_products.py
@@ -22,7 +22,6 @@ from cachetools import LRUCache
 from param_shift_dev import ParamShiftDerivativesDevice
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.workflow.jacobian_products import (
     DeviceDerivatives,
     DeviceJacobianProducts,
@@ -87,22 +86,22 @@ def test_no_gradients():
     jpc = NoGradients()
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.compute_jacobian(())
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.compute_vjp((), ())
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.execute_and_compute_jvp((), ())
 
     with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="cannot be calculated with diff_method=None"
+        qml.QuantumFunctionError, match="cannot be calculated with diff_method=None"
     ):
         jpc.execute_and_compute_jacobian(())
 

--- a/tests/workflow/test_resolve_diff_method.py
+++ b/tests/workflow/test_resolve_diff_method.py
@@ -17,7 +17,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.workflow import _resolve_diff_method
 
@@ -84,7 +83,7 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="adjoint")
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match=r"does not support adjoint with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
@@ -93,7 +92,7 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="backprop")
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match=r"does not support backprop with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
@@ -184,7 +183,7 @@ class TestResolveDiffMethod:
         dev = qml.device("default.qubit", wires=1)
         initial_config = ExecutionConfig(gradient_method="invalid-method")
         with pytest.raises(
-            pennylane.errors.QuantumFunctionError,
+            qml.QuantumFunctionError,
             match="Differentiation method invalid-method not recognized",
         ):
             _resolve_diff_method(initial_config, dev)

--- a/tests/workflow/test_resolve_diff_method.py
+++ b/tests/workflow/test_resolve_diff_method.py
@@ -17,6 +17,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.workflow import _resolve_diff_method
 
@@ -83,7 +84,8 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="adjoint")
         with pytest.raises(
-            qml.QuantumFunctionError, match=r"does not support adjoint with requested circuit"
+            pennylane.errors.QuantumFunctionError,
+            match=r"does not support adjoint with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
 
@@ -91,7 +93,8 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="backprop")
         with pytest.raises(
-            qml.QuantumFunctionError, match=r"does not support backprop with requested circuit"
+            pennylane.errors.QuantumFunctionError,
+            match=r"does not support backprop with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
 
@@ -181,6 +184,7 @@ class TestResolveDiffMethod:
         dev = qml.device("default.qubit", wires=1)
         initial_config = ExecutionConfig(gradient_method="invalid-method")
         with pytest.raises(
-            qml.QuantumFunctionError, match="Differentiation method invalid-method not recognized"
+            pennylane.errors.QuantumFunctionError,
+            match="Differentiation method invalid-method not recognized",
         ):
             _resolve_diff_method(initial_config, dev)

--- a/tests/workflow/test_resolve_diff_method.py
+++ b/tests/workflow/test_resolve_diff_method.py
@@ -17,6 +17,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig
 from pennylane.workflow import _resolve_diff_method
 
@@ -83,7 +84,7 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised if adjoint is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="adjoint")
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match=r"does not support adjoint with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
@@ -92,7 +93,7 @@ class TestCustomDeviceIntegration:
         """Test that an error is raised when backprop is requested for a device that does not support it."""
         config = ExecutionConfig(gradient_method="backprop")
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match=r"does not support backprop with requested circuit",
         ):
             _resolve_diff_method(config, self.dev)
@@ -183,7 +184,7 @@ class TestResolveDiffMethod:
         dev = qml.device("default.qubit", wires=1)
         initial_config = ExecutionConfig(gradient_method="invalid-method")
         with pytest.raises(
-            qml.QuantumFunctionError,
+            pennylane.errors.QuantumFunctionError,
             match="Differentiation method invalid-method not recognized",
         ):
             _resolve_diff_method(initial_config, dev)

--- a/tests/workflow/test_resolve_execution_config.py
+++ b/tests/workflow/test_resolve_execution_config.py
@@ -17,6 +17,7 @@
 import pytest
 
 import pennylane as qml
+import pennylane.errors
 from pennylane.devices import ExecutionConfig, MCMConfig
 from pennylane.transforms.core import TransformProgram
 from pennylane.workflow.resolution import _resolve_execution_config
@@ -141,5 +142,7 @@ def test_no_device_vjp_if_not_supported():
     config_parameter_shift = ExecutionConfig(
         use_device_jacobian_product=True, gradient_method="parameter-shift"
     )
-    with pytest.raises(qml.QuantumFunctionError, match="device_vjp=True is not supported"):
+    with pytest.raises(
+        pennylane.errors.QuantumFunctionError, match="device_vjp=True is not supported"
+    ):
         _resolve_execution_config(config_parameter_shift, DummyDev(), (tape,))

--- a/tests/workflow/test_resolve_execution_config.py
+++ b/tests/workflow/test_resolve_execution_config.py
@@ -17,7 +17,6 @@
 import pytest
 
 import pennylane as qml
-import pennylane.errors
 from pennylane.devices import ExecutionConfig, MCMConfig
 from pennylane.transforms.core import TransformProgram
 from pennylane.workflow.resolution import _resolve_execution_config
@@ -142,7 +141,5 @@ def test_no_device_vjp_if_not_supported():
     config_parameter_shift = ExecutionConfig(
         use_device_jacobian_product=True, gradient_method="parameter-shift"
     )
-    with pytest.raises(
-        pennylane.errors.QuantumFunctionError, match="device_vjp=True is not supported"
-    ):
+    with pytest.raises(qml.QuantumFunctionError, match="device_vjp=True is not supported"):
         _resolve_execution_config(config_parameter_shift, DummyDev(), (tape,))


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7205 adds the new `exceptions` module but doesn't use it internally in the source code because Catalyst and Lightning use the top-level imports and affect the CI.

**Description of the Change:**

Update to use that new module rather than top level imports.

**Benefits:** Should not depend on top-level imports.

**Possible Drawbacks:** None

[sc-88956]
