### PR TITLE
Fix `PSWAP` eigvals axis ordering with broadcasting 

### DIFF
--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -712,6 +712,7 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
 
 * `PSWAP.matrix()` and `PSWAP.eigvals()` now support parameter broadcasting.
   [(#7179)](https://github.com/PennyLaneAI/pennylane/pull/7179)
+  [(#7228)](https://github.com/PennyLaneAI/pennylane/pull/7228)
 
 * `Device.eval_jaxpr` now accepts an `execution_config` keyword argument.
   [(#6991)](https://github.com/PennyLaneAI/pennylane/pull/6991)

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -1702,7 +1702,7 @@ class PSWAP(Operation):
 
         e = qml.math.exp(1j * phi)
         one = qml.math.ones_like(phi)
-        return qml.math.stack([one, one, -e, e])
+        return qml.math.transpose(qml.math.stack([one, one, -e, e]))
 
     def adjoint(self) -> "PSWAP":
         (phi,) = self.parameters

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -699,8 +699,7 @@ class TestDecompositions:
         assert np.allclose(decomposed_matrix, exp)
 
 
-# 11 angles from the range [-pi, pi], including 0.
-standard_angles = list(np.linspace(-np.pi, np.pi, 11))
+pswap_angles = list(np.linspace(-np.pi, np.pi, 11)) + [np.linspace(-1, 1, 11)]
 
 
 class TestMatrix:
@@ -845,7 +844,7 @@ class TestMatrix:
 
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_pcphase(self, phi, dim, wires):
         """Test that the PCPhase operator matrix is correct."""
         num_wires = len(wires)
@@ -864,7 +863,7 @@ class TestMatrix:
     @pytest.mark.tf
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_pcphase_tf(self, phi, dim, wires):
         """Test that the PCPhase operator matrix is correct for tf."""
         import tensorflow as tf
@@ -888,7 +887,7 @@ class TestMatrix:
     @pytest.mark.torch
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_pcphase_torch(self, phi, dim, wires):
         import torch
 
@@ -911,7 +910,7 @@ class TestMatrix:
     @pytest.mark.jax
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_pcphase_jax(self, phi, dim, wires):
         import jax.numpy as jnp
 
@@ -1005,7 +1004,7 @@ class TestMatrix:
             qml.PSWAP(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
-    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
+    @pytest.mark.parametrize("phi", pswap_angles)
     def test_pswap_eigvals(self, phi):
         """Test eigenvalues computation for PSWAP"""
         evs = qml.PSWAP.compute_eigvals(phi)
@@ -1016,7 +1015,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
+    @pytest.mark.parametrize("phi", pswap_angles)
     def test_pswap_eigvals_tf(self, phi):
         """Test eigenvalues computation for PSWAP using Tensorflow interface"""
         import tensorflow as tf
@@ -1030,7 +1029,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
+    @pytest.mark.parametrize("phi", pswap_angles)
     def test_pswap_eigvals_torch(self, phi):
         """Test eigenvalues computation for PSWAP using Torch interface"""
         import torch
@@ -1044,7 +1043,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
+    @pytest.mark.parametrize("phi", pswap_angles)
     def test_pswap_eigvals_jax(self, phi):
         """Test eigenvalues computation for PSWAP using JAX interface"""
         import jax
@@ -1058,7 +1057,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_pcphase_eigvals_tf(self, phi):
         """Test eigenvalues computation for PCPhase using Tensorflow interface"""
         import tensorflow as tf
@@ -1124,7 +1123,7 @@ class TestMatrix:
             qml.IsingXY(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_isingxy_eigvals(self, phi):
         """Test eigenvalues computation for IsingXY"""
         evs = qml.IsingXY.compute_eigvals(phi)
@@ -1138,7 +1137,7 @@ class TestMatrix:
 
     def test_isingxy_eigvals_broadcasted(self):
         """Test broadcasted eigenvalues computation for IsingXY"""
-        phi = np.array(standard_angles)
+        phi = np.linspace(-np.pi, np.pi, 10)
         evs = qml.IsingXY.compute_eigvals(phi)
         evs_expected = np.array(
             [[qml.math.exp(1j * _phi / 2), qml.math.exp(-1j * _phi / 2), 1, 1] for _phi in phi]
@@ -1146,7 +1145,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_isingxy_eigvals_tf(self, phi):
         """Test eigenvalues computation for IsingXY using Tensorflow interface"""
         import tensorflow as tf
@@ -1175,7 +1174,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, expected)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_isingxy_eigvals_torch(self, phi):
         """Test eigenvalues computation for IsingXY using Torch interface"""
         import torch
@@ -1204,7 +1203,7 @@ class TestMatrix:
         assert qml.math.allclose(evs.detach().numpy(), expected)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_isingxy_eigvals_jax(self, phi):
         """Test eigenvalues computation for IsingXY using JAX interface"""
         import jax
@@ -1347,7 +1346,7 @@ class TestMatrix:
         )
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     def test_isingzz_eigvals_tf(self, phi):
         """Test eigenvalues computation for IsingXY using Tensorflow interface"""
         import tensorflow as tf
@@ -1588,7 +1587,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [
@@ -1611,7 +1610,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [
@@ -1634,7 +1633,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", standard_angles)
+    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -698,6 +698,8 @@ class TestDecompositions:
 
         assert np.allclose(decomposed_matrix, exp)
 
+# 11 angles from the range [-pi, pi], including 0.
+standard_angles = list(np.linspace(-np.pi, np.pi, 11))
 
 class TestMatrix:
     def test_phase_shift(self, tol):
@@ -841,7 +843,7 @@ class TestMatrix:
 
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_pcphase(self, phi, dim, wires):
         """Test that the PCPhase operator matrix is correct."""
         num_wires = len(wires)
@@ -860,7 +862,7 @@ class TestMatrix:
     @pytest.mark.tf
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_pcphase_tf(self, phi, dim, wires):
         """Test that the PCPhase operator matrix is correct for tf."""
         import tensorflow as tf
@@ -884,7 +886,7 @@ class TestMatrix:
     @pytest.mark.torch
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_pcphase_torch(self, phi, dim, wires):
         import torch
 
@@ -907,7 +909,7 @@ class TestMatrix:
     @pytest.mark.jax
     @pytest.mark.parametrize("dim", range(3))
     @pytest.mark.parametrize("wires", (range(2), range(3)))
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_pcphase_jax(self, phi, dim, wires):
         import jax.numpy as jnp
 
@@ -1001,48 +1003,60 @@ class TestMatrix:
             qml.PSWAP(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
     def test_pswap_eigvals(self, phi):
         """Test eigenvalues computation for PSWAP"""
         evs = qml.PSWAP.compute_eigvals(phi)
-        evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
+        if len(qml.math.shape(phi)) > 0:
+            evs_expected = np.stack([[1, 1, -exp, exp] for exp in qml.math.exp(1j * phi)])
+        else:
+            evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
     def test_pswap_eigvals_tf(self, phi):
         """Test eigenvalues computation for PSWAP using Tensorflow interface"""
         import tensorflow as tf
 
         param_tf = tf.Variable(phi)
         evs = qml.PSWAP.compute_eigvals(param_tf)
-        evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
+        if len(qml.math.shape(phi)) > 0:
+            evs_expected = np.stack([[1, 1, -exp, exp] for exp in qml.math.exp(1j * phi)])
+        else:
+            evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
     def test_pswap_eigvals_torch(self, phi):
         """Test eigenvalues computation for PSWAP using Torch interface"""
         import torch
 
         param_torch = torch.tensor(phi)
         evs = qml.PSWAP.compute_eigvals(param_torch)
-        evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
+        if len(qml.math.shape(phi)) > 0:
+            evs_expected = np.stack([[1, 1, -exp, exp] for exp in qml.math.exp(1j * phi)])
+        else:
+            evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles + [np.linspace(-1, 1, 11)])
     def test_pswap_eigvals_jax(self, phi):
         """Test eigenvalues computation for PSWAP using JAX interface"""
         import jax
 
         param_jax = jax.numpy.array(phi)
         evs = qml.PSWAP.compute_eigvals(param_jax)
-        evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
+        if len(qml.math.shape(phi)) > 0:
+            evs_expected = np.stack([[1, 1, -exp, exp] for exp in qml.math.exp(1j * phi)])
+        else:
+            evs_expected = [1, 1, -qml.math.exp(1j * phi), qml.math.exp(1j * phi)]
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_pcphase_eigvals_tf(self, phi):
         """Test eigenvalues computation for PCPhase using Tensorflow interface"""
         import tensorflow as tf
@@ -1108,7 +1122,7 @@ class TestMatrix:
             qml.IsingXY(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_isingxy_eigvals(self, phi):
         """Test eigenvalues computation for IsingXY"""
         evs = qml.IsingXY.compute_eigvals(phi)
@@ -1122,7 +1136,7 @@ class TestMatrix:
 
     def test_isingxy_eigvals_broadcasted(self):
         """Test broadcasted eigenvalues computation for IsingXY"""
-        phi = np.linspace(-np.pi, np.pi, 10)
+        phi = np.array(standard_angles)
         evs = qml.IsingXY.compute_eigvals(phi)
         evs_expected = np.array(
             [[qml.math.exp(1j * _phi / 2), qml.math.exp(-1j * _phi / 2), 1, 1] for _phi in phi]
@@ -1130,7 +1144,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, evs_expected)
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_isingxy_eigvals_tf(self, phi):
         """Test eigenvalues computation for IsingXY using Tensorflow interface"""
         import tensorflow as tf
@@ -1159,7 +1173,7 @@ class TestMatrix:
         assert qml.math.allclose(evs, expected)
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_isingxy_eigvals_torch(self, phi):
         """Test eigenvalues computation for IsingXY using Torch interface"""
         import torch
@@ -1188,7 +1202,7 @@ class TestMatrix:
         assert qml.math.allclose(evs.detach().numpy(), expected)
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_isingxy_eigvals_jax(self, phi):
         """Test eigenvalues computation for IsingXY using JAX interface"""
         import jax
@@ -1331,7 +1345,7 @@ class TestMatrix:
         )
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     def test_isingzz_eigvals_tf(self, phi):
         """Test eigenvalues computation for IsingXY using Tensorflow interface"""
         import tensorflow as tf
@@ -1572,7 +1586,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.tf
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [
@@ -1595,7 +1609,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.torch
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [
@@ -1618,7 +1632,7 @@ class TestMatrix:
         assert np.allclose(res, np.diag(exp))
 
     @pytest.mark.jax
-    @pytest.mark.parametrize("phi", np.linspace(-np.pi, np.pi, 10))
+    @pytest.mark.parametrize("phi", standard_angles)
     @pytest.mark.parametrize(
         "cphase_op,gate_data_mat",
         [

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -698,8 +698,10 @@ class TestDecompositions:
 
         assert np.allclose(decomposed_matrix, exp)
 
+
 # 11 angles from the range [-pi, pi], including 0.
 standard_angles = list(np.linspace(-np.pi, np.pi, 11))
+
 
 class TestMatrix:
     def test_phase_shift(self, tol):

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -1004,6 +1004,39 @@ class TestMatrix:
             qml.PSWAP(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
         )
 
+    def test_pswap_broadcasted(self, tol):
+        """Test that the broadcasted PSWAP operation is correct"""
+        batch_size = 3
+        z = np.zeros(batch_size)
+        mat = qml.PSWAP.compute_matrix(z)
+        assert qml.math.shape(mat) == (batch_size, 4, 4)
+        assert np.allclose(mat, np.diag([1, 1, 1, 1])[[0, 2, 1, 3]], atol=tol, rtol=0)
+        mat = qml.PSWAP(z, wires=[0, 1]).matrix()
+        assert qml.math.shape(mat) == (batch_size, 4, 4)
+        assert np.allclose(
+            mat,
+            np.diag([1, 1, 1, 1])[[0, 2, 1, 3]],
+            atol=tol,
+            rtol=0,
+        )
+
+        def get_expected(theta):
+            return np.array(
+                [np.diag([1, np.exp(1j * t), np.exp(1j * t), 1])[[0, 2, 1, 3]] for t in theta]
+            )
+
+        param = np.array([np.pi / 2, np.pi])
+        assert np.allclose(qml.PSWAP.compute_matrix(param), get_expected(param), atol=tol, rtol=0)
+        assert np.allclose(
+            qml.PSWAP(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
+        )
+
+        param = np.array([2.152, np.pi / 2, 0.213])
+        assert np.allclose(qml.PSWAP.compute_matrix(param), get_expected(param), atol=tol, rtol=0)
+        assert np.allclose(
+            qml.PSWAP(param, wires=[0, 1]).matrix(), get_expected(param), atol=tol, rtol=0
+        )
+
     @pytest.mark.parametrize("phi", pswap_angles)
     def test_pswap_eigvals(self, phi):
         """Test eigenvalues computation for PSWAP"""


### PR DESCRIPTION
**Context:**
#7179 added broadcasting support to the matrix and eigvals of `PSWAP`. However, the broadcasting axis is currently the second (i.e. last) axis in broadcasted eigvals, although PL convention is to have the broadcasting axis first.

**Description of the Change:**
Transpose the eigenvalues. This does not change them when there is no broadcasting, and fixed the axis ordering whenever there is broadcasting.
Added tests for broadcasted eigenvalue computation, including ML interface tests.

**Benefits:**
Fixes eigenvalue broadcasting axis ordering.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
[sc-88504]