### PR TITLE
Fixing bug GlobalPhase in QubitUnitary

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug where the global phase was not being added in the ``QubitUnitary`` decomposition.  
+  [(#7244)](https://github.com/PennyLaneAI/pennylane/pull/7244)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Guillermo Alonso-Linaje

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -121,7 +121,7 @@ def _convert_to_su4(U, return_angle=False):
 
     exp_angle = -1j * math.cast_like(math.angle(det), 1j) / 4
     if return_angle:
-        return math.cast_like(U, det) * math.exp(exp_angle), np.angle(math.exp(exp_angle))
+        return math.cast_like(U, det) * math.exp(exp_angle), qml.math.angle(math.exp(exp_angle))
     return math.cast_like(U, det) * math.exp(exp_angle)
 
 

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -651,7 +651,8 @@ def two_qubit_decomposition(U, wires):
             decomp = _decomposition_3_cnots(U, wires)
 
     decomp_matrix = qml.matrix(qml.prod(*decomp[::-1]))
-    phase = decomp_matrix[0] @ qml.math.conj(U_copy[0]).T
+
+    phase = decomp_matrix[0] @ qml.math.transpose(qml.math.conj(U_copy[0]))
     decomp.append(qml.GlobalPhase(qml.math.angle(phase)))
 
     # If there is an active tape, queue the decomposition so that expand works

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -532,7 +532,7 @@ def _decomposition_3_cnots(U, wires):
     D_ops = one_qubit_decomposition(D, wires[1])
 
     # Return the full decomposition
-    return C_ops + D_ops + interior_decomp + A_ops + B_ops + [qml.GlobalPhase(-alpha / 2)]
+    return C_ops + D_ops + interior_decomp + A_ops + B_ops
 
 
 def two_qubit_decomposition(U, wires):
@@ -629,6 +629,7 @@ def two_qubit_decomposition(U, wires):
         raise qml.operation.DecompositionUndefinedError(
             "two_qubit_decomposition does not accept sparse matrics."
         )
+    U_copy = U
     U = _convert_to_su4(U)
 
     # The next thing we will do is compute the number of CNOTs needed, as this affects
@@ -648,6 +649,10 @@ def two_qubit_decomposition(U, wires):
             decomp = _decomposition_2_cnots(U, wires)
         else:
             decomp = _decomposition_3_cnots(U, wires)
+
+    decomp_matrix = qml.matrix(qml.prod(*decomp[::-1]))
+    phase = decomp_matrix[0] @ np.conj(U_copy[0]).T
+    decomp.append(qml.GlobalPhase(np.angle(phase)))
 
     # If there is an active tape, queue the decomposition so that expand works
     current_tape = qml.queuing.QueuingManager.active_context()

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -106,7 +106,7 @@ q_one_cnot = (1 / np.sqrt(2)) * np.array(
 global_arrays_name = ["E", "Edag", "CNOT01", "CNOT10", "SWAP", "S_SX", "v_one_cnot", "q_one_cnot"]
 
 
-def _convert_to_su4(U, return_angle=False):
+def _convert_to_su4(U, return_global_phase=False):
     r"""Convert a 4x4 matrix to :math:`SU(4)`.
 
     Args:
@@ -120,7 +120,7 @@ def _convert_to_su4(U, return_angle=False):
     det = math.linalg.det(U)
 
     exp_angle = -1j * math.cast_like(math.angle(det), 1j) / 4
-    if return_angle:
+    if return_global_phase:
         return math.cast_like(U, det) * math.exp(exp_angle), qml.math.angle(math.exp(exp_angle))
     return math.cast_like(U, det) * math.exp(exp_angle)
 
@@ -350,10 +350,10 @@ def _decomposition_1_cnot(U, wires):
 
     # Recover the operators in the decomposition; note that because of the
     # initial SWAP, we exchange the order of A and B
-    A_ops = one_qubit_decomposition(A, wires[1], return_global_phase=True)
-    B_ops = one_qubit_decomposition(B, wires[0], return_global_phase=True)
-    C_ops = one_qubit_decomposition(C, wires[0], return_global_phase=True)
-    D_ops = one_qubit_decomposition(D, wires[1], return_global_phase=True)
+    A_ops = one_qubit_decomposition(A, wires[1])
+    B_ops = one_qubit_decomposition(B, wires[0])
+    C_ops = one_qubit_decomposition(C, wires[0])
+    D_ops = one_qubit_decomposition(D, wires[1])
 
     return C_ops + D_ops + [qml.CNOT(wires=wires)] + A_ops + B_ops + [qml.GlobalPhase(np.pi / 4)]
 
@@ -632,7 +632,7 @@ def two_qubit_decomposition(U, wires):
             "two_qubit_decomposition does not accept sparse matrics."
         )
 
-    U, angle = _convert_to_su4(U, return_angle=True)
+    U, angle = _convert_to_su4(U, return_global_phase=True)
 
     # The next thing we will do is compute the number of CNOTs needed, as this affects
     # the form of the decomposition.

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -119,7 +119,7 @@ def _convert_to_su4(U, return_angle=False):
     # Compute the determinant
     det = math.linalg.det(U)
 
-    exp_angle = -1j * np.angle(det) / 4
+    exp_angle = -1j * math.cast_like(math.angle(det), 1j) / 4
     if return_angle:
         return math.cast_like(U, det) * math.exp(exp_angle), np.angle(math.exp(exp_angle))
     return math.cast_like(U, det) * math.exp(exp_angle)

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -651,8 +651,8 @@ def two_qubit_decomposition(U, wires):
             decomp = _decomposition_3_cnots(U, wires)
 
     decomp_matrix = qml.matrix(qml.prod(*decomp[::-1]))
-    phase = decomp_matrix[0] @ np.conj(U_copy[0]).T
-    decomp.append(qml.GlobalPhase(np.angle(phase)))
+    phase = decomp_matrix[0] @ qml.math.conj(U_copy[0]).T
+    decomp.append(qml.GlobalPhase(qml.math.angle(phase)))
 
     # If there is an active tape, queue the decomposition so that expand works
     current_tape = qml.queuing.QueuingManager.active_context()

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -532,7 +532,7 @@ def _decomposition_3_cnots(U, wires):
     D_ops = one_qubit_decomposition(D, wires[1])
 
     # Return the full decomposition
-    return C_ops + D_ops + interior_decomp + A_ops + B_ops
+    return C_ops + D_ops + interior_decomp + A_ops + B_ops + [qml.GlobalPhase(-alpha / 2)]
 
 
 def two_qubit_decomposition(U, wires):

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -119,9 +119,8 @@ def _convert_to_su4(U, return_angle=False):
     # Compute the determinant
     det = math.linalg.det(U)
 
-    exp_angle = -1j * np.angle(det) / 4  # divide by 4 for SU(4)
+    exp_angle = -1j * np.angle(det) / 4
     if return_angle:
-        print(np.angle(math.exp(exp_angle)))
         return math.cast_like(U, det) * math.exp(exp_angle), np.angle(math.exp(exp_angle))
     return math.cast_like(U, det) * math.exp(exp_angle)
 

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -528,10 +528,10 @@ def _decomposition_3_cnots(U, wires):
     # -╭U- = --C--╭X-RZ(d)-╭C-------╭X--B--
     # -╰U- = --D--╰C-RZ(b)-╰X-RY(a)-╰C--A--
 
-    A_ops = one_qubit_decomposition(A, wires[1], return_global_phase=True)
-    B_ops = one_qubit_decomposition(B, wires[0], return_global_phase=True)
-    C_ops = one_qubit_decomposition(C, wires[0], return_global_phase=True)
-    D_ops = one_qubit_decomposition(D, wires[1], return_global_phase=True)
+    A_ops = one_qubit_decomposition(A, wires[1])
+    B_ops = one_qubit_decomposition(B, wires[0])
+    C_ops = one_qubit_decomposition(C, wires[0])
+    D_ops = one_qubit_decomposition(D, wires[1])
 
     # Return the full decomposition
     return C_ops + D_ops + interior_decomp + A_ops + B_ops + [qml.GlobalPhase(np.pi / 4)]
@@ -632,7 +632,6 @@ def two_qubit_decomposition(U, wires):
             "two_qubit_decomposition does not accept sparse matrics."
         )
 
-    U_copy = U
     U, angle = _convert_to_su4(U, return_angle=True)
 
     # The next thing we will do is compute the number of CNOTs needed, as this affects

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -984,7 +984,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 3
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 18
+        assert len(obtained_decomposition) == 19
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1234,7 +1234,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
     @pytest.mark.jax
     @pytest.mark.parametrize("wires", [[0, 1], ["a", "b"], [3, 2], ["c", 0]])
     @pytest.mark.parametrize("U_pair", samples_su2_su2)
-    def _jax_jit(self, U_pair, wires):
+    def test_two_qubit_decomposition_tensor_products_jax_jit(self, U_pair, wires):
         """Test that a two-qubit tensor product is correctly decomposed with JAX-JIT."""
 
         # pylint: disable=import-outside-toplevel
@@ -1293,9 +1293,7 @@ def test_two_qubit_decomposition_special_case_discontinuity():
         return mat
 
     mat = make_unitary(np.pi / 2)
-    decomp_mat = qml.matrix(
-        qml.prod(*two_qubit_decomposition(mat, wires=(0, 1))[::-1]), wire_order=(0, 1)
-    )
+    decomp_mat = qml.matrix(two_qubit_decomposition, wire_order=(0, 1))(mat, wires=(0, 1))
     assert qml.math.allclose(mat, decomp_mat)
 
 

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1007,7 +1007,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 2
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 16
+        assert len(obtained_decomposition) == 17
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:
@@ -1028,7 +1028,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 1
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 13
+        assert len(obtained_decomposition) == 14
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:
@@ -1049,7 +1049,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 0
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 6
+        assert len(obtained_decomposition) == 7
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:
@@ -1234,7 +1234,7 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
     @pytest.mark.jax
     @pytest.mark.parametrize("wires", [[0, 1], ["a", "b"], [3, 2], ["c", 0]])
     @pytest.mark.parametrize("U_pair", samples_su2_su2)
-    def test_two_qubit_decomposition_tensor_products_jax_jit(self, U_pair, wires):
+    def _jax_jit(self, U_pair, wires):
         """Test that a two-qubit tensor product is correctly decomposed with JAX-JIT."""
 
         # pylint: disable=import-outside-toplevel

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1028,7 +1028,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 1
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 19
+        assert len(obtained_decomposition) == 15
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1293,7 +1293,9 @@ def test_two_qubit_decomposition_special_case_discontinuity():
         return mat
 
     mat = make_unitary(np.pi / 2)
-    decomp_mat = qml.matrix(two_qubit_decomposition, wire_order=(0, 1))(mat, wires=(0, 1))
+    decomp_mat = qml.matrix(
+        qml.prod(*two_qubit_decomposition(mat, wires=(0, 1))[::-1]), wire_order=(0, 1)
+    )
     assert qml.math.allclose(mat, decomp_mat)
 
 

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -984,7 +984,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 3
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 19
+        assert len(obtained_decomposition) == 20
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:
@@ -1028,7 +1028,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 1
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 14
+        assert len(obtained_decomposition) == 19
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:
@@ -1049,7 +1049,7 @@ class TestTwoQubitUnitaryDecomposition:
         assert _compute_num_cnots(U) == 0
 
         obtained_decomposition = two_qubit_decomposition(U, wires=wires)
-        assert len(obtained_decomposition) == 7
+        assert len(obtained_decomposition) == 9
 
         with qml.queuing.AnnotatedQueue() as q:
             for op in obtained_decomposition:

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -500,8 +500,8 @@ class TestQubitUnitary:
     def test_qubit_unitary_correct_global_phase(self, U):
         """Tests that the input matrix matches with the decomposition matrix even in the global phase"""
 
-        ops = qml.QubitUnitary.compute_decomposition(U, wires=[0, 1])
-        assert qml.math.allclose(U, qml.matrix(qml.prod(*ops[::-1]), wire_order=[0, 1]), atol=1e-7)
+        ops_decompostion = qml.QubitUnitary.compute_decomposition(U, wires=[0, 1])
+        assert qml.math.allclose(U, qml.matrix(qml.prod(*ops_decompostion[::-1]), wire_order=[0, 1]), atol=1e-7)
 
     def test_broadcasted_two_qubit_qubit_unitary_decomposition_raises_error(self):
         """Tests that broadcasted QubitUnitary decompositions are not supported."""

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -501,7 +501,9 @@ class TestQubitUnitary:
         """Tests that the input matrix matches with the decomposition matrix even in the global phase"""
 
         ops_decompostion = qml.QubitUnitary.compute_decomposition(U, wires=[0, 1])
-        assert qml.math.allclose(U, qml.matrix(qml.prod(*ops_decompostion[::-1]), wire_order=[0, 1]), atol=1e-7)
+        assert qml.math.allclose(
+            U, qml.matrix(qml.prod(*ops_decompostion[::-1]), wire_order=[0, 1]), atol=1e-7
+        )
 
     def test_broadcasted_two_qubit_qubit_unitary_decomposition_raises_error(self):
         """Tests that broadcasted QubitUnitary decompositions are not supported."""

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -484,7 +484,7 @@ class TestQubitUnitary:
         [
             (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.CRX(2, wires=[1, 0]))),  # 2 cnots
             (qml.matrix(qml.CRX(2, wires=[1, 0]))),  # 2 cnots
-            (qml.matrix(qml.TrotterProduct(qml.X(0) + 0.3 * qml.Y(1), time=1, n=5))),  # cnots
+            (qml.matrix(qml.TrotterProduct(qml.X(0) + 0.3 * qml.Y(1), time=1, n=5))),  # 0 cnots
             (
                 qml.matrix(qml.TrotterProduct(qml.X(0) @ qml.Z(1) - 0.3 * qml.Y(1), time=1))
             ),  # 2 cnots

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -479,6 +479,30 @@ class TestQubitUnitary:
             assert isinstance(decomp2[i], expected_gates[i])
             assert np.allclose(decomp2[i].parameters, expected_params[i], atol=1e-7)
 
+    @pytest.mark.parametrize(
+        "U",
+        [
+            (qml.matrix(qml.CRX(2, wires=[1, 0]))),
+            (qml.matrix(qml.TrotterProduct(qml.X(0) + 0.3 * qml.Y(1), time=1, n=5))),
+            (qml.matrix(qml.TrotterProduct(qml.X(0) @ qml.Z(1) - 0.3 * qml.Y(1), time=1))),
+            (qml.matrix(qml.CRY(1, wires=[0, 1]))),
+            (qml.matrix(qml.QFT(wires=[0, 1]))),
+            (qml.matrix(qml.GroverOperator(wires=[0, 1]))),
+            (qml.matrix(qml.CRY(-1, wires=[0, 1]))),
+            (qml.matrix(qml.SWAP(wires=[0, 1]))),
+            (
+                qml.matrix(
+                    qml.MottonenStatePreparation(np.sqrt([0.25, 0.15, 0.2, 0.4]), wires=[0, 1])
+                )
+            ),
+        ],
+    )
+    def test_qubit_unitary_correct_global_phase(self, U):
+        """Tests that the input matrix matches with the decomposition matrix even in the global phase"""
+
+        ops = qml.QubitUnitary.compute_decomposition(U, wires=[0, 1])
+        assert qml.math.allclose(U, qml.matrix(qml.prod(*ops[::-1]), wire_order=[0, 1]), atol=1e-7)
+
     def test_broadcasted_two_qubit_qubit_unitary_decomposition_raises_error(self):
         """Tests that broadcasted QubitUnitary decompositions are not supported."""
         U = qml.IsingYY.compute_matrix(np.array([1.2, 2.3, 3.4]))

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -482,25 +482,34 @@ class TestQubitUnitary:
     @pytest.mark.parametrize(
         "U",
         [
-            (qml.matrix(qml.CRX(2, wires=[1, 0]))),
-            (qml.matrix(qml.TrotterProduct(qml.X(0) + 0.3 * qml.Y(1), time=1, n=5))),
-            (qml.matrix(qml.TrotterProduct(qml.X(0) @ qml.Z(1) - 0.3 * qml.Y(1), time=1))),
-            (qml.matrix(qml.CRY(1, wires=[0, 1]))),
-            (qml.matrix(qml.QFT(wires=[0, 1]))),
-            (qml.matrix(qml.GroverOperator(wires=[0, 1]))),
-            (qml.matrix(qml.CRY(-1, wires=[0, 1]))),
-            (qml.matrix(qml.SWAP(wires=[0, 1]))),
+            (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.CRX(2, wires=[1, 0]))),  # 2 cnots
+            (qml.matrix(qml.CRX(2, wires=[1, 0]))),  # 2 cnots
+            (qml.matrix(qml.TrotterProduct(qml.X(0) + 0.3 * qml.Y(1), time=1, n=5))),  # cnots
+            (
+                qml.matrix(qml.TrotterProduct(qml.X(0) @ qml.Z(1) - 0.3 * qml.Y(1), time=1))
+            ),  # 2 cnots
+            (qml.matrix(qml.CRY(1, wires=[0, 1]))),  # 2 cnots
+            (qml.matrix(qml.QFT(wires=[0, 1]))),  # 3 cnots
+            (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.QFT(wires=[0, 1]))),  # 3 cnots
+            (qml.matrix(qml.RZ(1, wires=0) @ qml.GroverOperator(wires=[0, 1]))),  # 1 cnot
+            (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.GroverOperator(wires=[0, 1]))),  # 1 cnot
+            (qml.matrix(qml.CRY(-1, wires=[0, 1]))),  # 2 cnots
+            (qml.matrix(qml.SWAP(wires=[0, 1]))),  # 3 cnots
+            (qml.matrix(qml.SWAP(wires=[0, 1]) @ qml.GlobalPhase(3))),  # 3 cnots
+            (qml.matrix(qml.Hadamard(wires=[0]) @ qml.RX(2, wires=1))),  # 0 cnots
+            (qml.matrix(qml.RX(-1, wires=[0]) @ qml.RZ(-5, wires=1))),  # 0 cnots
             (
                 qml.matrix(
                     qml.MottonenStatePreparation(np.sqrt([0.25, 0.15, 0.2, 0.4]), wires=[0, 1])
                 )
-            ),
+            ),  # 2 cnots
         ],
     )
     def test_qubit_unitary_correct_global_phase(self, U):
         """Tests that the input matrix matches with the decomposition matrix even in the global phase"""
 
         ops_decompostion = qml.QubitUnitary.compute_decomposition(U, wires=[0, 1])
+
         assert qml.math.allclose(
             U, qml.matrix(qml.prod(*ops_decompostion[::-1]), wire_order=[0, 1]), atol=1e-7
         )

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -302,8 +302,8 @@ class TestQuantumMonteCarlo:
         # Do expansion in two steps to avoid also decomposing the first QubitUnitary
         queue_before_qpe = tape.operations[:2]
 
-        # 2-qubit decomposition has 18 operations, and after is a 3-qubit gate so start at 19
-        queue_after_qpe = tape.expand().operations[19:]
+        # 2-qubit decomposition has 19 operations, and after is a 3-qubit gate so start at 20
+        queue_after_qpe = tape.expand().operations[20:]
 
         A = probs_to_unitary(p)
         R = func_to_unitary(self.func, 4)

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -302,8 +302,8 @@ class TestQuantumMonteCarlo:
         # Do expansion in two steps to avoid also decomposing the first QubitUnitary
         queue_before_qpe = tape.operations[:2]
 
-        # 2-qubit decomposition has 19 operations, and after is a 3-qubit gate so start at 20
-        queue_after_qpe = tape.expand().operations[20:]
+        # 2-qubit decomposition has 20 operations, and after is a 3-qubit gate so start at 21
+        queue_after_qpe = tape.expand().operations[21:]
 
         A = probs_to_unitary(p)
         R = func_to_unitary(self.func, 4)

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -561,7 +561,7 @@ class TestTwoQubitUnitaryDifferentiability:
 
         # 3 normal operations + 18 for the first decomp and 6 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x, y, z)
-        assert len(tape.operations) == 27
+        assert len(tape.operations) == 28
 
         original_grad = qml.grad(original_qnode)(x, y, z)
         transformed_grad = qml.grad(transformed_qnode)(x, y, z)
@@ -612,7 +612,7 @@ class TestTwoQubitUnitaryDifferentiability:
         tape = qml.workflow.construct_tape(transformed_qnode)(
             transformed_x, transformed_y, transformed_z
         )
-        assert len(tape.operations) == 27
+        assert len(tape.operations) == 28
 
         original_result.backward()
         transformed_result.backward()
@@ -658,7 +658,7 @@ class TestTwoQubitUnitaryDifferentiability:
         assert qml.math.allclose(original_result, transformed_result)
 
         tape = qml.workflow.construct_tape(transformed_qnode)(transformed_x)
-        assert len(tape.operations) == 25
+        assert len(tape.operations) == 26
 
         with tf.GradientTape() as tape:
             loss = original_qnode(x)
@@ -704,7 +704,7 @@ class TestTwoQubitUnitaryDifferentiability:
 
         # 1 normal operations + 18 for the first decomp and 6 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x)
-        assert len(tape.operations) == 25
+        assert len(tape.operations) == 26
 
         original_grad = jax.grad(original_qnode, argnums=(0))(x)
         transformed_grad = jax.grad(transformed_qnode, argnums=(0))(x)

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -559,9 +559,9 @@ class TestTwoQubitUnitaryDifferentiability:
 
         assert qml.math.allclose(original_qnode(x, y, z), transformed_qnode(x, y, z))
 
-        # 3 normal operations + 19 for the first decomp and 6 for the second
+        # 3 normal operations + 9 for the first decomp and 20 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x, y, z)
-        assert len(tape.operations) == 29
+        assert len(tape.operations) == 32
 
         original_grad = qml.grad(original_qnode)(x, y, z)
         transformed_grad = qml.grad(transformed_qnode)(x, y, z)
@@ -612,7 +612,7 @@ class TestTwoQubitUnitaryDifferentiability:
         tape = qml.workflow.construct_tape(transformed_qnode)(
             transformed_x, transformed_y, transformed_z
         )
-        assert len(tape.operations) == 29
+        assert len(tape.operations) == 32
 
         original_result.backward()
         transformed_result.backward()
@@ -658,7 +658,7 @@ class TestTwoQubitUnitaryDifferentiability:
         assert qml.math.allclose(original_result, transformed_result)
 
         tape = qml.workflow.construct_tape(transformed_qnode)(transformed_x)
-        assert len(tape.operations) == 27
+        assert len(tape.operations) == 30
 
         with tf.GradientTape() as tape:
             loss = original_qnode(x)
@@ -702,9 +702,9 @@ class TestTwoQubitUnitaryDifferentiability:
 
         assert qml.math.allclose(original_qnode(x), transformed_qnode(x))
 
-        # 1 normal operations + 19 for the first decomp and 6 for the second
+        # 1 normal operations + 9 for the first decomp and 20 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x)
-        assert len(tape.operations) == 27
+        assert len(tape.operations) == 30
 
         original_grad = jax.grad(original_qnode, argnums=(0))(x)
         transformed_grad = jax.grad(transformed_qnode, argnums=(0))(x)

--- a/tests/transforms/test_unitary_to_rot.py
+++ b/tests/transforms/test_unitary_to_rot.py
@@ -559,9 +559,9 @@ class TestTwoQubitUnitaryDifferentiability:
 
         assert qml.math.allclose(original_qnode(x, y, z), transformed_qnode(x, y, z))
 
-        # 3 normal operations + 18 for the first decomp and 6 for the second
+        # 3 normal operations + 19 for the first decomp and 6 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x, y, z)
-        assert len(tape.operations) == 28
+        assert len(tape.operations) == 29
 
         original_grad = qml.grad(original_qnode)(x, y, z)
         transformed_grad = qml.grad(transformed_qnode)(x, y, z)
@@ -612,7 +612,7 @@ class TestTwoQubitUnitaryDifferentiability:
         tape = qml.workflow.construct_tape(transformed_qnode)(
             transformed_x, transformed_y, transformed_z
         )
-        assert len(tape.operations) == 28
+        assert len(tape.operations) == 29
 
         original_result.backward()
         transformed_result.backward()
@@ -658,7 +658,7 @@ class TestTwoQubitUnitaryDifferentiability:
         assert qml.math.allclose(original_result, transformed_result)
 
         tape = qml.workflow.construct_tape(transformed_qnode)(transformed_x)
-        assert len(tape.operations) == 26
+        assert len(tape.operations) == 27
 
         with tf.GradientTape() as tape:
             loss = original_qnode(x)
@@ -702,9 +702,9 @@ class TestTwoQubitUnitaryDifferentiability:
 
         assert qml.math.allclose(original_qnode(x), transformed_qnode(x))
 
-        # 1 normal operations + 18 for the first decomp and 6 for the second
+        # 1 normal operations + 19 for the first decomp and 6 for the second
         tape = qml.workflow.construct_tape(transformed_qnode)(x)
-        assert len(tape.operations) == 26
+        assert len(tape.operations) == 27
 
         original_grad = jax.grad(original_qnode, argnums=(0))(x)
         transformed_grad = jax.grad(transformed_qnode, argnums=(0))(x)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Fixes issue #7242

**Description of the Change:**

Adding Global Phase in the decomposition

**Benefits:**

**Possible Drawbacks:**

Decompositions add more than one Global Phase


**Related GitHub Issues:**

#7242

