### PR TITLE
[Capture] `commute_controlled(direction="left")` works correctly with higher order primitives

### DIFF
--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -285,6 +285,7 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
   and target qubits of controlled operations when experimental program capture is enabled.
   It follows the same API as `qml.transforms.commute_controlled`.
   [(#6946)](https://github.com/PennyLaneAI/pennylane/pull/6946)
+  [(#)]()
 
 * `qml.QNode` can now cache plxpr. When executing a `QNode` for the first time, its plxpr representation will
   be cached based on the abstract evaluation of the arguments. Later executions that have arguments with the

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -285,7 +285,7 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
   and target qubits of controlled operations when experimental program capture is enabled.
   It follows the same API as `qml.transforms.commute_controlled`.
   [(#6946)](https://github.com/PennyLaneAI/pennylane/pull/6946)
-  [(#)]()
+  [(#7247)](https://github.com/PennyLaneAI/pennylane/pull/7247)
 
 * `qml.QNode` can now cache plxpr. When executing a `QNode` for the first time, its plxpr representation will
   be cached based on the abstract evaluation of the arguments. Later executions that have arguments with the

--- a/pennylane/transforms/optimization/commute_controlled.py
+++ b/pennylane/transforms/optimization/commute_controlled.py
@@ -160,6 +160,7 @@ def _get_plxpr_commute_controlled():  # pylint: disable=missing-function-docstri
                 for op in self.op_deque:
                     super().interpret_operation(op)
                 self.op_deque.clear()
+                self.current_index = 0
                 return
 
             # If the direction is right, push the gates in each sub-list

--- a/tests/capture/transforms/test_capture_commute_controlled.py
+++ b/tests/capture/transforms/test_capture_commute_controlled.py
@@ -25,7 +25,7 @@ jax = pytest.importorskip("jax")
 
 pytestmark = [pytest.mark.jax, pytest.mark.usefixtures("enable_disable_plxpr")]
 
-from pennylane.capture.primitives import cond_prim, for_loop_prim, measure_prim
+from pennylane.capture.primitives import cond_prim, for_loop_prim, measure_prim, while_loop_prim
 from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 from pennylane.transforms.optimization.commute_controlled import (
     CommuteControlledInterpreter,
@@ -504,130 +504,215 @@ class TestCommuteControlledHigherOrderPrimitives:
         assert qml.math.allclose(result, expected_result)
 
     @pytest.mark.parametrize(
-        "selector, expected_ops",
+        "selector, expected_cond_ops",
         [
             (
                 0.2,
-                [
-                    qml.CNOT(wires=[0, 1]),
-                    qml.CNOT(wires=[0, 2]),
-                    qml.Toffoli(wires=[0, 1, 2]),
-                    qml.RX(np.pi, wires=2),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                {
+                    "right": [
+                        qml.CNOT(wires=[0, 2]),
+                        qml.Toffoli(wires=[0, 1, 2]),
+                        qml.RX(np.pi, wires=2),
+                    ],
+                    "left": [
+                        qml.RX(np.pi, wires=2),
+                        qml.CNOT(wires=[0, 2]),
+                        qml.Toffoli(wires=[0, 1, 2]),
+                    ],
+                },
             ),
             (
                 0.8,
-                [
-                    qml.CNOT(wires=[0, 1]),
-                    qml.RY(np.pi, wires=2),
-                    qml.CNOT(wires=[0, 2]),
-                    qml.Toffoli(wires=[0, 1, 2]),
-                    qml.CNOT(wires=[0, 1]),
-                ],
+                {
+                    "right": [
+                        qml.CNOT(wires=[0, 2]),
+                        qml.Toffoli(wires=[0, 1, 2]),
+                        qml.RZ(np.pi, wires=0),
+                    ],
+                    "left": [
+                        qml.RZ(np.pi, wires=0),
+                        qml.CNOT(wires=[0, 2]),
+                        qml.Toffoli(wires=[0, 1, 2]),
+                    ],
+                },
             ),
         ],
     )
-    def test_cond(self, selector, expected_ops):
+    @pytest.mark.parametrize("direction", ["left", "right"])
+    def test_cond(self, selector, expected_cond_ops, direction):
         """Test that operations inside a conditional block are correctly pushed."""
 
-        @CommuteControlledInterpreter()
+        @CommuteControlledInterpreter(direction=direction)
         def circuit(selector, x):
 
             def true_branch(x):
-                qml.RY(x, wires=2)
                 qml.CNOT(wires=[0, 2])
+                qml.RZ(x, wires=0)
                 qml.Toffoli(wires=[0, 1, 2])
 
             # pylint: disable=unused-argument
             def false_branch(x):
-                qml.RX(x, wires=2)
                 qml.CNOT(wires=[0, 2])
+                qml.RX(x, wires=2)
                 qml.Toffoli(wires=[0, 1, 2])
 
+            qml.Z(0)
             qml.CNOT(wires=[0, 1])
+            qml.T(0)
             qml.cond(selector > 0.5, true_branch, false_branch)(x)
+            qml.Z(0)
             qml.CNOT(wires=[0, 1])
+            qml.T(0)
 
         jaxpr = jax.make_jaxpr(circuit)(selector, np.pi)
+        initial_gates = (
+            [qml.CNOT([0, 1]), qml.Z(0), qml.T(0)]
+            if direction == "right"
+            else [qml.Z(0), qml.T(0), qml.CNOT([0, 1])]
+        )
 
-        assert len(jaxpr.eqns) == 4
+        assert len(jaxpr.eqns) == 8
         assert jaxpr.eqns[0].primitive == jax.lax.gt_p
-        assert jaxpr.eqns[1].primitive == qml.CNOT._primitive
-        assert jaxpr.eqns[2].primitive == cond_prim
-        assert jaxpr.eqns[3].primitive == qml.CNOT._primitive
+        for e, i in enumerate(range(1, 4)):
+            assert jaxpr.eqns[i].primitive == initial_gates[e]._primitive
+
+        assert jaxpr.eqns[4].primitive == cond_prim
+
+        for e, i in enumerate(range(5, 8)):
+            assert jaxpr.eqns[i].primitive == initial_gates[e]._primitive
 
         collector = CollectOpsandMeas()
         collector.eval(jaxpr.jaxpr, jaxpr.consts, selector, np.pi)
         jaxpr_ops = collector.state["ops"]
-
+        expected_ops = initial_gates + expected_cond_ops[direction] + initial_gates
         for op1, op2 in zip(jaxpr_ops, expected_ops, strict=True):
             qml.assert_equal(op1, op2)
 
-    def test_for_loop(self):
+    @pytest.mark.parametrize("direction", ["left", "right"])
+    def test_for_loop(self, direction):
         """Test that operators inside a for loop are correctly pushed."""
 
-        @CommuteControlledInterpreter()
+        @CommuteControlledInterpreter(direction=direction)
         def circuit(x):
+
+            qml.Z(0)
+            qml.CNOT(wires=[0, 1])
+            qml.T(0)
 
             @qml.for_loop(0, 2)
             # pylint: disable=unused-argument
             def loop(i, x):
-                qml.RX(x, wires=2)
                 qml.CNOT(wires=[0, 2])
+                qml.RX(x, wires=2)
                 qml.Toffoli(wires=[0, 1, 2])
                 return x
 
             # pylint: disable=no-value-for-parameter
             loop(x)
+            qml.Z(0)
+            qml.CNOT(wires=[0, 1])
+            qml.T(0)
 
         jaxpr = jax.make_jaxpr(circuit)(np.pi)
-        assert len(jaxpr.eqns) == 1
-        assert jaxpr.eqns[0].primitive == for_loop_prim
+        assert len(jaxpr.eqns) == 7
+        assert jaxpr.eqns[3].primitive == for_loop_prim
 
         collector = CollectOpsandMeas()
         collector.eval(jaxpr.jaxpr, jaxpr.consts, np.pi)
         jaxpr_ops = collector.state["ops"]
-        assert len(jaxpr_ops) == 6
+        assert len(jaxpr_ops) == 12
 
-        expected_ops = [
-            qml.CNOT(wires=[0, 2]),
-            qml.Toffoli(wires=[0, 1, 2]),
-            qml.RX(np.pi, wires=[2]),
-            qml.CNOT(wires=[0, 2]),
-            qml.Toffoli(wires=[0, 1, 2]),
-            qml.RX(np.pi, wires=[2]),
-        ]
+        initial_gates = (
+            [qml.CNOT([0, 1]), qml.Z(0), qml.T(0)]
+            if direction == "right"
+            else [qml.Z(0), qml.T(0), qml.CNOT([0, 1])]
+        )
+        loop_ctrls = [qml.CNOT(wires=[0, 2]), qml.Toffoli(wires=[0, 1, 2])]
+        loop_rx = [qml.RX(np.pi, 2)]
+        expected_loop_ops = loop_ctrls + loop_rx if direction == "right" else loop_rx + loop_ctrls
+        expected_ops = initial_gates + expected_loop_ops * 2 + initial_gates
 
         for op1, op2 in zip(jaxpr_ops, expected_ops, strict=True):
             qml.assert_equal(op1, op2)
 
-    def test_mid_circuit_measurement(self):
+    @pytest.mark.parametrize("direction", ["left", "right"])
+    def test_while_loop(self, direction):
+        """Test that operators inside a while loop are correctly pushed."""
+
+        @CommuteControlledInterpreter(direction=direction)
+        def circuit(x):
+
+            qml.Z(0)
+            qml.CNOT(wires=[0, 1])
+            qml.T(0)
+
+            # pylint: disable=unused-argument
+            @qml.while_loop(lambda i, x: i < 2)
+            def loop(i, x):
+                qml.CNOT(wires=[0, 2])
+                qml.RX(x, wires=2)
+                qml.Toffoli(wires=[0, 1, 2])
+                return i + 1, x
+
+            # pylint: disable=no-value-for-parameter
+            loop(0, x)
+            qml.Z(0)
+            qml.CNOT(wires=[0, 1])
+            qml.T(0)
+
+        jaxpr = jax.make_jaxpr(circuit)(np.pi)
+        assert len(jaxpr.eqns) == 7
+        assert jaxpr.eqns[3].primitive == while_loop_prim
+
+        collector = CollectOpsandMeas()
+        collector.eval(jaxpr.jaxpr, jaxpr.consts, np.pi)
+        jaxpr_ops = collector.state["ops"]
+        assert len(jaxpr_ops) == 12
+
+        initial_gates = (
+            [qml.CNOT([0, 1]), qml.Z(0), qml.T(0)]
+            if direction == "right"
+            else [qml.Z(0), qml.T(0), qml.CNOT([0, 1])]
+        )
+        loop_ctrls = [qml.CNOT(wires=[0, 2]), qml.Toffoli(wires=[0, 1, 2])]
+        loop_rx = [qml.RX(np.pi, 2)]
+        expected_loop_ops = loop_ctrls + loop_rx if direction == "right" else loop_rx + loop_ctrls
+        expected_ops = initial_gates + expected_loop_ops * 2 + initial_gates
+
+        for op1, op2 in zip(jaxpr_ops, expected_ops, strict=True):
+            qml.assert_equal(op1, op2)
+
+    @pytest.mark.parametrize("direction", ["left", "right"])
+    def test_mid_circuit_measurement(self, direction):
         """Test that mid-circuit measurements are correctly handled."""
 
-        @CommuteControlledInterpreter()
+        @CommuteControlledInterpreter(direction=direction)
         def circuit(x):
-            qml.RX(x, wires=2)
             qml.CNOT(wires=[0, 2])
+            qml.RX(x, wires=2)
             qml.Toffoli(wires=[0, 1, 2])
             qml.measure(0)
-            qml.RX(x, wires=2)
             qml.CNOT(wires=[0, 2])
+            qml.RX(x, wires=2)
             qml.Toffoli(wires=[0, 1, 2])
             return qml.expval(qml.PauliZ(0))
 
         jaxpr = jax.make_jaxpr(circuit)(np.pi)
         assert len(jaxpr.eqns) == 9
 
+        jaxpr_controlled_ops = [qml.CNOT([0, 2]), qml.Toffoli([0, 1, 2])]
+        rx_op = [qml.RX(np.pi, 2)]
+        initial_gates = (
+            jaxpr_controlled_ops + rx_op if direction == "right" else rx_op + jaxpr_controlled_ops
+        )
+
         # I test the jaxpr like this because `CollectOpsandMeas`
         # currently interprets a mid-circuit measurement as an operator, not a measurement
-        assert jaxpr.eqns[0].primitive == qml.CNOT._primitive
-        assert jaxpr.eqns[1].primitive == qml.Toffoli._primitive
-        assert jaxpr.eqns[2].primitive == qml.RX._primitive
+        for e, i in enumerate(range(3)):
+            assert jaxpr.eqns[i].primitive == initial_gates[e]._primitive
         assert jaxpr.eqns[3].primitive == measure_prim
-        assert jaxpr.eqns[4].primitive == qml.CNOT._primitive
-        assert jaxpr.eqns[5].primitive == qml.Toffoli._primitive
-        assert jaxpr.eqns[6].primitive == qml.RX._primitive
+        for e, i in enumerate(range(4, 7)):
+            assert jaxpr.eqns[i].primitive == initial_gates[e]._primitive
         assert jaxpr.eqns[7].primitive == qml.PauliZ._primitive
 
 


### PR DESCRIPTION
[sc-88726]

**Context:**
`commute_controlled` isn't working correctly when applying commutable ops after higher order primitives when `direction="left"`.

The following example currently doesn't work in the RC branch:
```python
from functools import partial
import pennylane as qml
import jax

qml.capture.enable()

@qml.capture.expand_plxpr_transforms
@partial(qml.transforms.commute_controlled, direction="left")
def qfunc(theta):
    qml.CZ(wires=[0, 2])
    qml.S(wires=0)

    qml.CNOT(wires=[0, 1])

    @qml.for_loop(2)
    def loop_fn(i):
        qml.X(i)

    loop_fn()

    qml.Y(1)
    qml.CRY(theta, wires=[0, 1])
    qml.PhaseShift(theta/2, wires=0)

    qml.Toffoli(wires=[0, 1, 2])
    qml.T(wires=0)
    qml.RZ(theta/2, wires=1)
    qml.Y(1)

    return qml.expval(qml.Z(0))
```
```pycon
>>> jax.make_jaxpr(qfunc)(1.5)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[85], line 32
     28     qml.Y(1)
     30     return qml.expval(qml.Z(0))
---> 32 jax.make_jaxpr(qfunc)(1.5)

    [... skipping hidden 6 frame]

File ~/repos/pennylane/pennylane/capture/expand_transforms.py:101, in expand_plxpr_transforms.<locals>.wrapper(*args, **kwargs)
     98 @wraps(f)
     99 def wrapper(*args, **kwargs):
    100     transformed_f = ExpandTransformsInterpreter()(f)
--> 101     return transformed_f(*args, **kwargs)

File ~/repos/pennylane/pennylane/capture/base_interpreter.py:401, in PlxprInterpreter.__call__.<locals>.wrapper(*args, **kwargs)
    398     jaxpr = jax.make_jaxpr(partial(flat_f, **kwargs))(*args)
    400 flat_args = jax.tree_util.tree_leaves(args)
--> 401 results = self.eval(jaxpr.jaxpr, jaxpr.consts, *flat_args)
    402 assert flat_f.out_tree
    403 # slice out any dynamic shape variables

File ~/repos/pennylane/pennylane/capture/base_interpreter.py:364, in PlxprInterpreter.eval(self, jaxpr, consts, *args)
    362 if custom_handler:
    363     invals = [self.read(invar) for invar in eqn.invars]
--> 364     outvals = custom_handler(self, *invals, **eqn.params)
    365 elif getattr(primitive, "prim_type", "") == "operator":
    366     outvals = self.interpret_operation_eqn(eqn)

File ~/repos/pennylane/pennylane/transforms/core/transform_dispatcher.py:93, in _register_primitive_for_expansion.<locals>._(self, inner_jaxpr, args_slice, consts_slice, targs_slice, tkwargs, *invals)
     90     return copy(self).eval(inner_jaxpr, consts, *inner_args)
     92 jaxpr = jax.make_jaxpr(wrapper)(*args)
---> 93 jaxpr = plxpr_transform(jaxpr.jaxpr, jaxpr.consts, targs, tkwargs, *args)
     94 return copy(self).eval(jaxpr.jaxpr, jaxpr.consts, *args)

File ~/repos/pennylane/pennylane/transforms/optimization/commute_controlled.py:244, in _get_plxpr_commute_controlled.<locals>.commute_controlled_plxpr_to_plxpr(jaxpr, consts, targs, tkwargs, *args)
    241 def wrapper(*inner_args):
    242     return interpreter.eval(jaxpr, consts, *inner_args)
--> 244 return make_jaxpr(wrapper)(*args)

    [... skipping hidden 6 frame]

File ~/repos/pennylane/pennylane/transforms/optimization/commute_controlled.py:242, in _get_plxpr_commute_controlled.<locals>.commute_controlled_plxpr_to_plxpr.<locals>.wrapper(*inner_args)
    241 def wrapper(*inner_args):
--> 242     return interpreter.eval(jaxpr, consts, *inner_args)

File ~/repos/pennylane/pennylane/transforms/optimization/commute_controlled.py:203, in _get_plxpr_commute_controlled.<locals>.CommuteControlledInterpreter.eval(self, jaxpr, consts, *args)
    201     outvals = custom_handler(self, *invals, **eqn.params)
    202 elif prim_type == "operator":
--> 203     outvals = self.interpret_operation_eqn(eqn)
    204 elif prim_type == "measurement":
    205     self.interpret_all_previous_ops()

File ~/repos/pennylane/pennylane/capture/base_interpreter.py:309, in PlxprInterpreter.interpret_operation_eqn(self, eqn)
    307     op = eqn.primitive.impl(*invals, **eqn.params)
    308 if isinstance(eqn.outvars[0], jax.core.DropVar):
--> 309     return self.interpret_operation(op)
    310 return op

File ~/repos/pennylane/pennylane/transforms/optimization/commute_controlled.py:149, in _get_plxpr_commute_controlled.<locals>.CommuteControlledInterpreter.interpret_operation(self, op)
    146 """Interpret a PennyLane operation instance."""
    148 if self.direction == "left":
--> 149     return self._interpret_operation_left(op)
    151 # If the direction is right, we append the operator
    152 # to the list while we scan through the operators forwards.
    153 self.op_deque.append(op)

File ~/repos/pennylane/pennylane/transforms/optimization/commute_controlled.py:90, in _get_plxpr_commute_controlled.<locals>.CommuteControlledInterpreter._interpret_operation_left(self, op)
     87 new_index = self.current_index
     89 while prev_gate_idx is not None:
---> 90     prev_gate = self.op_deque[new_index - (prev_gate_idx + 1)]
     92     if not _can_push_through(prev_gate) or not _can_commute(op, prev_gate):
     93         break

IndexError: deque index out of range
```

**Description of the Change:**
* Update `CommuteControlledInterpreter.interpret_all_previous_ops` to reset `current_index` when `direction="left"`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
