### PR TITLE
[BUG] Fix sparse `BlockEncode` bug

### DIFF
--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -692,55 +692,16 @@ class BlockEncode(Operation):
                [ 0.94561648, -0.07621992, -0.1       , -0.3       ],
                [-0.07621992,  0.89117368, -0.2       , -0.4       ]])
         """
-        A = params[0]
-        if sp.sparse.issparse(A):
+        if sp.sparse.issparse(params[0]):
             raise qml.operation.MatrixUndefinedError(
                 "A is sparse matrix. Use sparse_matrix method instead."
             )
-        n, m, k = hyperparams["subspace"]
-        shape_a = qml.math.shape(A)
-
-        sqrtm = sqrt_matrix_sparse if sp.sparse.issparse(A) else sqrt_matrix
-
-        def _stack(lst, h=False, like=None):
-            if like == "tensorflow":
-                axis = 1 if h else 0
-                return qml.math.concat(lst, like=like, axis=axis)
-            return qml.math.hstack(lst) if h else qml.math.vstack(lst)
-
-        interface = qml.math.get_interface(A)
-
-        if qml.math.sum(shape_a) <= 2:
-            col1 = _stack([A, sqrt(1 - A * conj(A))], like=interface)
-            col2 = _stack([sqrt(1 - A * conj(A)), -conj(A)], like=interface)
-            u = _stack([col1, col2], h=True, like=interface)
-        else:
-            d1, d2 = shape_a
-            col1 = _stack(
-                [A, sqrtm(cast(eye(d2, like=A), A.dtype) - qml.math.transpose(conj(A)) @ A)],
-                like=interface,
-            )
-            col2 = _stack(
-                [
-                    sqrtm(cast(eye(d1, like=A), A.dtype) - A @ transpose(conj(A))),
-                    -transpose(conj(A)),
-                ],
-                like=interface,
-            )
-            u = _stack([col1, col2], h=True, like=interface)
-
-        if n + m < k:
-            r = k - (n + m)
-            col1 = _stack([u, zeros((r, n + m), like=A)], like=interface)
-            col2 = _stack([zeros((n + m, r), like=A), eye(r, like=A)], like=interface)
-            u = _stack([col1, col2], h=True, like=interface)
-
-        return u
+        return _process_blockencode(*params, **hyperparams)
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
         if sp.sparse.issparse(params[0]):
-            return BlockEncode.compute_matrix(*params, **hyperparams)
+            return _process_blockencode(*params, **hyperparams)
         raise qml.operation.SparseMatrixUndefinedError(
             "A is dense matrix. Use matrix method instead."
         )
@@ -756,3 +717,49 @@ class BlockEncode(Operation):
         cache: Optional[dict] = None,
     ):
         return super().label(decimals=decimals, base_label=base_label or "BlockEncode", cache=cache)
+
+
+def _process_blockencode(*params, **hyperparams):
+    """
+    Process the BlockEncode operation.
+    """
+    A = params[0]
+    n, m, k = hyperparams["subspace"]
+    shape_a = qml.math.shape(A)
+
+    sqrtm = sqrt_matrix_sparse if sp.sparse.issparse(A) else sqrt_matrix
+
+    def _stack(lst, h=False, like=None):
+        if like == "tensorflow":
+            axis = 1 if h else 0
+            return qml.math.concat(lst, like=like, axis=axis)
+        return qml.math.hstack(lst) if h else qml.math.vstack(lst)
+
+    interface = qml.math.get_interface(A)
+
+    if qml.math.sum(shape_a) <= 2:
+        col1 = _stack([A, sqrt(1 - A * conj(A))], like=interface)
+        col2 = _stack([sqrt(1 - A * conj(A)), -conj(A)], like=interface)
+        u = _stack([col1, col2], h=True, like=interface)
+    else:
+        d1, d2 = shape_a
+        col1 = _stack(
+            [A, sqrtm(cast(eye(d2, like=A), A.dtype) - qml.math.transpose(conj(A)) @ A)],
+            like=interface,
+        )
+        col2 = _stack(
+            [
+                sqrtm(cast(eye(d1, like=A), A.dtype) - A @ transpose(conj(A))),
+                -transpose(conj(A)),
+            ],
+            like=interface,
+        )
+        u = _stack([col1, col2], h=True, like=interface)
+
+    if n + m < k:
+        r = k - (n + m)
+        col1 = _stack([u, zeros((r, n + m), like=A)], like=interface)
+        col2 = _stack([zeros((n + m, r), like=A), eye(r, like=A)], like=interface)
+        u = _stack([col1, col2], h=True, like=interface)
+
+    return u

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -648,6 +648,18 @@ class BlockEncode(Operation):
         self.hyperparameters["norm"] = normalization
         self.hyperparameters["subspace"] = subspace
 
+        self._issparse = sp.sparse.issparse(A)
+
+    @property
+    def has_sparse_matrix(self) -> bool:
+        """bool: Whether the operator has a sparse matrix representation."""
+        return self._issparse
+
+    @property
+    def has_matrix(self) -> bool:
+        """bool: Whether the operator has a sparse matrix representation."""
+        return not self._issparse
+
     def _flatten(self) -> FlatPytree:
         return self.data, (self.wires, ())
 
@@ -720,6 +732,10 @@ class BlockEncode(Operation):
             u = _stack([col1, col2], h=True, like=interface)
 
         return u
+
+    @staticmethod
+    def compute_sparse_matrix(*params, **hyperparams):
+        return BlockEncode.compute_matrix(*params, **hyperparams)
 
     def adjoint(self) -> "BlockEncode":
         A = self.parameters[0]

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -693,6 +693,10 @@ class BlockEncode(Operation):
                [-0.07621992,  0.89117368, -0.2       , -0.4       ]])
         """
         A = params[0]
+        if sp.sparse.issparse(A):
+            raise qml.operation.MatrixUndefinedError(
+                "A is sparse matrix. Use sparse_matrix method instead."
+            )
         n, m, k = hyperparams["subspace"]
         shape_a = qml.math.shape(A)
 
@@ -735,7 +739,11 @@ class BlockEncode(Operation):
 
     @staticmethod
     def compute_sparse_matrix(*params, **hyperparams):
-        return BlockEncode.compute_matrix(*params, **hyperparams)
+        if sp.sparse.issparse(params[0]):
+            return BlockEncode.compute_matrix(*params, **hyperparams)
+        raise qml.operation.SparseMatrixUndefinedError(
+            "A is dense matrix. Use matrix method instead."
+        )
 
     def adjoint(self) -> "BlockEncode":
         A = self.parameters[0]

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -650,11 +650,13 @@ class BlockEncode(Operation):
 
         self._issparse = sp.sparse.issparse(A)
 
+    # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_sparse_matrix(self) -> bool:
         """bool: Whether the operator has a sparse matrix representation."""
         return self._issparse
 
+    # pylint: disable=arguments-renamed, invalid-overridden-method
     @property
     def has_matrix(self) -> bool:
         """bool: Whether the operator has a sparse matrix representation."""

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -1338,7 +1338,7 @@ class TestBlockEncode:
         op = qml.BlockEncode(sparse_matrix, wires=range(num_wires))
 
         # Test the operator is unitary
-        mat = qml.matrix(op)
+        mat = op.sparse_matrix()
         assert np.allclose(np.eye(mat.shape[0]), (mat @ mat.T.conj()).toarray())
         mat_dense = qml.matrix(qml.BlockEncode(sparse_matrix.toarray(), wires=range(num_wires)))
         assert qml.math.allclose(mat, mat_dense)

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -966,6 +966,13 @@ class TestBlockEncode:
         op = qml.BlockEncode(input_matrix, wires=range(2))
         assert op.has_matrix != issparse
         assert op.has_sparse_matrix == issparse
+        if issparse:
+            # Test if there's correct error out
+            with pytest.raises(qml.operation.MatrixUndefinedError):
+                op.matrix()
+        else:
+            with pytest.raises(qml.operation.SparseMatrixUndefinedError):
+                op.sparse_matrix()
 
     @pytest.mark.parametrize(
         ("input_matrix", "wires", "expected_hyperparameters"),

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -954,6 +954,20 @@ class TestBlockEncode:
     """Test the BlockEncode operation."""
 
     @pytest.mark.parametrize(
+        ("input_matrix", "issparse"),
+        [
+            (np.array([[1, 0], [0, 1]]), False),
+            (X, False),
+            (csr_matrix([[1, 0], [0, 1]]), True),
+        ],
+    )
+    def test_property(self, input_matrix, issparse):
+        """Test that BlockEncode has the correct properties."""
+        op = qml.BlockEncode(input_matrix, wires=range(2))
+        assert op.has_matrix != issparse
+        assert op.has_sparse_matrix == issparse
+
+    @pytest.mark.parametrize(
         ("input_matrix", "wires", "expected_hyperparameters"),
         [
             (1, 1, {"norm": 1, "subspace": (1, 1, 2)}),


### PR DESCRIPTION
**Context:**
`BlockEncode` initialized with sparse matrices seems not working properly when applied into states. We would like to match its strcuture similar with `QubitUnitary`

**Description of the Change:**
 - Extract the logic of building encoder matrices and place them into a separate private helper method
 - Construct similar `issparse` logic following the same pattern as `QubitUnitary`

**Benefits:**
Users can use sparse types of `BlockEncode` as a normal operator to apply in their circuits now.

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/7254
[sc-88769]