### PR TITLE
Bugfix for vibronic_fragments function

### DIFF
--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1140,6 +1140,9 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
 * Minor docstring upgrades for `qml.labs.trotter_error`.
   [(#7190)](https://github.com/PennyLaneAI/pennylane/pull/7190)
 
+* Function `qml.labs.trotter_error.vibronic_fragments` now returns `RealspaceMatrix` objects with the correct number of electronic states.
+  [(#7251)](https://github.com/PennyLaneAI/pennylane/pull/7251)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/labs/tests/trotter_error/fragments/test_vibronic.py
+++ b/pennylane/labs/tests/trotter_error/fragments/test_vibronic.py
@@ -30,6 +30,20 @@ def _vibronic_hamiltonian(states, modes, freqs, taylor_coeffs):
     return sum(frags, RealspaceMatrix.zero(states, modes))
 
 
+def test_vibronic_fragments():
+    """Test that vibronic_fragments returns RealspaceMatrix objects with the correct number of states and modes."""
+    n_states = 5
+    n_modes = 5
+    freqs = np.array([1, 2, 3, 4, 5])
+
+    frags = vibronic_fragments(n_states, n_modes, freqs, [])
+
+    for frag in frags:
+        assert isinstance(frag, RealspaceMatrix)
+        assert frag.states == n_states
+        assert frag.modes == n_modes
+
+
 class Test1Mode:
     """Test a simple one mode, one state vibronic Hamiltonian"""
 

--- a/pennylane/labs/trotter_error/fragments/vibronic_fragments.py
+++ b/pennylane/labs/trotter_error/fragments/vibronic_fragments.py
@@ -73,17 +73,15 @@ def _position_fragment(
     i: int, states: int, modes: int, freqs: np.ndarray, taylor_coeffs: Sequence[np.ndarray]
 ) -> RealspaceMatrix:
     """Return the ``i``th position fragment"""
-    pow2 = _next_pow_2(states)
     blocks = {
         (j, i ^ j): _realspace_sum(j, i ^ j, states, modes, freqs, taylor_coeffs)
-        for j in range(pow2)
+        for j in range(_next_pow_2(states))
     }
-    return RealspaceMatrix(pow2, modes, blocks)
+    return RealspaceMatrix(states, modes, blocks)
 
 
 def _momentum_fragment(states: int, modes: int, freqs: np.ndarray) -> RealspaceMatrix:
     """Return the fragment consisting only of momentum operators."""
-    pow2 = _next_pow_2(states)
     term = RealspaceOperator(
         modes,
         ("P", "P"),
@@ -92,7 +90,7 @@ def _momentum_fragment(states: int, modes: int, freqs: np.ndarray) -> RealspaceM
     word = RealspaceSum(modes, (term,))
     blocks = {(i, i): word for i in range(states)}
 
-    return RealspaceMatrix(pow2, modes, blocks)
+    return RealspaceMatrix(states, modes, blocks)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments


### PR DESCRIPTION
This PR fixes a bug in `vibronic_fragments` that prevents it from returning `RealspaceMatrix` objects with the correct number of electronic states.