### PR TITLE
[stale] enforce `optimize` as an "auxiliary" module

### DIFF
--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -15,11 +15,15 @@
 import copy
 
 # pylint: disable= no-value-for-parameter, protected-access, not-callable
-import pennylane as qml
+from pennylane import math
 from pennylane import numpy as pnp
-from pennylane import transform
+from pennylane._grad import grad
 from pennylane.tape import QuantumScript, QuantumScriptBatch
+from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
+from pennylane.workflow import construct_tape
+
+from .gradient_descent import GradientDescentOptimizer
 
 
 @transform
@@ -199,7 +203,7 @@ class AdaptiveOptimizer:
         """
         cost = circuit()
         qnode = copy.copy(circuit)
-        tape = qml.workflow.construct_tape(qnode)()
+        tape = construct_tape(qnode)()
 
         if drain_pool:
             operator_pool = [
@@ -213,10 +217,10 @@ class AdaptiveOptimizer:
 
         params = pnp.array([gate.parameters[0] for gate in operator_pool], requires_grad=True)
         qnode.func = self._circuit
-        grads = qml.grad(qnode)(params, gates=operator_pool, initial_circuit=circuit.func)
+        grads = grad(qnode)(params, gates=operator_pool, initial_circuit=circuit.func)
 
         selected_gates = [operator_pool[pnp.argmax(abs(grads))]]
-        optimizer = qml.GradientDescentOptimizer(stepsize=self.stepsize)
+        optimizer = GradientDescentOptimizer(stepsize=self.stepsize)
 
         if params_zero:
             params = pnp.zeros(len(selected_gates))
@@ -230,4 +234,4 @@ class AdaptiveOptimizer:
 
         qnode.func = append_gate(circuit.func, params, selected_gates)
 
-        return qnode, cost, max(abs(qml.math.toarray(grads)))
+        return qnode, cost, max(abs(math.toarray(grads)))

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -14,7 +14,7 @@
 """Adaptive optimizer"""
 import copy
 
-# pylint: disable= no-value-for-parameter, protected-access, not-callable
+# pylint: disable= not-callable
 from pennylane import math
 from pennylane import numpy as pnp
 from pennylane._grad import grad

--- a/pennylane/optimize/momentum_qng.py
+++ b/pennylane/optimize/momentum_qng.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Quantum natural gradient optimizer with momentum"""
 
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-arguments
 from pennylane import numpy as pnp
 
 from .qng import QNGOptimizer, _flatten_np, _unflatten_np

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -15,21 +15,23 @@
 import numbers
 from collections.abc import Iterable
 
-import pennylane as qml
-
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-arguments
+from pennylane import math
 from pennylane import numpy as pnp
+from pennylane.gradients.metric_tensor import metric_tensor
+from pennylane.wires import Wires
+from pennylane.workflow import QNode
 
 from .gradient_descent import GradientDescentOptimizer
 
 
 def _reshape_and_regularize(tensor, lam):
-    shape = qml.math.shape(tensor)
-    size = 1 if shape == () else qml.math.prod(shape[: len(shape) // 2])
-    tensor = qml.math.reshape(tensor, (size, size))
+    shape = math.shape(tensor)
+    size = 1 if shape == () else math.prod(shape[: len(shape) // 2])
+    tensor = math.reshape(tensor, (size, size))
     # Add regularization
-    tensor += lam * qml.math.eye(size, like=tensor)
+    tensor += lam * math.eye(size, like=tensor)
     return tensor
 
 
@@ -198,7 +200,7 @@ class QNGOptimizer(GradientDescentOptimizer):
             prior to the step
         """
         # pylint: disable=arguments-differ
-        if not isinstance(qnode, qml.QNode) and metric_tensor_fn is None:
+        if not isinstance(qnode, QNode) and metric_tensor_fn is None:
             raise ValueError(
                 "The objective function must be encoded as a single QNode for the natural gradient "
                 "to be automatically computed. Otherwise, metric_tensor_fn must be explicitly "
@@ -207,7 +209,7 @@ class QNGOptimizer(GradientDescentOptimizer):
 
         if recompute_tensor or self.metric_tensor is None:
             if metric_tensor_fn is None:
-                metric_tensor_fn = qml.metric_tensor(qnode, approx=self.approx)
+                metric_tensor_fn = metric_tensor(qnode, approx=self.approx)
 
             mt = metric_tensor_fn(*args, **kwargs)
             if isinstance(mt, tuple):
@@ -304,9 +306,9 @@ def _flatten_np(x):
         yield from _flatten_np(
             x.flat
         )  # should we allow object arrays? or just "yield from x.flat"?
-    elif isinstance(x, qml.wires.Wires):
+    elif isinstance(x, Wires):
         # Reursive calls to flatten `Wires` will cause infinite recursion (`Wires` atoms are `Wires`).
-        # Since Wires are always flat, just yield.
+        # Since Wires are always flat,djust yield.
         yield from x
     elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         for item in x:

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -15,8 +15,6 @@
 import numbers
 from collections.abc import Iterable
 
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-arguments
 from pennylane import math
 from pennylane import numpy as pnp
 from pennylane.gradients.metric_tensor import metric_tensor
@@ -361,7 +359,6 @@ def _unflatten_np(flat, model):
     Raises:
         ValueError: if ``flat`` has more elements than ``model``
     """
-    # pylint:disable=len-as-condition
     res, tail = _unflatten_np_dispatch(pnp.asarray(flat), model)
     if len(tail) != 0:
         raise ValueError("Flattened iterable has more elements than the model.")

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -306,7 +306,7 @@ def _flatten_np(x):
         )  # should we allow object arrays? or just "yield from x.flat"?
     elif isinstance(x, Wires):
         # Reursive calls to flatten `Wires` will cause infinite recursion (`Wires` atoms are `Wires`).
-        # Since Wires are always flat,djust yield.
+        # Since Wires are always flat, just yield.
         yield from x
     elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         for item in x:

--- a/pennylane/optimize/riemannian_gradient.py
+++ b/pennylane/optimize/riemannian_gradient.py
@@ -276,7 +276,6 @@ class RiemannianGradientOptimizer:
             tuple[.QNode, float]: the optimized circuit and the objective function output prior
             to the step.
         """
-        # pylint: disable=not-callable
 
         cost = self.circuit()
         omegas = self.get_omegas()

--- a/pennylane/optimize/riemannian_gradient.py
+++ b/pennylane/optimize/riemannian_gradient.py
@@ -16,9 +16,15 @@ import warnings
 
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
+from pennylane.ops import LinearCombination, PauliRot
+from pennylane.ops.functions import evolve
+from pennylane.pauli import pauli_group, pauli_word_to_string
 from pennylane.tape import QuantumScript, QuantumScriptBatch
+from pennylane.templates import ApproxTimeEvolution
+from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
+from pennylane.workflow import QNode
 
 
 def null_postprocessing(results):
@@ -28,7 +34,7 @@ def null_postprocessing(results):
     return results[0]
 
 
-@qml.transform
+@transform
 def append_time_evolution(
     tape: QuantumScript, riemannian_gradient, t, n, exact=False
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
@@ -71,16 +77,16 @@ def append_time_evolution(
 
     """
     if exact:
-        op = qml.evolve(riemannian_gradient, t)
+        op = evolve(riemannian_gradient, t)
     else:
-        op = qml.templates.ApproxTimeEvolution(riemannian_gradient, t, n)
+        op = ApproxTimeEvolution(riemannian_gradient, t, n)
 
     new_tape = tape.copy(operations=tape.operations + [op])
 
     return [new_tape], null_postprocessing
 
 
-@qml.transform
+@transform
 def algebra_commutator(tape, lie_algebra_basis_names, nqubits):
     """Calculate the Riemannian gradient in the Lie algebra with the parameter shift rule
     (see :meth:`RiemannianGradientOptimizer.get_omegas`).
@@ -104,17 +110,15 @@ def algebra_commutator(tape, lie_algebra_basis_names, nqubits):
     """
 
     wires = list(range(nqubits))
-    paulis_plus = (qml.PauliRot(np.pi / 2, pauli, wires=wires) for pauli in lie_algebra_basis_names)
-    paulis_minus = (
-        qml.PauliRot(-np.pi / 2, pauli, wires=wires) for pauli in lie_algebra_basis_names
-    )
+    paulis_plus = (PauliRot(np.pi / 2, pauli, wires=wires) for pauli in lie_algebra_basis_names)
+    paulis_minus = (PauliRot(-np.pi / 2, pauli, wires=wires) for pauli in lie_algebra_basis_names)
 
     tapes_plus = [tape.copy(operations=tape.operations + [op]) for op in paulis_plus]
     tapes_minus = [tape.copy(operations=tape.operations + [op]) for op in paulis_minus]
 
     def calculate_omegas(results):
-        results_plus = qml.math.hstack(results[: len(results) // 2])
-        results_minus = qml.math.hstack(results[len(results) // 2 :])
+        results_plus = math.hstack(results[: len(results) // 2])
+        results_minus = math.hstack(results[len(results) // 2 :])
         return results_plus - results_minus
 
     return tapes_plus + tapes_minus, calculate_omegas
@@ -225,7 +229,7 @@ class RiemannianGradientOptimizer:
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     # pylint: disable=too-many-instance-attributes
     def __init__(self, circuit, stepsize=0.01, restriction=None, exact=False, trottersteps=1):
-        if not isinstance(circuit, qml.QNode):
+        if not isinstance(circuit, QNode):
             raise TypeError(f"circuit must be a QNode, received {type(circuit)}")
 
         self.circuit = circuit.update(diff_method=None)
@@ -235,7 +239,7 @@ class RiemannianGradientOptimizer:
         self.nqubits = len(circuit.device.wires)
 
         self.hamiltonian = circuit.func().obs
-        if not isinstance(self.hamiltonian, qml.ops.LinearCombination):
+        if not isinstance(self.hamiltonian, LinearCombination):
             raise TypeError(
                 f"circuit must return the expectation value of a Hamiltonian,"
                 f"received {type(circuit.func().obs)}"
@@ -248,7 +252,7 @@ class RiemannianGradientOptimizer:
                 f"optimizing a {self.nqubits} qubit circuit may be slow.",
                 UserWarning,
             )
-        if restriction is not None and not isinstance(restriction, qml.ops.LinearCombination):
+        if restriction is not None and not isinstance(restriction, LinearCombination):
             raise TypeError(f"restriction must be a Hamiltonian, received {type(restriction)}")
         (
             self.lie_algebra_basis_ops,
@@ -279,7 +283,7 @@ class RiemannianGradientOptimizer:
         non_zero_omegas = -omegas[omegas != 0]
         nonzero_idx = np.nonzero(omegas)[0]
 
-        lie_gradient = qml.Hamiltonian(
+        lie_gradient = LinearCombination(
             non_zero_omegas,
             [self.lie_algebra_basis_ops[i] for i in nonzero_idx],
         )
@@ -300,8 +304,8 @@ class RiemannianGradientOptimizer:
 
         # construct the corresponding pennylane observables
         wire_map = {i: i for i in range(self.nqubits)}
-        ops = list(restriction.ops) if restriction else list(qml.pauli.pauli_group(self.nqubits))
-        return ops, [qml.pauli.pauli_word_to_string(ps, wire_map=wire_map) for ps in ops]
+        ops = list(restriction.ops) if restriction else list(pauli_group(self.nqubits))
+        return ops, [pauli_word_to_string(ps, wire_map=wire_map) for ps in ops]
 
     def get_omegas(self):
         r"""Measure the coefficients of the Riemannian gradient with respect to a Pauli word basis.

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -90,8 +90,6 @@ class RotoselectOptimizer:
     the circuit, while steps-vs-cost can be seen by plotting ``cost_rotosel``.
     """
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, possible_generators=None):
         self.possible_generators = possible_generators or [RX, RY, RZ]
 

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 
-import pennylane as qml
+from pennylane.ops import RX, RY, RZ
 
 from .qng import _flatten_np, _unflatten_np
 
@@ -93,7 +93,7 @@ class RotoselectOptimizer:
     # pylint: disable=too-few-public-methods
 
     def __init__(self, possible_generators=None):
-        self.possible_generators = possible_generators or [qml.RX, qml.RY, qml.RZ]
+        self.possible_generators = possible_generators or [RX, RY, RZ]
 
     def step_and_cost(self, objective_fn, x, generators, **kwargs):
         """Update trainable arguments with one step of the optimizer and return the corresponding

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -18,6 +18,7 @@ from inspect import signature
 import numpy as np
 import scipy as sp
 
+# TODO: Remove dependency of optimize on fourier, sc-89244.
 from pennylane import fourier  # tach-ignore
 from pennylane import math
 from pennylane.workflow import QNode

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -19,7 +19,8 @@ from inspect import signature
 import numpy as np
 import scipy as sp
 
-import pennylane as qml
+from pennylane import fourier, math
+from pennylane.workflow import QNode
 
 
 def _brute_optimizer(fun, num_steps, bounds=None, **kwargs):
@@ -64,7 +65,7 @@ def _validate_inputs(requires_grad, args, nums_frequency, spectra):
             _spectra = spectra.get(arg_name, {})
             all_keys = set(_nums_frequency) | set(_spectra)
 
-            shape = qml.math.shape(arg)
+            shape = math.shape(arg)
             indices = np.ndindex(shape) if len(shape) > 0 else [()]
             for par_idx in indices:
                 if par_idx not in all_keys:
@@ -92,11 +93,11 @@ def _restrict_to_univariate(fn, arg_idx, par_idx, args, kwargs):
         function is added to the marked parameter.
     """
     the_arg = args[arg_idx]
-    if len(qml.math.shape(the_arg)) == 0:
-        shift_vec = qml.math.ones_like(the_arg)
+    if len(math.shape(the_arg)) == 0:
+        shift_vec = math.ones_like(the_arg)
     else:
-        shift_vec = qml.math.zeros_like(the_arg)
-        shift_vec = qml.math.scatter_element_add(shift_vec, par_idx, 1.0)
+        shift_vec = math.zeros_like(the_arg)
+        shift_vec = math.scatter_element_add(shift_vec, par_idx, 1.0)
 
     def _univariate_fn(x):
         return fn(*args[:arg_idx], the_arg + shift_vec * x, *args[arg_idx + 1 :], **kwargs)
@@ -419,10 +420,10 @@ class RotosolveOptimizer:
 
         """
         # todo: does this signature call cover all cases?
-        sign_fn = objective_fn.func if isinstance(objective_fn, qml.QNode) else objective_fn
+        sign_fn = objective_fn.func if isinstance(objective_fn, QNode) else objective_fn
         arg_names = list(signature(sign_fn).parameters.keys())
         requires_grad = {
-            arg_name: qml.math.requires_grad(arg) for arg_name, arg in zip(arg_names, args)
+            arg_name: math.requires_grad(arg) for arg_name, arg in zip(arg_names, args)
         }
         nums_frequency = nums_frequency or {}
         spectra = spectra or {}
@@ -446,7 +447,7 @@ class RotosolveOptimizer:
             if not requires_grad[arg_name]:
                 before_args.append(arg)
                 continue
-            shape = qml.math.shape(arg)
+            shape = math.shape(arg)
             indices = np.ndindex(shape) if len(shape) > 0 else [()]
             for par_idx in indices:
                 _fun_at_zero = fun_at_zero if first_substep_in_step else None
@@ -463,7 +464,7 @@ class RotosolveOptimizer:
                     )
                     freq = 1.0 if num_freq is not None else spectrum[spectrum > 0][0]
                     x_min, y_min = self.min_analytic(univariate, freq, _fun_at_zero)
-                    arg = qml.math.scatter_element_add(arg, par_idx, x_min)
+                    arg = math.scatter_element_add(arg, par_idx, x_min)
 
                 else:
                     ids = {arg_name: (par_idx,)}
@@ -473,7 +474,7 @@ class RotosolveOptimizer:
                     _spectra = {arg_name: {par_idx: spectrum}} if spectrum is not None else None
 
                     # Set up the reconstruction function
-                    recon_fn = qml.fourier.reconstruct(
+                    recon_fn = fourier.reconstruct(
                         objective_fn, ids, _nums_frequency, _spectra, shifts
                     )
                     # Perform the reconstruction
@@ -485,7 +486,7 @@ class RotosolveOptimizer:
                     x_min, y_min = self._min_numeric(recon, spectrum)
 
                     # Update the currently treated argument
-                    arg = qml.math.scatter_element_add(arg, par_idx, x_min - arg[par_idx])
+                    arg = math.scatter_element_add(arg, par_idx, x_min - arg[par_idx])
                 first_substep_in_step = False
 
                 if full_output:
@@ -612,8 +613,8 @@ class RotosolveOptimizer:
         """
         opt_kwargs = self.substep_kwargs.copy()
         if "bounds" not in self.substep_kwargs:
-            spectrum = qml.math.array(spectrum)
-            half_width = np.pi / qml.math.min(spectrum[spectrum > 0])
+            spectrum = math.array(spectrum)
+            half_width = np.pi / math.min(spectrum[spectrum > 0])
             opt_kwargs["bounds"] = ((-half_width, half_width),)
 
         x_min, y_min = self.substep_optimizer(objective_fn, **opt_kwargs)

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -341,6 +341,7 @@ class RotosolveOptimizer:
         else:
             self.substep_optimizer = substep_optimizer
 
+    # pylint: disable=too-many-arguments
     def step_and_cost(
         self,
         objective_fn,
@@ -502,6 +503,7 @@ class RotosolveOptimizer:
 
         return args, fun_at_zero
 
+    # pylint: disable=too-many-arguments
     def step(
         self,
         objective_fn,

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Rotosolve gradient free optimizer"""
-# pylint: disable=too-many-branches,cell-var-from-loop
 
 from inspect import signature
 
@@ -330,8 +329,6 @@ class RotosolveOptimizer:
     to converge than previously, Rotosolve was able to adapt to the more complicated
     dependence on the input arguments and still found the global minimum successfully.
     """
-
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, substep_optimizer="brute", substep_kwargs=None):
         self.substep_kwargs = {} if substep_kwargs is None else substep_kwargs

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -341,7 +341,6 @@ class RotosolveOptimizer:
         else:
             self.substep_optimizer = substep_optimizer
 
-    # pylint: disable=too-many-arguments
     def step_and_cost(
         self,
         objective_fn,
@@ -503,7 +502,6 @@ class RotosolveOptimizer:
 
         return args, fun_at_zero
 
-    # pylint: disable=too-many-arguments
     def step(
         self,
         objective_fn,

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -18,7 +18,8 @@ from inspect import signature
 import numpy as np
 import scipy as sp
 
-from pennylane import fourier, math
+from pennylane import fourier  # tach-ignore
+from pennylane import math
 from pennylane.workflow import QNode
 
 

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -18,7 +18,12 @@ from copy import copy
 import numpy as np
 import scipy as sp
 
-import pennylane as qml
+from pennylane import math, measurements
+from pennylane._grad import jacobian
+from pennylane.ops import LinearCombination
+from pennylane.queuing import apply
+from pennylane.tape import make_qscript
+from pennylane.workflow import QNode, construct_tape
 
 from .gradient_descent import GradientDescentOptimizer
 
@@ -174,6 +179,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
           <https://quantum-journal.org/papers/q-2020-05-11-263/>`__ (2020).
     """
 
+    # pylint: disable = too-many-positional-arguments
     def __init__(self, min_shots, term_sampling=None, mu=0.99, b=1e-6, stepsize=0.07):
         self.term_sampling = term_sampling
         self.trainable_args = set()
@@ -243,10 +249,10 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
                 continue
 
             def func(*qnode_args, **qnode_kwargs):
-                qs = qml.tape.make_qscript(base_func)(*qnode_args, **qnode_kwargs)
+                qs = make_qscript(base_func)(*qnode_args, **qnode_kwargs)
                 for op in qs.operations:
-                    qml.apply(op)
-                return qml.expval(o)  # pylint:disable=cell-var-from-loop
+                    apply(op)
+                return measurements.expval(o)  # pylint:disable=cell-var-from-loop
 
             qnode.func = func
 
@@ -256,12 +262,12 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
 
                 def cost(*args, **kwargs):
                     # pylint: disable=cell-var-from-loop
-                    return qml.math.stack(qnode(*args, **kwargs))
+                    return math.stack(qnode(*args, **kwargs))
 
             else:
                 cost = qnode
 
-            jacs = qml.jacobian(cost, argnum=argnums)(*args, **kwargs, shots=new_shots)
+            jacs = jacobian(cost, argnum=argnums)(*args, **kwargs, shots=new_shots)
 
             if s == 1:
                 jacs = [np.expand_dims(j, 0) for j in jacs]
@@ -308,11 +314,11 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         """Compute the single shot gradients of a QNode."""
         self.check_device(qnode.device)
 
-        tape = qml.workflow.construct_tape(qnode)(*args, **kwargs)
+        tape = construct_tape(qnode)(*args, **kwargs)
         [expval] = tape.measurements
         coeffs, observables = (
             expval.obs.terms()
-            if isinstance(expval.obs, qml.ops.LinearCombination)
+            if isinstance(expval.obs, LinearCombination)
             else ([1.0], [expval.obs])
         )
 
@@ -333,9 +339,9 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
         new_shots = [(1, int(self.max_shots))]
 
         def cost(*args, **kwargs):
-            return qml.math.stack(qnode(*args, **kwargs, shots=new_shots))
+            return math.stack(qnode(*args, **kwargs, shots=new_shots))
 
-        grads = [qml.jacobian(cost, argnum=i)(*args, **kwargs) for i in self.trainable_args]
+        grads = [jacobian(cost, argnum=i)(*args, **kwargs) for i in self.trainable_args]
 
         return grads
 
@@ -354,7 +360,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
             tuple[array[float], array[float]]: a tuple of NumPy arrays containing the gradient
             :math:`\nabla f(x^{(t)})` and the variance of the gradient
         """
-        if isinstance(objective_fn, qml.QNode) or hasattr(objective_fn, "device"):
+        if isinstance(objective_fn, QNode) or hasattr(objective_fn, "device"):
             grads = self._single_shot_qnode_gradients(objective_fn, args, kwargs)
         else:
             raise ValueError(

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Shot adaptive optimizer"""
-# pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-branches
+# pylint: disable=too-many-instance-attributes,too-many-arguments
 from copy import copy
 
 import numpy as np
@@ -261,7 +261,6 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
             if s > 1:
 
                 def cost(*args, **kwargs):
-                    # pylint: disable=cell-var-from-loop
                     return math.stack(qnode(*args, **kwargs))
 
             else:
@@ -345,9 +344,7 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
 
         return grads
 
-    def compute_grad(
-        self, objective_fn, args, kwargs
-    ):  # pylint: disable=signature-differs,arguments-differ,arguments-renamed
+    def compute_grad(self, objective_fn, args, kwargs):  # pylint: disable=arguments-renamed
         r"""Compute the gradient of the objective function, as well as the variance of the gradient,
         at the given point.
 

--- a/pennylane/optimize/shot_adaptive.py
+++ b/pennylane/optimize/shot_adaptive.py
@@ -344,7 +344,9 @@ class ShotAdaptiveOptimizer(GradientDescentOptimizer):
 
         return grads
 
-    def compute_grad(self, objective_fn, args, kwargs):  # pylint: disable=arguments-renamed
+    def compute_grad(
+        self, objective_fn, args, kwargs
+    ):  # pylint: disable = arguments-renamed, arguments-differ
         r"""Compute the gradient of the objective function, as well as the variance of the gradient,
         at the given point.
 

--- a/pennylane/optimize/spsa.py
+++ b/pennylane/optimize/spsa.py
@@ -165,7 +165,7 @@ class SPSAOptimizer:
             <https://www.jhuapl.edu/spsa/PDF-SPSA/Spall_Implementation_of_the_Simultaneous.PDF>`_.
     """
 
-    # pylint: disable-msg=too-many-arguments
+    # pylint: disable=too-many-positional-arguments, too-many-arguments
     def __init__(self, maxiter=None, alpha=0.602, gamma=0.101, c=0.2, A=None, a=None):
         self.a = a
         self.A = A
@@ -265,7 +265,6 @@ class SPSAOptimizer:
         yplus = objective_fn(*thetaplus, **kwargs)
         yminus = objective_fn(*thetaminus, **kwargs)
         try:
-            # pylint: disable=protected-access
             dev_shots = objective_fn.device.shots
 
             shots = dev_shots if dev_shots.has_partitioned_shots else Shots(None)

--- a/tach.toml
+++ b/tach.toml
@@ -142,12 +142,12 @@ layer = "auxiliary"
 path = "pennylane.optimize"
 layer = "auxiliary"
 
-[[modules]]
-path = "pennylane.fourier"
-layer = "auxiliary"
-
 ## TERTIARY modules
 # These modules can only import from CORE or AUXILIARY modules.
+
+[[modules]]
+path = "pennylane.fourier"
+layer = "tertiary"
 
 [[modules]]
 path = "pennylane.data"

--- a/tach.toml
+++ b/tach.toml
@@ -142,6 +142,10 @@ layer = "auxiliary"
 path = "pennylane.optimize"
 layer = "auxiliary"
 
+[[modules]]
+path = "pennylane.fourier"
+layer = "auxiliary"
+
 ## TERTIARY modules
 # These modules can only import from CORE or AUXILIARY modules.
 
@@ -167,10 +171,6 @@ layer = "tertiary"
 
 [[modules]]
 path = "pennylane.drawer"
-layer = "tertiary"
-
-[[modules]]
-path = "pennylane.fourier"
 layer = "tertiary"
 
 ## UNSORTED

--- a/tach.toml
+++ b/tach.toml
@@ -146,10 +146,6 @@ layer = "auxiliary"
 # These modules can only import from CORE or AUXILIARY modules.
 
 [[modules]]
-path = "pennylane.fourier"
-layer = "tertiary"
-
-[[modules]]
 path = "pennylane.data"
 layer = "tertiary"
 
@@ -171,6 +167,10 @@ layer = "tertiary"
 
 [[modules]]
 path = "pennylane.drawer"
+layer = "tertiary"
+
+[[modules]]
+path = "pennylane.fourier"
 layer = "tertiary"
 
 ## UNSORTED

--- a/tach.toml
+++ b/tach.toml
@@ -138,6 +138,10 @@ layer = "auxiliary"
 path = "pennylane.gradients"
 layer = "auxiliary"
 
+[[modules]]
+path = "pennylane.optimize"
+layer = "auxiliary"
+
 ## TERTIARY modules
 # These modules can only import from CORE or AUXILIARY modules.
 
@@ -250,11 +254,6 @@ unchecked = true
 [[modules]]
 path = "pennylane.qnn"
 depends_on = ["pennylane"]
-unchecked = true
-
-[[modules]]
-path = "pennylane.optimize"
-depends_on = ["pennylane.numpy", "pennylane.typing", "pennylane._grad", "pennylane.tape", "pennylane", "pennylane.measurements"]
 unchecked = true
 
 [[modules]]

--- a/tach.toml
+++ b/tach.toml
@@ -185,7 +185,6 @@ path = "pennylane.transforms.core"
 depends_on = ["pennylane", "pennylane.typing", "pennylane.tape", "pennylane.capture"]
 unchecked = true
 
-
 [[modules]]
 path = "pennylane.operation"
 depends_on = ["pennylane.typing", "pennylane", "pennylane.math", "pennylane.wires", "pennylane.queuing", "pennylane.pytrees", "pennylane.capture"]

--- a/tests/optimize/test_optimize_shot_adaptive.py
+++ b/tests/optimize/test_optimize_shot_adaptive.py
@@ -17,6 +17,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as np
+from pennylane import optimize
 
 
 class TestExceptions:
@@ -556,7 +557,8 @@ class TestQNodeWeightedRandomSampling:
         weights = np.random.random(qml.templates.StronglyEntanglingLayers.shape(3, 2))
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
-        spy = mocker.spy(qml, "jacobian")
+
+        spy = mocker.spy(optimize.shot_adaptive, "jacobian")
         mocker.patch(
             "scipy.stats._multivariate.multinomial_gen.rvs", return_value=np.array([[4, 0, 6]])
         )
@@ -582,7 +584,7 @@ class TestQNodeWeightedRandomSampling:
 
         opt = qml.ShotAdaptiveOptimizer(min_shots=10)
 
-        spy = mocker.spy(qml, "jacobian")
+        spy = mocker.spy(optimize.shot_adaptive, "jacobian")
         mocker.patch(
             "scipy.stats._multivariate.multinomial_gen.rvs", return_value=np.array([[4, 1, 5]])
         )


### PR DESCRIPTION
**Context:**

The goal of this PR is to isolate the `optimize` module as an `auxiliary` module.

**Description of the Change:**

- Removes all top-level imports, `import pennylane as qml` from this module.
- Define it to be an auxiliary module in the tach.toml
- Ignore the fact that `optimize` (auxiliary), depends on fourier (tertiary) using `# tach-ignore` ([sc-89244])
- Cleans up useless pylint disables.

**Benefits:** Module dependency enforcement

**Possible Drawbacks:** N/A

[sc-88817]
