### PR TITLE
BugFix: disable graph for device program

### DIFF
--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -122,6 +122,7 @@ With `qml.decompositions.enable_graph()`, the following new features are availab
   [(#6966)](https://github.com/PennyLaneAI/pennylane/pull/6966)
   [(#7149)](https://github.com/PennyLaneAI/pennylane/pull/7149)
   [(#7184)](https://github.com/PennyLaneAI/pennylane/pull/7184)
+  [(#7263)](https://github.com/PennyLaneAI/pennylane/pull/7263)
 
   Each keyword argument must be assigned a dictionary that maps operator types to decomposition rules.
   Here is an example of both keyword arguments in use:

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -232,7 +232,11 @@ def _(*args, qnode, shots, device, execution_config, qfunc_jaxpr, n_consts, batc
     qfunc_jaxpr = qfunc_jaxpr.jaxpr
 
     # Apply device preprocessing transforms
+    graph_enabled = qml.decomposition.enabled_graph()
+    qml.decomposition.disable_graph()
     qfunc_jaxpr = device_program(qfunc_jaxpr, temp_consts, *temp_args)
+    if graph_enabled:
+        qml.decomposition.enable_graph()
     consts = qfunc_jaxpr.consts
     qfunc_jaxpr = qfunc_jaxpr.jaxpr
 

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -233,10 +233,12 @@ def _(*args, qnode, shots, device, execution_config, qfunc_jaxpr, n_consts, batc
 
     # Apply device preprocessing transforms
     graph_enabled = qml.decomposition.enabled_graph()
-    qml.decomposition.disable_graph()
-    qfunc_jaxpr = device_program(qfunc_jaxpr, temp_consts, *temp_args)
-    if graph_enabled:
-        qml.decomposition.enable_graph()
+    try:
+        qml.decomposition.disable_graph()
+        qfunc_jaxpr = device_program(qfunc_jaxpr, temp_consts, *temp_args)
+    finally:
+        if graph_enabled:
+            qml.decomposition.enable_graph()
     consts = qfunc_jaxpr.consts
     qfunc_jaxpr = qfunc_jaxpr.jaxpr
 

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -301,6 +301,7 @@ class TestDecomposeGraphEnabled:
         ]
 
 
+@pytest.mark.jax
 @pytest.mark.system
 @pytest.mark.usefixtures("enable_graph_decomposition", "enable_disable_plxpr")
 def test_decompose_qnode():

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -20,8 +20,6 @@ import pytest
 
 import pennylane as qml
 
-# pylint: disable=no-name-in-module, too-few-public-methods
-
 
 @pytest.mark.unit
 def test_fixed_alt_decomps_not_available():

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 """Tests the ``decompose`` transform with the new experimental graph-based decomposition system."""
-
-# pylint: disable=no-name-in-module, too-few-public-methods
+from functools import partial
 
 import numpy as np
 import pytest
 
 import pennylane as qml
+
+# pylint: disable=no-name-in-module, too-few-public-methods
 
 
 @pytest.mark.unit
@@ -298,3 +299,18 @@ class TestDecomposeGraphEnabled:
             qml.RY(-0.2, wires=[0]),
             qml.RX(-0.1, wires=[0]),
         ]
+
+
+@pytest.mark.system
+@pytest.mark.usefixtures("enable_graph_decomposition", "enable_disable_plxpr")
+def test_decompose_qnode():
+    """Tests that the decompose transform works with a QNode."""
+
+    @partial(qml.transforms.decompose, gate_set={"CZ", "Hadamard"})
+    @qml.qnode(qml.device("default.qubit", wires=2))
+    def circuit():
+        qml.CNOT(wires=[0, 1])
+        return qml.expval(qml.PauliZ(0))
+
+    res = circuit()
+    assert qml.math.allclose(res, 1.0)


### PR DESCRIPTION
**Context:**
The new decomposition still does not support specifying the gate set via a callable stopping condition. Temporarily disable graph for when a device preprocess program is applied.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-88853]