### PR TITLE
Remove duplicate import of ExecutionConfig from NullQubit

### DIFF
--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -27,7 +27,6 @@ from typing import Optional, Union
 import numpy as np
 
 from pennylane import math
-from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.measurements import (
     ClassicalShadowMP,


### PR DESCRIPTION
**Context:**
`null_qubit.py` currently imports ExecutionConfig twice.

**Description of the Change:**
Removes redundant import of ExecutionConfig

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
