### PR TITLE
fixing queuing in `QubitUnitary` decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -18,6 +18,7 @@
 
 * Fixes a bug where the global phase was not being added in the ``QubitUnitary`` decomposition.  
   [(#7244)](https://github.com/PennyLaneAI/pennylane/pull/7244)
+  [(#7270)](https://github.com/PennyLaneAI/pennylane/pull/7270)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
+++ b/pennylane/ops/op_math/decompositions/two_qubit_unitary.py
@@ -652,7 +652,7 @@ def two_qubit_decomposition(U, wires):
         else:
             decomp = _decomposition_3_cnots(U, wires)
 
-    decomp.append(qml.GlobalPhase(angle))
+        decomp.append(qml.GlobalPhase(angle))
     # If there is an active tape, queue the decomposition so that expand works
     current_tape = qml.queuing.QueuingManager.active_context()
 

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -529,7 +529,7 @@ class TestQubitUnitary:
 
         tape = qml.workflow.construct_tape(circuit)()
         for op1, op2 in zip(tape.operations, ops_decompostion):
-            assert qml.equal(op1, op2)
+            qml.assert_equal(op1, op2)
 
     def test_broadcasted_two_qubit_qubit_unitary_decomposition_raises_error(self):
         """Tests that broadcasted QubitUnitary decompositions are not supported."""


### PR DESCRIPTION
**Context:**

The qubitUnitary decomposition was correct but the overall phase was not queued correctly.
Andrija found the solution  


**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

#7242
[sc-88637]