### PR TITLE
Improve display of large operators in text based circuit drawer

### DIFF
--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -206,6 +206,14 @@ def _finalize_layers(totals: _CurrentTotals, config: _Config) -> _CurrentTotals:
     return totals
 
 
+def _large_op_label(op, ind: int, max_length: int) -> str:
+    op_str = str(op)
+    threshold = max_length - 7 - len(str(ind))
+    if len(op_str) > threshold:
+        op_str = op_str[:threshold] + "..."
+    return f"\nH{ind} = {op_str}"
+
+
 # pylint: disable=too-many-arguments
 def tape_text(
     tape,
@@ -465,8 +473,10 @@ def tape_text(
         )
         tape_totals = "\n".join([tape_totals, label, tape_str])
 
-    if cache["observables"]:
-        obs_str = "".join(f"\nH{i} = {H}" for i, H in enumerate(cache["observables"]))
+    if cache["large_ops"]:
+        obs_str = "".join(
+            _large_op_label(H, i, max_length) for i, H in enumerate(cache["large_ops"])
+        )
         tape_totals = tape_totals + obs_str
     if show_matrices:
         mat_str = "".join(f"\nM{i} = \n{mat}" for i, mat in enumerate(cache["matrices"]))

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -403,6 +403,7 @@ def tape_text(
     cache = cache or {}
     cache.setdefault("tape_offset", 0)
     cache.setdefault("matrices", [])
+    cache.setdefault("observables", [])
     tape_cache = []
 
     wire_map = convert_wire_order(tape, wire_order=wire_order, show_all_wires=show_all_wires)
@@ -464,6 +465,9 @@ def tape_text(
         )
         tape_totals = "\n".join([tape_totals, label, tape_str])
 
+    if cache["observables"]:
+        obs_str = "".join(f"\nH{i} = {H}" for i, H in enumerate(cache["observables"]))
+        tape_totals = tape_totals + obs_str
     if show_matrices:
         mat_str = "".join(f"\nM{i} = \n{mat}" for i, mat in enumerate(cache["matrices"]))
         return tape_totals + mat_str

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -411,7 +411,7 @@ def tape_text(
     cache = cache or {}
     cache.setdefault("tape_offset", 0)
     cache.setdefault("matrices", [])
-    cache.setdefault("observables", [])
+    cache.setdefault("large_ops", [])
     tape_cache = []
 
     wire_map = convert_wire_order(tape, wire_order=wire_order, show_all_wires=show_all_wires)

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -162,14 +162,16 @@ class SProd(ScalarSymbolicOp):
 
     @handle_recursion_error
     def label(self, decimals=None, base_label=None, cache=None):
-        """The label produced for the SProd op."""
-        scalar_val = (
-            f"{self.scalar}"
-            if decimals is None
-            else format(qml.math.toarray(self.scalar), f".{decimals}f")
-        )
-
-        return base_label or f"{scalar_val}*{self.base.label(decimals=decimals, cache=cache)}"
+        if cache is None or not isinstance(cache.get("large_ops", None), list):
+            decimals = None if (len(self.parameters) > 3) else decimals
+            return Operator.label(
+                self, decimals=decimals, base_label=base_label or "𝓗", cache=cache
+            )
+        for i, obs in enumerate(cache["large_ops"]):
+            if obs == self:
+                return f"H:{i}"
+        cache["large_ops"].append(self)
+        return f"H:{len(cache["large_ops"])-1}"
 
     @property
     @handle_recursion_error

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -310,8 +310,16 @@ class Sum(CompositeOp):
 
     @handle_recursion_error
     def label(self, decimals=None, base_label=None, cache=None):
-        decimals = None if (len(self.parameters) > 3) else decimals
-        return Operator.label(self, decimals=decimals, base_label=base_label or "𝓗", cache=cache)
+        if cache is None or not isinstance(cache.get("observables", None), list):
+            decimals = None if (len(self.parameters) > 3) else decimals
+            return Operator.label(
+                self, decimals=decimals, base_label=base_label or "𝓗", cache=cache
+            )
+        for i, obs in enumerate(cache["observables"]):
+            if obs == self:
+                return f"H:{i}"
+        cache["observables"].append(self)
+        return f"H:{len(cache["observables"])-1}"
 
     @handle_recursion_error
     def matrix(self, wire_order=None):

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -309,19 +309,6 @@ class Sum(CompositeOp):
         return all(s.is_hermitian for s in self)
 
     @handle_recursion_error
-    def label(self, decimals=None, base_label=None, cache=None):
-        if cache is None or not isinstance(cache.get("observables", None), list):
-            decimals = None if (len(self.parameters) > 3) else decimals
-            return Operator.label(
-                self, decimals=decimals, base_label=base_label or "𝓗", cache=cache
-            )
-        for i, obs in enumerate(cache["observables"]):
-            if obs == self:
-                return f"H:{i}"
-        cache["observables"].append(self)
-        return f"H:{len(cache["observables"])-1}"
-
-    @handle_recursion_error
     def matrix(self, wire_order=None):
         r"""Representation of the operator as a matrix in the computational basis.
 


### PR DESCRIPTION
**Context:**

It can be hard to visualize large operators and observables in the circuit drawer.

**Description of the Change:**

```
def f():
    qml.evolve(qml.X(0) + qml.Y(0), 0.5)
    return qml.expval(qml.sum(*(qml.H(i) for i in range(5))))

print(qml.draw(f)())
```
```
0: ──Exp(-0.50j H:0)─┤ ╭<H:1>
1: ──────────────────┤ ├<H:1>
2: ──────────────────┤ ├<H:1>
3: ──────────────────┤ ├<H:1>
4: ──────────────────┤ ╰<H:1>
H0 = X(0) + Y(0)
H1 = H(0) + H(1) + H(2) + H(3) + H(4)
```

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
