### PR TITLE
Move tracker into devices module

### DIFF
--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -573,7 +573,7 @@ The device tracker stores and records information when tracking mode is turned o
 the number of executions, number of shots, number of batches, or remote simulator cost for users to interact with
 in a customizable way.
 
-Three aspects of the :class:`~.Tracker` class are relevant to plugin designers:
+Three aspects of the :class:`~pennylane.devices.Tracker` class are relevant to plugin designers:
 
 * The boolean ``active`` attribute that denotes whether or not to update and record
 * ``update`` method which accepts keyword-value pairs and stores the information
@@ -589,7 +589,7 @@ to the device:
         ...
 
 
-``simulator_tracking`` is useful when the device can simulataneously measure non-commuting measurements or
+``simulator_tracking`` is useful when the device can simultaneously measure non-commuting measurements or
 handle parameter-broadcasting, as it both tracks simulations and the corresponding number of QPU-like
 circuits.
 
@@ -609,7 +609,7 @@ number of execute and derivative batches, and number of derivatives.
 
 While this is the recommended usage, the ``update`` and ``record`` methods can be called at any location
 within the device. While the above example tracks executions, shots, and batches, the 
-:meth:`~.Tracker.update` method can accept any combination of
+:meth:`~pennylane.devices.Tracker.update` method can accept any combination of
 keyword-value pairs.  For example, a device could also track cost and a job ID via:
 
 .. code-block:: python

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,6 +12,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `Tracker` class has been moved into the `devices` module.
+
 <h3>Documentation 📝</h3>
 
 <h3>Bug fixes 🐛</h3>

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -73,7 +73,7 @@ from pennylane._version import __version__
 from pennylane.about import about
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.configuration import Configuration
-from pennylane.tracker import Tracker
+from pennylane.devices import Tracker
 from pennylane.registers import registers
 from pennylane.io import (
     from_pyquil,

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -73,7 +73,6 @@ from pennylane._version import __version__
 from pennylane.about import about
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.configuration import Configuration
-from pennylane.devices import Tracker
 from pennylane.registers import registers
 from pennylane.io import (
     from_pyquil,
@@ -173,6 +172,7 @@ import pennylane.data
 import pennylane.noise
 from pennylane.noise import NoiseModel
 
+from pennylane.devices import Tracker
 from pennylane.devices.device_constructor import device, refresh_devices
 
 import pennylane.spin

--- a/pennylane/devices/__init__.py
+++ b/pennylane/devices/__init__.py
@@ -59,6 +59,7 @@ replaces :class:`pennylane.devices.LegacyDevice` and :class:`pennylane.devices.Q
     ReferenceQubit
     DefaultQutritMixed
     LegacyDeviceFacade
+    Tracker
 
 Preprocessing Transforms
 ------------------------
@@ -151,6 +152,7 @@ Qutrit Mixed-State Simulation Tools
 
 """
 
+from .tracker import Tracker
 
 from .capabilities import DeviceCapabilities
 from .execution_config import ExecutionConfig, DefaultExecutionConfig, MCMConfig

--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -41,6 +41,8 @@ from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, expand_tape_state_prep
 from pennylane.wires import WireError, Wires
 
+from .tracker import Tracker
+
 
 def _local_tape_expand(tape, depth, stop_at):
     """Expand all objects in a tape to a specific depth excluding measurements.
@@ -155,7 +157,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
         self._obs_queue = None
         self._parameters = None
 
-        self.tracker = qml.Tracker()
+        self.tracker = Tracker()
         self.custom_expand_fn = None
 
     def __repr__(self):

--- a/pennylane/devices/device_api.py
+++ b/pennylane/devices/device_api.py
@@ -167,7 +167,7 @@ class Device(abc.ABC):
         return type(self).__name__
 
     tracker: Tracker = Tracker()
-    """A :class:`~.Tracker` that can store information about device executions, shots, batches,
+    """A :class:`~pennylane.devices.Tracker` that can store information about device executions, shots, batches,
     intermediate results, or any additional device dependent information.
 
     A plugin developer can store information in the tracker by:

--- a/pennylane/devices/device_api.py
+++ b/pennylane/devices/device_api.py
@@ -22,7 +22,6 @@ from numbers import Number
 from typing import Optional, Union, overload
 
 import pennylane as qml
-from pennylane import Tracker
 from pennylane.measurements import Shots
 from pennylane.tape import QuantumScript, QuantumScriptOrBatch
 from pennylane.tape.qscript import QuantumScriptBatch
@@ -42,6 +41,7 @@ from .preprocess import (
     validate_measurements,
     validate_observables,
 )
+from .tracker import Tracker
 
 
 # pylint: disable=unused-argument, no-self-use

--- a/pennylane/devices/legacy_facade.py
+++ b/pennylane/devices/legacy_facade.py
@@ -168,7 +168,7 @@ class LegacyDeviceFacade(Device):
 
     @property
     def tracker(self):
-        """A :class:`~.Tracker` that can store information about device executions, shots, batches,
+        """A :class:`~pennylane.devices.Tracker` that can store information about device executions, shots, batches,
         intermediate results, or any additional device dependent information.
         """
         return self._device.tracker

--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -15,8 +15,6 @@ r"""
 This module contains a class for updating and recording information about device executions.
 """
 
-# pylint: disable=attribute-defined-outside-init
-
 from numbers import Number
 
 
@@ -164,7 +162,7 @@ class Tracker:
 
     def __init__(self, dev=None, callback=None, persistent=False):
         self.persistent = persistent
-
+        self.latest = {}
         self.callback = callback
 
         self.reset()

--- a/pennylane/resource/__init__.py
+++ b/pennylane/resource/__init__.py
@@ -89,7 +89,7 @@ Resource Functions
 Tracking Resources for Custom Operations
 ----------------------------------------
 
-We can use the :code:`null.qubit` device with the :code:`qml.Tracker` to track the resources
+We can use the :code:`null.qubit` device with the :class:`pennylane.Tracker` to track the resources
 used in a quantum circuit with custom operations without execution.
 
 .. code-block:: python3

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -14,7 +14,7 @@
 """
 Unit tests for the Tracker and constructor
 """
-
+# pylint: disable=use-implicit-booleaness-not-comparison
 import pytest
 
 import pennylane as qml
@@ -32,9 +32,9 @@ class TestTrackerCoreBehavior:
         assert tracker.persistent is False
         assert tracker.callback is None
 
-        assert tracker.history == dict()
-        assert tracker.totals == dict()
-        assert tracker.latest == dict()
+        assert tracker.history == {}
+        assert tracker.totals == {}
+        assert tracker.latest == {}
 
         assert tracker.active is False
 
@@ -62,7 +62,7 @@ class TestTrackerCoreBehavior:
             short_name = "temp"
 
             def capabilities(self):
-                return dict()
+                return {}
 
         temp = TempDevice()
 
@@ -92,9 +92,9 @@ class TestTrackerCoreBehavior:
 
         tracker.reset()
 
-        assert tracker.totals == dict()
-        assert tracker.history == dict()
-        assert tracker.latest == dict()
+        assert tracker.totals == {}
+        assert tracker.history == {}
+        assert tracker.latest == {}
 
     def test_enter_and_exit(self):
         """Assert entering and exit work as expected"""
@@ -104,14 +104,14 @@ class TestTrackerCoreBehavior:
         tracker.history = {"a": [1]}
         tracker.latest = {"a": 1}
 
-        returned = tracker.__enter__()
+        returned = tracker.__enter__()  # pylint: disable=unnecessary-dunder-call
 
         assert id(tracker) == id(returned)
         assert tracker.active is True
 
-        assert tracker.totals == dict()
-        assert tracker.history == dict()
-        assert tracker.latest == dict()
+        assert tracker.totals == {}
+        assert tracker.history == {}
+        assert tracker.latest == {}
 
         tracker.__exit__(None, None, None)
 


### PR DESCRIPTION
**Context:**

While reviewing some of the module dependency work (#7185 ), I realized we were way overdo for putting the tracker in the devices module.

**Description of the Change:**

Move `Tracker` to the devices module.

**Benefits:**

Improved code organization.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-89071]