### PR TITLE
Adding light test runs for merge queue pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-logic:
+    if: github.event.pull_request.base.ref == 'master'
+    run:  |
+      echo "True"
+      
   tests:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/interface-unit-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Check if this is a pull request targeting the master branch
         shell: bash
         run: |
-          echo "${{ github.event.pull_request.base.ref }}" == "master"
           if [[ "${{ github.event.pull_request.base.ref }}" == "master" ]]; then
             echo "This is a pull request targeting the master branch."
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check if this is a pull request targeting the master branch
         shell: bash
         run: |
-          echo "True"
+          echo "${{ github.event.pull_request.base.ref }}" == "master"
           if [[ "${{ github.event.pull_request.base.ref }}" == "master" ]]; then
             echo "This is a pull request targeting the master branch."
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,19 +22,7 @@ concurrency:
   group: unit-tests-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  check-logic:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if this is a pull request targeting the master branch
-        shell: bash
-        run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "master" ]]; then
-            echo "This is a pull request targeting the master branch."
-          else
-            echo "This is not a pull request targeting the master branch."
-          fi
-          
+jobs:         
   tests:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/interface-unit-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,18 @@ concurrency:
 
 jobs:
   check-logic:
-    if: github.event.pull_request.base.ref == 'master'
-    run:  |
-      echo "True"
-      
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if this is a pull request targeting the master branch
+        shell: bash
+        run: |
+          echo "True"
+          if [[ "${{ github.event.pull_request.base.ref }}" == "master" ]]; then
+            echo "This is a pull request targeting the master branch."
+          else
+            echo "This is not a pull request targeting the master branch."
+          fi
+          
   tests:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/interface-unit-tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       run_lightened_ci: >-
         ${{
           github.event_name == 'pull_request'
-          || github.event.pull_request.base.ref == 'master'
+          && !contains(github.event.pull_request.labels.*.name, 'ci:run-full-test-suite') || github.event.pull_request.base.ref == 'master'
           || false
          }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ concurrency:
   group: unit-tests-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:         
+jobs:
   tests:
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/interface-unit-tests.yml
@@ -32,13 +32,14 @@ jobs:
       branch: ${{ github.ref }}
       use_large_runner: ${{ github.event_name == 'merge_group' }}
 
-      # Run a 'lightened' version of the CI on Pull Requests by default
+      # Run a 'lightened' version of the CI on Pull Requests and Merge Queues by default
       # Unless the label `ci:run-full-test-suite` is attached to the PR.
       # Always runs the full suite for push events.
       run_lightened_ci: >-
         ${{
-          github.event_name == 'pull_request'
-          && !contains(github.event.pull_request.labels.*.name, 'ci:run-full-test-suite') || github.event.pull_request.base.ref == 'master'
+          (github.event_name == 'pull_request'
+          && !contains(github.event.pull_request.labels.*.name, 'ci:run-full-test-suite') )
+          || github.event_name == 'merge_group'
           || false
          }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       run_lightened_ci: >-
         ${{
           github.event_name == 'pull_request'
-          && !contains(github.event.pull_request.labels.*.name, 'ci:run-full-test-suite')
+          || github.event.pull_request.base.ref == 'master'
           || false
          }}
 


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:**

Merge queues currently take a long time to process low volumes of PRs. One reason is that the full test suite is run twice, this PR will change things to only runs a lightened test suite.

**Description of the Change:**
Changing run_lightened_ci condition to also on merge queues; merge queues run on PRs that are merging to the master branch. 

**Benefits:**
Merge queues will run faster.

**Possible Drawbacks:**

**Related GitHub Issues:**
