### PR TITLE
[STALE]  enforce `qcut` as "tertiary" module

### DIFF
--- a/pennylane/qcut/cutcircuit.py
+++ b/pennylane/qcut/cutcircuit.py
@@ -19,10 +19,10 @@ from collections.abc import Callable
 from functools import partial
 from typing import Optional, Union
 
-import pennylane as qml
+from pennylane import ops, transforms
 from pennylane.measurements import ExpectationMP
 from pennylane.tape import QuantumScript, QuantumScriptBatch
-from pennylane.transforms import transform
+from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 from pennylane.wires import Wires
 
@@ -52,16 +52,18 @@ def _cut_circuit_expand(
 
     # Expand the tapes for handling Hamiltonian with two or more terms
     tape_meas_ops = tape.measurements
-    if tape_meas_ops and isinstance(tape_meas_ops[0].obs, qml.ops.Sum):
+    if tape_meas_ops and isinstance(tape_meas_ops[0].obs, ops.Sum):
         if len(tape_meas_ops) > 1:
             raise NotImplementedError(
                 "Hamiltonian expansion is supported only with a single Hamiltonian"
             )
 
-        new_meas_op = type(tape_meas_ops[0])(obs=qml.Hamiltonian(*tape_meas_ops[0].obs.terms()))
+        new_meas_op = type(tape_meas_ops[0])(
+            obs=ops.LinearCombination(*tape_meas_ops[0].obs.terms())
+        )
         new_tape = tape.copy(measurements=[new_meas_op])
 
-        tapes, tapes_fn = qml.transforms.split_non_commuting(new_tape, grouping_strategy=None)
+        tapes, tapes_fn = transforms.split_non_commuting(new_tape, grouping_strategy=None)
 
     return [_qcut_expand_fn(tape, max_depth, auto_cutter) for tape in tapes], tapes_fn
 
@@ -411,7 +413,7 @@ def cut_circuit(
     # convert decomposed DAGs into tapes, remap their wires for device and expand them
     fragment_tapes = [graph_to_tape(f) for f in fragments]
     fragment_tapes = [
-        qml.map_wires(t, dict(zip(t.wires, device_wires)))[0][0] for t in fragment_tapes
+        ops.functions.map_wires(t, dict(zip(t.wires, device_wires)))[0][0] for t in fragment_tapes
     ]
     expanded = [expand_fragment_tape(t) for t in fragment_tapes]
 

--- a/pennylane/qcut/cutcircuit_mc.py
+++ b/pennylane/qcut/cutcircuit_mc.py
@@ -23,12 +23,13 @@ from typing import Optional, Union
 import numpy as np
 from networkx import MultiDiGraph
 
-import pennylane as qml
-from pennylane.measurements import SampleMP
+from pennylane import ops
+from pennylane.measurements import SampleMP, Shots, sample
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform
 from pennylane.typing import PostprocessingFn
 from pennylane.wires import Wires
+from pennylane.workflow import QNode
 
 from .cutstrategy import CutStrategy
 from .kahypar import kahypar_cut
@@ -49,6 +50,7 @@ from .utils import (
 )
 
 
+# pylint: disable=too-many-positional-arguments
 def _cut_circuit_mc_expand(
     tape: QuantumScript,
     classical_processing_fn: Optional[callable] = None,
@@ -68,6 +70,7 @@ def _cut_circuit_mc_expand(
     return [_qcut_expand_fn(tape, max_depth, auto_cutter)], processing_fn
 
 
+# pylint: disable=too-many-positional-arguments
 @partial(transform, expand_transform=_cut_circuit_mc_expand)
 def cut_circuit_mc(
     tape: QuantumScript,
@@ -460,7 +463,7 @@ def cut_circuit_mc(
     fragments, communication_graph = fragment_graph(g)
     fragment_tapes = [graph_to_tape(f) for f in fragments]
     fragment_tapes = [
-        qml.map_wires(t, dict(zip(t.wires, device_wires)))[0][0] for t in fragment_tapes
+        ops.functions.map_wires(t, dict(zip(t.wires, device_wires)))[0][0] for t in fragment_tapes
     ]
 
     seed = kwargs.get("seed", None)
@@ -495,7 +498,7 @@ def cut_circuit_mc(
     return tapes, processing_fn
 
 
-class CustomQNode(qml.QNode):
+class CustomQNode(QNode):
     """
     A subclass with a custom __call__ method. The custom QNode transform returns an instance
     of this class.
@@ -510,7 +513,7 @@ class CustomQNode(qml.QNode):
                 "A shots value must be provided in the device "
                 "or when calling the QNode to be cut"
             )
-        if isinstance(shots, qml.measurements.Shots):
+        if isinstance(shots, Shots):
             shots = shots.total_shots
 
         # find the qcut transform inside the transform program and set the shots argument
@@ -566,19 +569,19 @@ MC_STATES = [
 
 
 def _identity(wire):
-    return qml.sample(qml.Identity(wires=wire))
+    return sample(ops.Identity(wires=wire))
 
 
 def _pauliX(wire):
-    return qml.sample(qml.X(wire))
+    return sample(ops.X(wire))
 
 
 def _pauliY(wire):
-    return qml.sample(qml.Y(wire))
+    return sample(ops.Y(wire))
 
 
 def _pauliZ(wire):
-    return qml.sample(qml.Z(wire))
+    return sample(ops.Z(wire))
 
 
 MC_MEASUREMENTS = [

--- a/pennylane/qcut/cutstrategy.py
+++ b/pennylane/qcut/cutstrategy.py
@@ -22,7 +22,7 @@ from typing import Any, ClassVar, Union
 
 from networkx import MultiDiGraph
 
-import pennylane as qml
+from pennylane.devices import Device, LegacyDevice
 from pennylane.ops.meta import WireCut
 
 SupportedDeviceAPIs = Union["qml.devices.LegacyDevice", "qml.devices.Device"]
@@ -127,12 +127,12 @@ class CutStrategy:
         if devices is None and self.max_free_wires is None:
             raise ValueError("One of arguments `devices` and max_free_wires` must be provided.")
 
-        if isinstance(devices, (qml.devices.LegacyDevice, qml.devices.Device)):
+        if isinstance(devices, (LegacyDevice, Device)):
             devices = (devices,)
 
         if devices is not None:
             if not isinstance(devices, Sequence) or any(
-                (not isinstance(d, (qml.devices.LegacyDevice, qml.devices.Device)) for d in devices)
+                (not isinstance(d, (LegacyDevice, Device)) for d in devices)
             ):
                 raise ValueError(
                     "Argument `devices` must be a list or tuple containing elements of type "

--- a/pennylane/qcut/kahypar.py
+++ b/pennylane/qcut/kahypar.py
@@ -24,10 +24,11 @@ from typing import Any, Union
 import numpy as np
 from networkx import MultiDiGraph
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
 
 
+# pylint: disable=too-many-positional-arguments
 def kahypar_cut(
     graph: MultiDiGraph,
     num_fragments: int,
@@ -194,7 +195,7 @@ def _graph_to_hmetis(
     wires = {w for _, _, w in edges}
 
     adj_nodes = [nodes.index(v) for ops in graph.edges(keys=False) for v in ops]
-    edge_splits = qml.math.cumsum([0] + [len(e) for e in graph.edges(keys=False)]).tolist()
+    edge_splits = math.cumsum([0] + [len(e) for e in graph.edges(keys=False)]).tolist()
     edge_weights = (
         edge_weights if edge_weights is not None and len(edges) == len(edge_weights) else None
     )

--- a/pennylane/qcut/ops.py
+++ b/pennylane/qcut/ops.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Nodes for use in qcut.
+"""
+import uuid
+
+from pennylane.operation import Operation
+
+
+class PrepareNode(Operation):
+    """Placeholder node for state preparations"""
+
+    num_wires = 1
+    grad_method = None
+    num_params = 0
+
+    def __init__(self, wires=None, id=None):
+        id = id or str(uuid.uuid4())
+
+        super().__init__(wires=wires, id=id)
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        op_label = base_label or self.__class__.__name__
+        return op_label
+
+
+class MeasureNode(Operation):
+    """Placeholder node for measurement operations"""
+
+    num_wires = 1
+    grad_method = None
+    num_params = 0
+
+    def __init__(self, wires=None, id=None):
+        id = id or str(uuid.uuid4())
+
+        super().__init__(wires=wires, id=id)
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        op_label = base_label or self.__class__.__name__
+        return op_label

--- a/pennylane/qcut/tapes.py
+++ b/pennylane/qcut/tapes.py
@@ -31,7 +31,7 @@ from pennylane.queuing import QueuingManager, WrappedObj
 from pennylane.tape import QuantumScript
 from pennylane.wires import Wires
 
-from .utils import MeasureNode, PrepareNode
+from .ops import MeasureNode, PrepareNode
 
 
 def tape_to_graph(tape: QuantumScript) -> MultiDiGraph:

--- a/pennylane/qcut/tapes.py
+++ b/pennylane/qcut/tapes.py
@@ -22,13 +22,12 @@ from typing import Union
 
 from networkx import MultiDiGraph
 
-import pennylane as qml
-from pennylane import expval
-from pennylane.measurements import ExpectationMP, MeasurementProcess, SampleMP
+from pennylane import ops
+from pennylane.measurements import ExpectationMP, MeasurementProcess, SampleMP, expval, sample
 from pennylane.operation import Operator
 from pennylane.ops.meta import WireCut
-from pennylane.pauli import string_to_pauli_word
-from pennylane.queuing import WrappedObj
+from pennylane.pauli import partition_pauli_group, string_to_pauli_word
+from pennylane.queuing import QueuingManager, WrappedObj
 from pennylane.tape import QuantumScript
 from pennylane.wires import Wires
 
@@ -81,20 +80,20 @@ def tape_to_graph(tape: QuantumScript) -> MultiDiGraph:
     order += 1  # pylint: disable=undefined-loop-variable
     for m in tape.measurements:
         obs = getattr(m, "obs", None)
-        if obs is not None and isinstance(obs, qml.ops.Prod):
+        if obs is not None and isinstance(obs, ops.Prod):
             if isinstance(m, SampleMP):
                 raise ValueError(
                     "Sampling from tensor products of observables "
                     "is not supported in circuit cutting"
                 )
 
-            for o in obs.operands if isinstance(obs, qml.ops.op_math.Prod) else obs.obs:
+            for o in obs.operands if isinstance(obs, ops.op_math.Prod) else obs.obs:
                 m_ = m.__class__(obs=o)
                 _add_operator_node(graph, m_, order, wire_latest_node)
 
         elif isinstance(m, SampleMP) and obs is None:
             for w in m.wires:
-                s_ = qml.sample(qml.Projector([1], wires=w))
+                s_ = sample(ops.Projector([1], wires=w))
                 _add_operator_node(graph, s_, order, wire_latest_node)
         else:
             _add_operator_node(graph, m, order, wire_latest_node)
@@ -167,7 +166,7 @@ def graph_to_tape(graph: MultiDiGraph) -> QuantumScript:
     operations_from_graph = []
     measurements_from_graph = []
     for op in copy_ops:
-        op = qml.map_wires(op, wire_map=wire_map, queue=False)
+        op = ops.functions.map_wires(op, wire_map=wire_map, queue=False)
         operations_from_graph.append(op)
         if isinstance(op, MeasureNode):
             assert len(op.wires) == 1
@@ -195,7 +194,7 @@ def graph_to_tape(graph: MultiDiGraph) -> QuantumScript:
             )
 
         for meas in copy_meas:
-            meas = qml.map_wires(meas, wire_map=wire_map)
+            meas = ops.functions.map_wires(meas, wire_map=wire_map)
             obs = meas.obs
             observables.append(obs)
 
@@ -204,9 +203,9 @@ def graph_to_tape(graph: MultiDiGraph) -> QuantumScript:
 
         if measurement_type is ExpectationMP:
             if len(observables) > 1:
-                measurements_from_graph.append(qml.expval(qml.prod(*observables)))
+                measurements_from_graph.append(expval(ops.op_math.prod(*observables)))
             else:
-                measurements_from_graph.append(qml.expval(obs))
+                measurements_from_graph.append(expval(obs))
 
     return QuantumScript(ops=operations_from_graph, measurements=measurements_from_graph)
 
@@ -239,16 +238,16 @@ def _create_prep_list():
     """
 
     def _prep_zero(wire):
-        return [qml.Identity(wire)]
+        return [ops.Identity(wire)]
 
     def _prep_one(wire):
-        return [qml.X(wire)]
+        return [ops.X(wire)]
 
     def _prep_plus(wire):
-        return [qml.Hadamard(wire)]
+        return [ops.Hadamard(wire)]
 
     def _prep_iplus(wire):
-        return [qml.Hadamard(wire), qml.S(wires=wire)]
+        return [ops.Hadamard(wire), ops.S(wires=wire)]
 
     return [_prep_zero, _prep_one, _prep_plus, _prep_iplus]
 
@@ -316,7 +315,7 @@ def expand_fragment_tape(
 
     n_meas = len(measure_nodes)
     if n_meas >= 1:
-        measure_combinations = qml.pauli.partition_pauli_group(len(measure_nodes))
+        measure_combinations = partition_pauli_group(len(measure_nodes))
     else:
         measure_combinations = [[""]]
 
@@ -337,7 +336,7 @@ def expand_fragment_tape(
 
             ops_list = []
 
-            with qml.QueuingManager.stop_recording():
+            with QueuingManager.stop_recording():
                 for op in tape.operations:
                     if isinstance(op, PrepareNode):
                         w = op.wires[0]
@@ -346,7 +345,7 @@ def expand_fragment_tape(
                         ops_list.append(op)
                 measurements = _get_measurements(group, tape.measurements)
 
-            qs = qml.tape.QuantumScript(ops=ops_list, measurements=measurements)
+            qs = QuantumScript(ops=ops_list, measurements=measurements)
             tapes.append(qs)
 
     return tapes, prepare_nodes, measure_nodes

--- a/pennylane/qcut/utils.py
+++ b/pennylane/qcut/utils.py
@@ -16,7 +16,6 @@ Support functions for cut_circuit and cut_circuit_mc.
 """
 
 
-import uuid
 import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -26,47 +25,14 @@ from networkx import MultiDiGraph, has_path, weakly_connected_components
 
 from pennylane import ops
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Operation
+from pennylane.ops import Operation
 from pennylane.ops.meta import WireCut
 from pennylane.queuing import WrappedObj
 
 from .cutstrategy import CutStrategy
 from .kahypar import kahypar_cut
+from .ops import MeasureNode, PrepareNode
 from .tapes import graph_to_tape
-
-
-class MeasureNode(Operation):
-    """Placeholder node for measurement operations"""
-
-    num_wires = 1
-    grad_method = None
-    num_params = 0
-
-    def __init__(self, wires=None, id=None):
-        id = id or str(uuid.uuid4())
-
-        super().__init__(wires=wires, id=id)
-
-    def label(self, decimals=None, base_label=None, cache=None):
-        op_label = base_label or self.__class__.__name__
-        return op_label
-
-
-class PrepareNode(Operation):
-    """Placeholder node for state preparations"""
-
-    num_wires = 1
-    grad_method = None
-    num_params = 0
-
-    def __init__(self, wires=None, id=None):
-        id = id or str(uuid.uuid4())
-
-        super().__init__(wires=wires, id=id)
-
-    def label(self, decimals=None, base_label=None, cache=None):
-        op_label = base_label or self.__class__.__name__
-        return op_label
 
 
 def _prep_zero_state(wire):

--- a/pennylane/qcut/utils.py
+++ b/pennylane/qcut/utils.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 from networkx import MultiDiGraph, has_path, weakly_connected_components
 
-import pennylane as qml
+from pennylane import ops
 from pennylane.measurements import MeasurementProcess
 from pennylane.operation import Operation
 from pennylane.ops.meta import WireCut
@@ -32,6 +32,7 @@ from pennylane.queuing import WrappedObj
 
 from .cutstrategy import CutStrategy
 from .kahypar import kahypar_cut
+from .tapes import graph_to_tape
 
 
 class MeasureNode(Operation):
@@ -69,27 +70,27 @@ class PrepareNode(Operation):
 
 
 def _prep_zero_state(wire):
-    return [qml.Identity(wire)]
+    return [ops.Identity(wire)]
 
 
 def _prep_one_state(wire):
-    return [qml.X(wire)]
+    return [ops.X(wire)]
 
 
 def _prep_plus_state(wire):
-    return [qml.Hadamard(wire)]
+    return [ops.Hadamard(wire)]
 
 
 def _prep_minus_state(wire):
-    return [qml.X(wire), qml.Hadamard(wire)]
+    return [ops.X(wire), ops.Hadamard(wire)]
 
 
 def _prep_iplus_state(wire):
-    return [qml.Hadamard(wire), qml.S(wires=wire)]
+    return [ops.Hadamard(wire), ops.S(wires=wire)]
 
 
 def _prep_iminus_state(wire):
-    return [qml.X(wire), qml.Hadamard(wire), qml.S(wires=wire)]
+    return [ops.X(wire), ops.Hadamard(wire), ops.S(wires=wire)]
 
 
 def find_and_place_cuts(
@@ -694,6 +695,7 @@ def fragment_graph(graph: MultiDiGraph) -> tuple[tuple[MultiDiGraph], MultiDiGra
     return subgraphs_connected_to_measurements, communication_graph
 
 
+# pylint: disable=too-many-positional-arguments
 def _is_valid_cut(
     fragments,
     num_cuts,
@@ -712,7 +714,7 @@ def _is_valid_cut(
     best_candidate_yet = (key not in cut_candidates) or (len(cut_candidates[key]) > num_cuts)
     # pylint: disable=no-member
     all_fragments_fit = all(
-        len(qml.qcut.graph_to_tape(f).wires) <= max_free_wires for j, f in enumerate(fragments)
+        len(graph_to_tape(f).wires) <= max_free_wires for j, f in enumerate(fragments)
     )
 
     return correct_num_fragments and best_candidate_yet and all_fragments_fit

--- a/tach.toml
+++ b/tach.toml
@@ -210,8 +210,7 @@ unchecked = true
 
 [[modules]]
 path = "pennylane.qcut"
-depends_on = ["pennylane.operation", "pennylane.ops", "pennylane.queuing", "pennylane.wires", "pennylane.measurements", "pennylane.numpy", "pennylane.typing", "pennylane.transforms", "pennylane", "pennylane.tape", "pennylane.pauli"]
-unchecked = true
+layer = "tertiary"
 
 [[modules]]
 path = "pennylane.qchem"


### PR DESCRIPTION
**Context:**

The goal of this PR is to isolate the `qcut` module as a `tertiary` module.

**Description of the Change:**

- Removes all top-level imports, `import pennylane as qml` from this module.

**Benefits:** Module dependency enforcement

**Possible Drawbacks:** N/A

[sc-89250]
