### PR TITLE
Fix Keras link after release

### DIFF
--- a/pennylane/qnn/__init__.py
+++ b/pennylane/qnn/__init__.py
@@ -17,7 +17,7 @@ with Keras and PyTorch.
 
 .. note::
 
-    Check out our :doc:`Keras <demos/tutorial_qnn_module_tf>` and
+    Check out our :doc:`Keras <demos/qnn_module_tf>` and
     :doc:`Torch <demos/tutorial_qnn_module_torch>` tutorials for further details.
 
 


### PR DESCRIPTION
**Context:**
This warning of Sphinx has been [observed](https://github.com/PennyLaneAI/pennylane/actions/runs/14500983235/job/40683589377) since release of 0.41:
```
2025-04-16T19:42:11.1180500Z /github/workspace/pennylane/qnn/__init__.py:docstring of pennylane.qnn:6: WARNING: unknown document: demos/tutorial_qnn_module_tf
```
This is because in recent qml we renamed this demo from `tutorial_qnn_module_tf` to `qnn_module_tf`.

**Description of the Change:**
Rename the involved docstr.

**Benefits:**
Healthy Sphinx

**Possible Drawbacks:**
Not at all

**Related GitHub Issues:**
