### PR TITLE
Catalyst now uses `capture.enable()` as well, removing `experimental_capture=True`

### DIFF
--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -404,12 +404,13 @@ Using program capture with Catalyst
 -----------------------------------
 
 To use the program capture feature with Catalyst, the ``qml.capture.enable()`` toggle
-is not required. Instead, when decorating a workflow with :func:`~.pennylane.qjit`, 
-add the ``experimental_capture=True`` flag:
+is also required.
 
 .. code-block:: python
 
     import pennylane as qml
+
+    qml.capture.enable()
 
     dev = qml.device('lightning.qubit', wires=1)
 


### PR DESCRIPTION
Related PR in Catalyst: https://github.com/PennyLaneAI/catalyst/pull/1657 (cc @rauletorresc)