### PR TITLE
Removing `inner_transform` and `config` keyword arguments in `qml.execute`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -54,12 +54,6 @@ Pending deprecations
   - Deprecated in v0.41
   - Will be removed in v0.42
 
-* The ``inner_transform_program`` and ``config`` keyword arguments in ``qml.execute`` have been deprecated.
-  If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.
-
-  - Deprecated in v0.41
-  - Will be removed in v0.42
-
 * ``op.ops`` and ``op.coeffs`` for ``Sum`` and ``Prod`` have been deprecated. Instead, please use
   :meth:`~.Operator.terms` instead.
 
@@ -104,6 +98,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``inner_transform`` and ``config`` keyword arguments in ``qml.execute`` have been removed.
+  If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.
+
+  - Deprecated in v0.41
+  - Removed in v0.42
 
 * ``MultiControlledX`` no longer accepts strings as control values.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -27,7 +27,6 @@
 
 * Specifying `pipeline=None` with `qml.compile` has been removed.
   [(#7307)](https://github.com/PennyLaneAI/pennylane/pull/7307)
-  
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,7 +20,7 @@
 <h3>Breaking changes 💔</h3>
 
 * The `inner_transform` and `config` keyword arguments in `qml.execute` have been removed.
-  [(#...)](https://github.com/PennyLaneAI/pennylane/pull/...)
+  [(#7300)](https://github.com/PennyLaneAI/pennylane/pull/7300)
 
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* The `inner_transform` and `config` keyword arguments in `qml.execute` have been removed.
+  [(#...)](https://github.com/PennyLaneAI/pennylane/pull/...)
+
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
 
@@ -62,6 +65,7 @@ This release contains contributions from (in alphabetical order):
 
 Guillermo Alonso-Linaje
 Lillian Frederiksen
+Pietropaolo Frisoni,
 Andrija Paurevic,
 Korbinian Kottmann,
 Christina Lee

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -27,6 +27,7 @@
 
 * Specifying `pipeline=None` with `qml.compile` has been removed.
   [(#7307)](https://github.com/PennyLaneAI/pennylane/pull/7307)
+
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -80,11 +80,9 @@
 This release contains contributions from (in alphabetical order):
 
 Guillermo Alonso-Linaje,
-Lillian Frederiksen,
-Pietropaolo Frisoni,
-Guillermo Alonso-Linaje,
 Yushao Chen,
 Lillian Frederiksen,
+Pietropaolo Frisoni,
 Korbinian Kottmann,
 Christina Lee,
 Andrija Paurevic

--- a/pennylane/workflow/execution.py
+++ b/pennylane/workflow/execution.py
@@ -55,8 +55,6 @@ def execute(
     mcm_method: Literal[None, "deferred", "one-shot", "tree-traversal"] = None,
     gradient_kwargs: dict = None,
     mcm_config="unset",
-    config="unset",
-    inner_transform="unset",
 ) -> ResultBatch:
     """A function for executing a batch of tapes on a device with compatibility for auto-differentiation.
 
@@ -98,10 +96,6 @@ def execute(
             determining the gradients of tapes.
         mcm_config="unset": **DEPRECATED**. This keyword argument has been replaced by ``postselect_mode``
             and ``mcm_method`` and will be removed in v0.42.
-        config="unset": **DEPRECATED**. This keyword argument has been deprecated and
-            will be removed in v0.42.
-        inner_transform="unset": **DEPRECATED**. This keyword argument has been deprecated
-            and will be removed in v0.42.
 
     Returns:
         list[tensor_like[float]]: A nested list of tape results. Each element in
@@ -164,22 +158,6 @@ def execute(
     """
     if not isinstance(device, qml.devices.Device):
         device = qml.devices.LegacyDeviceFacade(device)
-
-    if config != "unset":
-        warn(
-            "The config argument has been deprecated and will be removed in v0.42. "
-            "The provided config argument will be ignored. "
-            "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
-        )
-
-    if inner_transform != "unset":
-        warn(
-            "The inner_transform argument has been deprecated and will be removed in v0.42. "
-            "The provided inner_transform argument will be ignored. "
-            "If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.",
-            qml.PennyLaneDeprecationWarning,
-        )
 
     if mcm_config != "unset":
         warn(

--- a/tests/workflow/interfaces/execute/test_execute.py
+++ b/tests/workflow/interfaces/execute/test_execute.py
@@ -79,30 +79,6 @@ def test_mcm_config_deprecation(mocker):
             spy.assert_called_once()
 
 
-def test_config_deprecation():
-    """Test that the config argument has been deprecated."""
-
-    tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
-    dev = qml.device("default.qubit")
-    with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
-        match="The config argument has been deprecated",
-    ):
-        qml.execute((tape,), dev, config=qml.devices.DefaultExecutionConfig)
-
-
-def test_inner_transform_program_deprecation():
-    """Test that the inner_transform argument has been deprecated."""
-
-    tape = qml.tape.QuantumScript([qml.RX(qml.numpy.array(1.0), 0)], [qml.expval(qml.Z(0))])
-    dev = qml.device("default.qubit")
-    with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
-        match="The inner_transform argument has been deprecated",
-    ):
-        qml.execute((tape,), dev, inner_transform=qml.transforms.core.TransformProgram())
-
-
 def test_execution_with_empty_batch():
     """Test that qml.execute can be used with an empty batch."""
 


### PR DESCRIPTION
As the title says.

[sc-89155]