### PR TITLE
Remove `op.ops` and `op.coeffs` for `Sum` and `Prod`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -60,12 +60,6 @@ Pending deprecations
   - Deprecated in v0.41
   - Will be removed in v0.42
 
-* ``op.ops`` and ``op.coeffs`` for ``Sum`` and ``Prod`` have been deprecated. Instead, please use
-  :meth:`~.Operator.terms` instead.
-
-  - Deprecated in v0.35
-  - Will be removed in v0.42
-
 * Accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs`` is deprecated with new operator arithmetic.
   A user should use :class:`op.operands <~.CompositeOp>` instead.
 
@@ -104,6 +98,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* ``op.ops`` and ``op.coeffs`` for ``Sum`` and ``Prod`` have been removed. Instead, please use
+  :meth:`~.Operator.terms`.
+
+  - Deprecated in v0.35
+  - Removed in v0.42
 
 * ``MultiControlledX`` no longer accepts strings as control values.
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -98,12 +98,12 @@ Completed deprecation cycles
   :meth:`~.Operator.terms`.
 
   - Deprecated in v0.35
+  - Removed in v0.42
 
 * Specifying ``pipeline=None`` with ``qml.compile`` has been removed. 
   A sequence of transforms should now always be specified.
 
   - Deprecated in v0.41
-
   - Removed in v0.42
 
 * ``MultiControlledX`` no longer accepts strings as control values.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* `Sum.ops`, `Sum.coeffs`, `Prod.ops` and `Prod.coeffs` have been removed.
+  [(#7304)](https://github.com/PennyLaneAI/pennylane/pull/7304)
+
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -479,36 +479,6 @@ class Prod(CompositeOp):
                 ops.append(factor)
         return coeffs, ops
 
-    @property
-    def coeffs(self):
-        r"""
-        Scalar coefficients of the operator when flattened out.
-
-        This is a deprecated attribute, please use :meth:`~Prod.terms` instead.
-
-        .. seealso:: :attr:`~Prod.ops`, :class:`~Prod.pauli_rep`"""
-        warnings.warn(
-            "Prod.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        coeffs, _ = self.terms()
-        return coeffs
-
-    @property
-    def ops(self):
-        r"""
-        Operator terms without scalar coefficients of the operator when flattened out.
-
-        This is a deprecated attribute, please use :meth:`~Prod.terms` instead.
-
-        .. seealso:: :attr:`~Prod.coeffs`, :class:`~Prod.pauli_rep`"""
-        warnings.warn(
-            "Prod.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        _, ops = self.terms()
-        return ops
-
 
 def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:
     """Boolean expression that indicates if op1 and op2 don't have intersecting wires and if they

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -18,7 +18,6 @@ computing the sum of operations.
 # pylint: disable=too-many-arguments,too-many-instance-attributes,protected-access
 
 import itertools
-import warnings
 from collections import Counter
 from collections.abc import Iterable
 from copy import copy

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -530,36 +530,6 @@ class Sum(CompositeOp):
                 ops, grouping_type=grouping_type, method=method
             )
 
-    @property
-    def coeffs(self):
-        r"""
-        Scalar coefficients of the operator when flattened out.
-
-        This is a deprecated attribute, please use :meth:`~Sum.terms` instead.
-
-        .. seealso:: :attr:`~Sum.ops`, :class:`~Sum.pauli_rep`"""
-        warnings.warn(
-            "Sum.coeffs is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms(). Also consider using op.operands.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        coeffs, _ = self.terms()
-        return coeffs
-
-    @property
-    def ops(self):
-        r"""
-        Operator terms without scalar coefficients of the operator when flattened out.
-
-        This is a deprecated attribute, please use :meth:`~Sum.terms` instead.
-
-        .. seealso:: :attr:`~Sum.coeffs`, :class:`~Sum.pauli_rep`"""
-        warnings.warn(
-            "Sum.ops is deprecated and will be removed in Pennylane v0.42. You can access both (coeffs, ops) via op.terms() Also consider op.operands.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        _, ops = self.terms()
-        return ops
-
     @classmethod
     def _sort(cls, op_list, wire_map: dict = None) -> list[Operator]:
         """Sort algorithm that sorts a list of sum summands by their wire indices.

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -90,20 +90,6 @@ ops_hermitian_status = (  # computed manually
 )
 
 
-def test_legacy_ops():
-    """Test that PennyLaneDepcreationWarning is raised when Prod.ops is called"""
-    H = qml.prod(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.ops is deprecated and"):
-        _ = H.ops
-
-
-def test_legacy_coeffs():
-    """Test that PennyLaneDepcreationWarning is raised when Prod.coeffs is called"""
-    H = qml.prod(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Prod.coeffs is deprecated and"):
-        _ = H.coeffs
-
-
 def test_obs_attribute():
     """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
     op = qml.prod(X(0), X(1), X(2))

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -112,20 +112,6 @@ def compare_and_expand_mat(mat1, mat2):
     return smaller_mat, larger_mat
 
 
-def test_legacy_ops():
-    """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
-    H = qml.sum(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.ops is deprecated and"):
-        _ = H.ops
-
-
-def test_legacy_coeffs():
-    """Test that PennyLaneDepcreationWarning is raised when Sum.ops is called"""
-    H = qml.sum(X(0), X(1))
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="Sum.coeffs is deprecated and"):
-        _ = H.coeffs
-
-
 class TestInitialization:
     """Test the initialization."""
 


### PR DESCRIPTION
As the title says.

[sc-89156]