### PR TITLE
Removing support for `pipeline=None`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -14,11 +14,6 @@ Pending deprecations
   - Deprecated in v0.41
   - Will be removed in v0.42
 
-* Specifying ``pipeline=None`` with ``qml.compile`` is now deprecated.
-
-  - Deprecated in v0.41
-  - Will be removed in v0.42
-
 * The ``ControlledQubitUnitary`` will stop accepting `QubitUnitary` objects as arguments as its ``base``. Instead, use ``qml.ctrl`` to construct a controlled `QubitUnitary`.
 
   - Deprecated in v0.41
@@ -104,6 +99,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* Specifying ``pipeline=None`` with ``qml.compile`` has been removed. 
+  A sequence of transforms should now always be specified.
+
+  - Deprecated in v0.41
+  - Removed in v0.42
 
 * ``MultiControlledX`` no longer accepts strings as control values.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* Specifying `pipeline=None` with `qml.compile` has been removed.
+  [(#7307)](https://github.com/PennyLaneAI/pennylane/pull/7307)
+
 * `qml.tape.TapeError` has been removed.
   [(#7205)](https://github.com/PennyLaneAI/pennylane/pull/7205)
 

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -170,18 +170,10 @@ def compile(
 
     """
 
-    # Ensure that everything in the pipeline is a valid qfunc or tape transform
-    if pipeline is None:
-        warn(
-            "Specifying pipeline=None is now deprecated. Please specify a sequence of transforms",
-            qml.PennyLaneDeprecationWarning,
-        )
-        pipeline = default_pipeline
-    else:
-        for p in pipeline:
-            p_func = p.func if isinstance(p, partial) else p
-            if not isinstance(p_func, TransformDispatcher):
-                raise ValueError("Invalid transform function {p} passed to compile.")
+    for p in pipeline:
+        p_func = p.func if isinstance(p, partial) else p
+        if not isinstance(p_func, TransformDispatcher):
+            raise ValueError("Invalid transform function {p} passed to compile.")
 
     if num_passes < 1 or not isinstance(num_passes, int):
         raise ValueError("Number of passes must be an integer with value at least 1.")

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -16,7 +16,6 @@ from collections.abc import Sequence
 
 # pylint: disable=too-many-branches
 from functools import partial
-from warnings import warn
 
 import pennylane as qml
 from pennylane.ops import __all__ as all_ops

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -50,14 +50,6 @@ def build_qfunc(wires):
     return qfunc
 
 
-def test_deprecation_pipeline_None():
-    """Test that specifying `pipeline=None` is deprecated."""
-
-    tape = qml.tape.QuantumScript()
-    with pytest.warns(qml.PennyLaneDeprecationWarning, match="pipeline=None is now deprecated"):
-        qml.compile(tape, pipeline=None)
-
-
 class TestCompile:
     """Unit tests for compile function."""
 


### PR DESCRIPTION
As the title says.

[sc-89148]