### PR TITLE
Add informative error to capture + jit +  condition on abstract value + default qubit execution

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -42,6 +42,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Adds an informative error if `qml.cond` is used with an abstract condition with
+  jitting on `default.qubit` if capture is enabled.
+
 * Gradient transforms can now be used in conjunction with batch transforms with all interfaces.
   [(#7287)](https://github.com/PennyLaneAI/pennylane/pull/7287)
 

--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -678,7 +678,7 @@ def flattened_cond(self, *invals, jaxpr_branches, consts_slices, args_slice):
         consts = invals[const_slice]
         if math.is_abstract(pred):
             raise NotImplementedError(
-                f"{self}  does not yet support jitting cond with abstract conditions."
+                f"{self} does not yet support jitting cond with abstract conditions."
             )
         if pred and jaxpr is not None:
             return copy(self).eval(jaxpr, consts, *args)

--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -22,6 +22,7 @@ from typing import Callable, Optional, Sequence
 import jax
 
 import pennylane as qml
+from pennylane import math
 
 from .flatfn import FlatFn
 from .primitives import (
@@ -675,6 +676,10 @@ def flattened_cond(self, *invals, jaxpr_branches, consts_slices, args_slice):
 
     for pred, jaxpr, const_slice in zip(conditions, jaxpr_branches, consts_slices):
         consts = invals[const_slice]
+        if math.is_abstract(pred):
+            raise NotImplementedError(
+                f"{self}  does not yet support jitting cond with abstract conditions."
+            )
         if pred and jaxpr is not None:
             return copy(self).eval(jaxpr, consts, *args)
     return ()

--- a/tests/devices/qubit/test_dq_interpreter.py
+++ b/tests/devices/qubit/test_dq_interpreter.py
@@ -213,6 +213,22 @@ def test_projector(basis_state):
     assert qml.math.allclose(circuit(x), expected_state)
 
 
+def test_informative_error_if_jitting_abstract_conditionals():
+    """Test that an informative error is raised if jitting is attempted with abtract conditionals."""
+
+    config = ExecutionConfig()
+
+    @DefaultQubitInterpreter(num_wires=1, shots=None, execution_config=config)
+    def circuit(val):
+        qml.cond(val, qml.X, qml.Y)(0)
+        return qml.state()
+
+    with pytest.raises(
+        NotImplementedError, match="does not yet support jitting cond with abstract conditions"
+    ):
+        _ = jax.jit(circuit)(True)
+
+
 class TestSampling:
     """Test cases for generating samples."""
 


### PR DESCRIPTION
**Context:**

While many circuits can be jit-executed on default qubit with program capture, we cannot yet handle executing abstract conditions. This adds a more informative error to that effect.

If we decide that a full program capture pipeline with worth fully developing and maintaining, we can come back to this, but for now, we can just error out during device execution.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
