### PR TITLE
Update unit tests workflows to keep `dev` suffix for pennylane-lightning in frozen deps files

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Freeze dependencies
         shell: bash
         if: inputs.requirements_file != ''
-        run: pip freeze | grep -v "file:///" | sed 's/\(pennylane[-_]lightning==[0-9\.]\+\)\.dev[0-9]\+/\1/gI' > ${{ inputs.requirements_file }}
+        run: pip freeze | grep -v "file:///" > ${{ inputs.requirements_file }}
 
       - name: Upload frozen requirements
         if: inputs.requirements_file != ''


### PR DESCRIPTION
Test workflows for updating stable deps were installing dev versions of lightning, but the output file with the frozen deps showed that a stable version of lightning was installed. This was because the step in the workflow that created the frozen deps file was manually removing the `.devX` suffix from the version of pennylane-lightning. This PR removes the suffix removal from that step.