### PR TITLE
Remove accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs``

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -49,12 +49,6 @@ Pending deprecations
   - Deprecated in v0.41
   - Will be removed in v0.42
 
-* Accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs`` is deprecated with new operator arithmetic.
-  A user should use :class:`op.operands <~.CompositeOp>` instead.
-
-  - Deprecated in v0.36
-  - Will be removed in v0.42
-
 * Accessing ``lie_closure``, ``structure_constants`` and ``center`` via ``qml.pauli`` is deprecated. Top level import and usage is advised.
 
  - Deprecated in v0.40
@@ -87,6 +81,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* Accessing terms of a tensor product (e.g., ``op = X(0) @ X(1)``) via ``op.obs`` has been removed.
+  A user should use :class:`op.operands <~.CompositeOp>` instead.
+
+  - Deprecated in v0.36
+  - Removed in v0.42
 
 * The ``inner_transform`` and ``config`` keyword arguments in ``qml.execute`` have been removed.
   If more detailed control over the execution is required, use ``qml.workflow.run`` with these arguments instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* Accessing terms of a tensor product (e.g., `op = X(0) @ X(1)`) via `op.obs` has been removed.
+  [(#7324)](https://github.com/PennyLaneAI/pennylane/pull/7324)
+
 * The `inner_transform` and `config` keyword arguments in `qml.execute` have been removed.
   [(#7300)](https://github.com/PennyLaneAI/pennylane/pull/7300)
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -16,7 +16,6 @@ This file contains the implementation of the Prod class which contains logic for
 computing the product between operations.
 """
 import itertools
-import warnings
 from copy import copy
 from functools import reduce, wraps
 from itertools import combinations
@@ -252,18 +251,6 @@ class Prod(CompositeOp):
     @property
     def has_decomposition(self):
         return True
-
-    @property
-    def obs(self):
-        r"""Access the operands of a ``Prod`` instance"""
-        # This is temporary property to smoothen the transition to the new operator arithmetic system.
-        # In particular, the __matmul__ (@ python operator) method between operators now generates Prod instead of Tensor instances.
-        warnings.warn(
-            "Accessing the terms of a tensor product operator via op.obs is deprecated and will be removed "
-            "in Pennylane v0.42. Instead, please use op.operands.",
-            qml.PennyLaneDeprecationWarning,
-        )
-        return self.operands
 
     def decomposition(self):
         r"""Decomposition of the product operator is given by each factor applied in succession.

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -90,18 +90,6 @@ ops_hermitian_status = (  # computed manually
 )
 
 
-def test_obs_attribute():
-    """Test that operands can be accessed via Prod.obs and a deprecation warning is raised"""
-    op = qml.prod(X(0), X(1), X(2))
-    with pytest.warns(
-        qml.PennyLaneDeprecationWarning,
-        match="Accessing the terms of a tensor product operator via op.obs is deprecated",
-    ):
-        obs = op.obs
-
-    assert obs == (X(0), X(1), X(2))
-
-
 def test_basic_validity():
     """Run basic validity checks on a prod operator."""
     op1 = qml.PauliZ(0)


### PR DESCRIPTION
As the title says.

[sc-89157]