### PR TITLE
Fix snapshots with defer measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -155,6 +155,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Snapshots can now be used together with defer-measurements on `default.qubit`.
+
 * Fixes a bug where circuit execution fails with ``BlockEncode`` initialized with sparse matrices.
   [(#7285)](https://github.com/PennyLaneAI/pennylane/pull/7285)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -561,10 +561,11 @@ class DefaultQubit(Device):
 
         if config.interface == qml.math.Interface.JAX_JIT:
             transform_program.add_transform(no_counts)
-        transform_program.add_transform(validate_device_wires, self.wires, name=self.name)
         transform_program.add_transform(
             mid_circuit_measurements, device=self, mcm_config=config.mcm_config
         )
+        # validate_device_wires needs to be after defer_measurement has added more wires.
+        transform_program.add_transform(validate_device_wires, self.wires, name=self.name)
         transform_program.add_transform(
             decompose,
             stopping_condition=stopping_condition,

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -2215,6 +2215,22 @@ class TestIntegration:
 
         assert qml.math.allclose(grad, grad_jit)
 
+    def test_snapshot_with_defer_measurement(self):
+        """Test that snapshots can be taken with defer_measurements."""
+
+        dev = qml.device("default.qubit")
+
+        @qml.qnode(dev)
+        def func():
+            qml.Hadamard(wires=0)
+            qml.measure(0)
+            qml.Snapshot("label")
+            return qml.probs(wires=0)
+
+        snapshots = qml.snapshots(func)()
+        assert snapshots["label"].shape == (4,)
+        assert qml.math.allclose(snapshots["execution_results"], np.array([0.5, 0.5]))
+
 
 @pytest.mark.parametrize("max_workers", max_workers_list)
 def test_broadcasted_parameter(max_workers):


### PR DESCRIPTION
**Context:**

`Snapshot` wasn't working with defer measurements handling of mcms.
```
dev = qml.device("default.qubit", wires=1)

@qml.qnode(dev)
def func():
    qml.Hadamard(wires=0)
    m_0 = qml.measure(0)  # without this mcm everything's fine
    qml.Snapshot("label")
    return qml.probs()

print(qml.snapshots(func)())
```

**Description of the Change:**

Switch the order of applying defer measurements and adding the device wires.

**Benefits:**

Now it works.

**Possible Drawbacks:**

We still need to figure out dynamic one shot and tree-traversal. But those are harder problems.

**Related GitHub Issues:**

Partially solves #7334 . Only for defer measurements though. [sc-89863]