### PR TITLE
BugFix: fix special case discontinuity in two-qubit decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -246,6 +246,9 @@
 * Fixed a bug where the phase is used as the wire label for a `qml.GlobalPhase` when capture is enabled.
   [(#7211)](https://github.com/PennyLaneAI/pennylane/pull/7211)
 
+* Fixed a bug where `two_qubit_decomposition` provides an incorrect decomposition for some special matrices.
+  [(#7340)](https://github.com/PennyLaneAI/pennylane/pull/7340)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ops/op_math/decompositions/unitary_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/unitary_decompositions.py
@@ -679,8 +679,9 @@ def _decompose_3_cnots(U, wires, initial_phase):
     # -╭V- = -╭X--RZ(d)--╭C---------╭X--╭SWAP-
     # -╰V- = -╰C--RY(b)--╰X--RY(a)--╰C--╰SWAP-
 
-    RZd = ops.RZ.compute_matrix(math.cast_like(delta, 1j))
-    RYb = ops.RY.compute_matrix(beta)
+    EPS = math.finfo(delta.dtype).eps
+    RZd = ops.RZ.compute_matrix(math.cast_like(delta + 5 * EPS, 1j))
+    RYb = ops.RY.compute_matrix(beta + 5 * EPS)
     RYa = ops.RY.compute_matrix(alpha)
 
     V_mats = [

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1210,38 +1210,50 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         assert check_matrix_equivalence(U, jitted_matrix, atol=1e-7)
 
 
-def test_two_qubit_decomposition_special_case_discontinuity():
+def _make_unitary(theta1):
+    generator = (
+        theta1
+        / 2
+        * (
+            np.cos(0.2) / 2 * (np.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 2, 0, 0], [0, 0, 0, 0]]))
+            + np.sin(0.2)
+            / 2
+            * (np.array([[0, 0, 0, 0], [0, 0, 2j, 0], [0, -2j, 0, 0], [0, 0, 0, 0]]))
+        )
+    )
+
+    def expm(val):
+        d, U = np.linalg.eigh(-1.0j * val)
+        return np.dot(U, np.dot(np.diag(np.exp(1.0j * d)), np.conj(U).T))
+
+    mat = expm(-1j * generator)
+
+    assert np.allclose(
+        np.dot(np.transpose(np.conj(mat)), mat), np.eye(len(mat))
+    ), "mat is not unitary"
+
+    return mat
+
+
+@pytest.mark.parametrize(
+    "U",
+    [
+        _make_unitary(np.pi / 2),
+        np.array(
+            [
+                [-1, 0, 0, 0],
+                [0, 1 / np.sqrt(2), 1 / np.sqrt(2), 0],
+                [0, 1 / np.sqrt(2), -1 / np.sqrt(2), 0],
+                [0, 0, 0, -1],
+            ]
+        ),
+    ],
+)
+def test_two_qubit_decomposition_special_case_discontinuity(U):
     """Test that two_qubit_decomposition still provides accurate numbers at a special case."""
 
-    def make_unitary(theta1):
-        generator = (
-            theta1
-            / 2
-            * (
-                np.cos(0.2)
-                / 2
-                * (np.array([[0, 0, 0, 0], [0, 0, 2, 0], [0, 2, 0, 0], [0, 0, 0, 0]]))
-                + np.sin(0.2)
-                / 2
-                * (np.array([[0, 0, 0, 0], [0, 0, 2j, 0], [0, -2j, 0, 0], [0, 0, 0, 0]]))
-            )
-        )
-
-        def expm(val):
-            d, U = np.linalg.eigh(-1.0j * val)
-            return np.dot(U, np.dot(np.diag(np.exp(1.0j * d)), np.conj(U).T))
-
-        mat = expm(-1j * generator)
-
-        assert np.allclose(
-            np.dot(np.transpose(np.conj(mat)), mat), np.eye(len(mat))
-        ), "mat is not unitary"
-
-        return mat
-
-    mat = make_unitary(np.pi / 2)
-    decomp_mat = qml.matrix(two_qubit_decomposition, wire_order=(0, 1))(mat, wires=(0, 1))
-    assert qml.math.allclose(mat, decomp_mat)
+    decomp_mat = qml.matrix(two_qubit_decomposition, wire_order=(0, 1))(U, wires=(0, 1))
+    assert qml.math.allclose(U, decomp_mat)
 
 
 class TestTwoQubitDecompositionWarnings:

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1210,6 +1210,8 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
         assert check_matrix_equivalence(U, jitted_matrix, atol=1e-7)
 
 
+# This was the routine used to generate the problematic matrix in the original
+# bug report (see https://github.com/PennyLaneAI/pennylane/issues/5308)
 def _make_unitary(theta1):
     generator = (
         theta1


### PR DESCRIPTION
Follow up to https://github.com/PennyLaneAI/pennylane/pull/5448, applying the same solution to the 3-cnot case.

Fixes: https://github.com/PennyLaneAI/pennylane/issues/7339
[sc-90052]