### PR TITLE
Fix unnecessary finite-shot simulations in debugging tests

### DIFF
--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -722,7 +722,7 @@ class TestSnapshotUnsupportedQNode:
         assert not np.allclose(  # Since 200 does not have a factor of 3, we assert that there's no chance for finite-shot tape to reach 1/3 exactly here.
             finite_shot_result,
             analytic_result,
-            atol=0,
+            atol=np.finfo(np.float64).eps,
             rtol=0,
         )
 


### PR DESCRIPTION
**Context:**
This `tests/test_debugging.py::TestSnapshotUnsupportedQNode::test_default_qutrit` stochastic failure happens every now and then. We want to figure out what happened and how to fix.

**Description of the Change:**
No more accuracy check. It is not unnecessary according to the context. Instead, simply check the shape consistency.

**Benefits:**
No more annoying failure from `TestSnapshotUnsupportedQNode::test_default_qutrit`!

**Possible Drawbacks:**
Do we really worry about the possiblity of having the overriding scheme broken here?

**Related GitHub Issues:**
[sc-89311]