### PR TITLE
[Bugfix] Update handling of observables in `process_counts`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -246,6 +246,14 @@
 * Fixed a bug where the phase is used as the wire label for a `qml.GlobalPhase` when capture is enabled.
   [(#7211)](https://github.com/PennyLaneAI/pennylane/pull/7211)
 
+* Fixed a bug that caused `CountsMP.process_counts` to return results in the computational basis, even if
+  an observable was specified.
+  [(#7342)](https://github.com/PennyLaneAI/pennylane/pull/7342)
+
+* Fixed a bug that caused `SamplesMP.process_counts` used with an observable to return a list of eigenvalues 
+  for each individual operation in the observable, instead of the overall result.
+  [(#7342)](https://github.com/PennyLaneAI/pennylane/pull/7342)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -184,7 +184,7 @@ class CountsMP(SampleMeasurement):
 
     _shortname = "counts"
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(
         self,
         obs: Optional[Operator] = None,
@@ -381,6 +381,20 @@ class CountsMP(SampleMeasurement):
             self._include_all_outcomes(mapped_counts)
         else:
             _remove_unobserved_outcomes(mapped_counts)
+
+        if self.eigvals() is not None:
+            eigvals_dict = {k: qml.math.int64(0) for k in self.eigvals()}
+
+            def outcome_to_eigval(outcome: str):
+                return self.eigvals()[int(outcome, 2)]
+
+            for outcome, count in mapped_counts.items():
+                eigvals_dict[outcome_to_eigval(outcome)] += count
+
+            if not self.all_outcomes:
+                _remove_unobserved_outcomes(eigvals_dict)
+            return eigvals_dict
+
         return mapped_counts
 
     def _map_counts(self, counts_to_map: dict, wire_order: Wires) -> dict:

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -383,14 +383,11 @@ class CountsMP(SampleMeasurement):
             _remove_unobserved_outcomes(mapped_counts)
 
         if self.eigvals() is not None:
-            eigvals_dict = {k: qml.math.int64(0) for k in self.eigvals()}
-
-            def outcome_to_eigval(outcome: str):
-                return self.eigvals()[int(outcome, 2)]
-
+            eigvals = self.eigvals()
+            eigvals_dict = {k: qml.math.int64(0) for k in eigvals}
             for outcome, count in mapped_counts.items():
-                eigvals_dict[outcome_to_eigval(outcome)] += count
-
+                val = eigvals[int(outcome, 2)]
+                eigvals_dict[val] += count
             if not self.all_outcomes:
                 _remove_unobserved_outcomes(eigvals_dict)
             return eigvals_dict

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -302,8 +302,8 @@ class SampleMP(SampleMeasurement):
         mapped_counts = self._map_counts(counts, wire_order)
         for outcome, count in mapped_counts.items():
             outcome_sample = self._compute_outcome_sample(outcome)
-            if len(self.wires) == 1:
-                # If only one wire is sampled, flatten the list
+            if len(self.wires) == 1 and self.eigvals() is None:
+                # For sampling wires, if only one wire is sampled, flatten the list
                 outcome_sample = outcome_sample[0]
             samples.extend([outcome_sample] * count)
 
@@ -331,10 +331,8 @@ class SampleMP(SampleMeasurement):
             list: A list of outcome samples for given binary string.
                 If eigenvalues exist, the binary outcomes are mapped to their corresponding eigenvalues.
         """
-        outcome_samples = [int(bit) for bit in outcome]
-
         if self.eigvals() is not None:
             eigvals = self.eigvals()
-            outcome_samples = [eigvals[outcome] for outcome in outcome_samples]
+            return eigvals[int(outcome, 2)]
 
-        return outcome_samples
+        return [int(bit) for bit in outcome]

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -1002,3 +1002,48 @@ class TestProcessCounts:
         actual = qml.counts(wires=wires, all_outcomes=all_outcomes).process_counts(expected, wires)
 
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        "wire_order, expected_result", [((0, 1), {-1.0: 3, 1.0: 2}), ((1, 0), {1.0: 5})]
+    )
+    def test_with_observable(self, wire_order, expected_result):
+        """Test that processing counts to get the counts for an eigenvalue of an observable
+        works as expected for an observable with a single wire."""
+
+        counts_mp = qml.counts(qml.Z(0))
+
+        result = counts_mp.process_counts({"00": 2, "10": 3}, wire_order)
+
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "wire_order, expected_result",
+        [
+            ((0, 1, 2), {-1.0: 4, 1.0: 6}),
+            ((0, 2, 1), {-1.0: 3, 1.0: 7}),
+            ((2, 1, 0), {-1.0: 4, 1.0: 6}),
+        ],
+    )
+    def test_with_observable_multi_wire(self, wire_order, expected_result):
+        """Test that processing counts to get the counts for an eigenvalue of an observable
+        works as expected for an observable with a single wire."""
+
+        counts_mp = qml.counts(qml.Z(0) @ qml.Z(2))
+        counts = {"000": 2, "001": 1, "101": 2, "010": 1, "110": 3, "111": 1}
+
+        result = counts_mp.process_counts(counts, wire_order)
+
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        "all_outcomes, expected_result", [(True, {-1.0: 0, 1.0: 5}), (False, {1.0: 5})]
+    )
+    def test_process_counts_with_observable_all_outcomes(self, all_outcomes, expected_result):
+        """Test that all-outcomes works as expected when returning observable/eigenvalue outcomes
+        instead of counts in the computational basis"""
+
+        counts_mp = qml.counts(qml.Z(0), all_outcomes=all_outcomes)
+
+        result = counts_mp.process_counts({"00": 2, "10": 3}, [1, 0])
+
+        assert result == expected_result

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -326,6 +326,8 @@ class TestSample:
             expected_type = np.float64
         elif res.numeric_type == complex:
             expected_type = np.complex64
+        else:
+            raise ValueError("unexpected numeric type for result")
 
         assert expected_type == eigval_type
 
@@ -543,15 +545,37 @@ class TestSampleProcessCounts:
 
         assert np.array_equal(result, np.array([0, 0, 1, 1, 1]))
 
-    def test_process_counts_with_eigen_values(self):
+    @pytest.mark.parametrize(
+        "wire_order, expected_result", [((0, 1), [1, 1, -1, -1, -1]), ((1, 0), [1, 1, 1, 1, 1])]
+    )
+    def test_process_counts_with_eigen_values(self, wire_order, expected_result):
         """Test process_counts method with eigen values."""
         sample_mp = qml.sample(qml.Z(0))
         counts = {"00": 2, "10": 3}
-        wire_order = qml.wires.Wires((0, 1))
+        wire_order = qml.wires.Wires(wire_order)
 
         result = sample_mp.process_counts(counts, wire_order)
 
-        assert np.array_equal(result, np.array([1, 1, -1, -1, -1]))
+        assert np.array_equal(result, np.array(expected_result))
+
+    @pytest.mark.parametrize(
+        "wire_order, expected_result",
+        [
+            ((0, 1, 2), [1, -1, -1, 1, 1]),
+            ((0, 2, 1), [1, 1, -1, -1, -1]),
+            ((1, 2, 0), [1, 1, -1, -1, -1]),
+            ((2, 0, 1), [1, -1, 1, -1, -1]),
+        ],
+    )
+    def test_process_counts_with_eigen_values_multiple_wires(self, wire_order, expected_result):
+        """Test process_counts method with eigen values."""
+        sample_mp = qml.sample(qml.Z(0) @ qml.Z(1))
+        counts = {"000": 1, "101": 1, "011": 1, "110": 2}
+        wire_order = qml.wires.Wires(wire_order)
+
+        result = sample_mp.process_counts(counts, wire_order)
+
+        assert np.array_equal(result, np.array(expected_result))
 
     def test_process_counts_with_inverted_wire_order(self):
         """Test process_counts method with inverted wire order."""


### PR DESCRIPTION
**Context:**
The `process_counts` functions were added to `CountsMP` and `SamplesMP` a while back, to expand support in cases with `shots` where the initial device results are `counts` instead of `samples`. 

Some cases where these measurement processes included observables (i.e. `qml.counts(qml.Z(0))`, `qml.sample(qml.X("a")`) returned incorrect results, specifically:

```
>>> counts_mp = qml.counts(qml.Z(0))
>>> counts_mp.process_counts({"00": 2, "10": 3}, wire_order=[0, 1])
{"0": 2, "1": 3} 
```
instead of `{-1.0: 3, 1.0: 2}`, and

```
>>> sample_mp = qml.sample(qml.Z(0) @ qml.Z(1))
>>> sample_mp.process_counts({"00": 2, "10": 3}, wire_order=[0, 1])
[[ 1.  1.]
 [ 1.  1.]
 [-1.  1.]
 [-1.  1.]
 [-1.  1.]]
```
instead of `[1., 1., -1., -1., -1.]`.

**Description of the Change:**
Added/modified handling of samples/counts when `CountsMP` or `SamplesMP` have eigenvalues.

**Related GitHub Issues:**
#7344 #7343 

[sc-90071]