### PR TITLE
Fix repr for `Sum`  and `Prod`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -216,6 +216,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes the repr for empty `Prod` and `Sum` instances to better communicate the existance of an empty instance.
+
 * Fixes a bug where circuit execution fails with ``BlockEncode`` initialized with sparse matrices.
   [(#7285)](https://github.com/PennyLaneAI/pennylane/pull/7285)
 

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -100,6 +100,8 @@ class CompositeOp(Operator):
         self._batch_size = batch_sizes.pop() if batch_sizes else None
 
     def __repr__(self):
+        if len(self) == 0:
+            return f"{type(self).__name__}()"
         return f" {self._op_symbol} ".join(
             [f"({op})" if op.arithmetic_depth > 0 else f"{op}" for op in self]
         )

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -280,12 +280,16 @@ class Sum(CompositeOp):
     @handle_recursion_error
     def __str__(self):
         """String representation of the Sum."""
+        if len(self) == 0:
+            return "Sum()"
         ops = self.operands
         return " + ".join(f"{str(op)}" if i == 0 else f"{str(op)}" for i, op in enumerate(ops))
 
     @handle_recursion_error
     def __repr__(self):
         """Terminal representation for Sum"""
+        if len(self) == 0:
+            return "Sum()"
         # post-processing the flat str() representation
         # We have to do it like this due to the possible
         # nesting of Sums, e.g. X(0) + X(1) + X(2) is a sum(sum(X(0), X(1)), X(2))

--- a/tests/ops/op_math/test_composite.py
+++ b/tests/ops/op_math/test_composite.py
@@ -279,6 +279,11 @@ def _is_method_with_no_argument(method):
 class TestMscMethods:
     """Test dunder and other visualizing methods."""
 
+    def test_empty_repr(self):
+        """Test __repr__ on an empty composite op."""
+        op = ValidOp()
+        assert repr(op) == "ValidOp()"
+
     @pytest.mark.parametrize("ops_lst, op_rep", tuple((i, j) for i, j in zip(ops, ops_rep)))
     def test_repr(self, ops_lst, op_rep):
         """Test __repr__ method."""

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -302,6 +302,7 @@ class TestInitialization:
         assert np.allclose(eig_vecs, cached_vecs)
 
     SUM_REPR = (
+        (qml.sum(), "Sum()"),
         (qml.sum(X(0), Y(1), Z(2)), "X(0) + Y(1) + Z(2)"),
         (X(0) + X(1) + X(2), "X(0) + X(1) + X(2)"),
         (0.5 * X(0) + 0.7 * X(1), "0.5 * X(0) + 0.7 * X(1)"),


### PR DESCRIPTION
**Context:**

The repr for empty `Sum` and `Prod` was just an empty string. This did not communicate the existance of an operator instance, leading to confusion.

**Description of the Change:**

Adds a special repr for empty sums and prods.

**Benefits:**

Tracebacks and logging now communicate what actually exists.

**Possible Drawbacks:**

**Related GitHub Issues:**
