### PR TITLE
Changing sphinx-action to version 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
     steps:
     - uses: actions/checkout@v4
-    - uses: PennyLaneAI/sphinx-action@master
+    - uses: PennyLaneAI/sphinx-action@3.9
       with:
         docs-folder: "doc/"
         pre-build-command: >


### PR DESCRIPTION
**Context:**
As part of the sphinx upgrade, sphinx-action has been upgrade from python 3.9 to 3.10 and sphinx 2.2 to min 7.0. The upgrade has caused issues with the docs workflow as it has introduced new warnings that cause the workflow to fail.

**Description of the Change:**
This change will change sphinx-action to use a version fixed to python 3.9 until the [permanent sphinx](https://github.com/PennyLaneAI/pennylane/pull/7212) changes are merged.

**Benefits:**
Sphinx build will not give any more unnecessary warnings.

**Possible Drawbacks:**
None
**Related GitHub Issues:**
