### PR TITLE
Ensure size info matches MPI world-1 if not set

### DIFF
--- a/pennylane/concurrency/executors/external/mpi.py
+++ b/pennylane/concurrency/executors/external/mpi.py
@@ -56,7 +56,7 @@ class MPIPoolExec(ExtExec):  # pragma: no cover
         # Handle set-up upon object creation only.
         from mpi4py import MPI
 
-        self._size = max_workers
+        self._size = max_workers if max_workers else MPI.COMM_WORLD.Get_size() - 1
         self._comm = MPI.COMM_WORLD
 
         self._cfg = ExecBackendConfig(
@@ -83,10 +83,6 @@ class MPIPoolExec(ExtExec):  # pragma: no cover
             *args,
             **kwargs,
         )
-
-    @property
-    def size(self):
-        return self._size
 
     def submit(self, fn: Callable, *args, **kwargs):
         with self._exec_backend()(max_workers=self.size, use_pkl5=True) as executor:
@@ -193,10 +189,6 @@ class MPICommExec(ExtExec):  # pragma: no cover
         with self._exec_backend()(max_workers=self.size, use_pkl5=True) as executor:
             output_f = executor.starmap(fn, args, chunksize=chunksize, **kwargs)
         return list(output_f)
-
-    @property
-    def size(self):
-        return self._size
 
     def shutdown(self):
         "Shutdown the executor backend, if valid."


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** This PR fixes an issue with workgroup size using the `qml.concurrency` mpi executors. The size property should defer to definition of the base class, and to the communicator world size when not provided in a workload.

**Description of the Change:** As above.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
