### PR TITLE
Docs: Clarify lack of adjoint/MCM support in default.qubit

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -301,6 +301,27 @@ class DefaultQubit(Device):
             only the current process executes tapes. If you experience any
             issue, say using JAX, TensorFlow, Torch, try setting ``max_workers`` to ``None``.
 
+    .. note::
+       Adjoint differentiation (``diff_method="adjoint"``) is not currently supported
+       by this device. Supported analytic methods include ``"parameter-shift"``.
+       Finite difference (``"finite-diff"``) is also available.
+
+    .. note::
+       Native mid-circuit measurements and conditional operations (using
+       :func:`~.pennylane.measure` and :func:`~.pennylane.cond`) are not
+       supported by ``default.qubit`` in simulation workflows that require
+       gradients or specific state preparations dependent on measurement outcomes.
+       For simple sampling workflows, measurement may return values, but
+       dynamic circuit execution is limited. Consider devices explicitly
+       supporting dynamic circuits if required.
+
+
+    **Example:** # This existing section follows the notes
+
+        >>> dev = qml.device("default.qubit", wires=2)
+        [...]            
+
+
     **Example:**
 
     .. code-block:: python


### PR DESCRIPTION
**Context:**
While testing device capabilities using `default.qubit` (with a recent dev version installed via pip), I observed through the `device.capabilities` property and test execution that adjoint differentiation and native mid-circuit measurements are not supported. This information wasn't immediately obvious in the main docstring for the device.

**Description of the Change:**
This PR adds two small `.. note::` blocks to the class docstring of `pennylane.devices.DefaultQubit` (in `pennylane/devices/default_qubit.py`).
- The first note clarifies that `diff_method="adjoint"` is not supported.
- The second note clarifies the limitations of mid-circuit measurement support on this device.

*(Note: The PR template requests adding an entry to `doc/releases/changelog-dev.md`, but this file does not currently exist in the `master` branch. No changelog entry has been added as the correct location is unclear.)*

**Benefits:**
Improves documentation clarity for `default.qubit` users, helping them quickly understand the device's limitations regarding adjoint differentiation and mid-circuit measurements without needing to run tests or dig deep into code/capabilities dictionaries. This prevents potential confusion.

**Possible Drawbacks:**
None anticipated for this documentation clarification.

**Related GitHub Issues:**
None.