### PR TITLE
[FTQC] Change return type of arbitrary-basis measurement primitive from int to bool

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -129,6 +129,7 @@
 * The `ftqc` module `measure_arbitrary_basis`, `measure_x` and `measure_y` functions
   can now be captured when program capture is enabled.
   [(#7219)](https://github.com/PennyLaneAI/pennylane/pull/7219)
+  [(#7368)](https://github.com/PennyLaneAI/pennylane/pull/7368)
 
 * `Operator.num_wires` now defaults to `None` to indicate that the operator can be on
   any number of wires.

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -65,8 +65,7 @@ def _create_parametrized_mid_measure_primitive():
 
     @measure_in_basis_p.def_abstract_eval
     def _(*_, **__):
-        dtype = jax.numpy.int64 if jax.config.jax_enable_x64 else jax.numpy.int32
-        return jax.core.ShapedArray((), dtype)
+        return jax.core.ShapedArray((), jax.numpy.bool)
 
     return measure_in_basis_p
 

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -529,7 +529,7 @@ class TestMeasureFunctions:
         # measurement value is assigned and passed forward
         conditional = str(plxpr.eqns[1])
         assert "cond" in conditional
-        assert captured_measurement[:7] == "a:i64[]"
+        assert captured_measurement[:8] == "a:bool[]"
         assert "lambda ; a:i64[]" in conditional
 
     @pytest.mark.jax
@@ -568,7 +568,7 @@ class TestMeasureFunctions:
         # measurement value is assigned and passed forward
         conditional = str(plxpr.eqns[1])
         assert "cond" in conditional
-        assert captured_measurement[:7] == "a:i64[]"
+        assert captured_measurement[:8] == "a:bool[]"
         assert "lambda ; a:i64[]" in conditional
 
     @pytest.mark.jax


### PR DESCRIPTION
**Context:** The JAX primitive representing arbitrary-basis measurements currently returns a `jax.core.ShapedArray` of type `int64` (or `int32` if `jax.config.jax_enable_x64` is False). However, the corresponding operation in Catalyst returns a `bool`. Having different return types is generally fine, except in certain circumstances when qjit compiling a circuit containing bitwise operations on a measurement result and boolean literals. For instance, the following workload would generate the following Catalyst jaxpr:

```python
dev = qml.device("null.qubit", wires=1)

qml.capture.enable()

@qjit(target="jaxpr")
@qml.qnode(dev)
def foo():
    m0 = qml.ftqc.measure_x(0)
    x = m0 ^ True
    return qml.expval(qml.Z(0))

qml.capture.disable()
```

```pycon
>>> print(foo.jaxpr)  # Output abbreviated for clarity
...
d:bool[] e:AbstractQbit() = measure_in_basis[
  plane=MeasurementPlane.XY
  postselect=None
] 0.0 c
_:bool[] = xor d 1    # <-- Literal `True` implicitly converted to `1`
...
```

Lowering this jaxpr to MLIR results in a compiler error because the `xor` operation applied to variable `d` (a `bool`) and a literal `1` (interpreted as an `int64`) is not permitted. 

**Description of the Change:** Changes the return type of `measure_in_basis_p` abstract eval from `int` to `bool` and updates the affected tests appropriately. Running the same example above generates the following Catalyst jaxpr, as expected:

```
d:bool[] e:AbstractQbit() = measure_in_basis[
  plane=MeasurementPlane.XY
  postselect=None
] 0.0 c
_:bool[] = xor d True    # <-- Literal `True` unchanged
```

**Benefits:** This change will enable us to qjit compile a CNOT gate expressed in the MBQC formalism, which contains a by-product correction of the form `m0 ^ m1 ^ ... ^ 1`, where `m*` are measurement outcomes. 

**Possible Drawbacks:** The computation-basis mid-circuit measurement operation `qml.measure()` continues to return 32-/64-bit `ints`, putting the MCMs in the `ftqc` module out of sync with their core PennyLane counterpart. We may be able to change the abstract eval return type of the computation-basis measurement primitives as well, although such a change could have broader implications elsewhere.
