### PR TITLE
Raising a warning if latest JAX is installed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
     steps:
     - uses: actions/checkout@v4
-    - uses: PennyLaneAI/sphinx-action@master
+    - uses: PennyLaneAI/sphinx-action@3.9
       with:
         docs-folder: "doc/"
         pre-build-command: >

--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -65,9 +65,9 @@ jobs:
         id: catalyst
         run: echo "nightly=--index https://test.pypi.org/simple/ --prerelease=allow --upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
       
-      - name: PennyLane-Lightning Latest Version
+      - name: PennyLane-Lightning Stable Version
         id: pennylane-lightning
-        run: echo "latest=--index https://test.pypi.org/simple/ --prerelease=allow --upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
+        run: echo "latest=--upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
     
     outputs:
       jax-version: jax==${{ steps.jax.outputs.version }} jaxlib==${{ steps.jax.outputs.version }}

--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -63,9 +63,9 @@ jobs:
       
       - name: Nightly Catalyst Version
         id: catalyst
-        run: echo "nightly=--index https://test.pypi.org/simple/ --prerelease=allow --upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
+        run: echo "nightly=--upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
       
-      - name: PennyLane-Lightning Stable Version
+      - name: PennyLane-Lightning Latest Version
         id: pennylane-lightning
         run: echo "latest=--upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
     

--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-0.41.1.md
+
 .. mdinclude:: ../releases/changelog-0.41.0.md
 
 .. mdinclude:: ../releases/changelog-0.40.0.md

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.41.0 (current release)
+# Release 0.41.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.41.1.md
+++ b/doc/releases/changelog-0.41.1.md
@@ -1,0 +1,14 @@
+:orphan:
+
+# Release 0.41.1 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* A warning is raised if PennyLane is imported and a version of JAX greater than 0.4.28 is installed.
+  [(#7369)](https://github.com/PennyLaneAI/pennylane/pull/7369)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Pietropaolo Frisoni

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -22,6 +22,8 @@ import warnings
 def _warn_if_jax_incompatible():  # pragma: no cover
     """Warn the user if an incompatible JAX version is installed."""
 
+    # pylint: disable=import-outside-toplevel
+
     import importlib.metadata as importlib_metadata
 
     try:
@@ -35,7 +37,7 @@ def _warn_if_jax_incompatible():  # pragma: no cover
         warnings.warn(
             f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
             f"You have JAX {jax_version} installed. "
-            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors. ",
+            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors.",
             RuntimeWarning,
         )
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -16,34 +16,6 @@ This is the top level module from which all basic functions and classes of
 PennyLane can be directly imported.
 """
 
-import warnings
-
-# pylint: disable=wrong-import-position, wrong-import-order, import-outside-toplevel
-
-
-def _warn_if_jax_incompatible():  # pragma: no cover
-    """Warn the user if an incompatible JAX version is installed."""
-
-    import importlib.metadata as importlib_metadata
-
-    try:
-        jax_version = importlib_metadata.version("jax")
-    except importlib_metadata.PackageNotFoundError:
-        return
-
-    from packaging.version import Version
-
-    if Version(jax_version) > Version("0.4.28"):
-        warnings.warn(
-            f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
-            f"You have JAX {jax_version} installed. "
-            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors.",
-            RuntimeWarning,
-        )
-
-
-_warn_if_jax_incompatible()
-
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -18,11 +18,11 @@ PennyLane can be directly imported.
 
 import warnings
 
+# pylint: disable=wrong-import-position, wrong-import-order, import-outside-toplevel
+
 
 def _warn_if_jax_incompatible():  # pragma: no cover
     """Warn the user if an incompatible JAX version is installed."""
-
-    # pylint: disable=import-outside-toplevel
 
     import importlib.metadata as importlib_metadata
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -16,6 +16,32 @@ This is the top level module from which all basic functions and classes of
 PennyLane can be directly imported.
 """
 
+import warnings
+
+
+def _warn_if_jax_incompatible():  # pragma: no cover
+    """Warn the user if an incompatible JAX version is installed."""
+
+    import importlib.metadata as importlib_metadata
+
+    try:
+        jax_version = importlib_metadata.version("jax")
+    except importlib_metadata.PackageNotFoundError:
+        return
+
+    from packaging.version import Version
+
+    if Version(jax_version) > Version("0.4.28"):
+        warnings.warn(
+            f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
+            f"You have JAX {jax_version} installed. "
+            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors. ",
+            RuntimeWarning,
+        )
+
+
+_warn_if_jax_incompatible()
+
 
 from pennylane.boolean_fn import BooleanFn
 import pennylane.numpy

--- a/pennylane/capture/capture_operators.py
+++ b/pennylane/capture/capture_operators.py
@@ -15,14 +15,29 @@
 This submodule defines the abstract classes and primitives for capturing operators.
 """
 
+import importlib.metadata as importlib_metadata
+import warnings
 from functools import lru_cache
 from typing import Optional, Type
+
+from packaging.version import Version
 
 import pennylane as qml
 
 has_jax = True
 try:
     import jax
+
+    jax_version = importlib_metadata.version("jax")
+    if Version(jax_version) > Version("0.4.28"):
+        warnings.warn(
+            f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
+            f"You have version {jax_version} installed. "
+            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors.",
+            RuntimeWarning,
+        )
+
+
 except ImportError:
     has_jax = False
 

--- a/pennylane/capture/capture_operators.py
+++ b/pennylane/capture/capture_operators.py
@@ -29,7 +29,7 @@ try:
     import jax
 
     jax_version = importlib_metadata.version("jax")
-    if Version(jax_version) > Version("0.4.28"):
+    if Version(jax_version) > Version("0.4.28"):  # pragma: no cover
         warnings.warn(
             f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
             f"You have version {jax_version} installed. "

--- a/pennylane/qnn/__init__.py
+++ b/pennylane/qnn/__init__.py
@@ -17,7 +17,7 @@ with Keras and PyTorch.
 
 .. note::
 
-    Check out our :doc:`Keras <demos/tutorial_qnn_module_tf>` and
+    Check out our `Keras <https://pennylane.ai/qml/demos/qnn_module_tf>`__. and
     :doc:`Torch <demos/tutorial_qnn_module_torch>` tutorials for further details.
 
 

--- a/pennylane/qnn/__init__.py
+++ b/pennylane/qnn/__init__.py
@@ -17,7 +17,7 @@ with Keras and PyTorch.
 
 .. note::
 
-    Check out our `Keras <https://pennylane.ai/qml/demos/qnn_module_tf>`__. and
+    Check out our `Keras <https://pennylane.ai/qml/demos/qnn_module_tf>`__ and
     :doc:`Torch <demos/tutorial_qnn_module_torch>` tutorials for further details.
 
 


### PR DESCRIPTION
**Context:** We need a bugfix release for `PennyLane 0.41`.

The reason is that if a user installs PennyLane, then latext JAX, and then imports PennyLane (in this sequence), the following error is raised:
```
AttributeError: jax.core.Primitive was removed in JAX v0.6.0. Use jax.extend.core.Primitive instead, and see https://docs.jax.dev/en/latest/jax.extend.html for details..
```

and there are no further details.
Therefore, we need to raise an informative warning at some point that tells the user that PL is not yet compatible with the latest JAX version.

Notice that this branch was created from the [tag](https://github.com/PennyLaneAI/pennylane/releases/tag/v0.41.0) of the latest PennyLane release, as the PL release guidance recommends.

**Description of the Change:**

- This is not a change implemented in this PR, but notice that `__version__` is set to `"0.41.1"` on this branch. This change was implemented before pushing this branch to GitHub, as the PL release guidance recommends.

- We need to install the stable version of `pennylane-lightning` and `pennylane-catalyst` instead of the latest, because the latest version of these packages is now incompatible with this branch (they are using the `pennylane.exceptions` module, which was introduced after the 0.41 release). Obviously, this change will not be merged into master.

- The actual warning message. This triggered `pylint` failures in the entire file, and I had to stick: 
```
# pylint: disable=wrong-import-position, wrong-import-order, import-outside-toplevel
```
at the very top of the file. This is certainly not ideal, but this is only temporary before PL is compatible with the latest JAX version (WIP to be completed before the next release).
Notice that we might also raise this warning somewhere else, catching the first `import jax` inside the capture folder that causes the issue, instead of the `init` file in PennyLane. There was a brief discussion about this with @mlxd. Happy to change if needed, so please let me know what you think.

- Downgraded `sphinx`. The reason is that I was getting so many [`sphinx` failures](https://github.com/PennyLaneAI/pennylane/actions/runs/14785640011/job/41513452178?pr=7369). 

I noticed that `sphinx` was updated recently in [this PR](https://github.com/PennyLaneAI/pennylane/pull/7212/) (@rashidnhm or @runora95), in which `PennyLaneAI/sphinx-action@3.9` has been replaced with `PennyLaneAI/sphinx-action@master` in `.github/workflows/docs.yml`.

This branch was using `PennyLaneAI/sphinx-action@master`, and it was created from the 0.41 tag, which therefore was also using `PennyLaneAI/sphinx-action@master` (you can check by downloading the source code from GitHub). 
Therefore, in between the 0.41 release and [this PR](https://github.com/PennyLaneAI/pennylane/pull/7212/), we must have changed `PennyLaneAI/sphinx-action@master` to `PennyLaneAI/sphinx-action@3.9` at some point.

Maybe @rashidnhm or @runora95 have some insight about what and why this happened. Thanks!

Obviously, this change (that is, downgrading `sphinx`) will not be merged into master.

- Replaced an outdated link in `qnn/__init__.py`. The reason is that I was getting an annoying `sphinx` failure: 

```
/github/workspace/pennylane/qnn/__init__.py:docstring of pennylane.qnn:6: WARNING: unknown document: demos/tutorial_qnn_module_tf
```

And I noticed that the link to this demo in the [stable doc version](https://docs.pennylane.ai/en/stable/code/qml_qnn.html) is broken (most probably because the demo has been moved/renamed on March 20th, after the 0.41 release). I replaced the link with a working one in the only way I know.

**Benefits:** An informative warning is raised when importing pennylane with the latest JAX installed.

**Possible Drawbacks:** Strictly speaking, none as this is a bugfix release.

**Related GitHub Issues:** None.

**Related Shortcut Story:** [sc-90355]

**Further details:** I tested this in a virtual conda environment. 

If `JAX` is installed with version <= 0.4.28 or if it is not installed at all, we get the following output when importing pennylane:
```
~/Desktop/repos/pennylane warning_latest_jax > python -c "import pennylane"                                                                                                       py PLPostRelease 19:15:18

~/Desktop/repos/pennylane warning_latest_jax >                                                                                                                                    py PLPostRelease 19:15:31
```

If `JAX` is installed with version > 0.4.28, we get the following output when importing pennylane:
```
~/Desktop/repos/pennylane warning_latest_jax > python -c "import pennylane"                                                                                                    6s py PLPostRelease 19:08:26
/home/pietropaolo.frisoni/Desktop/repos/pennylane/pennylane/__init__.py:35: RuntimeWarning: PennyLane is not yet compatible with JAX versions > 0.4.28. You have JAX 0.6.0 installed. Please downgrade JAX to <=0.4.28 to avoid runtime errors. 
  warnings.warn(
Traceback (most recent call last):
 (...)
```

I encourage you to try as well : )