### PR TITLE
Manual cherry picking sync from latest rc to master

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -5,6 +5,8 @@ This page contains the release notes for PennyLane.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.41.1.md
+
 .. mdinclude:: ../releases/changelog-0.41.0.md
 
 .. mdinclude:: ../releases/changelog-0.40.0.md

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.41.0 (current release)
+# Release 0.41.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.41.1.md
+++ b/doc/releases/changelog-0.41.1.md
@@ -1,0 +1,14 @@
+:orphan:
+
+# Release 0.41.1 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* A warning is raised if PennyLane is imported and a version of JAX greater than 0.4.28 is installed.
+  [(#7369)](https://github.com/PennyLaneAI/pennylane/pull/7369)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Pietropaolo Frisoni

--- a/pennylane/capture/capture_operators.py
+++ b/pennylane/capture/capture_operators.py
@@ -15,14 +15,28 @@
 This submodule defines the abstract classes and primitives for capturing operators.
 """
 
+import importlib.metadata as importlib_metadata
+import warnings
 from functools import lru_cache
 from typing import Optional, Type
+
+from packaging.version import Version
 
 import pennylane as qml
 
 has_jax = True
 try:
     import jax
+
+    jax_version = importlib_metadata.version("jax")
+    if Version(jax_version) > Version("0.4.28"):  # pragma: no cover
+        warnings.warn(
+            f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
+            f"You have version {jax_version} installed. "
+            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors.",
+            RuntimeWarning,
+        )
+
 except ImportError:
     has_jax = False
 

--- a/pennylane/qnn/__init__.py
+++ b/pennylane/qnn/__init__.py
@@ -17,8 +17,7 @@ with PyTorch.
 
 .. note::
 
-    Check out our `Keras <demos/qnn_module_tf>`__ and `Torch <demos/tutorial_qnn_module_torch>`__ tutorials for further details.
-
+    Check out our `Keras <https://pennylane.ai/qml/demos/qnn_module_tf>`__ and `Torch <https://pennylane.ai/qml/demos/tutorial_qnn_module_torch>`__ tutorials for further details.
 
 
 .. rubric:: Classes


### PR DESCRIPTION
This PR applies some changes to master coming from [this PR](https://github.com/PennyLaneAI/pennylane/pull/7369/), which has been merged in the release candidate branch for the bugfix release of PennyLane 0.41.1.

More details can be found in the original PR description. This PR aims to update the master branch with the changes currently present in the stable version of PennyLane (0.41.1, no longer 0.41.0)