### PR TITLE
Update release to adhere to PyPI BDF requirements

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Build PennyLane wheel
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r requirements-ci.txt --upgrade
-          python setup.py bdist_wheel
+          python -m pip install build
+          python -m build --wheel --outdir dist
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,6 +230,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Wheel releases for PennyLane now follow the `PyPA binary-distribution format <https://packaging.python.org/en/latest/specifications/binary-distribution-format/>_` guidelines more closely.
+  [(#7382)](https://github.com/PennyLaneAI/pennylane/pull/7382)
+
 * `null.qubit` can now support an optional `track_resources` argument which allows it to record which gates are executed.
   [(#7226)](https://github.com/PennyLaneAI/pennylane/pull/7226)
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
**Context:** The PyPI release process requires more strict adherence to the https://packaging.python.org/en/latest/specifications/binary-distribution-format/ guidelines. `PennyLane` the package name is not compliant with this naming, and requires the released wheels to be named `pennylane`. Older versions of setuptools were less strict about this naming, and forwarded what was requested in the package metadata. Upgrade setuptools and wheel build infrastructure ensures that we adhere with the wheel naming expectations of PyPI.
Additionally, this PR also removes the deprecated license classifier, removing a warning of `SetuptoolsDeprecationWarning: License classifiers are deprecated`.

**Description of the Change:** Replaces the direct call to setup.py for wheel building with a call to https://github.com/pypa/build

**Benefits:** Ensures adherence to Python packaging expectations coming into enforcement from PyPI. Fixes future failure expected during release.

**Possible Drawbacks:**

**Related GitHub Issues:**
