### PR TITLE
[BUG] `default.mixed` np to math

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -274,6 +274,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Bug fixes 🐛</h3>
 
+* Changed `np` used in `default.mixed` source code to `qml.math` to avoid
+  unnecessary dependency on `numpy` that might fail CUDA devices.
+
 * With program capture enabled (`qml.capture.enable()`), `QSVT` no treats abstract values as metadata.
   [(#7360)](https://github.com/PennyLaneAI/pennylane/pull/7360)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -276,6 +276,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 * Changed `np` used in `default.mixed` source code to `qml.math` to avoid
   unnecessary dependency on `numpy` that might fail CUDA devices.
+  [(#7384)](https://github.com/PennyLaneAI/pennylane/pull/7384)
 
 * With program capture enabled (`qml.capture.enable()`), `QSVT` no treats abstract values as metadata.
   [(#7360)](https://github.com/PennyLaneAI/pennylane/pull/7360)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -274,8 +274,8 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Bug fixes 🐛</h3>
 
-* Changed `np` used in `default.mixed` source code to `qml.math` to avoid
-  unnecessary dependency on `numpy` that might fail CUDA devices.
+* Usage of NumPy in `default.mixed` source code has been converted to `qml.math` to avoid
+  unnecessary dependency on NumPy and to fix a bug that caused an error when using `default.mixed` with PyTorch and GPUs.
   [(#7384)](https://github.com/PennyLaneAI/pennylane/pull/7384)
 
 * With program capture enabled (`qml.capture.enable()`), `QSVT` no treats abstract values as metadata.

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -22,8 +22,6 @@ providing a simple mixed-state simulation of qubit-based quantum circuits.
 # pylint: disable=wrong-import-order, ungrouped-imports
 import logging
 
-import numpy as np
-
 import pennylane as qml
 
 from pennylane.math import get_canonical_interface_name
@@ -237,13 +235,13 @@ class DefaultMixed(Device):
         super().__init__(wires=wires, shots=shots)
 
         # Seed setting
-        seed = np.random.randint(0, high=10000000) if seed == "global" else seed
+        seed = qml.math.random.randint(0, high=10000000) if seed == "global" else seed
         if qml.math.get_interface(seed) == "jax":
             self._prng_key = seed
-            self._rng = np.random.default_rng(None)
+            self._rng = qml.math.random.default_rng(None)
         else:
             self._prng_key = None
-            self._rng = np.random.default_rng(seed)
+            self._rng = qml.math.random.default_rng(seed)
 
         self._debugger = None
 

--- a/pennylane/devices/qubit_mixed/apply_operation.py
+++ b/pennylane/devices/qubit_mixed/apply_operation.py
@@ -28,7 +28,7 @@ from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 
 from .einsum_manpulation import get_einsum_mapping
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = math.array(list(alphabet))
 
 TENSORDOT_STATE_NDIM_PERF_THRESHOLD = 9
 

--- a/pennylane/devices/qubit_mixed/einsum_manpulation.py
+++ b/pennylane/devices/qubit_mixed/einsum_manpulation.py
@@ -17,9 +17,8 @@ from string import ascii_letters as alphabet
 
 import pennylane as qml
 from pennylane import math
-from pennylane import numpy as np
 
-alphabet_array = np.array(list(alphabet))
+alphabet_array = math.array(list(alphabet))
 
 
 def get_einsum_mapping(

--- a/pennylane/devices/qubit_mixed/initialize_state.py
+++ b/pennylane/devices/qubit_mixed/initialize_state.py
@@ -17,7 +17,6 @@ from collections.abc import Iterable
 from typing import Union
 
 import pennylane as qml
-import pennylane.numpy as np
 from pennylane import math
 
 
@@ -44,7 +43,7 @@ def create_initial_state(
         2 * num_wires
     )  # we initialize the density matrix as the tensor form to keep compatibility with the rest of the module
     if not prep_operation:
-        state = np.zeros((2,) * num_axes, dtype=complex)
+        state = math.zeros((2,) * num_axes, dtype=complex)
         state[(0,) * num_axes] = 1
         return math.asarray(state, like=like)
 
@@ -60,9 +59,9 @@ def create_initial_state(
         )  # don't assume the expected shape to be fixed
         if batch_size is None:
             is_state_batched = False
-            density_matrix = np.outer(pure_state, np.conj(pure_state))
+            density_matrix = math.outer(pure_state, math.conj(pure_state))
         else:
-            density_matrix = math.stack([np.outer(s, np.conj(s)) for s in pure_state])
+            density_matrix = math.stack([math.outer(s, math.conj(s)) for s in pure_state])
     return _post_process(density_matrix, num_axes, like, is_state_batched)
 
 
@@ -73,11 +72,11 @@ def _post_process(density_matrix, num_axes, like, is_state_batched=True):
     matrix form, as requested by all the other more fundamental chore functions
     in the module (again from some legacy code).
     """
-    density_matrix = np.reshape(density_matrix, (-1,) + (2,) * num_axes)
+    density_matrix = math.reshape(density_matrix, (-1,) + (2,) * num_axes)
     dtype = str(density_matrix.dtype)
     floating_single = "float32" in dtype or "complex64" in dtype
     dtype = "complex64" if floating_single else "complex128"
     dtype = "complex128" if like == "tensorflow" else dtype
     if not is_state_batched:
-        density_matrix = np.reshape(density_matrix, (2,) * num_axes)
+        density_matrix = math.reshape(density_matrix, (2,) * num_axes)
     return math.cast(math.asarray(density_matrix, like=like), dtype)

--- a/pennylane/devices/qubit_mixed/initialize_state.py
+++ b/pennylane/devices/qubit_mixed/initialize_state.py
@@ -59,6 +59,7 @@ def create_initial_state(
         )  # don't assume the expected shape to be fixed
         if batch_size is None:
             is_state_batched = False
+            pure_state = math.flatten(pure_state)
             density_matrix = math.outer(pure_state, math.conj(pure_state))
         else:
             density_matrix = math.stack([math.outer(s, math.conj(s)) for s in pure_state])

--- a/pennylane/devices/qubit_mixed/initialize_state.py
+++ b/pennylane/devices/qubit_mixed/initialize_state.py
@@ -59,10 +59,9 @@ def create_initial_state(
         )  # don't assume the expected shape to be fixed
         if batch_size is None:
             is_state_batched = False
-            pure_state = math.flatten(pure_state)
-            density_matrix = math.outer(pure_state, math.conj(pure_state))
+            density_matrix = _flatten_outer(pure_state)
         else:
-            density_matrix = math.stack([math.outer(s, math.conj(s)) for s in pure_state])
+            density_matrix = math.stack([_flatten_outer(s) for s in pure_state])
     return _post_process(density_matrix, num_axes, like, is_state_batched)
 
 
@@ -81,3 +80,9 @@ def _post_process(density_matrix, num_axes, like, is_state_batched=True):
     if not is_state_batched:
         density_matrix = math.reshape(density_matrix, (2,) * num_axes)
     return math.cast(math.asarray(density_matrix, like=like), dtype)
+
+
+def _flatten_outer(s):
+    r"""Flattens the outer product of a vector."""
+    s_flatten = math.flatten(s)
+    return math.outer(s_flatten, math.conj(s_flatten))

--- a/pennylane/devices/qubit_mixed/sampling.py
+++ b/pennylane/devices/qubit_mixed/sampling.py
@@ -207,17 +207,17 @@ def process_state_with_shots(mp, state, wire_order, shots, rng=None, is_state_ba
     # seed the random measurement generation so that recipes
     # are the same for different executions with the same seed
     seed = mp.seed
-    recipe_rng = np.random.RandomState(seed)
+    recipe_rng = math.random.RandomState(seed)
     recipes = recipe_rng.randint(0, 3, size=(n_snapshots, n_qubits))
 
-    outcomes = np.zeros((n_snapshots, n_qubits))
+    outcomes = math.zeros((n_snapshots, n_qubits))
     # Single-qubit diagonalizing ops for X, Y, Z
     diag_list = [
         qml.Hadamard.compute_matrix(),  # X
         qml.Hadamard.compute_matrix() @ qml.RZ.compute_matrix(-np.pi / 2),  # Y
         qml.Identity.compute_matrix(),  # Z
     ]
-    bit_rng = np.random.default_rng(rng)
+    bit_rng = math.random.default_rng(rng)
 
     for t in range(n_snapshots):
         for q_idx, q_wire in enumerate(mapped_wires):
@@ -235,13 +235,13 @@ def process_state_with_shots(mp, state, wire_order, shots, rng=None, is_state_ba
             rotated = math.dot(U, math.dot(rho_q, U_dag))
 
             # (C) probability of outcome 0 => rotated[0,0].real
-            p0 = np.clip(math.real(rotated[0, 0]), 0.0, 1.0)
+            p0 = math.clip(math.real(rotated[0, 0]), 0.0, 1.0)
             if bit_rng.random() < p0:
                 outcomes[t, q_idx] = 0
             else:
                 outcomes[t, q_idx] = 1
 
-    res = np.stack([outcomes, recipes]).astype(np.int8)
+    res = math.stack([outcomes, recipes]).astype(np.int8)
     return res
 
 

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -256,11 +256,11 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
         return prob_vector
 
     def process_density_matrix(self, density_matrix: TensorLike, wire_order: Wires):
-        if len(np.shape(density_matrix)) == 2:
+        if len(qml.math.shape(density_matrix)) == 2:
             prob = qml.math.diagonal(density_matrix)
         else:
-            prob = qml.math.array(
-                [qml.math.diagonal(density_matrix[i]) for i in range(np.shape(density_matrix)[0])]
+            prob = qml.math.stack(
+                [qml.math.diagonal(density_matrix[i]) for i in range(qml.math.shape(density_matrix)[0])]
             )
 
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -260,7 +260,10 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
             prob = qml.math.diagonal(density_matrix)
         else:
             prob = qml.math.stack(
-                [qml.math.diagonal(density_matrix[i]) for i in range(qml.math.shape(density_matrix)[0])]
+                [
+                    qml.math.diagonal(density_matrix[i])
+                    for i in range(qml.math.shape(density_matrix)[0])
+                ]
             )
 
         # Since we only care about the probabilities, we can simplify the task here by creating a 'pseudo-state' to carry the diagonal elements and reuse the process_state method

--- a/tests/devices/qubit_mixed/conftest.py
+++ b/tests/devices/qubit_mixed/conftest.py
@@ -16,8 +16,6 @@ import numpy as np
 import pytest
 from scipy.stats import unitary_group
 
-from pennylane import math
-
 
 def get_random_mixed_state(num_qubits: int) -> np.ndarray:
     """
@@ -31,12 +29,12 @@ def get_random_mixed_state(num_qubits: int) -> np.ndarray:
     """
     dim = 2**num_qubits
 
-    rng = math.random.default_rng(seed=4774)
+    rng = np.random.default_rng(seed=4774)
     basis = unitary_group(dim=dim, seed=584545).rvs()
-    schmidt_weights = rng.dirichlet(math.ones(dim), size=1).astype(complex)[0]
-    mixed_state = math.zeros((dim, dim)).astype(complex)
+    schmidt_weights = rng.dirichlet(np.ones(dim), size=1).astype(complex)[0]
+    mixed_state = np.zeros((dim, dim)).astype(complex)
     for i in range(dim):
-        mixed_state += schmidt_weights[i] * math.outer(math.conj(basis[i]), basis[i])
+        mixed_state += schmidt_weights[i] * np.outer(np.conj(basis[i]), basis[i])
 
     return mixed_state.reshape([2] * (2 * num_qubits))
 
@@ -53,4 +51,4 @@ def two_qubit_state():
 
 @pytest.fixture(scope="package")
 def two_qubit_batched_state():
-    return math.array([get_random_mixed_state(2) for _ in range(2)])
+    return np.array([get_random_mixed_state(2) for _ in range(2)])

--- a/tests/devices/qubit_mixed/conftest.py
+++ b/tests/devices/qubit_mixed/conftest.py
@@ -16,6 +16,8 @@ import numpy as np
 import pytest
 from scipy.stats import unitary_group
 
+from pennylane import math
+
 
 def get_random_mixed_state(num_qubits: int) -> np.ndarray:
     """
@@ -29,12 +31,12 @@ def get_random_mixed_state(num_qubits: int) -> np.ndarray:
     """
     dim = 2**num_qubits
 
-    rng = np.random.default_rng(seed=4774)
+    rng = math.random.default_rng(seed=4774)
     basis = unitary_group(dim=dim, seed=584545).rvs()
-    schmidt_weights = rng.dirichlet(np.ones(dim), size=1).astype(complex)[0]
-    mixed_state = np.zeros((dim, dim)).astype(complex)
+    schmidt_weights = rng.dirichlet(math.ones(dim), size=1).astype(complex)[0]
+    mixed_state = math.zeros((dim, dim)).astype(complex)
     for i in range(dim):
-        mixed_state += schmidt_weights[i] * np.outer(np.conj(basis[i]), basis[i])
+        mixed_state += schmidt_weights[i] * math.outer(math.conj(basis[i]), basis[i])
 
     return mixed_state.reshape([2] * (2 * num_qubits))
 
@@ -51,4 +53,4 @@ def two_qubit_state():
 
 @pytest.fixture(scope="package")
 def two_qubit_batched_state():
-    return np.array([get_random_mixed_state(2) for _ in range(2)])
+    return math.array([get_random_mixed_state(2) for _ in range(2)])

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -97,21 +97,25 @@ class TestDefaultMixedInit:
             processed_config.interface is Interface.NUMPY
         ), "The interface should be set to numpy for an invalid gradient method"
 
+
 # pylint: disable=too-few-public-methods
 class TestDefaultMixedTrainability:
     """Integration tests for DefaultMixed trainable parameters"""
 
     @pytest.mark.integration
+    @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ML_INTERFACES)
     def test_trainable_params_interface(self, interface):
         """Test that the trainable parameters are correctly identified"""
         dev = DefaultMixed(wires=2)
         param = qml.math.array(0.5, like=interface)
+
         # Make a trainable, parametrized circuit
         def circuit(x):
             qml.RX(x, wires=0)
             qml.RY(x, wires=1)
             return qml.expval(qml.PauliZ(0))
+
         # Create a QNode with the specified interface
         circuit = qml.QNode(
             circuit,
@@ -123,20 +127,28 @@ class TestDefaultMixedTrainability:
         # Check that the result is a tensor with the correct interface
         assert isinstance(result, qml.typing.TensorLike)
         assert qml.math.get_interface(result) == interface
-        
 
     @pytest.mark.integration
+    @pytest.mark.all_interfaces
     @pytest.mark.parametrize("interface", ["torch", "autograd"])
     def test_trainable_initial_state(self, interface):
         """Test that the trainable parameters are correctly applied to initial state"""
         num_qubits = 2
         dev = DefaultMixed(wires=num_qubits)
-        state = qml.math.array([1.0,], like=interface, requires_grad=True)
+        state = qml.math.array(
+            [
+                1.0,
+            ],
+            like=interface,
+            requires_grad=True,
+        )
+
         # Make a trainable, parametrized circuit
         def circuit_StatePrep(state):
             qml.StatePrep(state=state, wires=list(range(num_qubits)), normalize=True, pad_with=0)
 
             return [qml.expval(qml.PauliZ(wires=q)) for q in range(num_qubits)]
+
         # Create a QNode with the specified interface
         circuit = qml.QNode(
             circuit_StatePrep,
@@ -148,4 +160,3 @@ class TestDefaultMixedTrainability:
         # Check that the result is a tensor with the correct interface
         assert isinstance(result, qml.typing.TensorLike)
         assert qml.math.get_deep_interface(result) == interface
-        

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -96,3 +96,56 @@ class TestDefaultMixedInit:
         assert (
             processed_config.interface is Interface.NUMPY
         ), "The interface should be set to numpy for an invalid gradient method"
+
+# pylint: disable=too-few-public-methods
+class TestDefaultMixedTrainability:
+    """Integration tests for DefaultMixed trainable parameters"""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("interface", ML_INTERFACES)
+    def test_trainable_params_interface(self, interface):
+        """Test that the trainable parameters are correctly identified"""
+        dev = DefaultMixed(wires=2)
+        param = qml.math.array(0.5, like=interface)
+        # Make a trainable, parametrized circuit
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.RY(x, wires=1)
+            return qml.expval(qml.PauliZ(0))
+        # Create a QNode with the specified interface
+        circuit = qml.QNode(
+            circuit,
+            dev,
+            interface=interface,
+        )
+        # Execute the circuit
+        result = circuit(param)
+        # Check that the result is a tensor with the correct interface
+        assert isinstance(result, qml.typing.TensorLike)
+        assert qml.math.get_interface(result) == interface
+        
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("interface", ["torch", "autograd"])
+    def test_trainable_initial_state(self, interface):
+        """Test that the trainable parameters are correctly applied to initial state"""
+        num_qubits = 2
+        dev = DefaultMixed(wires=num_qubits)
+        state = qml.math.array([1.0,], like=interface, requires_grad=True)
+        # Make a trainable, parametrized circuit
+        def circuit_StatePrep(state):
+            qml.StatePrep(state=state, wires=list(range(num_qubits)), normalize=True, pad_with=0)
+
+            return [qml.expval(qml.PauliZ(wires=q)) for q in range(num_qubits)]
+        # Create a QNode with the specified interface
+        circuit = qml.QNode(
+            circuit_StatePrep,
+            dev,
+            interface=interface,
+        )
+        # Execute the circuit
+        result = circuit(state)
+        # Check that the result is a tensor with the correct interface
+        assert isinstance(result, qml.typing.TensorLike)
+        assert qml.math.get_deep_interface(result) == interface
+        


### PR DESCRIPTION
**Context:**
See https://github.com/PennyLaneAI/pennylane/issues/7215 for the bug here. Separately recorded as a standalone bug: https://github.com/PennyLaneAI/pennylane/issues/7395

**Description of the Change:**
change the `np.` in executable source code to `qml.math.` for agnosticity.
added several tests for `default.mixed` to make sure the trainable parameters are treated well

**Benefits:**
Users would be able to use `default.mixed` on other interfaces e.g. torch cuda

**Possible Drawbacks:**
We don't have the GPU test suites for `default.mixed`!

**Related GitHub Issues:**
[sc-90500]