### PR TITLE
[WIP] first pass of implementation with weighted gates

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,10 @@
 
 <h3>New features since last release</h3>
 
+* Support for weighted gates in target gatesets added which reflects the 
+  relative costs of executing different gates on a hardware backend i.e. T is more expensive
+  than a Pauli gate.
+
 * A new template called :class:`~.SelectPauliRot` that applies a sequence of uniformly controlled rotations to a target qubit 
   is now available. This operator appears frequently in unitary decomposition and block encoding techniques. 
   [(#7206)](https://github.com/PennyLaneAI/pennylane/pull/7206)
@@ -334,6 +338,7 @@ This release contains contributions from (in alphabetical order):
 Guillermo Alonso-Linaje,
 Astral Cai,
 Yushao Chen,
+Marcus Edwards,
 Lillian Frederiksen,
 Pietropaolo Frisoni,
 Korbinian Kottmann,

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -136,7 +136,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
             self._gate_set: set[str] = {translate_op_alias(op) for op in gate_set}
         else:
             # the gate_set is a dict
-            self._gate_set = {translate_op_alias(gate) if isinstance(gate, str) else gate.__name__  for gate in gate_set.keys()}
+            self._gate_set = {
+                translate_op_alias(gate) if isinstance(gate, str) else gate.__name__
+                for gate in gate_set.keys()
+            }
             self._weights = gate_set
 
         # Tracks the node indices of various operators.
@@ -329,19 +332,28 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
             self._original_ops_indices,
             self._op_indices,
             lazy,
-            self._weights if isinstance(self._weights, dict) else None
+            self._weights if isinstance(self._weights, dict) else None,
         )
         start = self._graph.add_node("dummy")
         if hasattr(self, "_weights"):
             self._graph.add_edges_from(
                 [
-                    (start, op_node_idx, self._weights[self._op_indices[op_node_idx]]
-                    if self._op_indices[op_node_idx] in self._weights.keys() else 1)
+                    (
+                        start,
+                        op_node_idx,
+                        (
+                            self._weights[self._op_indices[op_node_idx]]
+                            if self._op_indices[op_node_idx] in self._weights.keys()
+                            else 1
+                        ),
+                    )
                     for op_node_idx in self._target_ops_indices
                 ]
             )
         else:
-            self._graph.add_edges_from([(start, op_node_idx, 1) for op_node_idx in self._target_ops_indices])
+            self._graph.add_edges_from(
+                [(start, op_node_idx, 1) for op_node_idx in self._target_ops_indices]
+            )
         rx.dijkstra_search(
             self._graph,
             source=[start],
@@ -455,12 +467,12 @@ class _DecompositionSearchVisitor(DijkstraVisitor):
     """The visitor used in the Dijkstra search for the optimal decomposition."""
 
     def __init__(
-            self,
-            graph: rx.PyDiGraph,
-            original_op_indices: set[int],
-            op_indices: dict[int, str],
-            lazy: bool = True,
-            gate_set: dict = None
+        self,
+        graph: rx.PyDiGraph,
+        original_op_indices: set[int],
+        op_indices: dict[int, str],
+        lazy: bool = True,
+        gate_set: dict = None,
     ):
         self._graph = graph
         self._lazy = lazy

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -127,15 +127,21 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         operations: list[Operator | CompressedResourceOp],
-        gate_set: set[str],
+        gate_set: set[str] | dict[type | str, float],
         fixed_decomps: dict = None,
         alt_decomps: dict = None,
     ):
-        # The names of the gates in the target gate set.
-        self._gate_set: set[str] = {translate_op_alias(op) for op in gate_set}
+        if isinstance(gate_set, set):
+            # The names of the gates in the target gate set.
+            self._gate_set: set[str] = {translate_op_alias(op) for op in gate_set}
+        else:
+            # the gate_set is a dict
+            self._gate_set = {translate_op_alias(gate) if isinstance(gate, str) else gate.__name__  for gate in gate_set.keys()}
+            self._weights = gate_set
 
         # Tracks the node indices of various operators.
         self._original_ops_indices: set[int] = set()
+        self._op_indices: dict[int, str] = {}
         self._target_ops_indices: set[int] = set()
         self._all_op_indices: dict[CompressedResourceOp, int] = {}
 
@@ -179,6 +185,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
         self._all_op_indices[op_node] = op_node_idx
 
         if op_node.name in self._gate_set:
+            self._op_indices[op_node_idx] = op_node.name
             self._target_ops_indices.add(op_node_idx)
             return op_node_idx
 
@@ -317,11 +324,24 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
                 entire graph will be explored.
 
         """
-        self._visitor = _DecompositionSearchVisitor(self._graph, self._original_ops_indices, lazy)
-        start = self._graph.add_node("dummy")
-        self._graph.add_edges_from(
-            [(start, op_node_idx, 1) for op_node_idx in self._target_ops_indices]
+        self._visitor = _DecompositionSearchVisitor(
+            self._graph,
+            self._original_ops_indices,
+            self._op_indices,
+            lazy,
+            self._weights if isinstance(self._weights, dict) else None
         )
+        start = self._graph.add_node("dummy")
+        if hasattr(self, "_weights"):
+            self._graph.add_edges_from(
+                [
+                    (start, op_node_idx, self._weights[self._op_indices[op_node_idx]]
+                    if self._op_indices[op_node_idx] in self._weights.keys() else 1)
+                    for op_node_idx in self._target_ops_indices
+                ]
+            )
+        else:
+            self._graph.add_edges_from([(start, op_node_idx, 1) for op_node_idx in self._target_ops_indices])
         rx.dijkstra_search(
             self._graph,
             source=[start],
@@ -434,7 +454,14 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
 class _DecompositionSearchVisitor(DijkstraVisitor):
     """The visitor used in the Dijkstra search for the optimal decomposition."""
 
-    def __init__(self, graph: rx.PyDiGraph, original_op_indices: set[int], lazy: bool = True):
+    def __init__(
+            self,
+            graph: rx.PyDiGraph,
+            original_op_indices: set[int],
+            op_indices: dict[int, str],
+            lazy: bool = True,
+            gate_set: dict = None
+    ):
         self._graph = graph
         self._lazy = lazy
         # maps node indices to the optimal resource estimates
@@ -442,14 +469,19 @@ class _DecompositionSearchVisitor(DijkstraVisitor):
         # maps operator nodes to the optimal decomposition nodes
         self.predecessors: dict[int, int] = {}
         self.unsolved_op_indices = original_op_indices.copy()
+        self._op_indices = op_indices.copy()
         self._num_edges_examined: dict[int, int] = {}  # keys are decomposition node indices
+        self._gate_set = gate_set
 
     def edge_weight(self, edge_obj):
         """Calculates the weight of an edge."""
         if not isinstance(edge_obj, tuple):
             return float(edge_obj)
         op_node_idx, d_node_idx = edge_obj
-        return self.distances[d_node_idx].num_gates - self.distances[op_node_idx].num_gates
+        weight = self.distances[d_node_idx].num_gates - self.distances[op_node_idx].num_gates
+        if self._gate_set is not None and self._op_indices[op_node_idx] in self._gate_set.keys():
+            weight += self._gate_set[self._op_indices[op_node_idx]]
+        return weight
 
     def discover_vertex(self, v, _):
         """Triggered when a vertex is about to be explored during the Dijkstra search."""

--- a/pennylane/exceptions.py
+++ b/pennylane/exceptions.py
@@ -30,3 +30,6 @@ class PennyLaneDeprecationWarning(UserWarning):  # pragma: no cover
 
 class ExperimentalWarning(UserWarning):  # pragma: no cover
     """Warning raised to indicate experimental/non-stable feature or support."""
+
+class GraphFeaturesUsedButNotEnabled(UserWarning):  # pragma: no cover
+    """Warning raised when weights are provided with a gateset but graph decomposition is not enabled."""

--- a/tests/decomposition/conftest.py
+++ b/tests/decomposition/conftest.py
@@ -23,12 +23,33 @@ from pennylane.decomposition import Resources
 from pennylane.decomposition.decomposition_rule import _auto_wrap
 
 decompositions = defaultdict(list)
-
+weighted_decompositions = defaultdict(list)
 
 def to_resources(gate_count: dict) -> Resources:
     """Wrap a dictionary of gate counts in a Resources object."""
     return Resources({_auto_wrap(op): count for op, count in gate_count.items() if count >= 0})
 
+def _weighted_hadamard_decomposition_resources(num_wires):
+    return {qml.RZ: 1, qml.CNOT: 2 * (num_wires - 1)}  # TODO: replace with correct decomposition
+
+
+@qml.register_resources(_weighted_hadamard_decomposition_resources)
+def _weighted_hadamard_decomposition(*_, **__):
+    raise NotImplementedError
+
+
+weighted_decompositions[qml.Hadamard] = [_weighted_hadamard_decomposition]
+
+def _weighted_toffoli_decomposition_resources(num_wires):
+    return {qml.RZ: 1, qml.CNOT: 2 * (num_wires - 1)}  # TODO: replace with correct decomposition
+
+
+@qml.register_resources(_weighted_toffoli_decomposition_resources)
+def _weighted_toffoli_decomposition(*_, **__):
+    raise NotImplementedError
+
+
+weighted_decompositions[qml.Toffoli] = [_weighted_toffoli_decomposition]
 
 @qml.register_resources({qml.Hadamard: 2, qml.CNOT: 1})
 def _cz_to_cnot(*_, **__):

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 """Unit tests for the decomposition graph."""
-
+from functools import partial
 # pylint: disable=protected-access,no-name-in-module
 
 from unittest.mock import patch
 
 import numpy as np
 import pytest
-from conftest import decompositions, to_resources
+from conftest import decompositions, weighted_decompositions, to_resources
 
 import pennylane as qml
 from pennylane.decomposition import (
@@ -39,6 +39,23 @@ from pennylane.decomposition import (
     side_effect=lambda x: decompositions[x],
 )
 class TestDecompositionGraph:
+
+    def test_weighted_graph_solve(self, _):
+        """Tests solving a simple graph for the optimal decompositions with weighted gates."""
+
+        op = qml.CRX(2.5, wires=[0, 1])
+
+        # the RZ CZ RX CZ decomp is chosen when the RZ and CNOT weights are large.
+        graph = DecompositionGraph(
+            operations=[op],
+            gate_set={"RX": 1.0, "RY": 3.0, "RZ": 10.0, "GlobalPhase": 1.0, "CNOT": 20.0, "CZ": 1.0},
+        )
+        graph.solve()
+
+        expected_resource = to_resources({qml.CZ: 2, qml.RX: 2})
+        assert graph.resource_estimate(op) == expected_resource
+
+        # TODO: write more tests
 
     def test_get_decomp_rule(self, _):
         """Tests the internal method that gets the decomposition rules for an operator."""
@@ -75,7 +92,7 @@ class TestDecompositionGraph:
 
         graph = DecompositionGraph(
             operations=[qml.Hadamard(0)],
-            gate_set={"RX", "RY", "RZ"},
+            gate_set={"RX": 1.0, "RY": 1.0, "RZ": 1.0},
             alt_decomps={qml.Hadamard: alt_dec},
             fixed_decomps={qml.Hadamard: custom_hadamard},
         )
@@ -85,14 +102,14 @@ class TestDecompositionGraph:
         """Tests constructing a graph from a single Hadamard."""
 
         op = qml.Hadamard(wires=[0])
-        graph = DecompositionGraph(operations=[op], gate_set={"RX", "RZ", "GlobalPhase"})
+        graph = DecompositionGraph(operations=[op], gate_set={"RX": 1.0, "RZ": 1.0, "GlobalPhase": 1.0})
         # 5 ops and 3 decompositions (2 for Hadamard and 1 for RY)
         assert len(graph._graph.nodes()) == 8
         # 8 edges from ops to decompositions and 3 from decompositions to ops
         assert len(graph._graph.edges()) == 11
 
         # Check that graph construction stops at gates in the target gate set.
-        graph2 = DecompositionGraph(operations=[op], gate_set={"RY", "RZ", "GlobalPhase"})
+        graph2 = DecompositionGraph(operations=[op], gate_set={"RY": 1.0, "RZ": 1.0, "GlobalPhase": 1.0})
         # 5 ops and 2 decompositions (RY is in the target gate set now)
         assert len(graph2._graph.nodes()) == 7
         # 6 edges from ops to decompositions and 2 from decompositions to ops

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -29,6 +29,6 @@ filterwarnings =
     error::pennylane.exceptions.PennyLaneDeprecationWarning
     # Suppress expected AutoGraphWarnings that arise from the tests
     error:AutoGraph will not transform the function:pennylane.capture.autograph.AutoGraphWarning
-addopts = --benchmark-disable
+;addopts = --benchmark-disable
 xfail_strict=true
 rng_salt = v0.40.0


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:** In short, a decomposition system based on a graph traversal using Dijkstra's algorithm is applied to find the most optimal gate decompositions for non-native gates. The nodes in the graph represent either decompositions, operations in the target gateset, or higher order operations. The edges show either membership of a native op in a decomposition, or equivalence of a decomposition to a higher order operation. The cost of an edge between a native operation and a decomposition is the number of additional gates found in the decomposition. The cost of an edge between a decomposition and an equivalent higher order op is zero. For more context, see [sc-84664].

**Description of the Change:** Work in progress on implementing support for relatively weighted gates within a target gateset. The weights are provided by the user, and influence what gate decompositions are chosen by the graph decomposition algorithm. The implementation is such that the weights of the gates are represented by weights on the edges leading to and from native gates.

**Benefits:** Allows a user to more closely model the behaviour of their backends, and capture the relative cost of executing certain gates such as non-Clifford gates which are native, but more expensive.

**Possible Drawbacks:** The representation of weights in this way is possibly not intuitive.

**Related GitHub Issues:**
