### PR TITLE
Allow returning diagonalized parametric MCMs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -327,6 +327,11 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 * Fixes a bug where the powers of `qml.ISWAP` and `qml.SISWAP` were decomposed incorrectly.
   [(#7361)](https://github.com/PennyLaneAI/pennylane/pull/7361)
 
+* Returning `MeasurementValue`s from the `ftqc` module's parametric mid-circuit measurements
+  (`measure_arbitrary_basis`, `measure_x` and `measure_y`) no longer raises an error in circuits 
+  using `diagonalize_mcms`.
+  [(#7387)](https://github.com/PennyLaneAI/pennylane/pull/7387)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -17,6 +17,7 @@ mid-circuit measurements with a parameterized measurement axis."""
 
 import uuid
 from collections.abc import Hashable
+from copy import copy
 from functools import lru_cache
 from typing import Iterable, Optional, Union
 
@@ -783,6 +784,16 @@ def diagonalize_mcms(tape):
             new_operations.append(op)
 
         curr_idx += 1
+
+    new_measurements = []
+    for mp in tape.measurements:
+        if mp.mv is None:
+            new_measurements.append(mp)
+        else:
+            new_mp = copy(mp)
+            mps = [mps_mapping.get(m, m) for m in mp.mv.measurements]
+            new_mp.mv.measurements = mps
+            new_measurements.append(new_mp)
 
     new_tape = tape.copy(operations=new_operations)
 

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -919,6 +919,8 @@ class TestWorkflows:
 
     @pytest.mark.parametrize("mcm_method, shots", [("tree-traversal", None), ("one-shot", 10000)])
     def test_diagonalize_mcms_returns_parametrized_mcms(self, mcm_method, shots):
+        """Test that when diagonalizing, parametrized mid-circuit measurements can be returned
+        by the QNode"""
 
         dev = qml.device("default.qubit", shots=shots)
 
@@ -935,6 +937,8 @@ class TestWorkflows:
 
     @pytest.mark.parametrize("mcm_method, shots", [("tree-traversal", None), ("one-shot", 10000)])
     def test_diagonalize_mcms_returns_cond_measure_result(self, mcm_method, shots):
+        """Test that when diagonalizing, the MeasurementValue output by cond_measure can be returned
+        by the QNode"""
 
         if mcm_method == "one-shot":
             pytest.xfail(reason="not implemented yet")  # sc-90607

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -916,3 +916,37 @@ class TestWorkflows:
             assert np.allclose(circ(), [np.cos(2.345), -1], atol=0.03)
         else:
             assert np.allclose(circ(), [np.cos(2.345), -1])
+
+    @pytest.mark.parametrize("mcm_method, shots", [("tree-traversal", None), ("one-shot", 10000)])
+    def test_diagonalize_mcms_returns_parametrized_mcms(self, mcm_method, shots):
+
+        dev = qml.device("default.qubit", shots=shots)
+
+        @diagonalize_mcms
+        @qml.qnode(dev, mcm_method=mcm_method)
+        def circ():
+            m0 = measure_x(0)
+            m1 = measure_y(1)
+            m2 = measure_arbitrary_basis(2, angle=1.23, plane="XY")
+
+            return qml.expval(m0), qml.expval(m1), qml.expval(m2)
+
+        circ()
+
+    @pytest.mark.parametrize("mcm_method, shots", [("tree-traversal", None), ("one-shot", 10000)])
+    def test_diagonalize_mcms_returns_cond_measure_result(self, mcm_method, shots):
+
+        if mcm_method == "one-shot":
+            pytest.xfail(reason="not implemented yet")  # sc-90607
+
+        dev = qml.device("default.qubit", shots=shots)
+
+        @diagonalize_mcms
+        @qml.qnode(dev, mcm_method=mcm_method)
+        def circ():
+            qml.H(0)
+            m0 = measure_x(0)
+            m1 = cond_measure(m0, measure_x, measure_y)(1)
+            return qml.expval(m1)
+
+        circ()


### PR DESCRIPTION
**Context:**

When we diagonalize the parametric mid-circuit measurements to get analytic results to validate our protocols, we swap them out with new, updated measurements. This is currently updated in the conditionals, but not on the measurements. That means that returning parametric mcms when using the `diagonalize_mcms` transform currently fails.

**Description of the Change:**

We also update the measurements in the transform - if any MeasurementProcess contains MCMs, we update them based on the existing dictionary that's tracking updated measurement values, and create a copy of the MP with the new MeasurementValue(s) instead of the original ones.

**Benefits:**

We can do this:

```
@diagonalize_mcms
@qml.qnode(dev)
def circ():
    qml.H(0)
    m = measure_x(0, reset=True)
    return qml.expval(m)
```

[sc-90609]
