### PR TITLE
Remove `RuntimeWarning` about incompatible JAX versions from `qml.capture`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -242,6 +242,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* A `RuntimeWarning` raised when using versions of JAX > 0.4.28 has been removed.
+  [()]()
+
 * Wheel releases for PennyLane now follow the `PyPA binary-distribution format <https://packaging.python.org/en/latest/specifications/binary-distribution-format/>_` guidelines more closely.
   [(#7382)](https://github.com/PennyLaneAI/pennylane/pull/7382)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -243,7 +243,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 <h3>Internal changes ⚙️</h3>
 
 * A `RuntimeWarning` raised when using versions of JAX > 0.4.28 has been removed.
-  [()]()
+  [(#7398)](https://github.com/PennyLaneAI/pennylane/pull/7398)
 
 * Wheel releases for PennyLane now follow the `PyPA binary-distribution format <https://packaging.python.org/en/latest/specifications/binary-distribution-format/>_` guidelines more closely.
   [(#7382)](https://github.com/PennyLaneAI/pennylane/pull/7382)

--- a/pennylane/capture/capture_operators.py
+++ b/pennylane/capture/capture_operators.py
@@ -14,28 +14,14 @@
 """
 This submodule defines the abstract classes and primitives for capturing operators.
 """
-
-import importlib.metadata as importlib_metadata
-import warnings
 from functools import lru_cache
 from typing import Optional, Type
-
-from packaging.version import Version
 
 import pennylane as qml
 
 has_jax = True
 try:
     import jax
-
-    jax_version = importlib_metadata.version("jax")
-    if Version(jax_version) > Version("0.4.28"):  # pragma: no cover
-        warnings.warn(
-            f"PennyLane is not yet compatible with JAX versions > 0.4.28. "
-            f"You have version {jax_version} installed. "
-            f"Please downgrade JAX to <=0.4.28 to avoid runtime errors.",
-            RuntimeWarning,
-        )
 
 except ImportError:
     has_jax = False


### PR DESCRIPTION
Now that JAX 0.5.3 is supported, we no longer need the warning.

[sc-90873]