### PR TITLE
Assert equal measurement observable

### DIFF
--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -821,3 +821,10 @@ def _equal_prep_sel_prep(
     if not qml.equal(op1.lcu, op2.lcu):
         return f"op1 and op2 have different lcu. Got {op1.lcu} and {op2.lcu}"
     return True
+
+
+@_equal_dispatch.register(MeasurementProcess, MeasurementProcess)
+def _equal_measurement_measurement(m1, m2):
+    if m1.obs != m2.obs:
+        return f"{m1} and {m2} are not equal because their observables differ."
+    return True

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -2827,3 +2827,9 @@ def test_ops_with_abstract_parameters_not_equal():
 def test_not_equal_prep_sel_prep(op, other_op):
     """Test that two PrepSelPrep operators with different Hamiltonian are not equal."""
     assert not qml.equal(op, other_op)
+
+def test_expval_observable_mismatch():
+    m1 = qml.expval(qml.Z(0))
+    m2 = qml.expval(qml.X(0))
+    with pytest.raises(AssertionError, match="observables differ"):
+        qml.assert_equal(m1, m2)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
qml.assert_equal() does not provide helpful error messages when comparing unequal measurement results, making debugging more difficult during testing.


**Description of the Change:**
This PR added a basic check for unequal observables in MeasurementProcess to return a clear error message in qml.assert_equal().

**Benefits:**
 Makes test failures involving measurements easier to debug

**Related GitHub Issues:**
#7354