### PR TITLE
Revert `cotengra` version pin after bug fix in 0.7.4 release

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26 qualtran xdsl cotengra
+        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26 qualtran xdsl
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         jax==0.5.3 jaxlib==0.5.3
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26 qualtran xdsl cotengra==0.7.2
+        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26 qualtran xdsl cotengra
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         jax==0.5.3 jaxlib==0.5.3
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}


### PR DESCRIPTION
CI failures due to an internal error introduced in `cotengra` 0.7.3 release (see issue https://github.com/jcmgray/quimb/issues/300) have already been solved by a bug fix in version 0.7.4, including unit tests to avoid this issue to silently occur again in the future (see [here](https://github.com/jcmgray/cotengra/releases/tag/v0.7.4)).

Ready to unpin `cotengra` version for PennyLane `default.tensor` device (revert https://github.com/PennyLaneAI/pennylane/commit/b671d5e7a9ae9e015a36a029bbdac3346a724b6d).

[sc-91240]