### PR TITLE
Simple gates can be executed

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,8 @@
 
 <h3>New features since last release</h3>
 
+* [WIP] Can queue some basic series of QASM gates into a QNode. Not a complete implementation.
+
 * A new template called :class:`~.SelectPauliRot` that applies a sequence of uniformly controlled rotations to a target qubit 
   is now available. This operator appears frequently in unitary decomposition and block encoding techniques. 
   [(#7206)](https://github.com/PennyLaneAI/pennylane/pull/7206)

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -180,6 +180,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
 
         if op_node.name in self._gate_set:
             self._target_ops_indices.add(op_node_idx)
+
             return op_node_idx
 
         if op_node.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):

--- a/pennylane/exceptions.py
+++ b/pennylane/exceptions.py
@@ -30,3 +30,4 @@ class PennyLaneDeprecationWarning(UserWarning):  # pragma: no cover
 
 class ExperimentalWarning(UserWarning):  # pragma: no cover
     """Warning raised to indicate experimental/non-stable feature or support."""
+

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -706,4 +706,3 @@ def from_quil_file(quil_filename: str):
 
 def from_qasm_three(quantum_circuit: str, measurements=None):
     pass
-

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -702,3 +702,8 @@ def from_quil_file(quil_filename: str):
     """
     plugin_converter = plugin_converters["quil_file"].load()
     return plugin_converter(quil_filename)
+
+
+def from_qasm_three(quantum_circuit: str, measurements=None):
+    pass
+

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -159,12 +159,13 @@ class QasmInterpreter(QASMVisitor):
         def call():
             res = None
             for callable in call_stack[::-1]:
-                if ('partial' == call_stack[0].__class__.__name__ and
-                        'control' in call_stack[0].keywords):
+                if ('partial' == call_stack[0].__class__.__name__ and 'control' in call_stack[0].keywords):
                     if 'control' in callable.keywords:
                         res.keywords["wires"] = [res.keywords["wires"][-1]]
+                    # i.e. qml.ctrl(qml.RX, (1))(2, wires=0)
                     res = callable(res.func)(**res.keywords) if res is not None else callable
                 else:
+                    # i.e. qml.pow(qml.RX(1.5, wires=0), z=4)
                     res = callable(res) if res is not None else callable()
 
         return call

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -8,7 +8,7 @@ from pennylane import QNode, device, Identity, Hadamard, PauliX, PauliY, PauliZ,
 from openqasm3.visitor import QASMVisitor, QASMNode
 
 SINGLE_QUBIT_GATES = {
-    "ID": Identity,  # TODO: translate all other QASM std lib gates to equivalent series of pennylane gates
+    "ID": Identity,
     "H": Hadamard,
     "X": PauliX,
     "Y": PauliY,

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -111,16 +111,24 @@ class QasmInterpreter(QASMVisitor):
         """
         if "vars" not in context:
             context["vars"] = {}
-        context["vars"][node.identifier.name] = {
-            'ty': node.type.__class__.__name__,
-            'val': node.init_expression.value,
-            'line': node.init_expression.span.start_line
-        }
+        if node.init_expression is not None:
+            context["vars"][node.identifier.name] = {
+                'ty': node.type.__class__.__name__,
+                'val': node.init_expression.value,
+                'line': node.init_expression.span.start_line
+            }
+        else:
+            context["vars"][node.identifier.name] = {
+                'ty': node.type.__class__.__name__,
+                'val': None,
+                'line': node.span.start_line
+            }
 
     def quantum_gate(self, node: QASMNode, context: dict):
         """
         Registers a quantum gate application. TODO: support modifiers
         """
+        gate = None
         if "gates" not in context:
             context["gates"] = []
         if node.name.name.upper() in SINGLE_QUBIT_GATES:
@@ -202,7 +210,9 @@ class QasmInterpreter(QASMVisitor):
         return partial(
             gates_dict[node.name.name.upper()],
             wires=[
-                context["wires"].index(node.qubits[q].name)
+                context["wires"].index(
+                    node.qubits[q].name if isinstance(node.qubits[q].name, str) else node.qubits[q].name.name
+                )
                 for q in range(len(node.qubits))
             ]
         )

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -1,12 +1,12 @@
 from functools import partial
-from pennylane import QNode, device, Identity, Hadamard, PauliX, PauliY, PauliZ, S, T, SX, Rot, RX, RY, RZ, PauliRot, \
-    PhaseShift, U1, U2, U3, GlobalPhase, CNOT, CY, CZ, CRot, CH, SWAP, ISWAP, CSWAP, CPhase, CRX, CRY, CRZ, \
-    IsingXX, IsingYY, IsingZZ, Toffoli, MultiControlledX, Barrier
+from pennylane import QNode, device, Identity, Hadamard, PauliX, PauliY, PauliZ, S, T, SX, RX, RY, RZ, \
+    PhaseShift, U1, U2, U3, CNOT, CY, CZ, CH, SWAP, CSWAP, CPhase, CRX, CRY, CRZ, \
+    Toffoli, MultiControlledX, Barrier
 from openqasm3.visitor import QASMVisitor, QASMNode
 
 SINGLE_QUBIT_GATES = {
-    "Identity": Identity,  # TODO: make all keys according to qasm std lib
-    "Hadamard": Hadamard,
+    "ID": Identity,  # TODO: translate all other QASM std lib gates to equivalent series of pennylane gates
+    "H": Hadamard,
     "X": PauliX,
     "Y": PauliY,
     "Z": PauliZ,
@@ -16,16 +16,14 @@ SINGLE_QUBIT_GATES = {
 }
 
 PARAMETERIZED_SIGNLE_QUBIT_GATES = {
-    "Rot": Rot,
     "RX": RX,
     "RY": RY,
     "RZ": RZ,
-    "PauliRot": PauliRot,
-    "PhaseShift": PhaseShift,
+    "P": PhaseShift,
+    "PHASE": PhaseShift,
     "U1": U1,
     "U2": U2,
     "U3": U3,
-    "GlobalPhase": GlobalPhase
 }
 
 TWO_QUBIT_GATES = {
@@ -34,16 +32,12 @@ TWO_QUBIT_GATES = {
     "CZ": CZ,
     "CH": CH,
     "SWAP": SWAP,
-    "ISWAP": ISWAP,
     "CSWAP": CSWAP,
-    "CPhase": CPhase,
+    "CP": CPhase,
+    "CPHASE": CPhase,
     "CRX": CRX,
     "CRY": CRY,
     "CRZ": CRZ,
-    "CRot": CRot,
-    "IsingXX": IsingXX,
-    "IsingYY": IsingYY,
-    "IsingZZ": IsingZZ
 }
 
 MULTI_QUBIT_GATES = {

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -1,0 +1,29 @@
+from openqasm3.visitor import QASMVisitor, QASMNode
+from typing import Optional, TypeVar
+import re
+
+T = TypeVar("T")
+
+class QasmInterpreter(QASMVisitor):
+    """
+    Inherits generic_visit(self, node: QASMNode, context: Optional[T]) which takes the
+    top level node of the AST as a parameter and recursively descends the AST, calling the
+    user-defined visitor function on each node.
+    """
+
+    def visit(self, node: QASMNode, context: Optional[T] = None):
+        """
+        Applied to each node in the AST.
+        """
+        if hasattr(node, "name"):
+            if re.search("Identifier", node.name) is not None:
+                self.identifier(node, context)
+            # TODO: call appropriate handler methods here
+            else:
+                raise Warning(f"An unrecognized QASM instruction was encountered: {node.name}")
+
+    def identifier(self, node: QASMNode, context: Optional[T] = None):
+        """
+        Registerss an identifier in the current context.
+        """
+        context.identifiers.append(node.name.name)

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -1,8 +1,56 @@
+from functools import partial
+from pennylane import QNode, device, Identity, Hadamard, PauliX, PauliY, PauliZ, S, T, SX, Rot, RX, RY, RZ, PauliRot, \
+    PhaseShift, U1, U2, U3, GlobalPhase, CNOT, CY, CZ, CRot, CH, SWAP, ISWAP, CSWAP, CPhase, CRX, CRY, CRZ, \
+    IsingXX, IsingYY, IsingZZ, Toffoli, MultiControlledX, Barrier
 from openqasm3.visitor import QASMVisitor, QASMNode
-from typing import Optional, TypeVar
-import re
 
-T = TypeVar("T")
+SINGLE_QUBIT_GATES = {
+    "Identity": Identity,
+    "Hadamard": Hadamard,
+    "X": PauliX,
+    "Y": PauliY,
+    "Z": PauliZ,
+    "S": S,
+    "T": T,
+    "SX": SX
+}
+
+PARAMETERIZED_SIGNLE_QUBIT_GATES = {
+    "Rot": Rot,
+    "RX": RX,
+    "RY": RY,
+    "RZ": RZ,
+    "PauliRot": PauliRot,
+    "PhaseShift": PhaseShift,
+    "U1": U1,
+    "U2": U2,
+    "U3": U3,
+    "GlobalPhase": GlobalPhase
+}
+
+TWO_QUBIT_GATES = {
+    "CNOT": CNOT,
+    "CY": CY,
+    "CZ": CZ,
+    "CH": CH,
+    "SWAP": SWAP,
+    "ISWAP": ISWAP,
+    "CSWAP": CSWAP,
+    "CPhase": CPhase,
+    "CRX": CRX,
+    "CRY": CRY,
+    "CRZ": CRZ,
+    "CRot": CRot,
+    "IsingXX": IsingXX,
+    "IsingYY": IsingYY,
+    "IsingZZ": IsingZZ
+}
+
+MULTI_QUBIT_GATES = {
+    "Toffoli": Toffoli,
+    "MultiControlledX": MultiControlledX,
+    "Barrier": Barrier
+}
 
 class QasmInterpreter(QASMVisitor):
     """
@@ -11,19 +59,104 @@ class QasmInterpreter(QASMVisitor):
     user-defined visitor function on each node.
     """
 
-    def visit(self, node: QASMNode, context: Optional[T] = None):
+    def visit(self, node: QASMNode, context: dict):
         """
         Applied to each node in the AST.
         """
-        if hasattr(node, "name"):
-            if re.search("Identifier", node.name) is not None:
+        match node.__class__.__name__:
+            case "Identifier":
                 self.identifier(node, context)
+            case "QubitDeclaration":
+                self.qubit_declaration(node, context)
+            case "ClassicalDeclaraion":
+                self.classical_declaration(node, context)
+            case "QuantumGate":
+                self.quantum_gate(node, context)
             # TODO: call appropriate handler methods here
-            else:
-                raise Warning(f"An unrecognized QASM instruction was encountered: {node.name}")
+            case _:
+                print(f"An unrecognized QASM instruction was encountered: {node.__class__.__name__}")
+        return context
 
-    def identifier(self, node: QASMNode, context: Optional[T] = None):
+    def generic_visit(self, node: QASMNode, context: dict):
+        """Wraps the provided generic_visit method to make the context a required parameter
+        and return the context."""
+        super().generic_visit(node, context)
+        self.construct_qnode(context)
+        return context
+
+    @staticmethod
+    def construct_qnode(context: dict):
+        if "device" not in context:
+            context["device"] = device("default.qubit", wires=len(context["wires"]))
+        QNode(lambda _: [gate() for gate in context["gates"]], device=context["device"])
+
+    @staticmethod
+    def identifier(node: QASMNode, context: dict):
         """
-        Registerss an identifier in the current context.
+        Registers an identifier in the current context.
         """
-        context.identifiers.append(node.name.name)
+        if not hasattr(context, "identifiers"):
+            context["identifiers"] = []
+        context["identifiers"].append(node.name.name)
+
+    @staticmethod
+    def qubit_declaration(node: QASMNode, context: dict):
+        """
+        Registers a qubit declaration.
+        """
+        if "wires" not in context:
+            context["wires"] = []
+        context["wires"].append(node.qubit.name)
+
+    @staticmethod
+    def classical_declaration(node: QASMNode, context: dict):
+        """
+        Registers a classical declaration.
+        """
+        if "vars" not in context:
+            context["vars"] = []
+        context["vars"].append(node)  # TODO: pull out props we need only
+
+    def quantum_gate(self, node: QASMNode, context: dict):
+        """
+        Registers a quantum gate application.
+        """
+        if "gates" not in context:
+            context["gates"] = []
+        if node.name.name.upper() in SINGLE_QUBIT_GATES:
+            gate = self.single_qubit_gate(node, context)
+        elif node.name.name.upper() in PARAMETERIZED_SIGNLE_QUBIT_GATES:
+            gate = self.param_single_qubit_gate(node, context)
+        elif node.name.name.upper() in TWO_QUBIT_GATES:
+            gate = self.two_qubit_gate(node, context)
+        elif node.name.name.upper() in MULTI_QUBIT_GATES:
+            gate = self.multi_qubit_gate(node, context)
+        else:
+            print(f"Unsupported gate encountered in QASM: {node.name}")
+        context["gates"].append(gate)  # TODO: pull out props we need only
+
+    def single_qubit_gate(self, node: QASMNode, context: dict):
+        """
+        Registers a single qubit gate application.
+        """
+        return partial(SINGLE_QUBIT_GATES[node.name.name.upper()], wires=[context["wires"].index(node.qubits[0].name)])
+
+    def param_single_qubit_gate(self, node: QASMNode, context: dict):
+        """
+        Registers a parameterized single qubit gate application.
+        """
+        for arg in node.arguments:
+            pass # TODO
+        pass
+
+    def two_qubit_gate(self, node: QASMNode, context: dict):
+        """
+        Registers a two qubit gate application.
+        """
+        pass
+
+    def multi_qubit_gate(self, node: QASMNode, context: dict):
+        """
+        Registers a multi qubit gate application.
+        """
+        pass

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -41,9 +41,7 @@ TWO_QUBIT_GATES = {
 }
 
 MULTI_QUBIT_GATES = {
-    "Toffoli": Toffoli,
-    "MultiControlledX": MultiControlledX,
-    "Barrier": Barrier
+    "CCX": Toffoli,
 }
 
 class QasmInterpreter(QASMVisitor):
@@ -134,13 +132,15 @@ class QasmInterpreter(QASMVisitor):
             print(f"Unsupported gate encountered in QASM: {node.name}")
         context["gates"].append(gate)
 
-    def single_qubit_gate(self, node: QASMNode, context: dict):
+    @staticmethod
+    def single_qubit_gate(node: QASMNode, context: dict):
         """
         Registers a single qubit gate application.
         """
         return partial(SINGLE_QUBIT_GATES[node.name.name.upper()], wires=[context["wires"].index(node.qubits[0].name)])
 
-    def param_single_qubit_gate(self, node: QASMNode, context: dict):
+    @staticmethod
+    def param_single_qubit_gate(node: QASMNode, context: dict):
         """
         Registers a parameterized single qubit gate application.
         """
@@ -156,7 +156,8 @@ class QasmInterpreter(QASMVisitor):
             wires=[context["wires"].index(node.qubits[0].name)]
         )
 
-    def two_qubit_gate(self, node: QASMNode, context: dict):
+    @staticmethod
+    def two_qubit_gate(node: QASMNode, context: dict):
         """
         Registers a two qubit gate application.
         """
@@ -168,8 +169,15 @@ class QasmInterpreter(QASMVisitor):
             ]
         )
 
-    def multi_qubit_gate(self, node: QASMNode, context: dict):
+    @staticmethod
+    def multi_qubit_gate(node: QASMNode, context: dict):
         """
         Registers a multi qubit gate application.
         """
-        pass
+        return partial(
+            MULTI_QUBIT_GATES[node.name.name.upper()],
+            wires=[
+                context["wires"].index(node.qubits[q].name)
+                for q in range(len(node.qubits))
+            ]
+        )

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -177,12 +177,17 @@ class QasmInterpreter(QASMVisitor):
         """
         args = []
         for arg in node.arguments:
-            if arg.name in context["vars"]:
+            if hasattr(arg, "name") and arg.name in context["vars"]:
                 # the context at this point should reflect the states of the
                 # variables as evaluated in the correct (current) scope.
                 args.append(context["vars"][arg.name]["val"])
+            elif re.search('Literal', arg.__class__.__name__) is not None:
+                args.append(arg.value)
             else:
-                raise NameError(f"Uninitialized variable {arg.name} encountered in QASM.")
+                raise NameError(
+                    f"Uninitialized variable {arg.name if hasattr(arg, 'name') else arg.__class__.__name__} "
+                    f"encountered in QASM."
+                )
         return partial(
             PARAMETERIZED_SIGNLE_QUBIT_GATES[node.name.name.upper()],
             *args,

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -5,7 +5,7 @@ from pennylane import QNode, device, Identity, Hadamard, PauliX, PauliY, PauliZ,
 from openqasm3.visitor import QASMVisitor, QASMNode
 
 SINGLE_QUBIT_GATES = {
-    "Identity": Identity,
+    "Identity": Identity,  # TODO: make all keys according to qasm std lib
     "Hadamard": Hadamard,
     "X": PauliX,
     "Y": PauliY,
@@ -29,7 +29,7 @@ PARAMETERIZED_SIGNLE_QUBIT_GATES = {
 }
 
 TWO_QUBIT_GATES = {
-    "CNOT": CNOT,
+    "CX": CNOT,
     "CY": CY,
     "CZ": CZ,
     "CH": CH,
@@ -124,7 +124,7 @@ class QasmInterpreter(QASMVisitor):
 
     def quantum_gate(self, node: QASMNode, context: dict):
         """
-        Registers a quantum gate application.
+        Registers a quantum gate application. TODO: support modifiers
         """
         if "gates" not in context:
             context["gates"] = []
@@ -138,7 +138,7 @@ class QasmInterpreter(QASMVisitor):
             gate = self.multi_qubit_gate(node, context)
         else:
             print(f"Unsupported gate encountered in QASM: {node.name}")
-        context["gates"].append(gate)  # TODO: pull out props we need only
+        context["gates"].append(gate)
 
     def single_qubit_gate(self, node: QASMNode, context: dict):
         """
@@ -166,7 +166,13 @@ class QasmInterpreter(QASMVisitor):
         """
         Registers a two qubit gate application.
         """
-        pass
+        return partial(
+            TWO_QUBIT_GATES[node.name.name.upper()],
+            wires=[
+                context["wires"].index(node.qubits[0].name),
+                context["wires"].index(node.qubits[1].name),
+            ]
+        )
 
     def multi_qubit_gate(self, node: QASMNode, context: dict):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,6 @@ requests~=2.31.0
 typing_extensions>=4.6.0
 tomli~=2.0.0 # Drop once minimum Python version is 3.11
 tach~=0.28.5
+openqasm3~=1.0.1
+antlr4_python3_runtime~=4.13.2
 diastatic-malt

--- a/tests/decomposition/conftest.py
+++ b/tests/decomposition/conftest.py
@@ -25,6 +25,7 @@ from pennylane.decomposition.decomposition_rule import _auto_wrap
 decompositions = defaultdict(list)
 
 
+
 def to_resources(gate_count: dict) -> Resources:
     """Wrap a dictionary of gate counts in a Resources object."""
     return Resources({_auto_wrap(op): count for op, count in gate_count.items() if count >= 0})

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -32,6 +32,8 @@ from pennylane.decomposition import (
     pow_resource_rep,
 )
 
+# pylint: disable=protected-access,no-name-in-module
+
 
 @pytest.mark.unit
 @patch(
@@ -97,6 +99,7 @@ class TestDecompositionGraph:
         assert len(graph2._graph.nodes()) == 7
         # 6 edges from ops to decompositions and 2 from decompositions to ops
         assert len(graph2._graph.edges()) == 8
+
 
     def test_graph_construction_non_applicable_rules(self, _):
         """Tests rules that raise DecompositionNotApplicable are skipped."""

--- a/tests/qasm_interpreter/adder.qasm
+++ b/tests/qasm_interpreter/adder.qasm
@@ -1,0 +1,44 @@
+/*
+ * quantum ripple-carry adder
+ * Cuccaro et al, quant-ph/0410184
+ */
+include "stdgates.inc";
+
+gate majority a, b, c {
+    cx c, b;
+    cx c, a;
+    ccx a, b, c;
+}
+
+gate unmaj a, b, c {
+    ccx a, b, c;
+    cx c, a;
+    cx a, b;
+}
+
+qubit[1] cin;
+qubit[4] a;
+qubit[4] b;
+qubit[1] cout;
+bit[5] ans;
+uint[4] a_in = 1;  // a = 0001
+uint[4] b_in = 15; // b = 1111
+// initialize qubits
+reset cin;
+reset a;
+reset b;
+reset cout;
+
+// set input states
+for uint i in [0: 3] {
+  if(bool(a_in[i])) x a[i];
+  if(bool(b_in[i])) x b[i];
+}
+// add a to b, storing result in b
+majority cin[0], b[0], a[0];
+for uint i in [0: 2] { majority a[i], b[i + 1], a[i + 1]; }
+cx a[3], cout[0];
+for uint i in [2: -1: 0] { unmaj a[i],b[i+1],a[i+1]; }
+unmaj cin[0], b[0], a[0];
+measure b[0:3] -> ans[0:3];
+measure cout[0] -> ans[4];

--- a/tests/qasm_interpreter/classical.qasm
+++ b/tests/qasm_interpreter/classical.qasm
@@ -1,0 +1,3 @@
+int i = 4;
+const int j = i;
+qubit q0;

--- a/tests/qasm_interpreter/gates.qasm
+++ b/tests/qasm_interpreter/gates.qasm
@@ -1,0 +1,7 @@
+qubit q0;
+qubit q1;
+float theta = 0.5;
+x q0;
+rx(theta) q0;
+inv @ rx(theta) q0;
+ctrl @ x q1, q0;

--- a/tests/qasm_interpreter/gates.qasm
+++ b/tests/qasm_interpreter/gates.qasm
@@ -4,6 +4,7 @@ float theta = 0.5;
 x q0;
 cx q0, q1;
 rx(theta) q0;
+ry(0.2) q0;
 inv @ rx(theta) q0;
 pow(2) @ x q0;
 ctrl @ x q1, q0;

--- a/tests/qasm_interpreter/gates.qasm
+++ b/tests/qasm_interpreter/gates.qasm
@@ -2,6 +2,7 @@ qubit q0;
 qubit q1;
 float theta = 0.5;
 x q0;
+cx q0, q1;
 rx(theta) q0;
 inv @ rx(theta) q0;
 ctrl @ x q1, q0;

--- a/tests/qasm_interpreter/gates.qasm
+++ b/tests/qasm_interpreter/gates.qasm
@@ -5,4 +5,5 @@ x q0;
 cx q0, q1;
 rx(theta) q0;
 inv @ rx(theta) q0;
+pow(2) @ x q0;
 ctrl @ x q1, q0;

--- a/tests/qasm_interpreter/qec.qasm
+++ b/tests/qasm_interpreter/qec.qasm
@@ -1,0 +1,26 @@
+// Repetition code syndrome measurement
+include "stdgates.inc";
+
+qubit[3] q;
+qubit[2] a;
+bit[3] c;
+bit[2] syn;
+
+def syndrome(qubit[3] d, qubit[2] a) -> bit[2] {
+  bit[2] b;
+  cx d[0], a[0];
+  cx d[1], a[0];
+  cx d[1], a[1];
+  cx d[2], a[1];
+  measure a -> b;
+  return b;
+}
+reset q;
+reset a;
+x q[0]; // insert an error
+barrier q;
+syn = syndrome(q, a);
+if(int[2](syn)==1) x q[0];
+if(int[2](syn)==2) x q[2];
+if(int[2](syn)==3) x q[1];
+c = measure q;

--- a/tests/qasm_interpreter/teleport.qasm
+++ b/tests/qasm_interpreter/teleport.qasm
@@ -1,0 +1,23 @@
+// quantum teleportation example
+OPENQASM 3; // Version statement is optional
+include "stdgates.inc";
+qubit[3] q;
+bit c0;
+bit c1;
+bit c2;
+// optional post-rotation for state tomography
+// empty gate body => identity gate
+gate post q { }
+reset q;
+U(0.3, 0.2, 0.1) q[0];
+h q[1];
+cx q[1], q[2];
+barrier q;
+cx q[0], q[1];
+h q[0];
+c0 = measure q[0];
+c1 = measure q[1];
+if(c0==1) z q[2];
+if(c1==1) { x q[2]; }  // braces optional in this case
+post q[2];
+c2 = measure q[2];

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -1,5 +1,7 @@
 import pytest
+
 from openqasm3.parser import parse
+from pennylane import PauliX, CNOT, RX
 from pennylane.io.qasm_interpreter import QasmInterpreter
 
 class TestInterpreter:
@@ -30,7 +32,27 @@ class TestInterpreter:
         QasmInterpreter().generic_visit(ast, context={"program_name": program_name})
         assert spy.call_count == count_nodes
 
-    def test_parses_simple_qasm(self):
+    def test_parses_simple_qasm(self, mocker):
+
+        # parse the QASM program
         ast = parse(open('gates.qasm', mode='r').read(), permissive=True)
         context = QasmInterpreter().generic_visit(ast, context={"program_name": "gates"})
+
+        # setup mocks
+        x = mocker.spy(PauliX, "__init__")
+        cx = mocker.spy(CNOT, "__init__")
+        rx = mocker.spy(RX, "__init__")
+
+        # execute the QNode
         context["qnode"].func()
+
+        # asserts
+        assert x.call_count == 5  # RX calls PauliX under the hood
+        x.assert_called_with(PauliX(0), wires=0)
+
+        assert cx.call_count == 2  # verifies that ctrl @ x q1, q0 calls cx too
+        cx.assert_called_with(CNOT([0, 1]), wires=[0, 1])
+        cx.assert_called_with(CNOT([1, 0]), wires=[1, 0])
+
+        assert rx.call_count == 2  # one adjoint call and one direct call
+        rx.assert_called_with(RX(0.5, 0), 0.5, wires=0)

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -1,7 +1,7 @@
 import pytest
 
 from openqasm3.parser import parse
-from pennylane import PauliX, CNOT, RX
+from pennylane import PauliX, CNOT, RX, RY
 from pennylane.io.qasm_interpreter import QasmInterpreter
 
 class TestInterpreter:
@@ -42,6 +42,7 @@ class TestInterpreter:
         x = mocker.spy(PauliX, "__init__")
         cx = mocker.spy(CNOT, "__init__")
         rx = mocker.spy(RX, "__init__")
+        ry = mocker.spy(RY, "__init__")
 
         # execute the QNode
         context["qnode"].func()
@@ -58,3 +59,6 @@ class TestInterpreter:
 
         assert rx.call_count == 2  # one adjoint call and one direct call
         rx.assert_called_with(RX(0.5, 0), 0.5, wires=0)
+
+        assert ry.call_count == 1
+        ry.assert_called_with(RY(0.2, [0]), 0.2, wires=[0])

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -1,27 +1,16 @@
 import pytest
-
 from openqasm3.parser import parse
-from pennylane import PauliX, CNOT, RX, RY
+
+from pennylane import CNOT, RX, RY, PauliX
 from pennylane.io.qasm_interpreter import QasmInterpreter
+
 
 class TestInterpreter:
 
     qasm_programs = [
-        (
-            open('tests/qasm_interpreter/adder.qasm', mode='r').read(),
-            22,
-            'adder'
-        ),
-        (
-            open('tests/qasm_interpreter/qec.qasm', mode='r').read(),
-            15,
-            'qec'
-        ),
-        (
-            open('tests/qasm_interpreter/teleport.qasm', mode='r').read(),
-            19,
-            'teleport'
-        )
+        (open("tests/qasm_interpreter/adder.qasm", mode="r").read(), 22, "adder"),
+        (open("tests/qasm_interpreter/qec.qasm", mode="r").read(), 15, "qec"),
+        (open("tests/qasm_interpreter/teleport.qasm", mode="r").read(), 19, "teleport"),
     ]
 
     @pytest.mark.parametrize("qasm_program, count_nodes, program_name", qasm_programs)
@@ -35,7 +24,7 @@ class TestInterpreter:
     def test_parses_simple_qasm(self, mocker):
 
         # parse the QASM program
-        ast = parse(open('tests/qasm_interpreter/gates.qasm', mode='r').read(), permissive=True)
+        ast = parse(open("tests/qasm_interpreter/gates.qasm", mode="r").read(), permissive=True)
         context = QasmInterpreter().generic_visit(ast, context={"program_name": "gates"})
 
         # setup mocks

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -33,3 +33,4 @@ class TestInterpreter:
     def test_parses_simple_qasm(self):
         ast = parse(open('gates.qasm', mode='r').read(), permissive=True)
         context = QasmInterpreter().generic_visit(ast, context={"program_name": "gates"})
+        context["qnode"].func()

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -7,23 +7,29 @@ class TestInterpreter:
     qasm_programs = [
         (
             open('adder.qasm', mode='r').read(),
-            22
+            22,
+            'adder'
         ),
         (
             open('qec.qasm', mode='r').read(),
-            15
+            15,
+            'qec'
         ),
         (
             open('teleport.qasm', mode='r').read(),
-            19
+            19,
+            'teleport'
         )
     ]
 
-    @pytest.mark.parametrize("qasm_program, count_nodes", qasm_programs)
-    def test_visits_each_node(self, qasm_program, count_nodes, mocker):
+    @pytest.mark.parametrize("qasm_program, count_nodes, program_name", qasm_programs)
+    def test_visits_each_node(self, qasm_program, count_nodes, program_name, mocker):
         """Tests that visitor is called on each element of the AST."""
         ast = parse(qasm_program, permissive=True)
         spy = mocker.spy(QasmInterpreter, "visit")
-        QasmInterpreter().generic_visit(ast)
+        QasmInterpreter().generic_visit(ast, context={"program_name": program_name})
         assert spy.call_count == count_nodes
 
+    def test_parses_simple_qasm(self):
+        ast = parse(open('gates.qasm', mode='r').read(), permissive=True)
+        context = QasmInterpreter().generic_visit(ast, context={"program_name": "gates"})

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -8,17 +8,17 @@ class TestInterpreter:
 
     qasm_programs = [
         (
-            open('adder.qasm', mode='r').read(),
+            open('tests/qasm_interpreter/adder.qasm', mode='r').read(),
             22,
             'adder'
         ),
         (
-            open('qec.qasm', mode='r').read(),
+            open('tests/qasm_interpreter/qec.qasm', mode='r').read(),
             15,
             'qec'
         ),
         (
-            open('teleport.qasm', mode='r').read(),
+            open('tests/qasm_interpreter/teleport.qasm', mode='r').read(),
             19,
             'teleport'
         )
@@ -35,7 +35,7 @@ class TestInterpreter:
     def test_parses_simple_qasm(self, mocker):
 
         # parse the QASM program
-        ast = parse(open('gates.qasm', mode='r').read(), permissive=True)
+        ast = parse(open('tests/qasm_interpreter/gates.qasm', mode='r').read(), permissive=True)
         context = QasmInterpreter().generic_visit(ast, context={"program_name": "gates"})
 
         # setup mocks

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -47,6 +47,8 @@ class TestInterpreter:
         context["qnode"].func()
 
         # asserts
+        assert len(context["device"].wires) == 2
+
         assert x.call_count == 5  # RX calls PauliX under the hood
         x.assert_called_with(PauliX(0), wires=0)
 

--- a/tests/qasm_interpreter/test_interpreter.py
+++ b/tests/qasm_interpreter/test_interpreter.py
@@ -1,0 +1,29 @@
+import pytest
+from openqasm3.parser import parse
+from pennylane.io.qasm_interpreter import QasmInterpreter
+
+class TestInterpreter:
+
+    qasm_programs = [
+        (
+            open('adder.qasm', mode='r').read(),
+            22
+        ),
+        (
+            open('qec.qasm', mode='r').read(),
+            15
+        ),
+        (
+            open('teleport.qasm', mode='r').read(),
+            19
+        )
+    ]
+
+    @pytest.mark.parametrize("qasm_program, count_nodes", qasm_programs)
+    def test_visits_each_node(self, qasm_program, count_nodes, mocker):
+        """Tests that visitor is called on each element of the AST."""
+        ast = parse(qasm_program, permissive=True)
+        spy = mocker.spy(QasmInterpreter, "visit")
+        QasmInterpreter().generic_visit(ast)
+        assert spy.call_count == count_nodes
+


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:** We would like to get a basic start on an interpreter for OpenQASM 3.0 which first queues gates
into a QNode and then executes them when the QNode is called. This PR is a work in progress and intended only as a draft, which shows the beginnings of an approach with certain patterns that I welcome feedback on. This is not a complete feature and should not be merged. [sc-90384](https://app.shortcut.com/xanaduai/story/90384)

**Description of the Change:** This change includes a small file and two tests which verify its workings. The python file includes a class which extends the QASMVisitor class provided by openqasm3 in order to traverse a simple AST and build a QNode from it.

**Benefits:** This is the start of a project which will eventually allow users to convert arbitrary OpenQASM 3.0 programs into Pennylane QNodes.

**Possible Drawbacks:** This approach is laser focused on interpreting simple series of gates and does not include support for basic things like using expressions or references instead of literals to parameterize gates, etc. All of these necessary things will be added in future PRs according to [sc-90379](https://app.shortcut.com/xanaduai/story/90379).

**Related GitHub Issues:**
