### PR TITLE
enforce subset of `templates` submodules as "auxiliary" modules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -314,7 +314,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
-* Enforce subset of submodules in `templates` to be auxiliary modules.
+* Enforce subset of submodules in `templates` to be auxiliary layer modules.
   [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)
 
 * Enforce `noise` module to be a tertiary layer module.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -302,6 +302,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Enforce submodules of `templates` to be tertiary modules.
+  [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)
+
 * Enforce `noise` module to be a tertiary layer module.
   [(#7430)](https://github.com/PennyLaneAI/pennylane/pull/7430)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -314,7 +314,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
-* Enforce subset of submodules of `templates` to be auxiliary modules.
+* Enforce subset of submodules in `templates` to be auxiliary modules.
   [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)
 
 * Enforce `noise` module to be a tertiary layer module.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -314,7 +314,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
-* Enforce submodules of `templates` to be tertiary modules.
+* Enforce subset of submodules of `templates` to be auxiliary modules.
   [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)
 
 * Enforce `noise` module to be a tertiary layer module.

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -14,8 +14,9 @@
 r"""
 Contains the ``AngleEmbedding`` template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
 from pennylane.ops import RX, RY, RZ
 
@@ -85,7 +86,7 @@ class AngleEmbedding(Operation):
         if rotation not in ROT:
             raise ValueError(f"Rotation option {rotation} not recognized.")
 
-        shape = qml.math.shape(features)[-1:]
+        shape = math.shape(features)[-1:]
         n_features = shape[0]
         if n_features > len(wires):
             raise ValueError(
@@ -131,9 +132,9 @@ class AngleEmbedding(Operation):
         [RX(tensor(1.), wires=['a']),
          RX(tensor(2.), wires=['b'])]
         """
-        batched = qml.math.ndim(features) > 1
+        batched = math.ndim(features) > 1
         # We will iterate over the first axis of `features` together with iterating over the wires.
         # If the leading dimension is a batch dimension, exchange the wire and batching axes.
-        features = qml.math.T(features) if batched else features
+        features = math.T(features) if batched else features
 
         return [rotation(features[i], wires=wires[i]) for i in range(len(wires))]

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -14,9 +14,11 @@
 r"""
 Contains the ``DisplacementEmbedding`` template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops.cv import Displacement
 
 
 class DisplacementEmbedding(Operation):
@@ -106,9 +108,9 @@ class DisplacementEmbedding(Operation):
         return new_op
 
     def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
-        shape = qml.math.shape(features)
+        shape = math.shape(features)
         constants = [c] * shape[0]
-        constants = qml.math.convert_like(constants, features)
+        constants = math.convert_like(constants, features)
 
         if len(shape) != 1:
             raise ValueError(f"Features must be a one-dimensional tensor; got shape {shape}.")
@@ -118,10 +120,10 @@ class DisplacementEmbedding(Operation):
             raise ValueError(f"Features must be of length {len(wires)}; got length {n_features}.")
 
         if method == "amplitude":
-            pars = qml.math.stack([features, constants], axis=1)
+            pars = math.stack([features, constants], axis=1)
 
         elif method == "phase":
-            pars = qml.math.stack([constants, features], axis=1)
+            pars = math.stack([constants, features], axis=1)
 
         else:
             raise ValueError(f"did not recognize method {method}")
@@ -157,6 +159,5 @@ class DisplacementEmbedding(Operation):
          Displacement(tensor(2.), tensor(0.), wires=[1])]
         """
         return [
-            qml.Displacement(pars[i, 0], pars[i, 1], wires=wires[i : i + 1])
-            for i in range(len(wires))
+            Displacement(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i in range(len(wires))
         ]

--- a/pennylane/templates/embeddings/qaoaembedding.py
+++ b/pennylane/templates/embeddings/qaoaembedding.py
@@ -14,9 +14,12 @@
 r"""
 Contains the QAOAEmbedding template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access, consider-using-enumerate
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops import RX, RY, RZ, H, MultiRZ
+from pennylane.wires import Wires
 
 
 class QAOAEmbedding(Operation):
@@ -161,17 +164,15 @@ class QAOAEmbedding(Operation):
 
     def __init__(self, features, weights, wires, local_field="Y", id=None):
         if local_field == "Z":
-            local_field = qml.RZ
+            local_field = RZ
         elif local_field == "X":
-            local_field = qml.RX
+            local_field = RX
         elif local_field == "Y":
-            local_field = qml.RY
-        elif not (
-            isinstance(local_field, type) and issubclass(local_field, (qml.RX, qml.RY, qml.RZ))
-        ):
+            local_field = RY
+        elif not (isinstance(local_field, type) and issubclass(local_field, (RX, RY, RZ))):
             raise ValueError(f"did not recognize local field {local_field}")
 
-        shape = qml.math.shape(features)
+        shape = math.shape(features)
 
         if len(shape) not in {1, 2}:
             raise ValueError(
@@ -185,7 +186,7 @@ class QAOAEmbedding(Operation):
                 f"Features must be of length {len(wires)} or less; got length {n_features}."
             )
 
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
         if len(shape) not in {2, 3}:
             raise ValueError(
                 "Weights must be a two-dimensional tensor or three-dimensional with broadcasting;"
@@ -248,26 +249,26 @@ class QAOAEmbedding(Operation):
         MultiRZ(tensor(0.9000), wires=['a', 'b']), RY(tensor(-0.2000), wires=['a']), RY(tensor(-2.1000), wires=['b']),
         RX(tensor(1.), wires=['a']), RX(tensor(2.), wires=['b'])]
         """
-        wires = qml.wires.Wires(wires)
+        wires = Wires(wires)
         # second to last dimension of the weights tensor determines
         # the number of layers
-        repeat = qml.math.shape(weights)[-2]
+        repeat = math.shape(weights)[-2]
         op_list = []
-        n_features = qml.math.shape(features)[-1]
-        if qml.math.ndim(features) > 1:
+        n_features = math.shape(features)[-1]
+        if math.ndim(features) > 1:
             # If the features are broadcasted, move the broadcasting axis to the last place
             # in order to propagate broadcasted parameters to the gates in the decomposition.
-            features = qml.math.T(features)
-        if qml.math.ndim(weights) > 2:
+            features = math.T(features)
+        if math.ndim(weights) > 2:
             # If the weights are broadcasted, move the broadcasting axis to the last place
-            weights = qml.math.moveaxis(weights, 0, -1)
+            weights = math.moveaxis(weights, 0, -1)
 
         for l in range(repeat):
             # ---- apply encoding Hamiltonian
             for i in range(n_features):
-                op_list.append(qml.RX(features[i], wires=wires[i]))
+                op_list.append(RX(features[i], wires=wires[i]))
             for i in range(n_features, len(wires)):
-                op_list.append(qml.Hadamard(wires=wires[i]))
+                op_list.append(H(wires=wires[i]))
 
             # ---- apply weight Hamiltonian
             if len(wires) == 1:
@@ -276,13 +277,13 @@ class QAOAEmbedding(Operation):
             elif len(wires) == 2:
                 # deviation for 2 wires: we do not connect last to first qubit
                 # with the entangling gates
-                op_list.append(qml.MultiRZ(weights[l][0], wires=wires.subset([0, 1])))
+                op_list.append(MultiRZ(weights[l][0], wires=wires.subset([0, 1])))
                 op_list.append(local_field(weights[l][1], wires=wires[0:1]))
                 op_list.append(local_field(weights[l][2], wires=wires[1:2]))
 
             else:
                 multirz_gates = (
-                    qml.MultiRZ(weights[l][i], wires.subset([i, i + 1], periodic_boundary=True))
+                    MultiRZ(weights[l][i], wires.subset([i, i + 1], periodic_boundary=True))
                     for i in range(len(wires))
                 )
                 op_list.extend(multirz_gates)
@@ -294,9 +295,9 @@ class QAOAEmbedding(Operation):
 
         # repeat the feature encoding once more at the end
         for i in range(n_features):
-            op_list.append(qml.RX(features[i], wires=wires[i]))
+            op_list.append(RX(features[i], wires=wires[i]))
         for i in range(n_features, len(wires)):
-            op_list.append(qml.Hadamard(wires=wires[i]))
+            op_list.append(H(wires=wires[i]))
 
         return op_list
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -14,9 +14,11 @@
 r"""
 Contains the SqueezingEmbedding template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops.cv import Squeezing
 
 
 class SqueezingEmbedding(Operation):
@@ -108,9 +110,9 @@ class SqueezingEmbedding(Operation):
         return new_op
 
     def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
-        shape = qml.math.shape(features)
+        shape = math.shape(features)
         constants = [c] * shape[0]
-        constants = qml.math.convert_like(constants, features)
+        constants = math.convert_like(constants, features)
 
         if len(shape) != 1:
             raise ValueError(f"Features must be a one-dimensional tensor; got shape {shape}.")
@@ -120,10 +122,10 @@ class SqueezingEmbedding(Operation):
             raise ValueError(f"Features must be of length {len(wires)}; got length {n_features}.")
 
         if method == "amplitude":
-            pars = qml.math.stack([features, constants], axis=1)
+            pars = math.stack([features, constants], axis=1)
 
         elif method == "phase":
-            pars = qml.math.stack([constants, features], axis=1)
+            pars = math.stack([constants, features], axis=1)
 
         else:
             raise ValueError(f"did not recognize method {method}")
@@ -159,5 +161,5 @@ class SqueezingEmbedding(Operation):
         Squeezing(tensor(2.), tensor(0.), wires=['b'])]
         """
         return [
-            qml.Squeezing(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i in range(len(wires))
+            Squeezing(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i in range(len(wires))
         ]

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -14,9 +14,11 @@
 r"""
 Contains the BasicEntanglerLayers template.
 """
+from pennylane import math
+
 # pylint: disable=consider-using-enumerate,too-many-arguments
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops import CNOT, RX
 
 
 class BasicEntanglerLayers(Operation):
@@ -126,10 +128,10 @@ class BasicEntanglerLayers(Operation):
 
     def __init__(self, weights, wires=None, rotation=None, id=None):
         # convert weights to numpy array if weights is list otherwise keep unchanged
-        interface = qml.math.get_interface(weights)
-        weights = qml.math.asarray(weights, like=interface)
+        interface = math.get_interface(weights)
+        weights = math.asarray(weights, like=interface)
 
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
         if not (len(shape) == 3 or len(shape) == 2):  # 3 is when batching, 2 is no batching
             raise ValueError(
                 f"Weights tensor must be 2-dimensional "
@@ -142,7 +144,7 @@ class BasicEntanglerLayers(Operation):
                 f"Weights tensor must have last dimension of length {len(wires)}; got {shape[-1]}"
             )
 
-        self._hyperparameters = {"rotation": rotation or qml.RX}
+        self._hyperparameters = {"rotation": rotation or RX}
         super().__init__(weights, wires=wires, id=id)
 
     @property
@@ -179,7 +181,7 @@ class BasicEntanglerLayers(Operation):
         """
         # first dimension of the weights tensor (second when batching) determines
         # the number of layers
-        repeat = qml.math.shape(weights)[-2]
+        repeat = math.shape(weights)[-2]
 
         op_list = []
         for layer in range(repeat):
@@ -187,12 +189,12 @@ class BasicEntanglerLayers(Operation):
                 op_list.append(rotation(weights[..., layer, i], wires=wires[i : i + 1]))
 
             if len(wires) == 2:
-                op_list.append(qml.CNOT(wires=wires))
+                op_list.append(CNOT(wires=wires))
 
             elif len(wires) > 2:
                 for i in range(len(wires)):
                     w = wires.subset([i, i + 1], periodic_boundary=True)
-                    op_list.append(qml.CNOT(wires=w))
+                    op_list.append(CNOT(wires=w))
 
         return op_list
 

--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -14,9 +14,13 @@
 r"""
 Contains the CVNeuralNetLayers template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access,arguments-differ
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops.cv import Displacement, Kerr, Squeezing
+
+from ..subroutines import Interferometer
 
 
 class CVNeuralNetLayers(Operation):
@@ -105,7 +109,7 @@ class CVNeuralNetLayers(Operation):
 
         # check that first dimension is the same
         weights_list = [theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_2, a, phi_a, k]
-        shapes = [qml.math.shape(w) for w in weights_list]
+        shapes = [math.shape(w) for w in weights_list]
         first_dims = [s[0] for s in shapes]
         if len(set(first_dims)) > 1:
             raise ValueError(
@@ -195,10 +199,10 @@ class CVNeuralNetLayers(Operation):
         Kerr(tensor(0.2000), wires=['b'])]
         """
         op_list = []
-        n_layers = qml.math.shape(theta_1)[0]
+        n_layers = math.shape(theta_1)[0]
         for m in range(n_layers):
             op_list.append(
-                qml.Interferometer(
+                Interferometer(
                     theta=theta_1[m],
                     phi=phi_1[m],
                     varphi=varphi_1[m],
@@ -207,10 +211,10 @@ class CVNeuralNetLayers(Operation):
             )
 
             for i in range(len(wires)):  # pylint:disable=consider-using-enumerate
-                op_list.append(qml.Squeezing(r[m, i], phi_r[m, i], wires=wires[i]))
+                op_list.append(Squeezing(r[m, i], phi_r[m, i], wires=wires[i]))
 
             op_list.append(
-                qml.Interferometer(
+                Interferometer(
                     theta=theta_2[m],
                     phi=phi_2[m],
                     varphi=varphi_2[m],
@@ -219,10 +223,10 @@ class CVNeuralNetLayers(Operation):
             )
 
             for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-                op_list.append(qml.Displacement(a[m, i], phi_a[m, i], wires=wires[i]))
+                op_list.append(Displacement(a[m, i], phi_a[m, i], wires=wires[i]))
 
             for i in range(len(wires)):  # pylint:disable=consider-using-enumerate
-                op_list.append(qml.Kerr(k[m, i], wires=wires[i]))
+                op_list.append(Kerr(k[m, i], wires=wires[i]))
 
         return op_list
 

--- a/pennylane/templates/layers/gate_fabric.py
+++ b/pennylane/templates/layers/gate_fabric.py
@@ -17,8 +17,11 @@ Contains the quantum-number-preserving GateFabric template.
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
+from pennylane.ops import DoubleExcitation, OrbitalRotation
+
+from ..embeddings import BasisEmbedding
 
 
 class GateFabric(Operation):
@@ -184,7 +187,7 @@ class GateFabric(Operation):
                 f"This template requires an even number of qubits; got {len(wires)} wires"
             )
 
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
 
         if len(shape) != 3:
             raise ValueError(f"Weights tensor must be 3-dimensional; got shape {shape}")
@@ -245,7 +248,7 @@ class GateFabric(Operation):
         OrbitalRotation(tensor(1.), wires=['a', 'b', 'c', 'd'])]
         """
         op_list = []
-        n_layers = qml.math.shape(weights)[0]
+        n_layers = math.shape(weights)[0]
         wire_pattern = [
             wires[i : i + 4] for i in range(0, len(wires), 4) if len(wires[i : i + 4]) == 4
         ]
@@ -254,15 +257,15 @@ class GateFabric(Operation):
                 wires[i : i + 4] for i in range(2, len(wires), 4) if len(wires[i : i + 4]) == 4
             ]
 
-        op_list.append(qml.BasisEmbedding(init_state, wires=wires))
+        op_list.append(BasisEmbedding(init_state, wires=wires))
 
         for layer in range(n_layers):
             for idx, wires_ in enumerate(wire_pattern):
                 if include_pi:
-                    op_list.append(qml.OrbitalRotation(np.pi, wires=wires_))
+                    op_list.append(OrbitalRotation(np.pi, wires=wires_))
 
-                op_list.append(qml.DoubleExcitation(weights[layer][idx][0], wires=wires_))
-                op_list.append(qml.OrbitalRotation(weights[layer][idx][1], wires=wires_))
+                op_list.append(DoubleExcitation(weights[layer][idx][0], wires=wires_))
+                op_list.append(OrbitalRotation(weights[layer][idx][1], wires=wires_))
 
         return op_list
 

--- a/pennylane/templates/layers/particle_conserving_u2.py
+++ b/pennylane/templates/layers/particle_conserving_u2.py
@@ -14,9 +14,13 @@
 r"""
 Contains the hardware-efficient ParticleConservingU2 template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops import CNOT, CRX, RZ
+
+from ..embeddings import BasisEmbedding
 
 
 def u2_ex_gate(phi, wires=None):
@@ -42,7 +46,7 @@ def u2_ex_gate(phi, wires=None):
     Returns:
         list[.Operator]: sequence of operators defined by this function
     """
-    return [qml.CNOT(wires=wires), qml.CRX(2 * phi, wires=wires[::-1]), qml.CNOT(wires=wires)]
+    return [CNOT(wires=wires), CRX(2 * phi, wires=wires[::-1]), CNOT(wires=wires)]
 
 
 class ParticleConservingU2(Operation):
@@ -160,7 +164,7 @@ class ParticleConservingU2(Operation):
                 f"got a wire sequence with {len(wires)} elements"
             )
 
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
 
         if len(shape) != 2:
             raise ValueError(f"Weights tensor must be 2-dimensional; got shape {shape}")
@@ -214,12 +218,12 @@ class ParticleConservingU2(Operation):
         """
         nm_wires = [wires[l : l + 2] for l in range(0, len(wires) - 1, 2)]
         nm_wires += [wires[l : l + 2] for l in range(1, len(wires) - 1, 2)]
-        n_layers = qml.math.shape(weights)[0]
-        op_list = [qml.BasisEmbedding(init_state, wires=wires)]
+        n_layers = math.shape(weights)[0]
+        op_list = [BasisEmbedding(init_state, wires=wires)]
 
         for l in range(n_layers):
             for j, wires_ in enumerate(wires):
-                op_list.append(qml.RZ(weights[l, j], wires=wires_))
+                op_list.append(RZ(weights[l, j], wires=wires_))
 
             for i, wires_ in enumerate(nm_wires):
                 op_list.extend(u2_ex_gate(weights[l, len(wires) + i], wires=wires_))

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -18,8 +18,10 @@ Contains the RandomLayers template.
 
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
+from pennylane.ops import CNOT, RX, RY, RZ
+from pennylane.wires import Wires
 
 
 class RandomLayers(Operation):
@@ -179,14 +181,14 @@ class RandomLayers(Operation):
         seed=42,
         id=None,
     ):
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
         if len(shape) != 2:
             raise ValueError(f"Weights tensor must be 2-dimensional; got shape {shape}")
 
         self._hyperparameters = {
             "ratio_imprim": ratio_imprim,
-            "imprimitive": imprimitive or qml.CNOT,
-            "rotations": tuple(rotations) if rotations else (qml.RX, qml.RY, qml.RZ),
+            "imprimitive": imprimitive or CNOT,
+            "rotations": tuple(rotations) if rotations else (RX, RY, RZ),
             "seed": seed,
         }
 
@@ -231,11 +233,11 @@ class RandomLayers(Operation):
          CNOT(wires=['b', 'a']),
          RX(tensor(1.4000), wires=['a'])]
         """
-        wires = qml.wires.Wires(wires)
+        wires = Wires(wires)
         rng = np.random.default_rng(seed)
 
-        shape = qml.math.shape(weights)
-        n_layers = qml.math.shape(weights)[0]
+        shape = math.shape(weights)
+        n_layers = math.shape(weights)[0]
         op_list = []
 
         for l in range(n_layers):

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -14,9 +14,11 @@
 r"""
 Contains the SimplifiedTwoDesign template.
 """
+from pennylane import math
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops import CZ, RY
 
 
 class SimplifiedTwoDesign(Operation):
@@ -102,7 +104,7 @@ class SimplifiedTwoDesign(Operation):
     grad_method = None
 
     def __init__(self, initial_layer_weights, weights, wires, id=None):
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
 
         if len(shape) > 1:
             if shape[1] != len(wires) - 1:
@@ -115,7 +117,7 @@ class SimplifiedTwoDesign(Operation):
                     f"Weights tensor must have third dimension of length 2; got {shape[2]}"
                 )
 
-        shape2 = qml.math.shape(initial_layer_weights)
+        shape2 = math.shape(initial_layer_weights)
         if shape2 != (len(wires),):
             raise ValueError(
                 f"Initial layer weights must be of shape {(len(wires),)}; got {shape2}"
@@ -163,27 +165,27 @@ class SimplifiedTwoDesign(Operation):
         RY(tensor(3.1416), wires=['b']), RY(tensor(0.), wires=['c'])]
         """
 
-        n_layers = qml.math.shape(weights)[0]
+        n_layers = math.shape(weights)[0]
         op_list = []
 
         # initial rotations
         for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-            op_list.append(qml.RY(initial_layer_weights[i], wires=wires[i]))
+            op_list.append(RY(initial_layer_weights[i], wires=wires[i]))
 
         for layer in range(n_layers):
             # even layer of entanglers
             even_wires = [wires[i : i + 2] for i in range(0, len(wires) - 1, 2)]
             for i, wire_pair in enumerate(even_wires):
-                op_list.append(qml.CZ(wires=wire_pair))
-                op_list.append(qml.RY(weights[layer, i, 0], wires=wire_pair[0]))
-                op_list.append(qml.RY(weights[layer, i, 1], wires=wire_pair[1]))
+                op_list.append(CZ(wires=wire_pair))
+                op_list.append(RY(weights[layer, i, 0], wires=wire_pair[0]))
+                op_list.append(RY(weights[layer, i, 1], wires=wire_pair[1]))
 
             # odd layer of entanglers
             odd_wires = [wires[i : i + 2] for i in range(1, len(wires) - 1, 2)]
             for i, wire_pair in enumerate(odd_wires):
-                op_list.append(qml.CZ(wires=wire_pair))
-                op_list.append(qml.RY(weights[layer, len(wires) // 2 + i, 0], wires=wire_pair[0]))
-                op_list.append(qml.RY(weights[layer, len(wires) // 2 + i, 1], wires=wire_pair[1]))
+                op_list.append(CZ(wires=wire_pair))
+                op_list.append(RY(weights[layer, len(wires) // 2 + i, 0], wires=wire_pair[0]))
+                op_list.append(RY(weights[layer, len(wires) // 2 + i, 1], wires=wire_pair[1]))
 
         return op_list
 

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -14,9 +14,14 @@
 r"""
 Contains the StronglyEntanglingLayers template.
 """
+from pennylane import math
+from pennylane.control_flow import for_loop
+
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-import pennylane as qml
 from pennylane.operation import Operation
+from pennylane.ops import CNOT, Rot
+from pennylane.ops.op_math import cond
+from pennylane.wires import Wires
 
 
 class StronglyEntanglingLayers(Operation):
@@ -133,7 +138,7 @@ class StronglyEntanglingLayers(Operation):
     grad_method = None
 
     def __init__(self, weights, wires, ranges=None, imprimitive=None, id=None):
-        shape = qml.math.shape(weights)[-3:]
+        shape = math.shape(weights)[-3:]
 
         if shape[1] != len(wires):
             raise ValueError(
@@ -161,7 +166,7 @@ class StronglyEntanglingLayers(Operation):
                         f"Ranges must not be zero nor divisible by the number of wires; got {r}"
                     )
 
-        self._hyperparameters = {"ranges": ranges, "imprimitive": imprimitive or qml.CNOT}
+        self._hyperparameters = {"ranges": ranges, "imprimitive": imprimitive or CNOT}
 
         super().__init__(weights, wires=wires, id=id)
 
@@ -199,14 +204,14 @@ class StronglyEntanglingLayers(Operation):
         CNOT(wires=['a', 'a']),
         CNOT(wires=['b', 'b'])]
         """
-        n_layers = qml.math.shape(weights)[-3]
-        wires = qml.wires.Wires(wires)
+        n_layers = math.shape(weights)[-3]
+        wires = Wires(wires)
         op_list = []
 
         for l in range(n_layers):
             for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
                 op_list.append(
-                    qml.Rot(
+                    Rot(
                         weights[..., l, i, 0],
                         weights[..., l, i, 1],
                         weights[..., l, i, 2],
@@ -240,17 +245,18 @@ class StronglyEntanglingLayers(Operation):
     def compute_qfunc_decomposition(
         weights, *wires, ranges, imprimitive
     ):  # pylint: disable=arguments-differ
-        wires = qml.math.array(wires, like="jax")
-        ranges = qml.math.array(ranges, like="jax")
+        wires = math.array(wires, like="jax")
+        ranges = math.array(ranges, like="jax")
 
         n_wires = len(wires)
         n_layers = weights.shape[0]
 
-        @qml.for_loop(n_layers)
+        @for_loop(n_layers)
         def layers(l):
-            @qml.for_loop(n_wires)
+
+            @for_loop(n_wires)
             def rot_loop(i):
-                qml.Rot(
+                Rot(
                     weights[l, i, 0],
                     weights[l, i, 1],
                     weights[l, i, 2],
@@ -258,9 +264,10 @@ class StronglyEntanglingLayers(Operation):
                 )
 
             def imprim_true():
-                @qml.for_loop(n_wires)
+
+                @for_loop(n_wires)
                 def imprimitive_loop(i):
-                    act_on = qml.math.array([i, i + ranges[l]], like="jax") % n_wires
+                    act_on = math.array([i, i + ranges[l]], like="jax") % n_wires
                     imprimitive(wires=wires[act_on])
 
                 imprimitive_loop()
@@ -269,6 +276,6 @@ class StronglyEntanglingLayers(Operation):
                 pass
 
             rot_loop()
-            qml.cond(n_wires > 1, imprim_true, imprim_false)()
+            cond(n_wires > 1, imprim_true, imprim_false)()
 
         layers()

--- a/pennylane/templates/swapnetworks/ccl2.py
+++ b/pennylane/templates/swapnetworks/ccl2.py
@@ -19,7 +19,7 @@ import warnings
 
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
 from pennylane.ops import SWAP, FermionicSWAP
 
@@ -122,11 +122,11 @@ class TwoLocalSwapNetwork(Operation):
         if (
             weights is not None
             and acquaintances is not None
-            and qml.math.shape(weights)[0] != int(len(wires) * (len(wires) - 1) / 2)
+            and math.shape(weights)[0] != int(len(wires) * (len(wires) - 1) / 2)
         ):
             raise ValueError(
                 f"Weight tensor must be of length {int(len(wires) * (len(wires) - 1) / 2)}, \
-                    got {qml.math.shape(weights)[0]}"
+                    got {math.shape(weights)[0]}"
             )
 
         self._weights = weights

--- a/pennylane/templates/tensornetworks/mera.py
+++ b/pennylane/templates/tensornetworks/mera.py
@@ -20,8 +20,10 @@ from collections.abc import Callable
 
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
+from pennylane.queuing import QueuingManager, apply
+from pennylane.tape import make_qscript
 
 
 def compute_indices(wires, n_block_wires):
@@ -205,7 +207,7 @@ class MERA(Operation):
     ):
         ind_gates = compute_indices(wires, n_block_wires)
         n_wires = len(wires)
-        shape = qml.math.shape(template_weights)  # (n_params_block, n_blocks)
+        shape = math.shape(template_weights)  # (n_params_block, n_blocks)
         n_blocks = int(2 ** (np.floor(np.log2(n_wires / n_block_wires)) + 2) - 3)
 
         if shape == ():
@@ -245,7 +247,7 @@ class MERA(Operation):
             list[.Operator]: decomposition of the operator
         """
         op_list = []
-        block_gen = qml.tape.make_qscript(block)
+        block_gen = make_qscript(block)
         if block.__code__.co_argcount > 2:
             for idx, w in enumerate(ind_gates):
                 op_list += block_gen(*weights[idx], wires=w)
@@ -256,7 +258,7 @@ class MERA(Operation):
             for w in ind_gates:
                 op_list += block_gen(wires=w)
 
-        return [qml.apply(op) for op in op_list] if qml.QueuingManager.recording() else op_list
+        return [apply(op) for op in op_list] if QueuingManager.recording() else op_list
 
     @staticmethod
     def get_n_blocks(wires, n_block_wires):

--- a/pennylane/templates/tensornetworks/mps.py
+++ b/pennylane/templates/tensornetworks/mps.py
@@ -17,8 +17,10 @@ Contains the MPS template.
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
 import warnings
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
+from pennylane.queuing import QueuingManager, apply
+from pennylane.tape import make_qscript
 
 
 def compute_indices_MPS(wires, n_block_wires, offset=None):
@@ -206,7 +208,7 @@ class MPS(Operation):
         n_blocks = self.get_n_blocks(wires, n_block_wires, offset)
 
         if template_weights is not None:
-            shape = qml.math.shape(template_weights)  # (n_blocks, n_params_block)
+            shape = math.shape(template_weights)  # (n_blocks, n_params_block)
             if shape[0] != n_blocks:
                 raise ValueError(
                     f"Weights tensor must have first dimension of length {n_blocks}; got {shape[0]}"
@@ -251,7 +253,7 @@ class MPS(Operation):
         """
         decomp = []
         itrweights = iter([]) if weights is None else iter(weights)
-        block_gen = qml.tape.make_qscript(block)
+        block_gen = make_qscript(block)
         for w in ind_gates:
             weight = next(itrweights, None)
             decomp += (
@@ -259,7 +261,7 @@ class MPS(Operation):
                 if weight is None
                 else block_gen(weights=weight, wires=w, **kwargs)
             )
-        return [qml.apply(op) for op in decomp] if qml.QueuingManager.recording() else decomp
+        return [apply(op) for op in decomp] if QueuingManager.recording() else decomp
 
     @staticmethod
     def get_n_blocks(wires, n_block_wires, offset=None):

--- a/pennylane/templates/tensornetworks/ttn.py
+++ b/pennylane/templates/tensornetworks/ttn.py
@@ -19,8 +19,10 @@ import warnings
 
 import numpy as np
 
-import pennylane as qml
+from pennylane import math
 from pennylane.operation import Operation
+from pennylane.queuing import QueuingManager, apply
+from pennylane.tape import make_qscript
 
 
 def compute_indices(wires, n_block_wires):
@@ -176,7 +178,7 @@ class TTN(Operation):
     ):
         ind_gates = compute_indices(wires, n_block_wires)
         n_wires = len(wires)
-        shape = qml.math.shape(template_weights)  # (n_params_block, n_blocks)
+        shape = math.shape(template_weights)  # (n_params_block, n_blocks)
         n_blocks = 2 ** int(np.log2(n_wires / n_block_wires)) * 2 - 1
 
         if shape == ():
@@ -218,7 +220,7 @@ class TTN(Operation):
             list[.Operator]: decomposition of the operator
         """
         op_list = []
-        block_gen = qml.tape.make_qscript(block)
+        block_gen = make_qscript(block)
         if block.__code__.co_argcount > 2:
             for idx, w in enumerate(ind_gates):
                 op_list += block_gen(*weights[idx], wires=w)
@@ -229,7 +231,7 @@ class TTN(Operation):
             for w in ind_gates:
                 op_list += block_gen(wires=w)
 
-        return [qml.apply(op) for op in op_list] if qml.QueuingManager.recording() else op_list
+        return [apply(op) for op in op_list] if QueuingManager.recording() else op_list
 
     @staticmethod
     def get_n_blocks(wires, n_block_wires):

--- a/tach.toml
+++ b/tach.toml
@@ -205,6 +205,51 @@ path = "pennylane.noise"
 layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
+# TEMPLATES MODULE 
+# Once all submodules are cleaned up, uncomment the following and delete the submodules
+
+# [[modules]]
+# path = "pennylane.templates"
+# layer = "tertiary"
+# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.embeddings"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.layers"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.state_preparations"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.swapnetworks"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.tensornetworks"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.layer"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+# Must be addressed in another PR, too large of an effort
+
+# [[modules]]
+# path = "pennylane.templates.subroutines"
+# layer = "tertiary"
+# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
 ## UNSORTED
 # Due to circular import problems, these modules below have incorrect dependencies 
 # and need to be parsed and fixed accordingly.

--- a/tach.toml
+++ b/tach.toml
@@ -206,12 +206,12 @@ layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 # TEMPLATES MODULE 
-# Once all submodules are cleaned up, uncomment the following and delete the submodules
 
-# [[modules]]
-# path = "pennylane.templates"
+[[modules]]
+path = "pennylane.templates"
+# Once all submodules are cleaned up, uncomment the following and delete the submodules
 # layer = "tertiary"
-# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 [[modules]]
 path = "pennylane.templates.embeddings"
@@ -220,11 +220,6 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 [[modules]]
 path = "pennylane.templates.layers"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.state_preparations"
 layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
@@ -243,7 +238,12 @@ path = "pennylane.templates.layer"
 layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
-# Must be addressed in another PR, too large of an effort
+# Bottom two must be addressed in another PR, too large of an effort
+
+# [[modules]]
+# path = "pennylane.templates.state_preparations"
+# layer = "tertiary"
+# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 # [[modules]]
 # path = "pennylane.templates.subroutines"
@@ -314,10 +314,6 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 [[modules]]
 path = "pennylane.decomposition"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 [[modules]]

--- a/tach.toml
+++ b/tach.toml
@@ -152,6 +152,52 @@ path = "pennylane.optimize"
 layer = "auxiliary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
+
+# TEMPLATES MODULE 
+
+[[modules]]
+path = "pennylane.templates"
+# Once all submodules are cleaned up, uncomment the following and delete the submodules
+# layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.embeddings"
+layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.layers"
+layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.swapnetworks"
+layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.tensornetworks"
+layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+[[modules]]
+path = "pennylane.templates.layer"
+layer = "auxiliary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+# Bottom two must be addressed in another PR, too large of an effort
+
+# [[modules]]
+# path = "pennylane.templates.state_preparations"
+# layer = "auxiliary"
+# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
+# [[modules]]
+# path = "pennylane.templates.subroutines"
+# layer = "auxiliary"
+# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
+
 ## TERTIARY modules
 # These modules can only import from CORE or AUXILIARY modules.
 
@@ -204,51 +250,6 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 path = "pennylane.noise"
 layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-# TEMPLATES MODULE 
-
-[[modules]]
-path = "pennylane.templates"
-# Once all submodules are cleaned up, uncomment the following and delete the submodules
-# layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.embeddings"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.layers"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.swapnetworks"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.tensornetworks"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-[[modules]]
-path = "pennylane.templates.layer"
-layer = "tertiary"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-# Bottom two must be addressed in another PR, too large of an effort
-
-# [[modules]]
-# path = "pennylane.templates.state_preparations"
-# layer = "tertiary"
-# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
-
-# [[modules]]
-# path = "pennylane.templates.subroutines"
-# layer = "tertiary"
-# cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 ## UNSORTED
 # Due to circular import problems, these modules below have incorrect dependencies 


### PR DESCRIPTION
**Context:**

Following our PL module structure, the goal of this PR is to isolate straight forward submodules of `templates` as a `auxiliary` modules.

**Description of the Change:**

⚠️ This is a rather large and complex module which is unfortunately interconnected to the `ops` module. Due to this, there are circular import errors when trying to clean-up the `subroutines` and `state_preparations` submodules. 

This PR does the following,
- Updates `tach.toml` to break up `templates` into individual submodules (allows for submodule level enforcement)
- Address any errors that arise

**Benefits:** Module dependency enforcement.

**Possible Drawbacks:** None identified.

[sc-91368]
