### PR TITLE
fix `unnecessary-lambda-assignment` in `ftqc/utils.py`

### DIFF
--- a/pennylane/ftqc/utils.py
+++ b/pennylane/ftqc/utils.py
@@ -95,12 +95,15 @@ class QubitMgr:
         self._lock = RLock()
         self._num_qubits = num_qubits
         self._active = set()
-        is_valid = lambda x: (isinstance(x, int) and x >= 0)
-        if is_valid(num_qubits) and is_valid(start_idx):
+
+        def is_positive_integer(x):
+            return isinstance(x, int) and x >= 0
+
+        if is_positive_integer(num_qubits) and is_positive_integer(start_idx):
             self._inactive = set(range(start_idx, start_idx + num_qubits, 1))
         else:
             raise TypeError(
-                f"Index counts and starting values must be positive integers. Received {num_qubits} and {start_idx}"
+                f"Index counts and starting values must be positive integers. Received {num_qubits} and {start_idx}."
             )
 
     def __repr__(self):


### PR DESCRIPTION
**Context:**

Trying to make latest `pylint` happy locally.

**Description of the Change:**

Use `def` instead of `lambda` assignment.

**Benefits:**

Conforms to [PEP8](https://peps.python.org/pep-0008/). 

![image](https://github.com/user-attachments/assets/7f8c27ae-e80d-4248-ac74-a6e1aec0aa61)

**Possible Drawbacks:** None.
