### PR TITLE
Reduce `shots` in an MCM test to save about 14 minutes of CI (single-thread) runtime.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -314,6 +314,10 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* The shot count for a test for mid-circuit measurements has been reduced by a factor of 5, saving
+  significant computational effort in the test suite.
+  [(#7442)](https://github.com/PennyLaneAI/pennylane/pull/7442)
+
 * Enforce `noise` module to be a tertiary layer module.
   [(#7430)](https://github.com/PennyLaneAI/pennylane/pull/7430)
 

--- a/tests/devices/default_qubit/test_default_qubit_native_mcm.py
+++ b/tests/devices/default_qubit/test_default_qubit_native_mcm.py
@@ -120,7 +120,7 @@ def obs_tape(x, y, z, reset=False, postselect=None):
 
 
 @pytest.mark.parametrize("mcm_method", ["one-shot", "tree-traversal"])
-@pytest.mark.parametrize("shots", [None, 5500, [5500, 5501]])
+@pytest.mark.parametrize("shots", [None, 1050, [1050, 1051]])
 @pytest.mark.parametrize(
     "params",
     [
@@ -171,6 +171,7 @@ def test_multiple_measurements_and_reset(mcm_method, shots, params, postselect, 
 
     results0 = qml.QNode(func, dev, mcm_method=mcm_method)(*params)
     results1 = qml.QNode(func, dev, mcm_method="deferred")(*params)
+    atol = 1e-8 if shots is None else 0.07
 
     measurements = (
         [qml.expval, qml.probs, qml.var, qml.expval, qml.probs, qml.var]
@@ -185,7 +186,7 @@ def test_multiple_measurements_and_reset(mcm_method, shots, params, postselect, 
         for measure_f, r1, r0 in zip(measurements, res1, res0):
             if shots is None and measure_f in [qml.expval, qml.probs] and batch_size is not None:
                 r0 = qml.math.squeeze(r0)
-            mcm_utils.validate_measurements(measure_f, shot, r1, r0, batch_size=batch_size)
+            mcm_utils.validate_measurements(measure_f, shot, r1, r0, batch_size, atol=atol)
 
 
 @pytest.mark.parametrize("mcm_method", ["one-shot", "tree-traversal"])

--- a/tests/helpers/mcm_utils.py
+++ b/tests/helpers/mcm_utils.py
@@ -86,7 +86,7 @@ def validate_samples(shots, results1, results2, batch_size=None):
     np.allclose(qml.math.sum(results1), qml.math.sum(results2), atol=20, rtol=0.2)
 
 
-def validate_expval(shots, results1, results2, batch_size=None):
+def validate_expval(shots, results1, results2, batch_size=None, atol=0.01):
     """Compares two expval, probs or var.
 
     If the results are ``Sequence``s, validate the average of items.
@@ -112,10 +112,11 @@ def validate_expval(shots, results1, results2, batch_size=None):
         for r1, r2 in zip(results1, results2):
             validate_expval(shots, r1, r2, batch_size=None)
 
-    assert np.allclose(results1, results2, atol=0.01, rtol=0.2)
+    assert np.allclose(results1, results2, atol=atol, rtol=0.2)
 
 
-def validate_measurements(func, shots, results1, results2, batch_size=None):
+# pylint: disable=too-many-arguments
+def validate_measurements(func, shots, results1, results2, batch_size=None, atol=0.01):
     """Calls the correct validation function based on measurement type."""
     if func is qml.counts:
         validate_counts(shots, results1, results2, batch_size=batch_size)
@@ -125,4 +126,4 @@ def validate_measurements(func, shots, results1, results2, batch_size=None):
         validate_samples(shots, results1, results2, batch_size=batch_size)
         return
 
-    validate_expval(shots, results1, results2, batch_size=batch_size)
+    validate_expval(shots, results1, results2, batch_size=batch_size, atol=atol)


### PR DESCRIPTION
**Context:**
Some tests in our test suite take _a lot_ of time.
One test is `tests/devices/default_qubit/test_default_qubit_native_mcm.py::test_multiple_measurements_and_reset`.
It's not too surprising that simulating 5k and 10k circuit runs for the `shots1` and `shots2` settings of its parametrization takes a while... 
So one obvious way to reduce the load of this test is to reduce the shot count and accept higher tolerances in validation of the expectation value results obtained in the test.

**Description of the Change:**
Change 5500 shots to 1050 shots in the mentioned test while increasing `atol` to `0.07`.

**Benefits:**
In local testing, this achieved passing tests and reduced the test duration from 197 sec to 38 sec (so factor 5, basically linear in shots count) 
All parametrizations of the mentioned test that take >50 sec individually (10 parametrizations) together take ~1045 sec in CI according to the durations artifact.
So applying this change would reduce the cumulative runtime of those 10 parametrizations by a factor of 5, to about 210 sec, saving us ~840 sec, or 14 minutes, of CI runtime.
**edit:** In practice, the saving seems to be closer to 8 minutes. Splitting this single-thread reduction across the 6 core tests still can be expected to yield more than a minute of multi-thread runtime, assuming a rebalancing via the updated durations artifact.

core runtimes in some other recent PR:
![Screenshot from 2025-05-16 10-55-42](https://github.com/user-attachments/assets/5ed94fa7-debf-400d-864d-c335ae74fa95)
core runtimes in this PR:
![image](https://github.com/user-attachments/assets/49945034-1f7f-4d90-ba95-d24a054ba6c8)

**Possible Drawbacks:**
Slightly less precise testing. Effectively I'd expect this to not matter at all.

**Related GitHub Issues:**

[sc-91369]