### PR TITLE
Remove `pytest-timeout`

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -202,7 +202,7 @@ jobs:
           COV_CORE_DATAFILE: .coverage.eager
           TF_USE_LEGACY_KERAS: "1"  # sets to use tf-keras (Keras2) instead of keras (Keras3) when running TF tests
         # Calling PyTest by invoking Python first as that adds the current directory to sys.path
-        run: python -m pytest ${{ inputs.pytest_test_directory }} ${{ steps.pytest_args.outputs.args }} ${{ env.PYTEST_MARKER }} --timeout=500
+        run: python -m pytest ${{ inputs.pytest_test_directory }} ${{ steps.pytest_args.outputs.args }} ${{ env.PYTEST_MARKER }}
 
       - name: Freeze dependencies
         shell: bash

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -315,6 +315,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Stop using `pytest-timeout` in the PennyLane CI/CD pipeline.
+  [(#)]()
+
 * Enforce subset of submodules in `templates` to be auxiliary layer modules.
   [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -316,7 +316,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 <h3>Internal changes ⚙️</h3>
 
 * Stop using `pytest-timeout` in the PennyLane CI/CD pipeline.
-  [(#)]()
+  [(#7451)](https://github.com/PennyLaneAI/pennylane/pull/7451)
 
 * Enforce subset of submodules in `templates` to be auxiliary layer modules.
   [(#7437)](https://github.com/PennyLaneAI/pennylane/pull/7437)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ pytest-cov>=3.0.0
 pytest-mock>=3.7.0
 pytest-xdist>=2.5.0
 pytest-rng
-pytest-timeout
 flaky>=3.7.0
 pytest-forked>=1.4.0
 pytest-benchmark


### PR DESCRIPTION
Using pytest-timeout seems to have caused many tests to slow down significantly. This PR removes it as a CI dependency.

[sc-91511]