### PR TITLE
[WIP] Caching Improvements for Clifford+T Decomposition

### DIFF
--- a/pennylane/ops/op_math/decompositions/solovay_kitaev.py
+++ b/pennylane/ops/op_math/decompositions/solovay_kitaev.py
@@ -275,9 +275,7 @@ def _group_commutator_decompose(matrix, tol=1e-5):
     return w_hat, v_hat
 
 
-def sk_decomposition(
-    op, epsilon, *, max_depth=5, basis_set=("H", "S", "T"), basis_length=10, map_wires=True
-):
+def sk_decomposition(op, epsilon, *, max_depth=5, basis_set=("H", "S", "T"), basis_length=10):
     r"""Approximate an arbitrary single-qubit gate in the Clifford+T basis using the `Solovay-Kitaev algorithm <https://arxiv.org/abs/quant-ph/0505030>`_.
 
     This method implements the Solovay-Kitaev decomposition algorithm that approximates any single-qubit
@@ -299,8 +297,6 @@ def sk_decomposition(
             to the gate adjoint. Default value is ``('H', 'S', 'T')``.
         basis_length (int): Maximum expansion length of Clifford+T sequences in the internally-built approximate set.
             Default is ``10``.
-        map_wires (bool): If ``True``, the wires of the returned operations are mapped to the wires of the input and queued.
-            Default is ``True``.
 
     Returns:
         list[~pennylane.operation.Operation]: A list of gates in the Clifford+T basis set that approximates the given
@@ -412,7 +408,7 @@ def sk_decomposition(
         )
 
     # Map the wires to that of the operation and queue
-    if map_wires:
+    if op.wires[0] != 0:
         [new_tape], _ = qml.map_wires(new_tape, wire_map={0: op.wires[0]}, queue=True)
 
     # Get phase information based on the decomposition effort

--- a/pennylane/transforms/decompositions/clifford_t_transform.py
+++ b/pennylane/transforms/decompositions/clifford_t_transform.py
@@ -459,6 +459,7 @@ def clifford_t_decomposition(
 
         # Build the approximation set for Solovay-Kitaev decomposition
         if method == "sk":
+            # Cache the decomposition function for performance
             decompose_fn = lru_cache(maxsize=10000)(
                 partial(sk_decomposition, epsilon=epsilon, **method_kwargs, map_wires=False)
             )
@@ -472,8 +473,11 @@ def clifford_t_decomposition(
         phase = new_operations.pop().data[0]
         for op in tqdm(new_operations):
             if isinstance(op, qml.RZ):
+                # Decompose the RZ operation with a default wire
                 clifford_ops = decompose_fn(qml.RZ(op.data[0], [0]))
+                # Extract the global phase from the last operation
                 phase += qml.math.convert_like(clifford_ops[-1].data[0], phase)
+                # Map the operations to the original wires
                 mapped_ops = qml.map_wires(qml.prod(*clifford_ops[:-1]), {0: op.wires[0]})
                 decomp_ops.extend(getattr(mapped_ops, "operands", [mapped_ops]))
             else:

--- a/pennylane/transforms/decompositions/clifford_t_transform.py
+++ b/pennylane/transforms/decompositions/clifford_t_transform.py
@@ -362,7 +362,7 @@ class _CachedDecompose:
 
     def cached_decompose(self, angle):
         """Decomposes the angle into a sequence of gates."""
-        seq = self.decompose_fn(qml.RZ(abs(angle), [0]), 0.1)
+        seq = self.decompose_fn(qml.RZ(abs(angle), [0]))
         if angle != abs(angle):
             adj = [qml.adjoint(s, lazy=False) for s in seq][::-1]
             return adj[1:] + adj[:1]
@@ -492,7 +492,8 @@ def clifford_t_decomposition(
         # Compute the per-gate epsilon value
         epsilon /= number_ops or 1
 
-        # Every decomposition implementation should have the following shape:
+        # _CACHED_DECOMPOSE is a global variable that caches the decomposition function,
+        # where the implementation of each function should have the following signature:
         # def decompose_fn(op: Operator, epsilon: float, **method_kwargs) -> List[Operator]
         # note: the last operator in the decomposition must be a GlobalPhase
 


### PR DESCRIPTION
**Context:** Introduces caching improvements to the Clifford+T transform. 

**Description of the Change:**
1. Adds `_CachedCallable` to help maintain the a global cache that could be reused across different circuits. 
2. Class method `cached_decompose` allows computing decomposition of the `-angle` directly from the result stored for `angle` instead of doing a recomputation. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** [sc-91547]
