### PR TITLE
[BugFix] Discrepancy in output values of the example of `qml.pulse.drive`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -486,6 +486,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Bug fixes 🐛</h3>
 
+* The documentation of `qml.pulse.drive` has been updated and corrected.
+  [(#7459)](https://github.com/PennyLaneAI/pennylane/pull/7459)
+
 * Fixed a bug in `to_openfermion` where identity qubit-to-wires mapping was not obeyed.
   [(#7332)](https://github.com/PennyLaneAI/pennylane/pull/7332)
 

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -71,7 +71,6 @@ Hardware Compatible Hamiltonians
     ~rydberg_drive
     ~transmon_interaction
     ~transmon_drive
-    ~drive
 
 
 Creating a parametrized Hamiltonian

--- a/pennylane/pulse/__init__.py
+++ b/pennylane/pulse/__init__.py
@@ -71,6 +71,7 @@ Hardware Compatible Hamiltonians
     ~rydberg_drive
     ~transmon_interaction
     ~transmon_drive
+    ~drive
 
 
 Creating a parametrized Hamiltonian

--- a/pennylane/pulse/hardware_hamiltonian.py
+++ b/pennylane/pulse/hardware_hamiltonian.py
@@ -43,7 +43,7 @@ def drive(amplitude, phase, wires):
 
     Common hardware systems are superconducting qubits and neutral atoms. The electromagnetic field of the drive is
     realized by microwave and laser fields, respectively, operating at very different wavelengths.
-    To avoid nummerical problems due to using both very large and very small numbers, it is advisable to match
+    To avoid numerical problems due to using both very large and very small numbers, it is advisable to match
     the order of magnitudes of frequency and time arguments.
     Read the usage details for more information on how to choose :math:`\Omega` and :math:`\phi`.
 
@@ -71,6 +71,8 @@ def drive(amplitude, phase, wires):
 
     .. code-block:: python3
 
+        import jax.numpy as jnp
+
         wires = [0, 1, 2, 3]
         H_int = sum([qml.X(i) @ qml.X((i+1)%len(wires)) for i in wires])
 
@@ -79,10 +81,12 @@ def drive(amplitude, phase, wires):
         H_d = qml.pulse.drive(amplitude, phase, wires)
 
     >>> H_int
-    (1) [X0 X1]
-    + (1) [X1 X2]
-    + (1) [X2 X3]
-    + (1) [X3 X0]
+    (
+    X(0) @ X(1)
+    + X(1) @ X(2)
+    + X(2) @ X(3)
+    + X(3) @ X(0)
+    )
     >>> H_d
     HardwareHamiltonian:: terms=2
 
@@ -96,6 +100,8 @@ def drive(amplitude, phase, wires):
 
     .. code-block:: python3
 
+        import jax
+
         jax.config.update("jax_enable_x64", True)
 
         dev = qml.device("default.qubit", wires=wires)
@@ -107,9 +113,9 @@ def drive(amplitude, phase, wires):
 
     >>> params = [2.4]
     >>> circuit(params)
-    Array(0.32495208, dtype=float64)
+    Array(-0.17375104, dtype=float64)
     >>> jax.grad(circuit)(params)
-    [Array(1.31956098, dtype=float64, weak_type=True)]
+    [Array(13.66916253, dtype=float64, weak_type=True)]
 
     We can also create a Hamiltonian with multiple local drives. The following circuit corresponds to the
     evolution where an additional local drive that changes in time is acting on wires ``[0, 1]`` is added to the Hamiltonian:
@@ -137,8 +143,8 @@ def drive(amplitude, phase, wires):
     Array(0.37385014, dtype=float64)
     >>> jax.grad(circuit_local)(params)
     (Array(-3.35835837, dtype=float64),
-     [Array(-3.35835837, dtype=float64, weak_type=True),
-      Array(-3.35835837, dtype=float64, weak_type=True)],
+     [Array(-1.02229985, dtype=float64, weak_type=True),
+     Array(2.82368978, dtype=float64, weak_type=True)],
      Array(0.1339487, dtype=float64))
 
     .. details::
@@ -165,7 +171,7 @@ def drive(amplitude, phase, wires):
         levels, is unaffected by this transformation.
 
         Further, note that the factor :math:`\frac{1}{2}` is a matter of convention. We keep it for ``drive()`` as well as :func:`~.rydberg_drive`,
-        but ommit it in :func:`~.transmon_drive`, as is common in the respective fields.
+        but omit it in :func:`~.transmon_drive`, as is common in the respective fields.
 
     .. details::
         **Neutral Atom Rydberg systems**

--- a/pennylane/pulse/hardware_hamiltonian.py
+++ b/pennylane/pulse/hardware_hamiltonian.py
@@ -144,7 +144,7 @@ def drive(amplitude, phase, wires):
     >>> jax.grad(circuit_local)(params)
     (Array(-3.35835837, dtype=float64),
      [Array(-1.02229985, dtype=float64, weak_type=True),
-     Array(2.82368978, dtype=float64, weak_type=True)],
+      Array(2.82368978, dtype=float64, weak_type=True)],
      Array(0.1339487, dtype=float64))
 
     .. details::


### PR DESCRIPTION
**Context:** The output of [the code example](https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/pulse/hardware_hamiltonian.py#L105) in the `qml.pulse.hardware_hamiltonian.drive` function should be consistent with the output from the docs.

**Description of the Change:** There was a [long discussion](https://xanaduhq.slack.com/archives/C0743CNS9E3/p1721665038022359) (almost a year ago!) about this issue. The summary is provided by the following message that @Qottmann posted (you can check that the current output in the doc is recovered with the suggested change):

_we just never updated the example after changing the convention that amplitudes are implicitly multiplied by 2 pi (to account for radians). If you run the example with amplitude = lambda p, t: p * jnp.sin(jnp.pi * t) / np.pi / 2. you retrieve the same, old results. So just a matter of updating the docs, though as Tom mentioned this function is not user-facing anymore so low priority_

This also answers the question 'why is this function not appearing in the doc?'

**Benefits:** Corrected documentation.

**Possible Drawbacks:** None.

**Related GitHub Issues:**  #6025 

[sc-69413]
