### PR TITLE
De-indenting to save changelog highlight?

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -233,6 +233,7 @@
     1: ────╭●─────│─────╭●─────│───T─╰X──T†─╰X─┤
     2: ──H─╰X──T†─╰X──T─╰X──T†─╰X──T──H────────┤
     ```
+
   * Symbolic operator types can now be given as strings to the `op_type` argument of :func:`~.decomposition.add_decomps`,
     or as keys of the dictionaries passed to the `alt_decomps` and `fixed_decomps` arguments of the
     :func:`~.transforms.decompose` transform, allowing custom decomposition rules to be defined and

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -218,23 +218,23 @@
     operators in the target gate set.
     [(#7331)](https://github.com/PennyLaneAI/pennylane/pull/7331)
 
-    ```python
-    from functools import partial
-    import pennylane as qml
+  ```python
+  from functools import partial
+  import pennylane as qml
+
+  qml.decomposition.enable_graph()
   
-    qml.decomposition.enable_graph()
-   
-    @partial(qml.transforms.decompose, gate_set={"T", "Adjoint(T)", "H", "CNOT"})
-    @qml.qnode(qml.device("default.qubit"))
-    def circuit():
-        qml.Toffoli(wires=[0, 1, 2])
-    ```
-    ```pycon
-    >>> print(qml.draw(circuit)())
-    0: ───────────╭●───────────╭●────╭●──T──╭●─┤
-    1: ────╭●─────│─────╭●─────│───T─╰X──T†─╰X─┤
-    2: ──H─╰X──T†─╰X──T─╰X──T†─╰X──T──H────────┤
-    ```
+  @partial(qml.transforms.decompose, gate_set={"T", "Adjoint(T)", "H", "CNOT"})
+  @qml.qnode(qml.device("default.qubit"))
+  def circuit():
+      qml.Toffoli(wires=[0, 1, 2])
+  ```
+  ```pycon
+  >>> print(qml.draw(circuit)())
+  0: ───────────╭●───────────╭●────╭●──T──╭●─┤
+  1: ────╭●─────│─────╭●─────│───T─╰X──T†─╰X─┤
+  2: ──H─╰X──T†─╰X──T─╰X──T†─╰X──T──H────────┤
+  ```
 
   * Symbolic operator types can now be given as strings to the `op_type` argument of :func:`~.decomposition.add_decomps`,
     or as keys of the dictionaries passed to the `alt_decomps` and `fixed_decomps` arguments of the

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -216,6 +216,7 @@
   * The `gate_set` argument of the :func:`~.transforms.decompose` transform now supports adding symbolic
     operators in the target gate set.
     [(#7331)](https://github.com/PennyLaneAI/pennylane/pull/7331)
+
     ```python
     from functools import partial
     import pennylane as qml

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,6 +213,7 @@
 
 * Symbolic operator types (e.g., `Adjoint`, `Controlled`, and `Pow`) can now be specified as strings
   in various parts of the new graph-based decomposition system, specifically:
+
   * The `gate_set` argument of the :func:`~.transforms.decompose` transform now supports adding symbolic
     operators in the target gate set.
     [(#7331)](https://github.com/PennyLaneAI/pennylane/pull/7331)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -244,35 +244,35 @@
 
     [(#7352)](https://github.com/PennyLaneAI/pennylane/pull/7352)
 
-    ```python
-    @qml.register_resources({qml.RY: 1})
-    def my_adjoint_ry(phi, wires, **_):
-        qml.RY(-phi, wires=wires)
+  ```python
+  @qml.register_resources({qml.RY: 1})
+  def my_adjoint_ry(phi, wires, **_):
+      qml.RY(-phi, wires=wires)
 
-    @qml.register_resources({qml.RX: 1})
-    def my_adjoint_rx(phi, wires, **__):
-        qml.RX(-phi, wires)
+  @qml.register_resources({qml.RX: 1})
+  def my_adjoint_rx(phi, wires, **__):
+      qml.RX(-phi, wires)
 
-    # Registers a decomposition rule for the adjoint of RY globally
-    qml.add_decomps("Adjoint(RY)", my_adjoint_ry)
+  # Registers a decomposition rule for the adjoint of RY globally
+  qml.add_decomps("Adjoint(RY)", my_adjoint_ry)
 
-    @partial(
-        qml.transforms.decompose,
-        gate_set={"RX", "RY", "CNOT"},
-        fixed_decomps={"Adjoint(RX)": my_adjoint_rx}
-    )
-    @qml.qnode(qml.device("default.qubit"))
-    def circuit():
-        qml.adjoint(qml.RX(0.5, wires=[0]))
-        qml.CNOT(wires=[0, 1])
-        qml.adjoint(qml.RY(0.5, wires=[1]))
-        return qml.expval(qml.Z(0))
-    ```
-    ```pycon
-    >>> print(qml.draw(circuit)())
-    0: ──RX(-0.50)─╭●────────────┤  <Z>
-    1: ────────────╰X──RY(-0.50)─┤
-    ```
+  @partial(
+      qml.transforms.decompose,
+      gate_set={"RX", "RY", "CNOT"},
+      fixed_decomps={"Adjoint(RX)": my_adjoint_rx}
+  )
+  @qml.qnode(qml.device("default.qubit"))
+  def circuit():
+      qml.adjoint(qml.RX(0.5, wires=[0]))
+      qml.CNOT(wires=[0, 1])
+      qml.adjoint(qml.RY(0.5, wires=[1]))
+      return qml.expval(qml.Z(0))
+  ```
+  ```pycon
+  >>> print(qml.draw(circuit)())
+  0: ──RX(-0.50)─╭●────────────┤  <Z>
+  1: ────────────╰X──RY(-0.50)─┤
+  ```
 
 <h3>Improvements 🛠</h3>
 


### PR DESCRIPTION
**Context:**
Our changelog got sick due to unknown GH markdown syntax highlight issue, check https://github.com/PennyLaneAI/pennylane/blob/d591f173337302e1ad438460b2d5ae8c294b0f39/doc/releases/changelog-dev.md?plain=1 to see:
![image](https://github.com/user-attachments/assets/c438b191-9ab1-449d-b595-f2ac86344831)
And all the lines afterwards got affected:
![image](https://github.com/user-attachments/assets/ad58fb34-1ef7-4e98-8114-9f76adc05fb0)


**Description of the Change:**
Still don't know why but at least de-indenting two pieces of codeblock seems solved this problem. Check the results out by view the **"code"** of changelog; note that the rendered version is always good.

**Benefits:**
As mentioned above.

**Possible Drawbacks:**
Sllightly cringe if you look carefully into the logic of codeblocks and surrounding texts: they indeed **should** be indented. But apparently simply adding blank lines won't fix this directly; didn't see any other immediately feasible approaches. And this is much more minor than the whole wrong syntax highlight before.

**Related GitHub Issues:**
