### PR TITLE
`DefaultQubit` implements `setup_execution_config` and `preprocess_transforms` instead of `preprocess`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -441,6 +441,8 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* `DefaultQubit` now implements `preprocess_transforms` and `setup_execution_config` instead of `preprocess`.
+
 * Fix subset of `pylint` errors in the `tests` folder.
   [(#7446)](https://github.com/PennyLaneAI/pennylane/pull/7446)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -530,10 +530,9 @@ class DefaultQubit(Device):
         return False
 
     @debug_logger
-    def preprocess(
-        self,
-        execution_config: ExecutionConfig = DefaultExecutionConfig,
-    ) -> tuple[TransformProgram, ExecutionConfig]:
+    def preprocess_transforms(
+        self, execution_config: Optional[ExecutionConfig] = None
+    ) -> TransformProgram:
         """This function defines the device transform program to be applied and an updated device configuration.
 
         Args:
@@ -548,7 +547,7 @@ class DefaultQubit(Device):
         This device supports any qubit operations that provide a matrix
 
         """
-        config = self._setup_execution_config(execution_config)
+        config = execution_config or ExecutionConfig()
         transform_program = TransformProgram()
 
         if qml.capture.enabled():
@@ -557,7 +556,7 @@ class DefaultQubit(Device):
                 transform_program.add_transform(qml.defer_measurements, num_wires=len(self.wires))
             transform_program.add_transform(qml.transforms.decompose, gate_set=stopping_condition)
 
-            return transform_program, config
+            return transform_program
 
         if config.interface == qml.math.Interface.JAX_JIT:
             transform_program.add_transform(no_counts)
@@ -594,10 +593,12 @@ class DefaultQubit(Device):
                 transform_program, device_vjp=config.use_device_jacobian_product
             )
 
-        return transform_program, config
+        return transform_program
 
     # pylint: disable = too-many-branches
-    def _setup_execution_config(self, execution_config: ExecutionConfig) -> ExecutionConfig:
+    def setup_execution_config(
+        self, config: Optional[ExecutionConfig] = None, circuit: Optional[QuantumScript] = None
+    ) -> ExecutionConfig:
         """This is a private helper for ``preprocess`` that sets up the execution config.
 
         Args:
@@ -607,16 +608,17 @@ class DefaultQubit(Device):
             ExecutionConfig: a preprocessed execution config
 
         """
+        config = config or ExecutionConfig()
         updated_values = {}
 
         # uncomment once compilation overhead with jitting improved
         # TODO: [sc-82874]
         # jax_interfaces = {qml.math.Interface.JAX, qml.math.Interface.JAX_JIT}
         # updated_values["convert_to_numpy"] = (
-        #    execution_config.interface not in jax_interfaces
-        #    or execution_config.gradient_method == "adjoint"
+        #    config.interface not in jax_interfaces
+        #    or config.gradient_method == "adjoint"
         #    # need numpy to use caching, and need caching higher order derivatives
-        #    or execution_config.derivative_order > 1
+        #    or config.derivative_order > 1
         # )
 
         # If PRNGKey is present, we can't use a pure_callback, because that would cause leaked tracers
@@ -626,14 +628,14 @@ class DefaultQubit(Device):
             updated_values["convert_to_numpy"] = not (
                 (
                     self._prng_key is not None
-                    and execution_config.interface in jax_interfaces
-                    and execution_config.gradient_method != "adjoint"
+                    and config.interface in jax_interfaces
+                    and config.gradient_method != "adjoint"
                     # need numpy to use caching, and need caching higher order derivatives
-                    and execution_config.derivative_order == 1
+                    and config.derivative_order == 1
                 )
             )
 
-        for option, value in execution_config.device_options.items():
+        for option, value in config.device_options.items():
             if option not in self._device_options:
                 raise qml.DeviceError(f"device option {option} not present on {self}")
 
@@ -641,31 +643,31 @@ class DefaultQubit(Device):
                 if option == "max_workers" and value is not None:
                     raise qml.DeviceError("Cannot set 'max_workers' if program capture is enabled.")
 
-        gradient_method = execution_config.gradient_method
-        if execution_config.gradient_method == "best":
+        gradient_method = config.gradient_method
+        if config.gradient_method == "best":
             no_max_workers = (
-                execution_config.device_options.get("max_workers", self._max_workers) is None
+                config.device_options.get("max_workers", self._max_workers) is None
             ) or qml.capture.enabled()
             gradient_method = "backprop" if no_max_workers else "adjoint"
             updated_values["gradient_method"] = gradient_method
 
-        if execution_config.use_device_gradient is None:
+        if config.use_device_gradient is None:
             updated_values["use_device_gradient"] = gradient_method in {
                 "adjoint",
                 "backprop",
             }
-        if execution_config.use_device_jacobian_product is None:
+        if config.use_device_jacobian_product is None:
             updated_values["use_device_jacobian_product"] = gradient_method == "adjoint"
-        if execution_config.grad_on_execution is None:
+        if config.grad_on_execution is None:
             updated_values["grad_on_execution"] = gradient_method == "adjoint"
 
-        updated_values["device_options"] = dict(execution_config.device_options)  # copy
+        updated_values["device_options"] = dict(config.device_options)  # copy
         for option in self._device_options:
             if option not in updated_values["device_options"]:
                 updated_values["device_options"][option] = getattr(self, f"_{option}")
 
         if qml.capture.enabled():
-            mcm_config = execution_config.mcm_config
+            mcm_config = config.mcm_config
             mcm_updated_values = {}
             if (mcm_method := mcm_config.mcm_method) not in (
                 "deferred",
@@ -688,7 +690,7 @@ class DefaultQubit(Device):
                 mcm_updated_values["mcm_method"] = "deferred"
             updated_values["mcm_config"] = replace(mcm_config, **mcm_updated_values)
 
-        return replace(execution_config, **updated_values)
+        return replace(config, **updated_values)
 
     @debug_logger
     def execute(


### PR DESCRIPTION
**Context:**

We added `setup_execution_config` and `preprocess_transforms` to the device api for the two different responsibilities of `preprocess`, but never updated the implementation in `DefaultQubit`. 

**Description of the Change:**

Switches to implementing `setup_execution_config` and `preprocess_transforms`

**Benefits:**

Cleaner implementation that more clearly separates the two tasks.

**Possible Drawbacks:**

**Related GitHub Issues:**
