### PR TITLE
Can terminate QASM 3.0 programs early with "end"

### DIFF
--- a/tests/io/qasm_interpreter/test_interpreter.py
+++ b/tests/io/qasm_interpreter/test_interpreter.py
@@ -49,6 +49,33 @@ except (ModuleNotFoundError, ImportError) as import_error:
 @pytest.mark.external
 class TestInterpreter:
 
+    def test_end_statement(self):
+
+        # parse the QASM program
+        ast = parse(
+            """
+            qubit q0;
+            qubit q1;
+            ch q0, q1;
+            cx q1, q0;
+            end;
+            cy q0, q1;
+            cz q1, q0;
+            swap q0, q1;
+            """,
+            permissive=True,
+        )
+        context = QasmInterpreter().generic_visit(ast, context={"name": "end-early"})
+
+        # execute the callable
+        with queuing.AnnotatedQueue() as q:
+            context["callable"]()
+
+        assert q.queue == [
+            CH(wires=["q0", "q1"]),
+            CNOT(wires=["q1", "q0"]),
+        ]
+
     def test_mod_with_declared_param(self):
 
         # parse the QASM program


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:** We should be able to end QASM 3.0 programs early with the end statement per the [spec](https://openqasm.com/grammar/index.html). 

**Description of the Change:** This PR adds a change to allow us to gracefully end a program before the end of the QASM script. Begins to break up the functionality in [(#7469)](https://github.com/PennyLaneAI/pennylane/pull/7469).

**Benefits:** Conformity to the QASM 3.0 spec, support for spec'd features.

**Possible Drawbacks:** 

**Related ShortCut Stories:** [sc-91131]
