### PR TITLE
add `PennyLaneUserWarning` to `pennylane.exceptions` module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -288,7 +288,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* A new `PennyLaneUserWarning` has been added to `exceptions` to warn users about special PennyLane tricks that might confuse them.
+* Add `PennyLaneUserWarning` to `pennylane.exceptions` to provide specific warnings to users regarding improper package usage.
   [(#7496)](https://github.com/PennyLaneAI/pennylane/pull/7496)
 
 * Setting up the configuration of a workflow, including the determination of the best diff

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 <h3>New features since last release</h3>
 
+* A new `PennyLaneUserWarning` has been added to `exceptions` to warn users about special PennyLane tricks that might confuse them.
+  [(#7496)](https://github.com/PennyLaneAI/pennylane/pull/7496)
+
 * A new QNode transform called :func:`~.transforms.set_shots` has been added to set or update the number of shots to be performed, overriding shots specified in the device.
   [(#7337)](https://github.com/PennyLaneAI/pennylane/pull/7337)
   [(#7358)](https://github.com/PennyLaneAI/pennylane/pull/7358)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,9 +4,6 @@
 
 <h3>New features since last release</h3>
 
-* A new `PennyLaneUserWarning` has been added to `exceptions` to warn users about special PennyLane tricks that might confuse them.
-  [(#7496)](https://github.com/PennyLaneAI/pennylane/pull/7496)
-
 * A new QNode transform called :func:`~.transforms.set_shots` has been added to set or update the number of shots to be performed, overriding shots specified in the device.
   [(#7337)](https://github.com/PennyLaneAI/pennylane/pull/7337)
   [(#7358)](https://github.com/PennyLaneAI/pennylane/pull/7358)
@@ -290,6 +287,9 @@
   ```
 
 <h3>Improvements 🛠</h3>
+
+* A new `PennyLaneUserWarning` has been added to `exceptions` to warn users about special PennyLane tricks that might confuse them.
+  [(#7496)](https://github.com/PennyLaneAI/pennylane/pull/7496)
 
 * Setting up the configuration of a workflow, including the determination of the best diff
   method, is now done *after* user transforms have been applied. This allows transforms to

--- a/pennylane/exceptions.py
+++ b/pennylane/exceptions.py
@@ -28,5 +28,9 @@ class PennyLaneDeprecationWarning(UserWarning):  # pragma: no cover
     """Warning raised when a PennyLane feature is being deprecated."""
 
 
+class PennyLaneUserWarning(UserWarning):  # pragma: no cover
+    """Warning raised for user-facing issues or potential sources of confusion in PennyLane."""
+
+
 class ExperimentalWarning(UserWarning):  # pragma: no cover
     """Warning raised to indicate experimental/non-stable feature or support."""

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -30,7 +30,6 @@ filterwarnings =
     # Suppress expected AutoGraphWarnings that arise from the tests
     error:AutoGraph will not transform the function:pennylane.capture.autograph.AutoGraphWarning
     error::pennylane.exceptions.PennyLaneUserWarning
-    error::UserWarning
 #addopts = --benchmark-disable
 xfail_strict=true
 rng_salt = v0.40.0

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -29,6 +29,7 @@ filterwarnings =
     error::pennylane.exceptions.PennyLaneDeprecationWarning
     # Suppress expected AutoGraphWarnings that arise from the tests
     error:AutoGraph will not transform the function:pennylane.capture.autograph.AutoGraphWarning
+    error::pennylane.exceptions.PennyLaneUserWarning
 #addopts = --benchmark-disable
 xfail_strict=true
 rng_salt = v0.40.0

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -30,6 +30,7 @@ filterwarnings =
     # Suppress expected AutoGraphWarnings that arise from the tests
     error:AutoGraph will not transform the function:pennylane.capture.autograph.AutoGraphWarning
     error::pennylane.exceptions.PennyLaneUserWarning
+    error::UserWarning
 #addopts = --benchmark-disable
 xfail_strict=true
 rng_salt = v0.40.0


### PR DESCRIPTION
**Context:**
There are quite some PL-specific cornercases in the whole codebase, both for devs and users. To better track those who we are already aware of, it is good to introduce a new warnings different from the python default UserWarning so that we can filter things out specifically in the future.

For example,
```python
@qml.qnode(qml.device('default.qubit'))
def c():
    return qml.sample(wires=0)

qml.set_shots(c, 10)(shots=20)  # A PLUW to come up clarifying the final priority and setup order.
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-92053]