### PR TITLE
Remove fractional power decomposition test from assert_valid

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -255,6 +255,7 @@
     [(#7347)](https://github.com/PennyLaneAI/pennylane/pull/7347)
     [(#7352)](https://github.com/PennyLaneAI/pennylane/pull/7352)
     [(#7362)](https://github.com/PennyLaneAI/pennylane/pull/7362)
+    [(#7499)](https://github.com/PennyLaneAI/pennylane/pull/7499)
 
   ```python
   @qml.register_resources({qml.RY: 1})

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -118,7 +118,7 @@ def _check_decomposition_new(op, heuristic_resources=False):
         _test_decomposition_rule(adj_op, rule, heuristic_resources=heuristic_resources)
 
     for rule in qml.list_decomps(f"Pow({type(op).__name__})"):
-        for z in [0.25, 0.5, 2, 3, 4, 8, 9]:
+        for z in [2, 3, 4, 8, 9]:
             pow_op = qml.ops.Pow(op, z)
             _test_decomposition_rule(pow_op, rule, heuristic_resources=heuristic_resources)
 

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -1071,6 +1071,60 @@ class TestControlledMethod:
         qml.assert_equal(out, qml.CCZ(("a", 0, 1)))
 
 
+class TestSpecialPowDecomps:  # pylint: disable=too-few-public-methods
+    """Tests special decomposition rules for Pow of operators."""
+
+    @pytest.mark.parametrize("op", [qml.X(0), qml.Y(0), qml.Z(0), qml.S(0)])
+    def test_op_fractional_power(self, op):
+        """Test that fractional powers of operators are decomposed correctly."""
+
+        half_op = qml.pow(op, 0.5)
+        quart_op = qml.pow(op, 0.25)
+
+        decomps = qml.list_decomps(f"Pow({op.name})")
+        for rule in decomps:
+
+            if rule.is_applicable(**half_op.resource_params):
+
+                with qml.queuing.AnnotatedQueue() as q:
+                    rule(*half_op.parameters, wires=half_op.wires, **half_op.hyperparameters)
+                    rule(*half_op.parameters, wires=half_op.wires, **half_op.hyperparameters)
+
+                tape = qml.tape.QuantumScript.from_queue(q)
+                assert qml.math.allclose(qml.matrix(tape), qml.matrix(op))
+
+            if rule.is_applicable(**quart_op.resource_params):
+
+                with qml.queuing.AnnotatedQueue() as q:
+                    rule(*quart_op.parameters, wires=quart_op.wires, **quart_op.hyperparameters)
+                    rule(*quart_op.parameters, wires=quart_op.wires, **quart_op.hyperparameters)
+                    rule(*quart_op.parameters, wires=quart_op.wires, **quart_op.hyperparameters)
+                    rule(*quart_op.parameters, wires=quart_op.wires, **quart_op.hyperparameters)
+
+                tape = qml.tape.QuantumScript.from_queue(q)
+                assert qml.math.allclose(qml.matrix(tape), qml.matrix(op))
+
+    @pytest.mark.parametrize("z", [0.25, 0.5, 2, 4, 8, 9])
+    @pytest.mark.parametrize("op", [qml.ISWAP(wires=[0, 1]), qml.SISWAP(wires=[0, 1])])
+    def test_ISWAP_and_SISWAP_powers(self, op, z):
+        """Tests the power decomposition of ISWAP and SISWAP gates."""
+
+        pow_op = qml.pow(op, z)
+
+        decomps = qml.list_decomps(f"Pow({op.name})")
+        for rule in decomps:
+
+            if rule.is_applicable(**pow_op.resource_params):
+
+                with qml.queuing.AnnotatedQueue() as q:
+                    rule(*pow_op.parameters, wires=pow_op.wires, **pow_op.hyperparameters)
+
+                # It's fine to test matrix equivalence here because ISWAP and SISWAP
+                # have very specific power decompositions.
+                tape = qml.tape.QuantumScript.from_queue(q)
+                assert qml.math.allclose(qml.matrix(tape, wire_order=[0, 1]), qml.matrix(pow_op))
+
+
 SPARSE_MATRIX_SUPPORTED_OPERATIONS = (
     (qml.Identity(wires=0), I),
     (qml.Hadamard(wires=0), H),


### PR DESCRIPTION
**Context:**

Fractional powers of operators is not unique, therefore removing tests from `assert_valid`. Operators that defines special decompositions for certain fractional powers are tested individually on a case-by-case basis.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-92097]
