### PR TITLE
Fix `qml.TShift` power method

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1538,14 +1538,13 @@ class Operator(abc.ABC, metaclass=ABCCaptureMeta):
 
         """
         # Child methods may call super().pow(z%period) where op**period = I
-        # For example, PauliX**2 = I, SX**4 = I
-        # Hence we define 0 and 1 special cases here.
+        # For example, PauliX**2 = I, SX**4 = I, TShift**3 = I (for qutrit)
         if z == 0:
             return []
-        if z == 1:
+        if isinstance(z, int):
             if QueuingManager.recording():
-                return [qml.apply(self)]
-            return [copy.copy(self)]
+                return [qml.apply(self) for _ in range(z)]
+            return [copy.copy(self) for _ in range(z)]
         raise PowUndefinedError
 
     def queue(self, context: QueuingManager = QueuingManager):


### PR DESCRIPTION
This PR implements a fix for issue #6356 (`pow` method for non parametric operators acting on a single qutrit).

The method `Operator.pow` is supposed to return a list with a simplified "decomposition" of the given operator. For example, in the case of `TShift` we have `TShift**3` = `Identity` and so `TShift.pow(3)` returns an empty list. This PR handles the general case `TShift.pow(z)` returning a list with `z%3` copies of the given operator (actually the only relevant case is when `z=2`).

This fix should work also for the `qml.TClock` and `qml.TAdd` operators.

[sc-75304]