### PR TITLE
Pin `mitiq!=0.45.0`

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq==0.44.0 ply optax scipy-openblas32>=0.3.26 qualtran xdsl==0.38
+        pyzx matplotlib stim quimb mitiq!=0.45.0 ply optax scipy-openblas32>=0.3.26 qualtran xdsl==0.38
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq ply optax scipy-openblas32>=0.3.26 qualtran xdsl==0.38
+        pyzx matplotlib stim quimb mitiq==0.44.0 ply optax scipy-openblas32>=0.3.26 qualtran xdsl==0.38
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -649,7 +649,6 @@ class TestCatalystGrad:
 
         assert jnp.allclose(result, reference)
 
-    @pytest.mark.xfail(reason="Skipped temporarily to unblock CI, see sc-92105")
     def test_jacobian_fd(self):
         """Test the Jacobian transformation with 'fd'."""
         dev = qml.device("lightning.qubit", wires=1)


### PR DESCRIPTION
**Context:**
~external.txt said mitiq==0.44.0 so I don't understand why it's still updating.~ I see it's only `stable`
The mitiq 0.45 is [broken](https://github.com/unitaryfoundation/mitiq/issues/2767) for now and there's no way from PennyLane to fix very soon, so avoid it!

**Description of the Change:**
besides, we revert the `xfail` of a compiler test so that it doesn't fail wrongly.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
