### PR TITLE
[WIP] [Decomposition] The decompose transform accepts stopping_condition

### DIFF
--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -22,72 +22,13 @@ import warnings
 from collections import ChainMap
 from collections.abc import Generator, Iterable
 from functools import lru_cache, partial
-from typing import Callable, Optional, Sequence, Type
+from typing import Callable, Optional, Sequence
 
 import pennylane as qml
 from pennylane.decomposition import DecompositionGraph
 from pennylane.decomposition.utils import translate_op_alias
 from pennylane.operation import Operator
 from pennylane.transforms.core import transform
-
-
-def _resolve_gate_set(gate_set: set[type | str] | dict[type | str, float] = None):
-    """
-    From the provided gate_set dict, set (or None) resolves a standardized form for the gate_set,
-    as well as a tuple target_gate_types and set target_gate_names, and a function that
-    returns whether the gate set contains a given operator.
-
-    Args:
-        gate_set (set[type | str] | dict[type | str, float]): The gate_set to be resolved.
-
-    Returns:
-        gate_set (set[type | str] | dict[type | str, float]): The standardized gate_set.
-        target_gate_types tuple[type]: The types of the gates in the gate_set.
-        target_gate_names set[str]: The names of the gates in the gate_set.
-        gate_set_contains (Callable): A function that checks for the membership of a gate in the gate_set.
-    """
-    target_gate_types = tuple()
-    target_gate_names = set()
-
-    if gate_set is None:
-        gate_set: set[Type[Operator] | str] = set(qml.ops.__all__)
-
-    if isinstance(gate_set, (str, type)):
-        gate_set = {gate_set}
-
-    if isinstance(gate_set, dict):
-        for v in gate_set.values():
-            if v < 0.0:
-                raise ValueError(
-                    "Negative gate weights provided to gate_set in decompose" "are not supported."
-                )
-
-        if not qml.decomposition.enabled_graph():
-            raise TypeError(
-                "Specifying the gate_set with a dictionary of operator types and their weights is only supported "
-                "with the new experimental graph-based decomposition system. Enable the new system "
-                "using qml.decomposition.enable_graph()"
-            )
-
-    if isinstance(gate_set, Iterable):
-        target_gate_types = tuple(gate for gate in gate_set if isinstance(gate, type))
-        target_gate_names = set(
-            translate_op_alias(gate) for gate in gate_set if isinstance(gate, str)
-        )
-
-        def gate_set_contains(op):
-            return (op.name in target_gate_names) or isinstance(op, target_gate_types)
-
-    else:  # if isinstance(gate_set, Callable):
-        gate_set_contains = gate_set
-
-        if qml.decomposition.enabled_graph():
-            raise TypeError(
-                "Specifying gate_set as a function is not supported with the new "
-                "graph-based decomposition system enabled."
-            )
-
-    return gate_set, target_gate_types, target_gate_names, gate_set_contains
 
 
 def null_postprocessing(results):
@@ -137,43 +78,38 @@ def _get_plxpr_decompose():  # pylint: disable=missing-docstring, too-many-state
         when program capture is enabled.
         """
 
-        def __init__(self, gate_set=None, max_expansion=None, fixed_decomps=None, alt_decomps=None):
+        def __init__(
+            self,
+            gate_set=None,
+            stopping_condition=None,
+            max_expansion=None,
+            fixed_decomps=None,
+            alt_decomps=None,
+        ):
 
             self.max_expansion = max_expansion
             self._current_depth = 0
 
+            if not qml.decomposition.enabled_graph() and (fixed_decomps or alt_decomps):
+                raise TypeError(
+                    "The keyword arguments fixed_decomps and alt_decomps are only available with "
+                    "the new experimental graph-based decomposition system. Use qml.decomposition.enable_graph() "
+                    "to enable the new system."
+                )
+
             self._decomp_graph = None
             self._target_gate_names = None
-            _decomp_graph_kwargs_checks(fixed_decomps, alt_decomps)
             self._fixed_decomps, self._alt_decomps = fixed_decomps, alt_decomps
 
-            # We use a ChainMap to store the environment frames,
-            # which allows us to push and pop environments without copying
-            # the interpreter instance when we evaluate a jaxpr of a dynamic decomposition.
-
-            # The name is different from the _env in the parent class (a dictionary) to avoid confusion.
+            # We use a ChainMap to store the environment frames, which allows us to push and pop
+            # environments without copying the interpreter instance when we evaluate a jaxpr of
+            # a dynamic decomposition. The name is different from the _env in the parent class
+            # (a dictionary) to avoid confusion.
             self._env_map = ChainMap()
 
-            gate_set, target_gate_types, target_gate_names, _in_gate_set = _resolve_gate_set(
-                gate_set
-            )
-
-            if isinstance(gate_set, Iterable):
-
-                self.gate_set_contains = _in_gate_set
-
-                if qml.decomposition.enabled_graph():
-
-                    type_to_names = {op_type.__name__ for op_type in target_gate_types}
-                    self._gate_set = (
-                        gate_set
-                        if isinstance(gate_set, dict)
-                        else target_gate_names | type_to_names
-                    )
-
-            else:  # isinstance(gate_set, Callable)
-
-                self.gate_set_contains: Callable[[Operator], bool] = gate_set
+            gate_set, stopping_condition = _resolve_gate_set(gate_set, stopping_condition)
+            self._gate_set = gate_set
+            self._stopping_condition = stopping_condition
 
         def setup(self) -> None:
             """Setup the environment for the interpreter by pushing a new environment frame."""
@@ -207,10 +143,10 @@ def _get_plxpr_decompose():  # pylint: disable=missing-docstring, too-many-state
             # If the new graph-based decomposition is enabled,
             # we don't rely on the has_decomposition attribute.
             if qml.decomposition.enabled_graph():
-                return self.gate_set_contains(op)
+                return self._stopping_condition(op)
 
             if not op.has_decomposition:
-                if not self.gate_set_contains(op):
+                if not self._stopping_condition(op):
                     warnings.warn(
                         f"Operator {op.name} does not define a decomposition and was not "
                         f"found in the target gate set. To remove this warning, add the operator "
@@ -219,7 +155,7 @@ def _get_plxpr_decompose():  # pylint: disable=missing-docstring, too-many-state
                     )
                 return True
 
-            return self.gate_set_contains(op)
+            return self._stopping_condition(op)
 
         def decompose_operation(self, op: qml.operation.Operator):
             """Decompose a PennyLane operation instance if it does not satisfy the
@@ -234,7 +170,7 @@ def _get_plxpr_decompose():  # pylint: disable=missing-docstring, too-many-state
             See also: :meth:`~.interpret_operation_eqn`, :meth:`~.interpret_operation`.
             """
 
-            if self.gate_set_contains(op):
+            if self.stopping_condition(op):
                 return self.interpret_operation(op)
 
             max_expansion = (
@@ -256,7 +192,7 @@ def _get_plxpr_decompose():  # pylint: disable=missing-docstring, too-many-state
         def _evaluate_jaxpr_decomposition(self, op: qml.operation.Operator):
             """Creates and evaluates a Jaxpr of the plxpr decomposition of an operator."""
 
-            if self.gate_set_contains(op):
+            if self.stopping_condition(op):
                 return self.interpret_operation(op)
 
             if self.max_expansion is not None and self._current_depth >= self.max_expansion:
@@ -428,7 +364,9 @@ DecomposeInterpreter, decompose_plxpr_to_plxpr = _get_plxpr_decompose()
 @partial(transform, plxpr_transform=decompose_plxpr_to_plxpr)
 def decompose(
     tape,
+    *,
     gate_set=None,
+    stopping_condition=None,
     max_expansion=None,
     fixed_decomps: dict = None,
     alt_decomps: dict = None,
@@ -449,11 +387,17 @@ def decompose(
 
     Args:
         tape (QuantumScript or QNode or Callable): a quantum circuit.
-        gate_set (Iterable[str or type], Dict[type or str, float], or Callable, optional): The target gate
-            set specified as either (1) a sequence of operator types and/or names, (2) a function that returns
-            ``True`` if the operator belongs to the target gate set or (3) a dictionary of operator
-            types and/or names with weights. Defaults to ``None``, in which case the gate set is
-            considered to be all available :doc:`quantum operators </introduction/operations>`.
+        gate_set (Iterable[str or type], Dict[type or str, float] or Callable, optional): The
+            target gate set specified as either (1) a sequence of operator types and/or names,
+            (2) a dictionary mapping operator types and/or names to their respective costs, in
+            which case the total cost will be minimized (only available when the new graph-based
+            decomposition system is enabled), or (3) a function that returns ``True`` if the
+            operator belongs to the target gate set (not supported with the new graph-based
+            decomposition system). If ``None``, the gate set is considered to be all available
+            :doc:`quantum operators </introduction/operations>`.
+        stopping_condition (Callable, optional): a function that returns ``True`` if the operator
+            does not need to be decomposed. If ``None``, the default stopping condition is whether
+            the operator is in the target gate set. TODO: add details section about this.
         max_expansion (int, optional): The maximum depth of the decomposition. Defaults to ``None``.
             If ``None``, the circuit will be decomposed until the target gate set is reached.
         fixed_decomps (Dict[Type[Operator], DecompositionRule]): a dictionary mapping operator types
@@ -737,19 +681,24 @@ def decompose(
 
     """
 
-    _decomp_graph_kwargs_checks(fixed_decomps, alt_decomps)
+    if not qml.decomposition.enabled_graph() and (fixed_decomps or alt_decomps):
+        raise TypeError(
+            "The keyword arguments fixed_decomps and alt_decomps are only available with the new "
+            "experimental graph-based decomposition system. Use qml.decomposition.enable_graph() "
+            "to enable the new system."
+        )
 
-    gate_set, target_gate_types, target_gate_names, gate_set_contains = _resolve_gate_set(gate_set)
+    gate_set, stopping_condition = _resolve_gate_set(gate_set, stopping_condition)
 
-    def stopping_condition(op):
+    def _stopping_condition(op):
 
         # If the new graph-based decomposition is enabled,
         # we don't rely on the has_decomposition attribute.
         if qml.decomposition.enabled_graph():
-            return gate_set_contains(op)
+            return stopping_condition(op)
 
         if not op.has_decomposition:
-            if not gate_set_contains(op):
+            if not stopping_condition(op):
                 warnings.warn(
                     f"Operator {op.name} does not define a decomposition and was not "
                     f"found in the target gate set. To remove this warning, add the operator name "
@@ -758,9 +707,9 @@ def decompose(
                 )
             return True
 
-        return gate_set_contains(op)
+        return stopping_condition(op)
 
-    if all(stopping_condition(op) for op in tape.operations):
+    if all(_stopping_condition(op) for op in tape.operations):
         return (tape,), null_postprocessing
 
     # If the decomposition graph is enabled, we create a DecompositionGraph instance
@@ -769,12 +718,9 @@ def decompose(
 
     if qml.decomposition.enabled_graph():
 
-        types_to_names = {op_type.__name__ for op_type in target_gate_types}
-        target_gate_names = target_gate_names | types_to_names
-
         decomp_graph = _construct_and_solve_decomp_graph(
             tape.operations,
-            target_gate_names if not isinstance(gate_set, dict) else gate_set,
+            gate_set,
             fixed_decomps=fixed_decomps,
             alt_decomps=alt_decomps,
         )
@@ -784,7 +730,7 @@ def decompose(
             final_op
             for op in tape.operations
             for final_op in _operator_decomposition_gen(
-                op, stopping_condition, max_expansion=max_expansion, decomp_graph=decomp_graph
+                op, _stopping_condition, max_expansion=max_expansion, decomp_graph=decomp_graph
             )
         ]
     except RecursionError as e:
@@ -836,15 +782,77 @@ def _operator_decomposition_gen(
         )
 
 
-def _decomp_graph_kwargs_checks(fixed_decomps, alt_decomps):
-    """Check the keyword arguments for the decompose transform for the graph-based decomposition."""
+def _resolve_gate_set(
+    gate_set: set[type | str] | dict[type | str, float] = None,
+    stopping_condition: Callable[[qml.operation.Operator], bool] = None,
+) -> tuple[set[type | str] | dict[type | str, float], Callable[[qml.operation.Operator], bool]]:
+    """Resolve the gate set and the stopping condition from arguments.
 
-    if not qml.decomposition.enabled_graph() and (fixed_decomps or alt_decomps):
+    The ``gate_set`` can be provided in various forms, and the ``stopping_condition`` may or
+    may not be provided. This function will resolve the gate set and the stopping condition
+    to the following standardized form:
+
+    - The ``gate_set`` is set of operator **types** and/or names, or a dictionary mapping operator
+      types and/or names to their respective costs. This is only used by the DecompositionGraph
+    - The ``stopping_condition`` is a function that takes an operator **instances** and returns
+      ``True`` if the operator does not need to be decomposed. This is used during decomposition.
+
+    """
+
+    if not qml.decomposition.enabled_graph() and gate_set and stopping_condition:
+        # In the old decomposition system, we don't make the distinction between a set of
+        # target gates and the stopping condition, so to avoid ambiguity, we don't allow both
+        # to be specified at the same time.
         raise TypeError(
-            "The keyword arguments fixed_decomps and alt_decomps are only available with the new "
+            "Specifying both gate_set and stopping_condition is only supported with the new "
             "experimental graph-based decomposition system. Use qml.decomposition.enable_graph() "
             "to enable the new system."
         )
+
+    if gate_set is None:
+        gate_set = set(qml.ops.__all__)
+
+    if isinstance(gate_set, (str, type)):
+        gate_set = {gate_set}
+
+    if isinstance(gate_set, dict):
+
+        if any(v < 0 for v in gate_set.values()):
+            raise ValueError("Negative gate weights provided to gate_set are not supported.")
+
+        if not qml.decomposition.enabled_graph():
+            raise TypeError(
+                "Specifying the gate_set with a dictionary of operator types and their weights "
+                "is only supported with the new experimental graph-based decomposition system. "
+                "Enable the new system using qml.decomposition.enable_graph()."
+            )
+
+    if isinstance(gate_set, Iterable):
+
+        gate_types = tuple(gate for gate in gate_set if isinstance(gate, type))
+        gate_names = set(translate_op_alias(gate) for gate in gate_set if isinstance(gate, str))
+
+        def gate_set_contains(op: Operator) -> bool:
+            return (op.name in gate_names) or isinstance(op, gate_types)
+
+    elif isinstance(gate_set, Callable):
+
+        gate_set_contains = gate_set
+
+        if qml.decomposition.enabled_graph():
+            raise TypeError(
+                "Specifying gate_set as a function is not supported with the new "
+                "graph-based decomposition system enabled."
+            )
+
+    else:
+        raise TypeError("Invalid gate_set type. Must be an iterable, dictionary, or function.")
+
+    # If the stopping condition is not explicitly provided, the default is to simply check
+    # whether an operator belongs to the target gate set.
+    stopping_condition = stopping_condition or gate_set_contains
+
+    return gate_set, stopping_condition
 
 
 def _construct_and_solve_decomp_graph(operations, target_gates, fixed_decomps, alt_decomps):
@@ -860,5 +868,4 @@ def _construct_and_solve_decomp_graph(operations, target_gates, fixed_decomps, a
 
     # Find the efficient pathways to the target gate set
     decomp_graph.solve()
-
     return decomp_graph

--- a/tests/transforms/test_decompose_transform.py
+++ b/tests/transforms/test_decompose_transform.py
@@ -154,7 +154,7 @@ class TestDecompose:
         """Test that a recursion error is raised if decomposition enters an infinite loop."""
         tape = qml.tape.QuantumScript([InfiniteOp(1.23, 0)])
         with pytest.raises(RecursionError, match=r"Reached recursion limit trying to decompose"):
-            decompose(tape, lambda obj: obj.has_matrix)
+            decompose(tape, gate_set=lambda obj: obj.has_matrix)
 
     @pytest.mark.parametrize(
         "initial_ops, gate_set, expected_ops, warning_or_error_pattern", iterables_test

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -28,10 +28,7 @@ def test_weighted_graph_handles_negative_weight():
     tape = qml.tape.QuantumScript([])
 
     # edge case: negative gate weight
-    with pytest.raises(
-        ValueError,
-        match="Negative gate weights provided to gate_set in decompose" "are not supported.",
-    ):
+    with pytest.raises(ValueError, match="Negative gate weights"):
         qml.transforms.decompose(tape, gate_set={"CNOT": -10.0, "RZ": 1.0})
 
 


### PR DESCRIPTION
**Context:**

PennyLane currently relies on decompositions derived from a given stopping_condition (or stopping_condition_shots) function in multiple places within the broader code base. We want to be sure that the new decompositions system can be used in every internal facet of PennyLane.

The `gate_set` and `stopping_condition` are two different concepts. The `stopping_condition` is an acceptance criteria for operator instances that need no further decomposition, but on top of this, the decomposition graph requires a set of gate types as the target gate set. With graph enabled, the `decompose` transform would take both `gate_set` that is a set of gate types, and `stopping_condition` that takes operator instances.

**Description of the Change:**

Adds a `stopping_condition` argument to the `decompose` transform.

- Graph Enabled
  - `gate_set` must be an iterable of gate types and/or names or a dictionary (weighted gate set)
  - `stopping_condition` must be a callable that takes operator instances and returns `True` or `False`
    - If not provided, the default stopping condition is "whether the operator is part of the gate set"
- Graph Disabled
  - Either provide `gate_set` or `stopping_condition`, but not both (the old system does not make the distinction, so we require that only one of them is given to prevent ambiguity.
  - If `gate_set` is provided, it is ultimately translated to a callable stopping condition (same behaviour as before)
  - If `stopping_condition` is provided, it is used directly.

**Benefits:**

An instance-based stopping condition is supported in the new graph-based decomposition system.

**Related GitHub Issues:**

[sc-92234]
