### PR TITLE
[circ. deps] enforce `qnn` as "tertiary" module

### DIFF
--- a/pennylane/qnn/cost.py
+++ b/pennylane/qnn/cost.py
@@ -15,7 +15,7 @@
 This submodule contains frequently used loss and cost functions.
 """
 # pylint: disable=too-many-arguments
-import pennylane as qml
+from pennylane import measurements
 
 
 class SquaredErrorLoss:
@@ -98,12 +98,15 @@ class SquaredErrorLoss:
         diff_method="best",
         **kwargs,
     ):
-        @qml.qnode(device, diff_method=diff_method, interface=interface, *kwargs)
-        def qnode(params, **circuit_kwargs):
-            ansatz(params, wires=device.wires, **circuit_kwargs)
-            return [getattr(qml, measure)(o) for o in observables]
+        # pylint: disable=import-outside-toplevel
+        from pennylane.workflow.qnode import qnode
 
-        self.qnode = qnode
+        @qnode(device, diff_method=diff_method, interface=interface, *kwargs)
+        def qn(params, **circuit_kwargs):
+            ansatz(params, wires=device.wires, **circuit_kwargs)
+            return [getattr(measurements, measure)(o) for o in observables]
+
+        self.qnode = qn
 
     def loss(self, *args, target=None, **kwargs):
         r"""Calculates the squared error loss between the observables'

--- a/pennylane/qnn/torch.py
+++ b/pennylane/qnn/torch.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 """This module contains the classes and functions for integrating QNodes with the Torch Module
 API."""
+from __future__ import annotations
 
 import contextlib
 import functools
 import inspect
 import math
 from collections.abc import Callable, Iterable
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
-from pennylane import QNode
+if TYPE_CHECKING:
+    from pennylane.workflow.qnode import QNode
 
 try:
     import torch

--- a/tach.toml
+++ b/tach.toml
@@ -221,6 +221,11 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.pyth
 # These modules can only import from CORE, AUXILIARY and modules within their layer.
 
 [[modules]]
+path = "pennylane.qnn"
+layer = "tertiary"
+cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.python_compiler"]
+
+[[modules]]
 path = "pennylane.qaoa"
 layer = "tertiary"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.python_compiler"]
@@ -327,10 +332,6 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.pyth
 
 [[modules]]
 path = "pennylane.pulse"
-cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.python_compiler"]
-
-[[modules]]
-path = "pennylane.qnn"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs", "pennylane.compiler.python_compiler"]
 
 [[modules]]


### PR DESCRIPTION
**Context:**

The goal of this PR is to isolate the `qnn` module as a `tertiary` module.

**Description of the Change:**

- Updates `tach.toml` 
- Cleans-up the module's imports
- Fixes any errors `tach` identifies

**Benefits:** Module dependency enforcement.

**Possible Drawbacks:** None.

[sc-]