### PR TITLE
[Capture] grad and jacobian can be captured with dynamic shapes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -296,6 +296,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* `qml.grad` and `qml.jacobian` can now handle inputs with dynamic shapes being captured into plxpr.
+
 * Improved the drawing of `GlobalPhase`, `ctrl(GlobalPhase)`, `Identity` and `ctrl(Identity)` operations.
   The labels are grouped together like for other multi-qubit operations, and the drawing
   no longer depends on the wires of `GlobalPhase` or `Identity`. Control nodes of controlled global phases

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -300,6 +300,7 @@
 <h3>Improvements 🛠</h3>
 
 * `qml.grad` and `qml.jacobian` can now handle inputs with dynamic shapes being captured into plxpr.
+  [(#7544)](https://github.com/PennyLaneAI/pennylane/pull/7544/)
 
 * Improved the drawing of `GlobalPhase`, `ctrl(GlobalPhase)`, `Identity` and `ctrl(Identity)` operations.
   The labels are grouped together like for other multi-qubit operations, and the drawing

--- a/pennylane/_grad.py
+++ b/pennylane/_grad.py
@@ -87,7 +87,7 @@ def _capture_diff(func, argnum=None, diff_prim=None, method=None, h=None):
             *jaxpr.consts, *abstract_shapes, *flat_args, **prim_kwargs, method=method, h=h
         )
 
-        # fl --atten once more to go from 2D derivative structure (outputs, args) to flat structure
+        # flatten once more to go from 2D derivative structure (outputs, args) to flat structure
         out_flat = tree_leaves(out_flat)
         assert flat_fn.out_tree is not None, "out_tree should be set after executing flat_fn"
         # The derivative output tree is the composition of output tree and trainable input trees

--- a/pennylane/capture/capture_diff.py
+++ b/pennylane/capture/capture_diff.py
@@ -55,9 +55,15 @@ def _get_grad_prim():
     def _(*args, argnum, jaxpr, n_consts, method, h):
         if len(jaxpr.outvars) != 1 or jaxpr.outvars[0].aval.shape != ():
             raise TypeError("Grad only applies to scalar-output functions. Try jacobian.")
-        return tuple(jaxpr.invars[i].aval for i in argnum)
+        return tuple(args[i + n_consts] for i in argnum)
 
     return grad_prim
+
+
+def _shape(shape, dtype):
+    if jax.config.jax_dynamic_shapes and any(not isinstance(s, int) for s in shape):
+        return jax.core.DShapedArray(shape, dtype)
+    return jax.core.ShapedArray(shape, dtype)
 
 
 @lru_cache
@@ -89,10 +95,10 @@ def _get_jacobian_prim():
     # pylint: disable=unused-argument
     @jacobian_prim.def_abstract_eval
     def _(*args, argnum, jaxpr, n_consts, method, h):
-        in_avals = [jaxpr.invars[i].aval for i in argnum]
-        out_shapes = (outvar.aval.shape for outvar in jaxpr.outvars)
+        in_avals = tuple(args[i + n_consts] for i in argnum)
+        out_shapes = tuple(outvar.aval.shape for outvar in jaxpr.outvars)
         return [
-            jax.core.ShapedArray(out_shape + in_aval.shape, in_aval.dtype)
+            _shape(out_shape + in_aval.shape, in_aval.dtype)
             for out_shape in out_shapes
             for in_aval in in_avals
         ]

--- a/tests/capture/test_capture_diff.py
+++ b/tests/capture/test_capture_diff.py
@@ -329,6 +329,35 @@ class TestGrad:
         assert manual_out_tree == jax.tree_util.tree_flatten(manual_out_flat)[1]
         assert qml.math.allclose(jax_out_flat, manual_out_flat)
 
+    @pytest.mark.usefixtures("enable_disable_dynamic_shapes")
+    @pytest.mark.parametrize("same_dynamic_shape", (True, False))
+    def test_grad_dynamic_shape_inputs(self, same_dynamic_shape):
+        """Test that qml.grad can handle dynamic shapes"""
+
+        @qml.qnode(qml.device("default.qubit", wires=4))
+        def c(x, y):
+            qml.RX(x, 0)
+            qml.RY(y, 0)
+            return qml.expval(qml.Z(0))
+
+        def w(n):
+            x = jnp.arange(n)
+            if same_dynamic_shape:
+                y = jnp.arange(n)
+            else:
+                y = jnp.arange(n + 1)
+            return qml.grad(c, argnum=(0, 1))(x, y)
+
+        jaxpr = jax.make_jaxpr(w)(2)
+        grad_eqn = jaxpr.eqns[2] if same_dynamic_shape else jaxpr.eqns[3]
+        assert grad_eqn.primitive == grad_prim
+
+        shift = 1 if same_dynamic_shape else 2
+        assert grad_eqn.params["argnum"] == [shift, shift + 1]
+        assert len(grad_eqn.outvars) == 2
+        assert grad_eqn.outvars[0].aval.shape == grad_eqn.invars[shift].aval.shape
+        assert grad_eqn.outvars[1].aval.shape == grad_eqn.invars[shift + 1].aval.shape
+
 
 def _jac_allclose(jac1, jac2, num_axes, atol=1e-8):
     """Test that two Jacobians, given as nested sequences of arrays, are equal."""
@@ -582,3 +611,33 @@ class TestJacobian:
         # Assert that the output from the manual evaluation is flat
         assert manual_out_tree == jax.tree_util.tree_flatten(manual_out_flat)[1]
         assert qml.math.allclose(jax_out_flat, manual_out_flat)
+
+    @pytest.mark.usefixtures("enable_disable_dynamic_shapes")
+    @pytest.mark.parametrize("same_dynamic_shape", (True, False))
+    def test_jacobian_dynamic_shape_inputs(self, same_dynamic_shape):
+        """Test that qml.jacobian can handle dynamic shapes"""
+
+        @qml.qnode(qml.device("default.qubit", wires=4))
+        def c(x, y):
+            qml.RX(x, 0)
+            qml.RY(y, 0)
+            return qml.probs(wires=(0, 1))
+
+        def w(n):
+            x = jnp.arange(n)
+            if same_dynamic_shape:
+                y = jnp.arange(n)
+            else:
+                y = jnp.arange(n + 1)
+            return qml.jacobian(c, argnum=(0, 1))(x, y)
+
+        jaxpr = jax.make_jaxpr(w)(2)
+        grad_eqn = jaxpr.eqns[2] if same_dynamic_shape else jaxpr.eqns[3]
+        assert grad_eqn.primitive == jacobian_prim
+
+        shift = 1 if same_dynamic_shape else 2
+        assert grad_eqn.params["argnum"] == [shift, shift + 1]
+        assert len(grad_eqn.outvars) == 2
+
+        assert grad_eqn.outvars[0].aval.shape == (4, *grad_eqn.invars[shift].aval.shape)
+        assert grad_eqn.outvars[1].aval.shape == (4, *grad_eqn.invars[shift + 1].aval.shape)


### PR DESCRIPTION
**Context:**

`qml.grad` and `qml.jacobian` cannot yet handle arguments with dynamic shapes.

**Description of the Change:**

Update our handling of grad and jacobian so that we can handle arguments with dynamic shapes.

**Benefits:**

Improved capture.

**Possible Drawbacks:**

The same drawbacks of everything to do with dynamic shapes. They have flaky support from jax and using them couples us to some internal, experimental details.

**Related GitHub Issues:**

[sc-89308]