### PR TITLE
Fixed docstring in the qjit function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -629,6 +629,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   disabling program capture.
   [(#7298)](https://github.com/PennyLaneAI/pennylane/pull/7298)
 
+* Fixed the wrong `sum` to `sum_abstracted` in the :doc:`/news/qjit_api` page.
+  [(#7587)](https://github.com/PennyLaneAI/pennylane/pull/7587)
+
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug where certain transforms with a native program capture implementation give incorrect results when
@@ -733,6 +736,7 @@ Marcus Edwards,
 Lillian Frederiksen,
 Pietropaolo Frisoni,
 Simone Gasperini,
+Sengthai Heng,
 Korbinian Kottmann,
 Christina Lee,
 Anton Naim Ibrahim,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -450,6 +450,9 @@
 
 * Updated documentation check to remove duplicate docstring references. [(#7453)](https://github.com/PennyLaneAI/pennylane/pull/7453)
 
+* Fixed the wrong `sum` to `sum_abstracted` in the docstring on :func:`~pennylane.compiler.qjit`.
+  [(#7587)](https://github.com/PennyLaneAI/pennylane/pull/7587)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 
@@ -628,9 +631,6 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   with the global toggles ``qml.capture.enable()`` and ``qml.capture.disable()`` for enabling and
   disabling program capture.
   [(#7298)](https://github.com/PennyLaneAI/pennylane/pull/7298)
-
-* Fixed the wrong `sum` to `sum_abstracted` in the :doc:`/news/qjit_api` page.
-  [(#7587)](https://github.com/PennyLaneAI/pennylane/pull/7587)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/pennylane/compiler/qjit_api.py
+++ b/pennylane/compiler/qjit_api.py
@@ -277,8 +277,8 @@ def qjit(fn=None, *args, compiler="catalyst", **kwargs):  # pylint:disable=keywo
             def sum_abstracted(arr):
                 return jnp.sum(arr)
 
-            sum(jnp.array([1]))     # Compilation happens here.
-            sum(jnp.array([1, 1]))  # No need to recompile.
+            sum_abstracted(jnp.array([1]))     # Compilation happens here.
+            sum_abstracted(jnp.array([1, 1]))  # No need to recompile.
 
         The ``sum_abstracted`` function would only compile once and its definition would be
         reused for subsequent function calls.


### PR DESCRIPTION
**Description of the Change:**
Updated the qjit function to utilize the `sum_abstracted` function instead of directly calling `sum`. 