### PR TITLE
Add controlled decomposition methods for single qubit operators

### DIFF
--- a/pennylane/labs/resource_estimation/ops/identity.py
+++ b/pennylane/labs/resource_estimation/ops/identity.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""Resource operators for identity operations."""
-
+import pennylane.labs.resource_estimation as re
+from pennylane.labs.resource_estimation.qubit_manager import AllocWires, FreeWires
 from pennylane.labs.resource_estimation.resource_operator import (
     CompressedResourceOp,
     GateCount,
     ResourceOperator,
+    resource_rep,
 )
 
 # pylint: disable=arguments-differ,no-self-use,too-many-ancestors
@@ -190,6 +192,50 @@ class ResourceGlobalPhase(ResourceOperator):
                 in the decomposition.
         """
         return [GateCount(cls.resource_rep())]
+
+    @classmethod
+    def default_controlled_resource_decomp(
+        cls,
+        ctrl_num_ctrl_wires: int,
+        ctrl_num_ctrl_values: int,
+    ) -> list[GateCount]:
+        r"""Returns a dictionary representing the resources for a controlled version of the operator.
+
+        Args:
+            ctrl_num_ctrl_wires (int): the number of qubits the operation is controlled on
+            ctrl_num_ctrl_values (int): the number of control qubits, that are controlled when in the :math:`|0\rangle` state
+
+        Resources:
+            The resources are generated from the fact that a global phase controlled on a
+            single qubit is equivalent to a local phase shift on that control qubit.
+
+            This idea can be generalized to a multi-qubit global phase by introducing one
+            'clean' auxilliary qubit which gets reset at the end of the computation. In this
+            case, we sandwich the phase shift operation with two multi-controlled X gates.
+
+        Returns:
+            list[GateCount]: A list of GateCount objects, where each object
+                represents a specific quantum gate and the number of times it appears
+                in the decomposition.
+        """
+        if ctrl_num_ctrl_wires == 1:
+            gate_types = [GateCount(resource_rep(re.ResourcePhaseShift))]
+
+            if ctrl_num_ctrl_values:
+                gate_types.append(GateCount(resource_rep(re.ResourceX), 2))
+
+            return gate_types
+
+        ps = resource_rep(re.ResourcePhaseShift)
+        mcx = resource_rep(
+            re.ResourceMultiControlledX,
+            {
+                "num_ctrl_wires": ctrl_num_ctrl_wires,
+                "num_ctrl_values": ctrl_num_ctrl_values,
+            },
+        )
+
+        return [AllocWires(1), GateCount(ps), GateCount(mcx, 2), FreeWires(1)]
 
     @classmethod
     def default_pow_resource_decomp(cls, pow_z) -> list[GateCount]:

--- a/pennylane/labs/tests/resource_estimation/ops/qubit/test_non_parametric_ops.py
+++ b/pennylane/labs/tests/resource_estimation/ops/qubit/test_non_parametric_ops.py
@@ -48,6 +48,57 @@ class TestHadamard:
         expected = [re.GateCount(re.ResourceHadamard.resource_rep(), 1)]
         assert h_dag == expected
 
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceCH.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceCH.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceHadamard.resource_rep(), 2),
+                re.GateCount(re.ResourceRY.resource_rep(), 2),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(2, 0), 1),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceHadamard.resource_rep(), 2),
+                re.GateCount(re.ResourceRY.resource_rep(), 2),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 1),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceHadamard(0)
+        op2 = re.ResourceControlled(op, num_ctrl_wires, num_ctrl_values)
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
     pow_data = (
         (1, [re.GateCount(re.ResourceHadamard.resource_rep(), 1)]),
         (2, [re.GateCount(re.ResourceIdentity.resource_rep(), 1)]),
@@ -60,6 +111,9 @@ class TestHadamard:
         """Test that the pow decomposition is correct."""
         op = re.ResourceHadamard(0)
         assert op.pow_resource_decomp(z) == expected_res
+
+        op2 = re.ResourcePow(op, z)
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
 
 
 class TestS:
@@ -100,7 +154,6 @@ class TestS:
         ]
         assert re.ResourceS.adjoint_resource_decomp() == expected
 
-
     pow_data = (
         (1, [re.GateCount(re.ResourceS.resource_rep(), 1)]),
         (2, [re.GateCount(re.ResourceZ.resource_rep(), 1)]),
@@ -135,6 +188,61 @@ class TestS:
         """Test that the pow decomposition is correct."""
         op = re.ResourceS(0)
         assert op.pow_resource_decomp(z) == expected_res
+        op2 = re.ResourcePow(op, z)
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(2, 0), 2),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 2),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceS(0)
+        op2 = re.ResourceControlled(
+            op,
+            num_ctrl_wires,
+            num_ctrl_values,
+        )
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
 
 
 class TestT:
@@ -164,6 +272,58 @@ class TestT:
             re.GateCount(re.ResourceZ.resource_rep(), 1),
         ]
         assert re.ResourceT.adjoint_resource_decomp() == expected
+
+        t_dag = re.ResourceAdjoint(re.ResourceT())
+        assert t_dag.resource_decomp(**t_dag.resource_params) == expected
+
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(2, 0), 2),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceControlledPhaseShift.resource_rep(), 1),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 2),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceT(0)
+        op2 = re.ResourceControlled(op, num_ctrl_wires, num_ctrl_values)
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
 
     pow_data = (
         (1, [re.GateCount(re.ResourceT.resource_rep(), 1)]),
@@ -230,17 +390,79 @@ class TestX:
         expected = re.CompressedResourceOp(re.ResourceX, {})
         assert re.ResourceX.resource_rep() == expected
 
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceCNOT.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+                re.GateCount(re.ResourceCNOT.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceToffoli.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [0, 0],
+            [
+                re.GateCount(re.ResourceX.resource_rep(), 4),
+                re.GateCount(re.ResourceToffoli.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 1),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3", "c4"],
+            [1, 0, 0, 1],
+            [
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(4, 2), 1),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceX(0)
+        op2 = re.ResourceControlled(op, num_ctrl_wires, num_ctrl_values)
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
     def test_adjoint_decomposition(self):
         """Test that the adjoint resources are correct."""
         expected = [re.GateCount(re.ResourceX.resource_rep(), 1)]
         assert re.ResourceX.adjoint_resource_decomp() == expected
 
-        # x = re.ResourceX(0)
-        # x_dag = re.ResourceAdjoint(x)
+        x = re.ResourceX(0)
+        x_dag = re.ResourceAdjoint(x)
 
-        # r1 = re.get_resources(x)
-        # r2 = re.get_resources(x_dag)
-        # assert r1 == r2
+        r1 = re.estimate_resources(x)
+        r2 = re.estimate_resources(x_dag)
+        assert r1 == r2
 
     pow_data = (
         (1, [re.GateCount(re.ResourceX.resource_rep(), 1)]),
@@ -255,6 +477,9 @@ class TestX:
         op = re.ResourceX(0)
         assert op.pow_resource_decomp(z) == expected_res
 
+        op2 = re.ResourcePow(op, z)
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
 
 class TestY:
     """Tests for the ResourceY gate"""
@@ -264,8 +489,10 @@ class TestY:
         expected = [
             re.GateCount(re.resource_rep(re.ResourceS), 1),
             re.GateCount(re.resource_rep(re.ResourceZ), 1),
-            re.GateCount(re.resource_rep(re.ResourceAdjoint, {"base_cmpr_op": re.resource_rep(re.ResourceS)})),
-            re.GateCount(re.resource_rep(re.ResourceHadamard), 2)
+            re.GateCount(
+                re.resource_rep(re.ResourceAdjoint, {"base_cmpr_op": re.resource_rep(re.ResourceS)})
+            ),
+            re.GateCount(re.resource_rep(re.ResourceHadamard), 2),
         ]
         assert re.ResourceY.resource_decomp() == expected
 
@@ -279,10 +506,92 @@ class TestY:
         expected = re.CompressedResourceOp(re.ResourceY, {})
         assert re.ResourceY.resource_rep() == expected
 
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceCY.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceCY.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceS.resource_rep(), 1),
+                re.GateCount(
+                    re.resource_rep(
+                        re.ResourceAdjoint, {"base_cmpr_op": re.ResourceS.resource_rep()}
+                    ),
+                    1,
+                ),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(2, 0), 1),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [0, 0],
+            [
+                re.GateCount(re.ResourceS.resource_rep(), 1),
+                re.GateCount(
+                    re.resource_rep(
+                        re.ResourceAdjoint, {"base_cmpr_op": re.ResourceS.resource_rep()}
+                    ),
+                    1,
+                ),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(2, 2), 1),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceS.resource_rep(), 1),
+                re.GateCount(
+                    re.resource_rep(
+                        re.ResourceAdjoint, {"base_cmpr_op": re.ResourceS.resource_rep()}
+                    ),
+                    1,
+                ),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 1),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceY(0)
+        op2 = re.ResourceControlled(op, num_ctrl_wires, num_ctrl_values)
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
     def test_adjoint_decomposition(self):
         """Test that the adjoint resources are correct."""
         expected = [re.GateCount(re.ResourceY.resource_rep(), 1)]
         assert re.ResourceY.adjoint_resource_decomp() == expected
+
+        y = re.ResourceY(0)
+        y_dag = re.ResourceAdjoint(y)
+
+        r1 = re.estimate_resources(y)
+        r2 = re.estimate_resources(y_dag)
+        assert r1 == r2
 
     pow_data = (
         (1, [re.GateCount(re.ResourceY.resource_rep())]),
@@ -316,10 +625,73 @@ class TestZ:
         expected = re.CompressedResourceOp(re.ResourceZ, {})
         assert re.ResourceZ.resource_rep() == expected
 
+    ctrl_data = (
+        (
+            ["c1"],
+            [1],
+            [
+                re.GateCount(re.ResourceCZ.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1"],
+            [0],
+            [
+                re.GateCount(re.ResourceCZ.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 2),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [1, 1],
+            [
+                re.GateCount(re.ResourceCCZ.resource_rep(), 1),
+            ],
+        ),
+        (
+            ["c1", "c2"],
+            [0, 0],
+            [
+                re.GateCount(re.ResourceCCZ.resource_rep(), 1),
+                re.GateCount(re.ResourceX.resource_rep(), 4),
+            ],
+        ),
+        (
+            ["c1", "c2", "c3"],
+            [1, 0, 0],
+            [
+                re.GateCount(re.ResourceHadamard.resource_rep(), 2),
+                re.GateCount(re.ResourceMultiControlledX.resource_rep(3, 2), 1),
+            ],
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "ctrl_wires, ctrl_values, expected_res",
+        ctrl_data,
+    )
+    def test_resource_controlled(self, ctrl_wires, ctrl_values, expected_res):
+        """Test that the controlled resources are as expected"""
+        num_ctrl_wires = len(ctrl_wires)
+        num_ctrl_values = len([v for v in ctrl_values if not v])
+
+        op = re.ResourceZ(0)
+        op2 = re.ResourceControlled(op, num_ctrl_wires, num_ctrl_values)
+
+        assert op.controlled_resource_decomp(num_ctrl_wires, num_ctrl_values) == expected_res
+        assert op2.resource_decomp(**op2.resource_params) == expected_res
+
     def test_adjoint_decomposition(self):
         """Test that the adjoint resources are correct."""
         expected = [re.GateCount(re.ResourceZ.resource_rep(), 1)]
         assert re.ResourceZ.adjoint_resource_decomp() == expected
+
+        z = re.ResourceZ(0)
+        z_dag = re.ResourceAdjoint(z)
+
+        r1 = re.estimate_resources(z)
+        r2 = re.estimate_resources(z_dag)
+        assert r1 == r2
 
     pow_data = (
         (1, [re.GateCount(re.ResourceZ.resource_rep())]),
@@ -333,3 +705,5 @@ class TestZ:
         """Test that the pow decomposition is correct."""
         op = re.ResourceZ(0)
         assert op.pow_resource_decomp(z) == expected_res
+        op2 = re.ResourcePow(op, z)
+        assert repr(op2.resource_decomp(**op2.resource_params)) == repr(expected_res)


### PR DESCRIPTION
**Context:**
Adds controlled decomposition class methods for all single qubit operators

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-91013]