### PR TITLE
fix removal version in deprecation message

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -529,6 +529,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   [(#7292)](https://github.com/PennyLaneAI/pennylane/pull/7292)
   [(#7477)](https://github.com/PennyLaneAI/pennylane/pull/7477)
   [(#7508)](https://github.com/PennyLaneAI/pennylane/pull/7508)
+  [(#7603)](https://github.com/PennyLaneAI/pennylane/pull/7603)
 
 * `qml.operation.Observable` and the corresponding `Observable.compare` have been deprecated, as
   pennylane now depends on the more general `Operator` interface instead. The

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -199,7 +199,7 @@ def __getattr__(name):
         warnings.warn(
             f"pennylane.{name} is no longer accessible at top-level \
                 and must be imported as pennylane.exceptions.{name}. \
-                    Support for top-level access will be removed in v0.42.",
+                    Support for top-level access will be removed in v0.43.",
             pennylane.exceptions.PennyLaneDeprecationWarning,
         )
         return getattr(pennylane.exceptions, name)


### PR DESCRIPTION
**Context:**

Wrong removal version.

**Description of the Change:**

Update the deprecation message to say it will be removed in `v0.43`.