### PR TITLE
Fix `PhaseShift` operation with a batch size of 1

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -665,6 +665,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Bug fixes 🐛</h3>
 
+* `qml.PhaseShift` operation is now working correctly with a batch size of 1.
+  [(#7622)](https://github.com/PennyLaneAI/pennylane/pull/7622)
+
 * `qml.metric_tensor` can now be calculated with catalyst.
   [(#7528)](https://github.com/PennyLaneAI/pennylane/pull/7528)
 

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -454,7 +454,7 @@ def apply_phaseshift(op: qml.PhaseShift, state, is_state_batched: bool = False, 
     params = math.cast(op.parameters[0], dtype=complex)
     state0 = state[sl_0]
     state1 = state[sl_1]
-    if op.batch_size is not None and len(params) > 1:
+    if op.batch_size is not None:
         interface = math.get_interface(state)
         if interface == "torch":
             params = math.array(params, like=interface)
@@ -467,8 +467,6 @@ def apply_phaseshift(op: qml.PhaseShift, state, is_state_batched: bool = False, 
             state1 = math.expand_dims(state1, 0)
     state1 = math.multiply(math.cast(state1, dtype=complex), math.exp(1.0j * params))
     state = math.stack([state0, state1], axis=axis)
-    if not is_state_batched and op.batch_size == 1:
-        state = math.stack([state], axis=0)
     return state
 
 


### PR DESCRIPTION
The `PhaseShift` operation was raising an unexpected error when used with a batch size of 1 on the `default.qubit` device (see #6874 and sc-82871). This PR fixes the issue to return the expected output, for example:
```python
import pennylane as qml
import numpy as np

@qml.qnode(qml.device("default.qubit"))
def circuit(x):
    qml.PhaseShift(x, wires=0)
    return qml.expval(qml.Z(0))

params = np.array([1.57])
print(circuit(params))
```
`[1.]`

Fixes https://github.com/PennyLaneAI/pennylane/issues/6874