### PR TITLE
No more NP2 `xfail`'s for `OpenFermion` tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -572,6 +572,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Tests using `OpenFermion` in `tests/qchem` do not fail with NumPy>=2.0.0 any more.
+  [(#7626)](https://github.com/PennyLaneAI/pennylane/pull/7626)
+
 * Move `givens_decomposition` and private helpers from `qchem` to `math` module.
   [(#7545)](https://github.com/PennyLaneAI/pennylane/pull/7545)
 

--- a/tests/qchem/openfermion_pyscf_tests/conftest.py
+++ b/tests/qchem/openfermion_pyscf_tests/conftest.py
@@ -31,7 +31,7 @@ OPENFERMION_XFAIL_INFO = (
     "This test requires numpy 1.x. Double check OpenFermion compatibility with numpy 2.x."
 )
 xfail_on_numpy2 = pytest.mark.xfail(
-    condition=IS_NUMPY_2,
+    condition=False,
     reason=OPENFERMION_XFAIL_INFO,
 )
 

--- a/tests/qchem/openfermion_pyscf_tests/conftest.py
+++ b/tests/qchem/openfermion_pyscf_tests/conftest.py
@@ -22,19 +22,6 @@ from packaging.version import Version
 
 import pennylane as qml
 
-__all__ = ["xfail_on_numpy2"]
-
-# NumPy 2.0 compatibility detection
-NUMPY_VERSION = Version(np.__version__)
-IS_NUMPY_2 = NUMPY_VERSION >= Version("2.0.0")
-OPENFERMION_XFAIL_INFO = (
-    "This test requires numpy 1.x. Double check OpenFermion compatibility with numpy 2.x."
-)
-xfail_on_numpy2 = pytest.mark.xfail(
-    condition=False,
-    reason=OPENFERMION_XFAIL_INFO,
-)
-
 
 def cmd_exists(cmd):
     """Returns True if a binary exists on

--- a/tests/qchem/openfermion_pyscf_tests/conftest.py
+++ b/tests/qchem/openfermion_pyscf_tests/conftest.py
@@ -16,9 +16,7 @@ Pytest configuration file for PennyLane quantum chemistry open fermion test suit
 """
 import shutil
 
-import numpy as np
 import pytest
-from packaging.version import Version
 
 import pennylane as qml
 

--- a/tests/qchem/openfermion_pyscf_tests/test_dipole_of.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_dipole_of.py
@@ -17,7 +17,6 @@ Unit tests for the ``dipole_of`` function.
 # pylint: disable=too-many-arguments
 import numpy as np
 import pytest
-from conftest import xfail_on_numpy2  # pylint: disable=no-name-in-module
 
 import pennylane as qml
 
@@ -200,7 +199,6 @@ ops_h2o.append(
 )
 
 
-@xfail_on_numpy2
 @pytest.mark.parametrize(
     ("symbols", "coords", "charge", "core", "active", "mapping", "coeffs", "ops"),
     [
@@ -238,7 +236,6 @@ def test_dipole_obs(symbols, coords, charge, core, active, mapping, coeffs, ops,
             qml.assert_equal(o1, o2)
 
 
-@xfail_on_numpy2
 @pytest.mark.parametrize(
     ("symbols", "coords", "charge", "hf_state", "exp_dipole"),
     [

--- a/tests/qchem/openfermion_pyscf_tests/test_meanfield.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_meanfield.py
@@ -18,7 +18,6 @@ import os
 
 import numpy as np
 import pytest
-from conftest import xfail_on_numpy2  # pylint: disable=no-name-in-module
 
 from pennylane import qchem
 
@@ -26,7 +25,6 @@ name = "h2"
 symbols, coordinates = (["H", "H"], np.array([0.0, 0.0, -0.66140414, 0.0, 0.0, 0.66140414]))
 
 
-@xfail_on_numpy2
 @pytest.mark.usefixtures("skip_if_no_openfermion_support")
 @pytest.mark.parametrize(("package", "basis"), [("PySCF", "sto-3g"), ("PySCF", "6-31g")])
 def test_path_to_file(package, basis, tmpdir):
@@ -42,7 +40,6 @@ def test_path_to_file(package, basis, tmpdir):
     assert res_path == exp_path
 
 
-@xfail_on_numpy2
 @pytest.mark.usefixtures("skip_if_no_openfermion_support")
 @pytest.mark.parametrize("package", ["PySCF"])
 def test_hf_calculations(package, tmpdir, tol):

--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
@@ -16,7 +16,6 @@ Unit tests for molecular dipole.
 """
 # pylint: disable=too-many-arguments, protected-access
 import pytest
-from conftest import xfail_on_numpy2  # pylint: disable=no-name-in-module
 
 import pennylane as qml
 from pennylane import I, X, Y, Z
@@ -210,7 +209,6 @@ eig_h2o.append([0.0, 0.0])
 eig_h2o.append([-0.67873019, -0.45673019, -0.45673019])
 
 
-@xfail_on_numpy2
 @pytest.mark.parametrize(
     (
         "symbols",
@@ -300,7 +298,6 @@ def test_differentiable_molecular_dipole(
         assert np.allclose(np.sort(eig), np.sort(eig_ref[idx]))
 
 
-@xfail_on_numpy2
 @pytest.mark.parametrize(
     ("wiremap"),
     [
@@ -356,7 +353,7 @@ def test_molecular_dipole_error():
 @pytest.mark.parametrize(
     ("method", "args"),
     [
-        pytest.param("openfermion", None, marks=xfail_on_numpy2),
+        ("openfermion", None),
         (
             "dhf",
             None,
@@ -388,7 +385,7 @@ def test_real_dipole(method, args, tmpdir):
 @pytest.mark.parametrize(
     ("method"),
     [
-        pytest.param("openfermion", marks=xfail_on_numpy2),
+        "openfermion",
         "dhf",
     ],
 )

--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
@@ -16,7 +16,6 @@ Unit tests for molecular Hamiltonians.
 """
 # pylint: disable=too-many-arguments, protected-access
 import pytest
-from conftest import xfail_on_numpy2  # pylint: disable=no-name-in-module
 
 import pennylane as qml
 from pennylane import I, X, Y, Z
@@ -65,8 +64,8 @@ test_coordinates = np.array(
     ),
     [
         (0, 1, "pyscf", 2, 2, "jordan_WIGNER"),
-        pytest.param(1, 2, "openfermion", 3, 4, "BRAVYI_kitaev", marks=xfail_on_numpy2),
-        pytest.param(-1, 2, "openfermion", 1, 2, "jordan_WIGNER", marks=xfail_on_numpy2),
+        (1, 2, "openfermion", 3, 4, "BRAVYI_kitaev"),
+        (-1, 2, "openfermion", 1, 2, "jordan_WIGNER"),
         (2, 1, "pyscf", 2, 2, "BRAVYI_kitaev"),
     ],
 )
@@ -113,8 +112,8 @@ def test_building_hamiltonian(
     ),
     [
         (0, 1, "pyscf", 2, 2, "jordan_WIGNER"),
-        pytest.param(1, 2, "openfermion", 3, 4, "BRAVYI_kitaev", marks=xfail_on_numpy2),
-        pytest.param(-1, 2, "openfermion", 1, 2, "jordan_WIGNER", marks=xfail_on_numpy2),
+        (1, 2, "openfermion", 3, 4, "BRAVYI_kitaev"),
+        (-1, 2, "openfermion", 1, 2, "jordan_WIGNER"),
         (2, 1, "pyscf", 2, 2, "BRAVYI_kitaev"),
     ],
 )
@@ -969,7 +968,6 @@ def test_error_raised_for_missing_molecule_information():
         qchem.molecular_hamiltonian(charge=0, mult=1, method="dhf")
 
 
-@xfail_on_numpy2
 @pytest.mark.parametrize(
     ("symbols", "geometry", "charge", "mapping", "h_ref_data"),
     [
@@ -1244,7 +1242,7 @@ def test_mapped_hamiltonian_pyscf_openfermion(
     [
         "pyscf",
         "dhf",
-        pytest.param("openfermion", marks=xfail_on_numpy2),
+        "openfermion",
     ],
 )
 def test_coordinate_units_for_molecular_hamiltonian(method, tmpdir):
@@ -1277,7 +1275,7 @@ def test_coordinate_units_for_molecular_hamiltonian(method, tmpdir):
     [
         "pyscf",
         "dhf",
-        pytest.param("openfermion", marks=xfail_on_numpy2),
+        "openfermion",
     ],
 )
 def test_coordinate_units_for_molecular_hamiltonian_molecule_class(method, tmpdir):


### PR DESCRIPTION
------------------------------------------------------------------

**Context:**
[OpenFermion 1.7.1](https://github.com/quantumlib/OpenFermion/releases/tag/v1.7.1) is compatible with numpy2. We need to release those xfails we set up before so that Ci doesn't block anyone irrelevant.

**Description of the Change:**

**Benefits:**
Unblock CI

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-92720]
