### PR TITLE
[WIP] [Decomposition] better decomposition of IntegerComparator

### DIFF
--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -15,6 +15,8 @@
 This submodule contains the discrete-variable quantum operations that perform
 arithmetic operations on their input states.
 """
+from collections import Counter
+
 # pylint: disable=arguments-differ
 from copy import copy
 from typing import Optional
@@ -22,7 +24,12 @@ from typing import Optional
 import numpy as np
 
 import pennylane as qml
-from pennylane.decomposition import add_decomps, register_resources
+from pennylane.decomposition import (
+    add_decomps,
+    register_condition,
+    register_resources,
+    resource_rep,
+)
 from pennylane.decomposition.symbolic_decomposition import pow_involutory, self_adjoint
 from pennylane.operation import FlatPytree, Operation
 from pennylane.ops import Identity
@@ -409,6 +416,8 @@ class IntegerComparator(Operation):
 
     grad_method = None
 
+    resource_keys = {"num_wires", "value", "geq", "num_work_wires"}
+
     def _flatten(self) -> FlatPytree:
         hp = self.hyperparameters
         metadata = (
@@ -455,6 +464,15 @@ class IntegerComparator(Operation):
         self.value = value
 
         super().__init__(wires=total_wires)
+
+    @property
+    def resource_params(self) -> dict:
+        return {
+            "num_wires": len(self.wires),
+            "value": self.value,
+            "geq": self.geq,
+            "num_work_wires": len(self.hyperparameters["work_wires"]),
+        }
 
     def label(
         self,
@@ -573,35 +591,23 @@ class IntegerComparator(Operation):
         if wires is None:
             raise ValueError("Must specify the wires that the operation acts on.")
 
-        if len(wires) > 1:
-            control_wires = Wires(wires[:-1])
-            wires = Wires(wires[-1])
-        else:
+        if len(wires) < 2:
             raise ValueError(
                 f"IntegerComparator: wrong number of wires. {len(wires)} wire(s) given. Need at least 2."
             )
 
-        small_val = not geq and value == 0
-        large_val = geq and value > 2 ** len(control_wires) - 1
-        if small_val or large_val:
-            gates = [Identity(wires[0])]
+        work_wires = Wires([]) if work_wires is None else Wires(work_wires)
+        with qml.queuing.AnnotatedQueue() as q:
+            if geq:
+                _integer_comparator_ge_decomposition(wires, value, work_wires)
+            else:
+                _integer_comparator_lt_decomposition(wires, value, work_wires)
 
-        else:
-            values = range(value, 2 ** (len(control_wires))) if geq else range(value)
-            binary = "0" + str(len(control_wires)) + "b"
-            control_values_list = [format(n, binary) for n in values]
-            gates = []
-            for control_values in control_values_list:
-                control_values = [int(n) for n in control_values]
-                gates.append(
-                    qml.MultiControlledX(
-                        wires=control_wires + wires,
-                        control_values=control_values,
-                        work_wires=work_wires,
-                    )
-                )
+        if qml.queuing.QueuingManager.recording():
+            for op in q.queue:
+                qml.apply(op)
 
-        return gates
+        return q.queue
 
     @property
     def control_wires(self) -> Wires:
@@ -612,3 +618,284 @@ class IntegerComparator(Operation):
 
     def pow(self, z: int) -> list["IntegerComparator"]:
         return super().pow(z % 2)
+
+
+def _integer_comparator_lt_resource(num_wires, value, num_work_wires, **_):
+
+    if value == 0:
+        return {}
+
+    if value > 2 ** (num_wires - 1) - 1:
+        return {qml.X: 1}
+
+    num_controls = num_wires - 1
+    binary_str = format(value, f"0{num_controls}b")
+    last_significant = binary_str.rfind("1")
+    gate_counts = {resource_rep(qml.X): (last_significant + 1) * 2}
+
+    first_significant = binary_str.find("1")
+    gate_counts[
+        resource_rep(
+            qml.MultiControlledX,
+            num_control_wires=first_significant + 1,
+            num_work_wires=num_work_wires + num_wires - 2 - first_significant,
+            num_zero_control_values=0,
+            work_wire_type="dirty",
+        )
+    ] = 1
+
+    while (first_significant := binary_str.find("1", first_significant + 1)) != -1:
+        gate_counts[
+            resource_rep(
+                qml.MultiControlledX,
+                num_control_wires=first_significant + 1,
+                num_work_wires=num_work_wires + num_wires - 2 - first_significant,
+                num_zero_control_values=0,
+                work_wire_type="dirty",
+            )
+        ] = 1
+
+    return gate_counts
+
+
+@register_condition(lambda geq, **_: not geq)
+@register_resources(_integer_comparator_lt_resource)
+def _integer_comparator_lt_decomposition(wires, value, work_wires, **_):
+    """Decompose the IntegerComparator for when the flipping condition is ``n < value``.
+
+    This decomposition uses the minimum number of ``MultiControlledX`` gates. For a given value,
+    we first convert it to binary, and iteratively look for the significant bits. For example,
+    with 6 control wires, if the value is 22, which is 010110 in 6-bit binary, we observe
+    that all 6-bit numbers that start with 00 will satisfy the flipping condition, so we apply
+    a ``MultiControlledX`` with only the first two wires as controls, and 00 as the control values.
+    Then we look for the next significant bit, and observe that 22 starts with 0101. Therefore,
+    all 6-bit numbers that start with 0100 will also satisfy the flipping condition, so we apply
+    a ``MultiControlledX`` with the first four wires as controls, and 0100 as the control values.
+    This continues until we add a ``MultiControlledX`` for every significant bit in the value.
+
+    .. code-block:: pycon
+
+        0: ─╭○─╭○─╭○─┤
+        1: ─├○─├●─├●─┤
+        2: ─│──├○─├○─┤
+        3: ─│──├○─├●─┤
+        4: ─│──│──├○─┤
+        6: ─╰X─╰X─╰X─┤
+
+    If we decompose this circuit one level further, we get
+
+    .. code-block:: pycon
+
+        0: ──X─╭●──X──X─╭●──X──X─╭●──X─┤
+        1: ──X─├●──X────├●───────├●────┤
+        2: ────│───X────├●──X──X─├●──X─┤
+        3: ────│───X────├●──X────├●────┤
+        4: ────│────────│───X────├●──X─┤
+        6: ────╰X───────╰X───────╰X────┤
+
+    And we observe that the ``PauliX`` gates used to flip the control values can be merged:
+
+    .. code-block:: pycon
+
+        0: ──X─╭●────╭●────╭●──X─┤
+        1: ──X─├●──X─├●────├●────┤
+        2: ──X─│─────├●────├●──X─┤
+        3: ──X─│─────├●──X─├●────┤
+        4: ──X─│─────│─────├●──X─┤
+        6: ────╰X────╰X────╰X────┤
+
+    """
+
+    # If the value is zero, the flipping condition is never satisfied.
+    if value == 0:
+        return
+
+    num_controls = len(wires) - 1
+
+    # If the value is larger than the maximum value that can be represented by
+    # the number of control bits, the flipping condition is always satisfied, in
+    # which case we apply an X gate to the target wire and terminate.
+    if value > 2**num_controls - 1:
+        qml.X(wires[-1])
+        return
+
+    # Track which control bits have been flipped back
+    control_value_tracker = [0] * num_controls
+
+    # First apply X to all wires until the last significant bit to flip control values to 1.
+    binary_str = format(value, f"0{num_controls}b")
+    last_significant = binary_str.rfind("1")
+    for i in range(last_significant + 1):
+        qml.X(wires[i])
+
+    # The flipping condition is satisfied if all bits from the first bit to the
+    # first non-zero bit of the value are zeroes.
+    first_significant = binary_str.find("1")
+    qml.MultiControlledX(
+        wires=wires[: first_significant + 1] + wires[-1:],
+        work_wires=wires[first_significant + 1 : -1] + work_wires,
+    )
+    control_value_tracker[first_significant] = 1
+    qml.X(wires[first_significant])
+
+    # If the wire corresponding to the first significant bit of the value is 1, then we
+    # iteratively look for the next significant bit, and apply a flip conditioned on all
+    # bits from the last significant bit to this next significant bit being zeroes.
+    while (first_significant := binary_str.find("1", first_significant + 1)) != -1:
+        qml.MultiControlledX(
+            wires=wires[: first_significant + 1] + wires[-1:],
+            work_wires=wires[first_significant + 1 : -1] + work_wires,
+        )
+        control_value_tracker[first_significant] = 1
+        qml.X(wires[first_significant])
+
+    for i in range(last_significant + 1):
+        if control_value_tracker[i] == 0:
+            qml.X(wires[i])
+
+
+def _integer_comparator_ge_resource(num_wires, value, num_work_wires, **_):
+
+    # If the value is 0, the flipping condition is always satisfied.
+    if value == 0:
+        return {qml.X: 1}
+
+    num_controls = num_wires - 1
+
+    if value > 2**num_controls - 1:
+        return {}
+
+    binary_str = format(value, f"0{num_controls}b")
+    first_zero = binary_str.find("0")
+
+    if first_zero == -1:
+        return {
+            resource_rep(
+                qml.MultiControlledX,
+                num_control_wires=num_controls,
+                num_work_wires=num_work_wires,
+                num_zero_control_values=0,
+                work_wire_type="dirty",
+            ): 1
+        }
+
+    gate_set = Counter()
+
+    gate_set[
+        resource_rep(
+            qml.MultiControlledX,
+            num_control_wires=first_zero + 1,
+            num_work_wires=num_work_wires + num_wires - 2 - first_zero,
+            num_zero_control_values=0,
+            work_wire_type="dirty",
+        )
+    ] = 1
+    gate_set[resource_rep(qml.X)] = 2
+
+    while (first_zero := binary_str.find("0", first_zero + 1)) != -1:
+        gate_set[
+            resource_rep(
+                qml.MultiControlledX,
+                num_control_wires=first_zero + 1,
+                num_work_wires=num_work_wires + num_wires - 2 - first_zero,
+                num_zero_control_values=0,
+                work_wire_type="dirty",
+            )
+        ] = 1
+        gate_set[resource_rep(qml.X)] += 2
+
+    gate_set[
+        resource_rep(
+            qml.MultiControlledX,
+            num_control_wires=num_controls,
+            num_work_wires=num_work_wires,
+            num_zero_control_values=0,
+            work_wire_type="dirty",
+        )
+    ] += 1
+
+    return dict(gate_set)
+
+
+@register_condition(lambda geq, **_: geq)
+@register_resources(_integer_comparator_ge_resource)
+def _integer_comparator_ge_decomposition(wires, value, work_wires, **_):
+    """Decompose the IntegerComparator for when the flipping condition is ``n >= value``.
+
+    This decomposition rule mirrors the implementation for the ``n < value`` case.
+
+    """
+
+    # If the value is 0, the flipping condition is always satisfied.
+    if value == 0:
+        qml.X(wires[-1])
+        return
+
+    num_controls = len(wires) - 1
+
+    # If the value is larger than the maximum value that can be represented by
+    # the number of control bits, the flipping condition is never satisfied,
+    if value > 2**num_controls - 1:
+        return
+
+    # Track which control bits have been flipped
+    control_value_tracker = [0] * num_controls
+
+    binary_str = format(value, f"0{num_controls}b")
+    first_zero = binary_str.find("0")
+
+    if first_zero == -1:
+        # If the value happens to be the all-one state, then we apply a single MCX
+        qml.MultiControlledX(wires=wires, work_wires=work_wires)
+        return
+
+    qml.MultiControlledX(
+        wires=wires[: first_zero + 1] + wires[-1:],
+        work_wires=wires[first_zero + 1 : -1] + work_wires,
+    )
+    control_value_tracker[first_zero] = 1
+    qml.X(wires[first_zero])
+
+    while (first_zero := binary_str.find("0", first_zero + 1)) != -1:
+        qml.MultiControlledX(
+            wires=wires[: first_zero + 1] + wires[-1:],
+            work_wires=wires[first_zero + 1 : -1] + work_wires,
+        )
+        control_value_tracker[first_zero] = 1
+        qml.X(wires[first_zero])
+
+    # The last MCX corresponds to the equal case.
+    qml.MultiControlledX(wires=wires, work_wires=work_wires)
+
+    for i in range(num_controls):
+        if control_value_tracker[i]:
+            qml.X(wires[i])
+
+
+def _integer_comparator_flip_geq_resource(num_wires, value, num_work_wires, geq, **_):
+    """Resource estimation for flipping the geq condition."""
+    return {
+        qml.X: 1,
+        resource_rep(
+            qml.IntegerComparator,
+            num_wires=num_wires,
+            value=value,
+            geq=not geq,
+            num_work_wires=num_work_wires,
+        ): 1,
+    }
+
+
+@register_resources(_integer_comparator_flip_geq_resource)
+def _integer_comparator_flip_geq(value, geq, wires, work_wires, **_):
+    """Decompose the IntegerComparator by flipping geq to lt or vice versa."""
+    qml.X(wires[-1])
+    IntegerComparator(value, wires, geq=not geq, work_wires=work_wires)
+
+
+add_decomps(
+    IntegerComparator,
+    _integer_comparator_lt_decomposition,
+    _integer_comparator_ge_decomposition,
+    _integer_comparator_flip_geq,
+)

--- a/tests/ops/qubit/test_arithmetic_ops.py
+++ b/tests/ops/qubit/test_arithmetic_ops.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.wires import Wires
 
 label_data = [
@@ -410,38 +411,36 @@ class TestIntegerComparator:
         with pytest.raises(ValueError, match=expected_error_message):
             qml.IntegerComparator.compute_decomposition(value, wires=wires, geq=geq)
 
-    def test_decomposition(self):
-        """Test operator's ``compute_decomposition()`` method."""
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.IntegerComparator.compute_decomposition(2, wires=[0, 1, 2])
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
-        assert all(isinstance(op, qml.MultiControlledX) for op in tape1.operations)
+    @pytest.mark.parametrize("geq", [True, False])
+    @pytest.mark.parametrize("value", list(range(9)))
+    @pytest.mark.parametrize("initial_state", list(itertools.product([0, 1], repeat=3)))
+    def test_decomposition(self, value, geq, initial_state):
+        """Tests the decomposition of the IntegerComparator operator."""
 
-        with qml.queuing.AnnotatedQueue() as q2:
-            qml.IntegerComparator.compute_decomposition(2, wires=[0, 1, 2], geq=False)
-        tape2 = qml.tape.QuantumScript.from_queue(q2)
-        assert all(isinstance(op, qml.MultiControlledX) for op in tape2.operations)
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.Projector(initial_state, wires=[0, 1, 2])
+            qml.IntegerComparator.compute_decomposition(value, wires=[0, 1, 2, 3], geq=geq)
+        tape = qml.tape.QuantumScript.from_queue(q)
 
-        num_wires = 3
-        num_workers = 1
-        dev = qml.device("default.qubit", wires=num_wires + num_workers)
+        with qml.queuing.AnnotatedQueue() as q:
+            qml.Projector(initial_state, wires=[0, 1, 2])
+            val = int("".join(str(i) for i in initial_state), 2)
+            if (geq and val >= value) or (not geq and val < value):
+                qml.PauliX(3)
+        equivalent_tape = qml.tape.QuantumScript.from_queue(q)
 
-        @qml.qnode(dev)
-        def f(bitstring, tape, geq):
-            qml.BasisState(bitstring, wires=range(num_wires + num_workers))
-            qml.adjoint(qml.IntegerComparator(2, wires=(0, 1, 2), geq=geq), lazy=False)
-            for op in tape.operations:
-                op.queue()
-            return qml.probs(wires=range(num_wires + num_workers))
+        matrix = qml.matrix(tape, wire_order=[0, 1, 2, 3])
+        equivalent_matrix = qml.matrix(equivalent_tape, wire_order=[0, 1, 2, 3])
+        assert qml.math.allclose(matrix, equivalent_matrix)
 
-        for tape, geq in zip([tape1, tape2], [True, False]):
-            u = np.array(
-                [
-                    f(np.array(b), tape, geq)
-                    for b in itertools.product(range(2), repeat=num_wires + num_workers)
-                ]
-            ).T
-            assert np.allclose(u, np.eye(2 ** (num_wires + num_workers)))
+    @pytest.mark.parametrize("geq", [True, False])
+    @pytest.mark.parametrize("value", list(range(9)))
+    @pytest.mark.parametrize("initial_state", list(itertools.product([0, 1], repeat=3)))
+    def test_decomposition_qfuncs(self, value, geq, initial_state):
+        """Tests the qfunc decompositions of the IntegerComparator operator."""
+        op = qml.IntegerComparator(value, wires=[0, 1, 2, 3], geq=geq)
+        for rule in qml.list_decomps(qml.IntegerComparator):
+            _test_decomposition_rule(op, rule)
 
     def test_decomposition_extraneous_value(self):
         """Test operator's ``compute_decomposition()`` method when ``value`` is such that


### PR DESCRIPTION
**Context:**

The current decomposition of `IntegerComparator` produces `max(value, 2**n_control_wires - value)` number of `MultiControlledX` gates acting on all wires, but this isn't necessary.

**Description of the Change:**

Reimplement the decomposition rule of `IntegerComparator` to use the minimum number of MCX gates acting on minimum number of wires. The rules are implemented in a way that is compatible with the new system.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-89619]
