### PR TITLE
Adding `requirements_labs.txt` to the Labs repo

### DIFF
--- a/pennylane/labs/requirements_labs.txt
+++ b/pennylane/labs/requirements_labs.txt
@@ -1,0 +1,3 @@
+h5py
+galois
+matplotlib


### PR DESCRIPTION
**Context:**
As we add more and more modules and experimental features to the lab repository, we start to run into the problem of dependancy management. Currently, labs contains certain modules which require dependancies that are not installed with the default install of Pennylane. 

**Description of the Change:**
Added a requirements file which should allow non-developer users an easier time with installing all of the requirements in order to run certain features with labs.

**Benefits:**
Easy installation 

**Possible Drawbacks:**
Dependancy management could get messy when considering different versions of each dependancy between the modules.
