### PR TITLE
Restrict `labs` dependencies to the functions that introduce them

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -502,6 +502,11 @@
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
+* The imports of dependencies introduced by ``labs`` functionalities have been modified such that
+  these dependencies only have to be installed for the functions that use them, not to use
+  ``labs`` functionalities in general. This decouples the various submodules, and even functions
+  within the same submodule, from each other.
+  [(#7xxx)](https://github.com/PennyLaneAI/pennylane/pull/7xxx)
 
 * A new module :mod:`pennylane.labs.intermediate_reps <pennylane.labs.intermediate_reps>`
   provides functionality to compute intermediate representations for particular circuits.

--- a/pennylane/labs/dla/variational_kak.py
+++ b/pennylane/labs/dla/variational_kak.py
@@ -24,19 +24,20 @@ from pennylane.liealg import adjvec_to_op, op_to_adjvec
 from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence
 
-has_jax = True
 try:
     import jax
     import jax.numpy as jnp
     import optax
 
     jax.config.update("jax_enable_x64", True)
+    has_jax = True
 except ImportError:
     has_jax = False
 
-has_plt = True
 try:
     import matplotlib.pyplot as plt
+
+    has_plt = True
 except ImportError:
     has_plt = False
 

--- a/pennylane/labs/dla/variational_kak.py
+++ b/pennylane/labs/dla/variational_kak.py
@@ -95,7 +95,7 @@ def variational_kak_adj(H, g, dims, adj, verbose=False, opt_kwargs=None, pick_mi
             Cartan decomposition :math:`\mathfrak{g} = \mathfrak{k} \oplus (\tilde{\mathfrak{m}} \oplus \mathfrak{a})`
         adj (np.ndarray): Adjoint representation of dimension ``(dim_g, dim_g, dim_g)``,
             with the implicit ordering ``(k, mtilde, a)``.
-        verbose (bool): Plot the optimization. Requires matplotlib to be installed (pip install matplotlib)
+        verbose (bool): Plot the optimization. Requires matplotlib to be installed (``pip install matplotlib``)
         opt_kwargs (dict): Keyword arguments for the optimization like initial starting values
             for :math:`\theta` of dimension ``(dim_k,)``, given as ``theta0``.
             Also includes ``n_epochs``, ``lr``, ``b1``, ``b2``, ``verbose``, ``interrupt_tol``, see :func:`~run_opt`

--- a/pennylane/labs/dla/variational_kak.py
+++ b/pennylane/labs/dla/variational_kak.py
@@ -17,7 +17,6 @@ import warnings
 from datetime import datetime
 from functools import partial
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 import pennylane as qml
@@ -34,6 +33,12 @@ try:
     jax.config.update("jax_enable_x64", True)
 except ImportError:
     has_jax = False
+
+has_plt = True
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    has_plt = False
 
 
 def variational_kak_adj(H, g, dims, adj, verbose=False, opt_kwargs=None, pick_min=False):
@@ -90,7 +95,7 @@ def variational_kak_adj(H, g, dims, adj, verbose=False, opt_kwargs=None, pick_mi
             Cartan decomposition :math:`\mathfrak{g} = \mathfrak{k} \oplus (\tilde{\mathfrak{m}} \oplus \mathfrak{a})`
         adj (np.ndarray): Adjoint representation of dimension ``(dim_g, dim_g, dim_g)``,
             with the implicit ordering ``(k, mtilde, a)``.
-        verbose (bool): Plot the optimization
+        verbose (bool): Plot the optimization. Requires matplotlib to be installed (pip install matplotlib)
         opt_kwargs (dict): Keyword arguments for the optimization like initial starting values
             for :math:`\theta` of dimension ``(dim_k,)``, given as ``theta0``.
             Also includes ``n_epochs``, ``lr``, ``b1``, ``b2``, ``verbose``, ``interrupt_tol``, see :func:`~run_opt`
@@ -218,6 +223,11 @@ def variational_kak_adj(H, g, dims, adj, verbose=False, opt_kwargs=None, pick_mi
         raise ImportError(
             "jax and optax are required for variational_kak_adj. You can install them with pip install jax jaxlib optax."
         )  # pragma: no cover
+    if verbose >= 1 and not has_plt:  # pragma: no cover
+        print(
+            "variational_kak_adj requires matplotlib to display a figure with the optimization "
+            "progress (for verbose>=1). You can install it with pip install matplotlib"
+        )
 
     if opt_kwargs is None:
         opt_kwargs = {}

--- a/pennylane/labs/intermediate_reps/rowcol.py
+++ b/pennylane/labs/intermediate_reps/rowcol.py
@@ -19,12 +19,12 @@ import networkx as nx
 import numpy as np
 from networkx.algorithms.approximation import steiner_tree
 
-has_galois = True
 try:
     import galois
 
     # Create the Galois number field F_2, in which we can create arrays in _get_S.
     F_2 = galois.GF(2)
+    has_galois = True
 
 except ImportError:
     has_galois = False

--- a/pennylane/labs/intermediate_reps/rowcol.py
+++ b/pennylane/labs/intermediate_reps/rowcol.py
@@ -645,7 +645,7 @@ def rowcol(P: np.ndarray, connectivity: nx.Graph = None, verbose: bool = False) 
     """
     if not has_galois:  # pragma: no cover
         raise ImportError(
-            "The package galois is required by rowcol. You can install it with pip install galois."
+            "rowcol requires the package galois. You can install it with pip install galois."
         )  # pragma: no cover
 
     P = P.copy()

--- a/pennylane/labs/intermediate_reps/rowcol.py
+++ b/pennylane/labs/intermediate_reps/rowcol.py
@@ -15,10 +15,19 @@
 
 from typing import Iterable
 
-import galois
 import networkx as nx
 import numpy as np
 from networkx.algorithms.approximation import steiner_tree
+
+has_galois = True
+try:
+    import galois
+
+    # Create the Galois number field F_2, in which we can create arrays in _get_S.
+    F_2 = galois.GF(2)
+
+except ImportError:
+    has_galois = False
 
 
 def postorder_traverse(tree: nx.Graph, source: int, source_parent: int = None):
@@ -201,10 +210,6 @@ def _update(P: np.ndarray, cnots: list[tuple[int]], control: int, target: int):
     return P, cnots
 
 
-# Create the Galois number field F_2, in which we can create arrays in _get_S.
-F_2 = galois.GF(2)
-
-
 def _get_S(P: np.ndarray, idx: int, node_set: Iterable[int], mode: str):
     # Find S (S') either by simply extracting a column or by solving a linear system for the row
     if mode == "column":
@@ -297,6 +302,12 @@ def rowcol(P: np.ndarray, connectivity: nx.Graph = None, verbose: bool = False) 
     Returns:
         list[tuple[int]]: Wire pairs for CNOTs that implement the parity matrix (control first,
         target second).
+
+    .. note::
+
+        This function requires the package ``galois`` to be installed. It can be installed via
+        ``pip install galois``, for details see
+        `its documentation <https://mhostetter.github.io/galois/latest/>`__.
 
     **Example**
 
@@ -632,6 +643,11 @@ def rowcol(P: np.ndarray, connectivity: nx.Graph = None, verbose: bool = False) 
         4: ─╰●────╰●────╰X─╰●────╰●─────────────╰●──────────╰X────┤
 
     """
+    if not has_galois:  # pragma: no cover
+        raise ImportError(
+            "The package galois is required by rowcol. You can install it with pip install galois."
+        )  # pragma: no cover
+
     P = P.copy()
     connectivity = connectivity.copy()
     n = len(P)

--- a/pennylane/labs/vibrational/christiansen_utils.py
+++ b/pennylane/labs/vibrational/christiansen_utils.py
@@ -23,10 +23,10 @@ from pennylane import concurrency
 
 # pylint: disable = redefined-outer-name
 
-has_h5py = True
 try:
     import h5py
 
+    has_h5py = True
 except ImportError:
     has_h5py = False
 

--- a/pennylane/labs/vibrational/christiansen_utils.py
+++ b/pennylane/labs/vibrational/christiansen_utils.py
@@ -1062,7 +1062,7 @@ def christiansen_integrals(pes, n_states=16, cubic=False, num_workers=1, backend
     """
     if not has_h5py:  # pragma: no cover
         raise ImportError(
-            "The h5py package is required by christiansen_integrals. "
+            "christiansen_integrals requires the h5py package. "
             "You can install it with pip install h5py"
         )  # pragma: no cover
     with TemporaryDirectory() as path:
@@ -1111,7 +1111,7 @@ def christiansen_integrals_dipole(pes, n_states=16, num_workers=1, backend="seri
     """
     if not has_h5py:  # pragma: no cover
         raise ImportError(
-            "The h5py package is required by christiansen_integrals_dipole. "
+            "christiansen_integrals_dipole requires the h5py package. "
             "You can install it with pip install h5py"
         )  # pragma: no cover
     with TemporaryDirectory() as path:

--- a/pennylane/labs/vibrational/christiansen_utils.py
+++ b/pennylane/labs/vibrational/christiansen_utils.py
@@ -16,13 +16,19 @@ import itertools
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import h5py
 import numpy as np
 from scipy.special import factorial
 
 from pennylane import concurrency
 
-# pylint: disable = redefined-outer-name,
+# pylint: disable = redefined-outer-name
+
+has_h5py = True
+try:
+    import h5py
+
+except ImportError:
+    has_h5py = False
 
 
 def _cform_onemode_kinetic(freqs, n_states, num_workers=1, backend="serial", path=None):
@@ -1045,10 +1051,20 @@ def christiansen_integrals(pes, n_states=16, cubic=False, num_workers=1, backend
         backend (string): the executor backend from the list of supported backends.
             Available options : "mp_pool", "cf_procpool", "cf_threadpool", "serial", "mpi4py_pool", "mpi4py_comm". Default value is set to "serial".
 
-
     Returns:
         TensorLike[float]: the integrals for the Christiansen Hamiltonian
+
+    .. note::
+
+        This function requires the ``h5py`` package to be installed.
+        It can be installed with ``pip install h5py``.
+
     """
+    if not has_h5py:  # pragma: no cover
+        raise ImportError(
+            "The h5py package is required by christiansen_integrals. "
+            "You can install it with pip install h5py"
+        )  # pragma: no cover
     with TemporaryDirectory() as path:
         ham_cform_onebody = _cform_onemode(
             pes, n_states, num_workers=num_workers, backend=backend, path=path
@@ -1084,10 +1100,20 @@ def christiansen_integrals_dipole(pes, n_states=16, num_workers=1, backend="seri
         backend (string): the executor backend from the list of supported backends.
             Available options : "mp_pool", "cf_procpool", "cf_threadpool", "serial", "mpi4py_pool", "mpi4py_comm". Default value is set to "serial".
 
-
     Returns:
         TensorLike[float]: the integrals for the Christiansen dipole operator
+
+    .. note::
+
+        This function requires the ``h5py`` package to be installed.
+        It can be installed with ``pip install h5py``.
+
     """
+    if not has_h5py:  # pragma: no cover
+        raise ImportError(
+            "The h5py package is required by christiansen_integrals_dipole. "
+            "You can install it with pip install h5py"
+        )  # pragma: no cover
     with TemporaryDirectory() as path:
         dipole_cform_onebody = _cform_onemode_dipole(
             pes, n_states, num_workers=num_workers, backend=backend, path=path

--- a/pennylane/labs/zxopt/basic_optimization.py
+++ b/pennylane/labs/zxopt/basic_optimization.py
@@ -13,14 +13,19 @@
 # limitations under the License.
 """Optimization pass ``basic_optimization`` from pyzx using ZX calculus."""
 
-import pyzx as zx
-
 import pennylane as qml
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform
 from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
+
+has_zx = True
+try:
+    import pyzx as zx
+
+except ImportError:
+    has_zx = False
 
 
 def null_postprocessing(results):
@@ -93,6 +98,12 @@ def basic_optimization(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postpro
         3: ─╰X──H──T─╰●──H───────────┤
 
     """
+    if not has_zx:  # pragma: no cover
+        raise ImportError(
+            "The package pyzx is required by basic_optimization. "
+            "You can install it with pip install pyzx"
+        )  # pragma: no cover
+
     pyzx_circ = _tape2pyzx(tape)
 
     pyzx_circ = pyzx_circ.to_basic_gates()

--- a/pennylane/labs/zxopt/basic_optimization.py
+++ b/pennylane/labs/zxopt/basic_optimization.py
@@ -20,10 +20,10 @@ from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
 
-has_zx = True
 try:
     import pyzx as zx
 
+    has_zx = True
 except ImportError:
     has_zx = False
 

--- a/pennylane/labs/zxopt/basic_optimization.py
+++ b/pennylane/labs/zxopt/basic_optimization.py
@@ -100,7 +100,7 @@ def basic_optimization(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postpro
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "The package pyzx is required by basic_optimization. "
+            "basic_optimization requires the package pyzx. "
             "You can install it with pip install pyzx"
         )  # pragma: no cover
 

--- a/pennylane/labs/zxopt/full_optimize.py
+++ b/pennylane/labs/zxopt/full_optimize.py
@@ -14,14 +14,19 @@
 """Optimization pass ``full_optimize`` from pyzx using ZX calculus."""
 import warnings
 
-import pyzx as zx
-
 import pennylane as qml
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform
 from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
+
+has_zx = True
+try:
+    import pyzx as zx
+
+except ImportError:
+    has_zx = False
 
 
 def null_postprocessing(results):
@@ -118,6 +123,12 @@ def full_optimize(
             new_circ = full_optimize(circ, clifford_t_args = {"epsilon": 0.1})
 
     """
+    if not has_zx:  # pragma: no cover
+        raise ImportError(
+            "The package pyzx is required by full_optimize. "
+            "You can install it with pip install pyzx"
+        )  # pragma: no cover
+
     try:
         pyzx_circ = _tape2pyzx(tape)
 

--- a/pennylane/labs/zxopt/full_optimize.py
+++ b/pennylane/labs/zxopt/full_optimize.py
@@ -21,10 +21,10 @@ from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
 
-has_zx = True
 try:
     import pyzx as zx
 
+    has_zx = True
 except ImportError:
     has_zx = False
 
@@ -125,8 +125,7 @@ def full_optimize(
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "full_optimize requires the package pyzx. "
-            "You can install it with pip install pyzx"
+            "full_optimize requires the package pyzx. " "You can install it with pip install pyzx"
         )  # pragma: no cover
 
     try:

--- a/pennylane/labs/zxopt/full_optimize.py
+++ b/pennylane/labs/zxopt/full_optimize.py
@@ -125,7 +125,7 @@ def full_optimize(
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "The package pyzx is required by full_optimize. "
+            "full_optimize requires the package pyzx. "
             "You can install it with pip install pyzx"
         )  # pragma: no cover
 

--- a/pennylane/labs/zxopt/full_reduce.py
+++ b/pennylane/labs/zxopt/full_reduce.py
@@ -110,7 +110,7 @@ def full_reduce(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocessing
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "The package pyzx is required by full_reduce. "
+            "full_reduce requires the package pyzx. "
             "You can install it with pip install pyzx"
         )  # pragma: no cover
 

--- a/pennylane/labs/zxopt/full_reduce.py
+++ b/pennylane/labs/zxopt/full_reduce.py
@@ -20,11 +20,11 @@ from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
 
-has_zx = True
 try:
     import pyzx as zx
     from pyzx.graph.base import BaseGraph
 
+    has_zx = True
 except ImportError:
     has_zx = False
 
@@ -110,8 +110,7 @@ def full_reduce(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocessing
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "full_reduce requires the package pyzx. "
-            "You can install it with pip install pyzx"
+            "full_reduce requires the package pyzx. " "You can install it with pip install pyzx"
         )  # pragma: no cover
 
     pyzx_circ = _tape2pyzx(tape)

--- a/pennylane/labs/zxopt/full_reduce.py
+++ b/pennylane/labs/zxopt/full_reduce.py
@@ -13,15 +13,20 @@
 # limitations under the License.
 """Optimization pass ``full_reduce`` from pyzx using ZX calculus."""
 
-import pyzx as zx
-from pyzx.graph.base import BaseGraph
-
 import pennylane as qml
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform
 from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
+
+has_zx = True
+try:
+    import pyzx as zx
+    from pyzx.graph.base import BaseGraph
+
+except ImportError:
+    has_zx = False
 
 
 def null_postprocessing(results):
@@ -103,6 +108,11 @@ def full_reduce(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocessing
 
     The original circuit has five :class:`~T` gates which are reduced to just one.
     """
+    if not has_zx:  # pragma: no cover
+        raise ImportError(
+            "The package pyzx is required by full_reduce. "
+            "You can install it with pip install pyzx"
+        )  # pragma: no cover
 
     pyzx_circ = _tape2pyzx(tape)
 

--- a/pennylane/labs/zxopt/todd.py
+++ b/pennylane/labs/zxopt/todd.py
@@ -107,7 +107,7 @@ def todd(
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "The package pyzx is required by todd. You can install it with pip install pyzx"
+            "todd requires the pyzx package. You can install it with pip install pyzx"
         )  # pragma: no cover
 
     pyzx_circ = _tape2pyzx(tape)

--- a/pennylane/labs/zxopt/todd.py
+++ b/pennylane/labs/zxopt/todd.py
@@ -13,14 +13,19 @@
 # limitations under the License.
 """Third order duplicate and destroy (TODD) optimization method from pyzx, using ZX calculus."""
 
-import pyzx as zx
-
 import pennylane as qml
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform
 from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
+
+has_zx = True
+try:
+    import pyzx as zx
+
+except ImportError:
+    has_zx = False
 
 
 def null_postprocessing(results):
@@ -100,6 +105,10 @@ def todd(
     The original five T gates are reduced to just one.
 
     """
+    if not has_zx:  # pragma: no cover
+        raise ImportError(
+            "The package pyzx is required by todd. You can install it with pip install pyzx"
+        )  # pragma: no cover
 
     pyzx_circ = _tape2pyzx(tape)
 

--- a/pennylane/labs/zxopt/todd.py
+++ b/pennylane/labs/zxopt/todd.py
@@ -20,10 +20,10 @@ from pennylane.typing import PostprocessingFn
 
 from .util import _tape2pyzx
 
-has_zx = True
 try:
     import pyzx as zx
 
+    has_zx = True
 except ImportError:
     has_zx = False
 

--- a/pennylane/labs/zxopt/util.py
+++ b/pennylane/labs/zxopt/util.py
@@ -15,7 +15,12 @@
 
 import re
 
-from pyzx import Circuit
+has_zx = True
+try:
+    from pyzx import Circuit
+
+except ImportError:
+    has_zx = False
 
 
 def _remove_measurement_patterns(text):
@@ -48,6 +53,12 @@ def _tape2pyzx(tape):
         pyzx.Graph: graph instance of the pyzx circuit
 
     """
+    if not has_zx:  # pragma: no cover
+        raise ImportError(
+            "The package pyzx is required by _tape2pyzx. "
+            "You can install it with pip install pyzx"
+        )  # pragma: no cover
+
     g = Circuit.from_qasm(_remove_measurement_patterns(tape.to_openqasm()))
 
     return g

--- a/pennylane/labs/zxopt/util.py
+++ b/pennylane/labs/zxopt/util.py
@@ -15,10 +15,10 @@
 
 import re
 
-has_zx = True
 try:
     from pyzx import Circuit
 
+    has_zx = True
 except ImportError:
     has_zx = False
 
@@ -55,8 +55,7 @@ def _tape2pyzx(tape):
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "_tape2pyzx requires the package pyzx. "
-            "You can install it with pip install pyzx"
+            "_tape2pyzx requires the package pyzx. " "You can install it with pip install pyzx"
         )  # pragma: no cover
 
     g = Circuit.from_qasm(_remove_measurement_patterns(tape.to_openqasm()))

--- a/pennylane/labs/zxopt/util.py
+++ b/pennylane/labs/zxopt/util.py
@@ -55,7 +55,7 @@ def _tape2pyzx(tape):
     """
     if not has_zx:  # pragma: no cover
         raise ImportError(
-            "The package pyzx is required by _tape2pyzx. "
+            "_tape2pyzx requires the package pyzx. "
             "You can install it with pip install pyzx"
         )  # pragma: no cover
 


### PR DESCRIPTION
**Context:**
The labs module contains experimental features, some of which require additional packages, causing dependencies that PennyLane itself does not (want to) have.
Currently, these additional packages are imported as soon as any `labs` functionality is imported. 

**Description of the Change:**
Change the imports so that they only cause a problem if a function is called that actually requires one of the additional dependencies.

**Benefits:**
Can use `labs.submodule_A` without installing dependencies of `labs.submodule_B`.
Can use `labs.submodule_A.fun_1` without installing dependencies of `labs.submodule_A.fun_2`.

**Possible Drawbacks:**
More cumbersome import structure. Not really a problem. We do this with JAX a lot in PennyLane already.

**Related GitHub Issues:**
This is an alternative approach to #7649.
