### PR TITLE
Only verify the matrix of a decomposition for ops that has matrix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -703,6 +703,11 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 * Fixed a failing integration test for `qml.QDrift`  which multiplied the operators of the decomposition incorrectly to evolve the state.
   [(#7621)](https://github.com/PennyLaneAI/pennylane/pull/7621)
+
+* The decomposition test in `assert_valid` no longer checks the matrix of the decomposition if the operator
+  does not define a matrix representation.
+  [(#7655)](https://github.com/PennyLaneAI/pennylane/pull/7655)
+
 <h3>Documentation 📝</h3>
 
 * Updated the circuit drawing for `qml.Select` to include two commonly used symbols for 

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -167,12 +167,12 @@ def _test_decomposition_rule(op, rule: DecompositionRule, heuristic_resources=Fa
         tape.operations.insert(0, qml.Projector([0] * len(work_wires), wires=work_wires))
 
     # Tests that the decomposition produces the same matrix
-    op_matrix = qml.matrix(op, wire_order=all_wires)
-
-    decomp_matrix = qml.matrix(tape, wire_order=all_wires)
-    assert qml.math.allclose(
-        op_matrix, decomp_matrix
-    ), "decomposition must produce the same matrix as the operator."
+    if op.has.matrix:
+        op_matrix = op.matrix(wire_order=all_wires)
+        decomp_matrix = qml.matrix(tape, wire_order=all_wires)
+        assert qml.math.allclose(
+            op_matrix, decomp_matrix
+        ), "decomposition must produce the same matrix as the operator."
 
 
 def _check_matrix(op):

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -167,7 +167,7 @@ def _test_decomposition_rule(op, rule: DecompositionRule, heuristic_resources=Fa
         tape.operations.insert(0, qml.Projector([0] * len(work_wires), wires=work_wires))
 
     # Tests that the decomposition produces the same matrix
-    if op.has.matrix:
+    if op.has_matrix:
         op_matrix = op.matrix(wire_order=all_wires)
         decomp_matrix = qml.matrix(tape, wire_order=all_wires)
         assert qml.math.allclose(


### PR DESCRIPTION
**Context:**

The current decomposition test in `assert_valid` compares the matrix of the decomposed circuit with the matrix of the operator by using `qml.matrix`, but when an operator does not have a well-defined matrix representation, `qml.matrix` simply returns the matrix of the operator's decomposition anyway, which is pointless. 

**Description of the Change:**

Change the matrix check for decomposition to use `op.matrix` when `op.has_matrix`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
