### PR TITLE
[Python Compiler] Remove unnecessary attribute from quantum.probs

### DIFF
--- a/pennylane/compiler/python_compiler/quantum_dialect.py
+++ b/pennylane/compiler/python_compiler/quantum_dialect.py
@@ -652,10 +652,7 @@ class ProbsOp(IRDLOperation):
         attr-dict ( `:` type($probabilities)^ )?
     """
 
-    irdl_options = [
-        AttrSizedOperandSegments(as_property=True),
-        AttrSizedResultSegments(as_property=True),
-    ]
+    irdl_options = [AttrSizedOperandSegments(as_property=True)]
 
     obs = operand_def(BaseAttr(ObservableType))
 


### PR DESCRIPTION
**Context:** The attribute `AttrSizedResultSegments` is not specified in the Catalyst `quantum.probs` operation, and therefore it also shouldn't be here.

**Description of the Change:** Removes `AttrSizedResultSegments` from the xDSL version of the quantum dialect.

**Benefits:** No errors.