### PR TITLE
[Prototype] Lazy Select decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -742,6 +742,11 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Bug fixes 🐛</h3>
 
+* A bug in `ops.op_math.Prod.simplify()` has been fixed that led to global phases being discarded
+  in special cases. Concretely, this problem occurs when Pauli factors combine into the identity
+  up to a global phase _and_ there is no Pauli representation of the product operator.
+  [(#7671)](https://github.com/PennyLaneAI/pennylane/pull/7671)
+
 * The behaviour of the `qml.FlipSign` operation has been fixed: passing an integer `m` as the wires argument is now
   interpreted as a single wire (i.e. `wires=[m]`). This is different from the previous interpretation of `wires=range(m)`.
   Also, the `qml.FlipSign.wires` attribute is now returning the correct `Wires` object as for all other operations in PennyLane.

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -54,7 +54,8 @@ def prod(*ops, id=None, lazy=True):
 
     Keyword Args:
         id (str or None): id for the product operator. Default is None.
-        lazy=True (bool): If ``lazy=False``, a simplification will be performed such that when any of the operators is already a product operator, its operands will be used instead.
+        lazy=True (bool): If ``lazy=False``, a simplification will be performed such that when any
+            of the operators is already a product operator, its operands will be used instead.
 
     Returns:
         ~ops.op_math.Prod: the operator representing the product.

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -640,7 +640,7 @@ class _ProductFactorsGrouping:
             if pauli_word != "Identity":
                 pauli_op = self._paulis[pauli_word](wire)
                 self._factors += ((pauli_op,),)
-                self.global_phase *= pauli_coeff
+            self.global_phase *= pauli_coeff
 
     def remove_factors(self, wires: list[int]):
         """Remove all factors from the ``self._pauli_factors`` and ``self._non_pauli_factors``

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1244,6 +1244,33 @@ class TestSimplify:
         simplified_op = prod_op.simplify()
         qml.assert_equal(simplified_op, final_op)
 
+    def test_grouping_with_equal_paulis_single_wire(self):
+        """Test that equal Pauli operators, creating global phase contributions, are simplified
+        correctly on one wire."""
+        prod_op = qml.prod(qml.X(0) @ qml.Y(0) @ qml.Z(0) @ qml.H(0))
+        final_op = 1j * qml.H(0)
+        simplified_op = prod_op.simplify()
+        assert np.allclose(qml.matrix(prod_op), qml.matrix(final_op))
+        qml.assert_equal(simplified_op, final_op)
+
+    def test_grouping_with_equal_paulis_two_wires(self):
+        """Test that equal Pauli operators, creating global phase contributions, are simplified
+        correctly on two wires."""
+        prod_op = qml.prod(
+            qml.X(0)
+            @ qml.Z("a")
+            @ qml.Y(0)
+            @ qml.Z(0)
+            @ qml.X("a")
+            @ qml.Y("a")
+            @ qml.H(0)
+            @ qml.H("a")
+        )
+        final_op = qml.simplify(-1 * qml.H(0) @ qml.H("a"))
+        simplified_op = prod_op.simplify()
+        assert np.allclose(qml.matrix(prod_op), qml.matrix(final_op))
+        qml.assert_equal(simplified_op, final_op)
+
     def test_grouping_with_product_of_sums(self):
         """Test that grouping works with product of two sums"""
         prod_op = qml.prod(qml.S(0) + qml.H(1), qml.S(0) + qml.H(1))


### PR DESCRIPTION
**Context:**
There is a decomposition of `Select` operators that reduces the control structure at the cost of classical processing.
We term this "lazy Select".

**Description of the Change:**

Add new decomposition using lazy Select approach.

**Benefits:**

Possibly cheaper decomposition

**Possible Drawbacks:**
It is not so easy to figure out in which cases the decomposition algorithm should go through the effort of computing the 
new resource requirements. Possibly, a conservative estimate can be filled in that keeps the cost to compute the resources within bounds. Additionally, once the lazy Select decomposition is chosen, the new operators to be applied actually have to be computed, which is possibly very expensive. 
For the scenario of all target operators being Pauli operators, this should be favourable though.

**Related GitHub Issues:**
