### PR TITLE
Add program capture to qubit allocation instructions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -371,6 +371,7 @@
 * Adds new `allocation` module containing `allocate`, `deallocate`, and `allocate_ctx` instructions for requesting dynamic wires. This is currently
   experimental and not integrated.
   [(#7663)](https://github.com/PennyLaneAI/pennylane/pull/7663)
+  [(#7673)](https://github.com/PennyLaneAI/pennylane/pull/7673)
 
 * Caching with finite shots now always warns about the lack of expected noise.
   [(#7644)](https://github.com/PennyLaneAI/pennylane/pull/7644)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -30,6 +30,7 @@ from pennylane.control_flow import for_loop, while_loop
 import pennylane.kernels
 import pennylane.math
 import pennylane.operation
+import pennylane.allocation
 import pennylane.decomposition
 from pennylane.decomposition import (
     register_resources,

--- a/pennylane/allocation.py
+++ b/pennylane/allocation.py
@@ -265,6 +265,8 @@ def deallocate(
 
     """
     if capture_enabled():
+        if not isinstance(wires, Sequence):
+            wires = (wires,)
         return _get_deallocate_prim().bind(*wires, reset_to_original=reset_to_original)
     wires = Wires(wires)
     if not_dynamic_wires := [w for w in wires if not isinstance(w, DynamicWire)]:


### PR DESCRIPTION
**Context:**

PR #7663  adds the core operator-based infrastructure for working with dynamic qubit allocation. This one makes the instructions capturable into plxpr

**Description of the Change:**

Adds `allocate_prim` and `deallocate_prim` that generate and consume dynamic wires (abstract ints) respectively.

**Benefits:**

Can convert these instructions into catalyst.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-93181]
