### PR TITLE
Add missing lightning devices to program capture docs

### DIFF
--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -181,8 +181,8 @@ NotImplementedError: Primitive ctrl_transform does not have a jvp rule and is no
 Gradients with lightning devices
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When executing a QNode on ``lightning.qubit`` with capture enabled, calculating 
-the gradient, jacobian, JVP, or VJP with JAX currently requires that we convert 
+When executing a QNode on ``lightning.qubit``, ``lightning.kokkos`` or ``lightning.gpu`` with capture enabled,
+calculating the gradient, jacobian, JVP, or VJP with JAX currently requires that we convert 
 the plxpr representation of the program back to a tape for the calculation of the 
 gradient, jacobian, JVP, or VJP. 
 

--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -193,8 +193,6 @@ For instance, calculating the jacobian of this circuit with ``lightning.qubit``
 raises an error due to a discrepancy in the ordering of the positional arguments 
 when tape conversion happens.
 
-The same is true of the ``lightning.kokkos`` and ``lightning.gpu`` devices.
-
 .. code-block:: python 
 
     import pennylane as qml 

--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -37,13 +37,13 @@ features that will help get your existing tape-based code working with program c
 Device compatibility
 --------------------
 
-Currently, ``default.qubit`` and ``lightning.qubit`` are the only devices compatible 
-with program capture.
+Currently, ``default.qubit``, ``lightning.qubit``, ``lightning.kokkos``, and ``lightning.gpu`` are the only 
+devices compatible with program capture.
 
 Device wires 
 ~~~~~~~~~~~~
 
-With program capture enabled, both ``lightning.qubit`` and ``default.qubit`` require 
+With program capture enabled, for all supported devices it is required 
 that ``wires`` be specified at device instantiation (this is in contrast to when 
 program capture is disabled, where automatic qubit management takes place internally
 with ``default.qubit``).
@@ -99,9 +99,9 @@ Array([0.99875027+0.j        , 0.        +0.j        ,
 Gradients
 ---------
 
-Currently the devices ``default.qubit`` and ``lightning.qubit`` are the only devices
-that support gradients with program capture enabled. ``default.qubit`` currently supports
-``adjoint``, ``backprop`` and ``finite-diff``. ``lightning.qubit`` currently only supports 
+Currently the devices ``default.qubit``, ``lightning.qubit``, ``lightning.kokkos``, and ``lightning.gpu`` 
+are the only devices that support gradients with program capture enabled. ``default.qubit`` currently 
+supports ``adjoint``, ``backprop`` and ``finite-diff``. ``lightning.qubit`` currently only supports 
 ``adjoint``. The ``parameter_shift`` method is not yet supported with program capture enabled, 
 and will raise an error if used. 
 
@@ -178,8 +178,8 @@ when using ``"adjoint"`` with ``default.qubit``. For example, the following code
 >>> jax.jacobian(f)(x)
 NotImplementedError: Primitive ctrl_transform does not have a jvp rule and is not supported.
 
-Gradients with lightning.qubit
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Gradients with lightning devices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When executing a QNode on ``lightning.qubit`` with capture enabled, calculating 
 the gradient, jacobian, JVP, or VJP with JAX currently requires that we convert 
@@ -192,6 +192,8 @@ of the QNode's arguments are trainable, which can lead to a host of unique error
 For instance, calculating the jacobian of this circuit with ``lightning.qubit`` 
 raises an error due to a discrepancy in the ordering of the positional arguments 
 when tape conversion happens.
+
+The same is true of the ``lightning.kokkos`` and ``lightning.gpu`` devices.
 
 .. code-block:: python 
 

--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -43,7 +43,7 @@ devices compatible with program capture.
 Device wires 
 ~~~~~~~~~~~~
 
-With program capture enabled, for all supported devices it is required 
+With program capture enabled, all currently supported devices require 
 that ``wires`` be specified at device instantiation (this is in contrast to when 
 program capture is disabled, where automatic qubit management takes place internally
 with ``default.qubit``).

--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -101,9 +101,9 @@ Gradients
 
 Currently the devices ``default.qubit``, ``lightning.qubit``, ``lightning.kokkos``, and ``lightning.gpu`` 
 are the only devices that support gradients with program capture enabled. ``default.qubit`` currently 
-supports ``adjoint``, ``backprop`` and ``finite-diff``. ``lightning.qubit`` currently only supports 
-``adjoint``. The ``parameter_shift`` method is not yet supported with program capture enabled, 
-and will raise an error if used. 
+supports ``adjoint``, ``backprop`` and ``finite-diff``. ``lightning.qubit``, ``lightning.kokkos``, and 
+``lightning.gpu`` currently only support ``adjoint``. The ``parameter_shift`` method is not yet supported 
+with program capture enabled, and will raise an error if used. 
 
 .. code-block:: python
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -719,6 +719,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Documentation 📝</h3>
 
+* The entry in the :doc:`/news/program_capture_sharp_bits` has been updated to include additional supported lightning devices.
+  [(#7674)](https://github.com/PennyLaneAI/pennylane/pull/7674)
+
 * Updated the circuit drawing for `qml.Select` to include two commonly used symbols for 
   Select-applying, or multiplexing, an operator. Added a similar drawing for `qml.SelectPauliRot`.
   [(#7464)](https://github.com/PennyLaneAI/pennylane/pull/7464)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -719,7 +719,8 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Documentation 📝</h3>
 
-* The entry in the :doc:`/news/program_capture_sharp_bits` has been updated to include additional supported lightning devices.
+* The entry in the :doc:`/news/program_capture_sharp_bits` has been updated to include
+  additional supported lightning devices: ``lightning.kokkos`` and ``lightning.gpu``.
   [(#7674)](https://github.com/PennyLaneAI/pennylane/pull/7674)
 
 * Updated the circuit drawing for `qml.Select` to include two commonly used symbols for 


### PR DESCRIPTION
**Context:**
The program capture "sharp bits" documentation page incorrectly states that the only supported devices are `default.qubit` and `lightning.qubit`.

**Description of the Change:**
Adds `lightning.kokkos` and `lightning.gpu` to the documentation as devices that support program capture.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-93195]