### PR TITLE
Interpret built-in constants in QASM 3.0

### DIFF
--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Iterable
 
+import numpy as np
 from numpy import uint
 from openqasm3.ast import (
     AliasStatement,
@@ -93,6 +94,15 @@ PARAMETERIZED_GATES = {
     "CRX": ops.CRX,
     "CRY": ops.CRY,
     "CRZ": ops.CRZ,
+}
+
+CONSTANTS = {
+    "π": np.pi,
+    "τ": np.pi * 2,
+    "ℇ": np.e,
+    "pi": np.pi,
+    "tau": np.pi * 2,
+    "e": np.e,
 }
 
 
@@ -399,6 +409,8 @@ class Context:
             return name
         if name in self.aliases:
             return self.aliases[name](self)  # evaluate the alias and de-reference
+        if name in CONSTANTS:
+            return CONSTANTS[name]
         raise TypeError(f"Attempt to use undeclared variable {name} in {self.name}")
 
     def process_measurement(self, operator: str, line: int, lhs: Variable, rhs: Variable = None):

--- a/tests/io/qasm_interpreter/test_interpreter.py
+++ b/tests/io/qasm_interpreter/test_interpreter.py
@@ -5,6 +5,7 @@ Unit tests for the :mod:`pennylane.io.qasm_interpreter` module.
 from re import escape
 from unittest.mock import MagicMock, call
 
+import numpy as np
 import pytest
 
 from pennylane import (
@@ -53,6 +54,31 @@ try:
     )
 except (ModuleNotFoundError, ImportError) as import_error:
     pass
+
+
+@pytest.mark.external
+class TestBuiltIns:
+
+    def test_constants(self):
+        ast = parse(
+            """
+            const float one = π;
+            const float two = τ;
+            const float three = ℇ;
+            const float four = pi;
+            const float five = tau;
+            const float six = e;
+            """
+        )
+
+        context = QasmInterpreter().interpret(ast, context={"name": "constants", "wire_map": None})
+
+        assert context.vars["one"].val == np.pi
+        assert context.vars["two"].val == np.pi * 2
+        assert context.vars["three"].val == np.e
+        assert context.vars["four"].val == np.pi
+        assert context.vars["five"].val == np.pi * 2
+        assert context.vars["six"].val == np.e
 
 
 @pytest.mark.external


### PR DESCRIPTION


------------------------------------------------------------------------------------------------------------

**Context:** We would like to be able to interpret built-in constants in QASM 3.0.

**Description of the Change:** Adds support for the six built-in constants regardless of scope.

**Benefits:** We can now use the exact values of pi, tau, e.

**Possible Drawbacks:**

**Related ShortCut Stories:** [sc-91133]
