### PR TITLE
Adding qutrit density matrix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -521,6 +521,12 @@
   default basis set of `qml.ops.sk_decomposition` to `(H, S, T)`, resulting in shorter decomposition sequences.
   [(#7454)](https://github.com/PennyLaneAI/pennylane/pull/7454)
 
+<h4>Community contributions 🥳</h4>
+
+* New operation `qml.QutritDensityMatix` added used to initialize density matrix states for the device
+  `qml.devices.DefaultQutritMixed`.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * The imports of dependencies introduced by ``labs`` functionalities have been modified such that

--- a/pennylane/devices/default_qutrit_mixed.py
+++ b/pennylane/devices/default_qutrit_mixed.py
@@ -68,7 +68,7 @@ def observable_stopping_condition(obs: qml.operation.Operator) -> bool:
 
 def stopping_condition(op: qml.operation.Operator) -> bool:
     """Specify whether an Operator object is supported by the device."""
-    expected_set = DefaultQutrit.operations | {"Snapshot"} | channels
+    expected_set = DefaultQutrit.operations | {"Snapshot"} | channels | {"QutritDensityMatrix"}
     return op.name in expected_set
 
 

--- a/pennylane/devices/qutrit_mixed/initialize_state.py
+++ b/pennylane/devices/qutrit_mixed/initialize_state.py
@@ -17,6 +17,7 @@ from collections.abc import Iterable
 from typing import Union
 
 import pennylane as qml
+from pennylane import math
 from pennylane.operation import StatePrepBase
 
 from .utils import QUDIT_DIM
@@ -40,35 +41,55 @@ def create_initial_state(
         array: The initial state of a circuit
     """
     num_wires = len(wires)
+    num_axes = 2 * num_wires
 
     if not prep_operation:
-        rho = _create_basis_state(num_wires, 0)
+        return qml.math.asarray(_create_basis_state(num_wires, 0), like=like)
 
+    if isinstance(prep_operation, qml.QubitDensityMatrix):
+        rho = prep_operation.data
     else:
         rho = _apply_state_vector(prep_operation.state_vector(wire_order=wires), num_wires)
 
-    # TODO: add instance for prep_operations as added
-
-    return qml.math.asarray(rho, like=like)
+    return _post_process(rho, num_axes, like)
 
 
-def _apply_state_vector(state, num_wires):  # function is easy to abstract for qudit
+def _post_process(rho, num_axes, like):
+    r"""
+    This post-processor is necessary to ensure that the density matrix is in
+    the correct format, i.e. the original tensor form, instead of the pure
+    matrix form, as requested by all the other more fundamental chore functions
+    in the module (again from some legacy code).
+    """
+    # Ensure correct shape and remove batch dimension if unused.
+    rho = math.reshape(rho, (-1,) + (3,) * num_axes)
+    rho = math.squeeze(rho)
+
+    dtype = str(rho.dtype)
+    floating_single = "float32" in dtype or "complex64" in dtype
+    dtype = "complex64" if floating_single else "complex128"
+    dtype = "complex128" if like == "tensorflow" else dtype
+    return math.cast(math.asarray(rho, like=like), dtype)
+
+
+def _apply_state_vector(pure_state, num_wires):  # function is easy to abstract for qudit
     """Initialize the internal state in a specified pure state.
 
     Args:
-        state (array[complex]): normalized input state of length
-            ``QUDIT_DIM**num_wires``, where ``QUDIT_DIM`` is the dimension of the system.
+        state (array[complex]): normalized input state of length ``3**num_wires``.
         num_wires (int): number of wires that get initialized in the state
 
     Returns:
-        array[complex]: complex array of shape ``[QUDIT_DIM] * (2 * num_wires)``
-        representing the density matrix of this state, where ``QUDIT_DIM`` is
-        the dimension of the system.
+        array[complex]: complex array of shape ``[3] * (2 * num_wires)``
+        representing the density matrix of this state.
     """
-
-    # Initialize the entire set of wires with the state
-    rho = qml.math.outer(state, qml.math.conj(state))
-    return qml.math.reshape(rho, [QUDIT_DIM] * 2 * num_wires)
+    # Don't assume the expected shape to be fixed
+    batch_size = math.get_batch_size(
+        pure_state, expected_shape=(3,) * num_wires, expected_size=3**num_wires
+    )
+    if batch_size is None:
+        return _flatten_outer(pure_state)
+    return math.stack([_flatten_outer(s) for s in pure_state])
 
 
 def _create_basis_state(num_wires, index):  # function is easy to abstract for qudit
@@ -79,10 +100,15 @@ def _create_basis_state(num_wires, index):  # function is easy to abstract for q
         index (int): integer representing the computational basis state.
 
     Returns:
-        array[complex]: complex array of shape ``[QUDIT_DIM] * (2 * num_wires)``
-        representing the density matrix of the basis state, where ``QUDIT_DIM`` is
-        the dimension of the system.
+        array[complex]: complex array of shape ``[3] * (2 * num_wires)``
+        representing the density matrix of the basis state.
     """
-    rho = qml.math.zeros((QUDIT_DIM**num_wires, QUDIT_DIM**num_wires))
+    rho = qml.math.zeros((3**num_wires, 3**num_wires))
     rho[index, index] = 1
-    return qml.math.reshape(rho, [QUDIT_DIM] * (2 * num_wires))
+    return qml.math.reshape(rho, [3] * (2 * num_wires))
+
+
+def _flatten_outer(s):
+    r"""Flattens the outer product of a vector."""
+    s_flatten = math.flatten(s)
+    return math.outer(s_flatten, math.conj(s_flatten))

--- a/pennylane/ops/qutrit/__init__.py
+++ b/pennylane/ops/qutrit/__init__.py
@@ -20,18 +20,13 @@ The operations are in one file:
   either unitary or hermitian depending.
 """
 
-from ..identity import Identity, I
-from .channel import (
-    QutritDepolarizingChannel,
-    QutritAmplitudeDamping,
-    TritFlip,
-    QutritChannel,
-)
-from .matrix_ops import QutritUnitary, ControlledQutritUnitary
-from .non_parametric_ops import TShift, TClock, TAdd, TSWAP, THadamard
+from ..identity import I, Identity
+from .channel import QutritAmplitudeDamping, QutritChannel, QutritDepolarizingChannel, TritFlip
+from .matrix_ops import ControlledQutritUnitary, QutritUnitary
+from .non_parametric_ops import TSWAP, TAdd, TClock, THadamard, TShift
+from .observables import GellMann, THermitian
 from .parametric_ops import TRX, TRY, TRZ, validate_subspace
-from .observables import THermitian, GellMann
-from .state_preparation import QutritBasisState
+from .state_preparation import QutritBasisState, QutritDensityMatrix
 
 # TODO: Change `qml.Identity` for qutrit support or add `qml.TIdentity` for qutrits
 __ops__ = {
@@ -47,6 +42,7 @@ __ops__ = {
     "TRY",
     "TRZ",
     "QutritBasisState",
+    "QutritDensityMatrix",
 }
 
 __obs__ = {

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from pennylane import math
 from pennylane.operation import StatePrepBase
+from pennylane.ops.qubit.state_preparation import QubitDensityMatrix
 from pennylane.templates.state_preparations import QutritBasisStatePreparation
 from pennylane.wires import WireError, Wires
 
@@ -116,3 +117,52 @@ class QutritBasisState(StatePrepBase):
         ket = np.zeros((3,) * num_wires)
         ket[tuple(indices)] = 1
         return math.convert_like(ket, prep_vals)
+
+    class QutritDensityMatrix(QubitDensityMatrix):
+        r"""QutritDensityMatrix(state, wires)
+        Prepare subsystems using the given density matrix.
+        If not all the wires are specified, remaining dimension is filled by :math:`\mathrm{tr}_{in}(\rho)`,
+        where :math:`\rho` is the full system density matrix before this operation and :math:`\mathrm{tr}_{in}` is a
+        partial trace over the subsystem to be replaced by input state.
+        **Details:**
+        * Number of wires: Any (the operation can act on any number of wires)
+        * Number of parameters: 1
+        * Gradient recipe: None
+        .. note::
+            Exception raised if the ``QutritDensityMatrix`` operation is not supported natively on the
+            target device.
+        Args:
+            state (array[complex]): a density matrix of size ``(3**len(wires), 3**len(wires))``
+            wires (Sequence[int] or int): the wire(s) the operation acts on
+            id (str): custom label given to an operator instance,
+                can be useful for some applications where the instance has to be identified.
+        .. details::
+            :title: Usage Details
+            Example:
+            .. code-block:: python
+                import pennylane as qml
+                nr_wires = 2
+                rho = np.zeros((3 ** nr_wires, 3 ** nr_wires), dtype=np.complex128)
+                rho[0, 0] = 1  # initialize the pure state density matrix for the |0><0| state
+                dev = qml.device("default.qutrit.mixed", wires=2)
+                @qml.qnode(dev)
+                def circuit():
+                    qml.QutritDensityMatrix(rho, wires=[0, 1])
+                    return qml.state()
+            Running this circuit:
+            >>> circuit()
+            [[1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+        """
+
+        num_params = 1
+        """int: Number of trainable parameters that the operator depends on."""
+
+        grad_method = None

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -118,51 +118,51 @@ class QutritBasisState(StatePrepBase):
         ket[tuple(indices)] = 1
         return math.convert_like(ket, prep_vals)
 
-    class QutritDensityMatrix(QubitDensityMatrix):
-        r"""QutritDensityMatrix(state, wires)
-        Prepare subsystems using the given density matrix.
-        If not all the wires are specified, remaining dimension is filled by :math:`\mathrm{tr}_{in}(\rho)`,
-        where :math:`\rho` is the full system density matrix before this operation and :math:`\mathrm{tr}_{in}` is a
-        partial trace over the subsystem to be replaced by input state.
-        **Details:**
-        * Number of wires: Any (the operation can act on any number of wires)
-        * Number of parameters: 1
-        * Gradient recipe: None
-        .. note::
-            Exception raised if the ``QutritDensityMatrix`` operation is not supported natively on the
-            target device.
-        Args:
-            state (array[complex]): a density matrix of size ``(3**len(wires), 3**len(wires))``
-            wires (Sequence[int] or int): the wire(s) the operation acts on
-            id (str): custom label given to an operator instance,
-                can be useful for some applications where the instance has to be identified.
-        .. details::
-            :title: Usage Details
-            Example:
-            .. code-block:: python
-                import pennylane as qml
-                nr_wires = 2
-                rho = np.zeros((3 ** nr_wires, 3 ** nr_wires), dtype=np.complex128)
-                rho[0, 0] = 1  # initialize the pure state density matrix for the |0><0| state
-                dev = qml.device("default.qutrit.mixed", wires=2)
-                @qml.qnode(dev)
-                def circuit():
-                    qml.QutritDensityMatrix(rho, wires=[0, 1])
-                    return qml.state()
-            Running this circuit:
-            >>> circuit()
-            [[1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-             [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
-        """
+class QutritDensityMatrix(QubitDensityMatrix):
+    r"""QutritDensityMatrix(state, wires)
+    Prepare subsystems using the given density matrix.
+    If not all the wires are specified, remaining dimension is filled by :math:`\mathrm{tr}_{in}(\rho)`,
+    where :math:`\rho` is the full system density matrix before this operation and :math:`\mathrm{tr}_{in}` is a
+    partial trace over the subsystem to be replaced by input state.
+    **Details:**
+    * Number of wires: Any (the operation can act on any number of wires)
+    * Number of parameters: 1
+    * Gradient recipe: None
+    .. note::
+        Exception raised if the ``QutritDensityMatrix`` operation is not supported natively on the
+        target device.
+    Args:
+        state (array[complex]): a density matrix of size ``(3**len(wires), 3**len(wires))``
+        wires (Sequence[int] or int): the wire(s) the operation acts on
+        id (str): custom label given to an operator instance,
+            can be useful for some applications where the instance has to be identified.
+    .. details::
+        :title: Usage Details
+        Example:
+        .. code-block:: python
+            import pennylane as qml
+            nr_wires = 2
+            rho = np.zeros((3 ** nr_wires, 3 ** nr_wires), dtype=np.complex128)
+            rho[0, 0] = 1  # initialize the pure state density matrix for the |0><0| state
+            dev = qml.device("default.qutrit.mixed", wires=2)
+            @qml.qnode(dev)
+            def circuit():
+                qml.QutritDensityMatrix(rho, wires=[0, 1])
+                return qml.state()
+        Running this circuit:
+        >>> circuit()
+        [[1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
+         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+    """
 
-        num_params = 1
-        """int: Number of trainable parameters that the operator depends on."""
+    num_params = 1
+    """int: Number of trainable parameters that the operator depends on."""
 
-        grad_method = None
+    grad_method = None


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The `DefaultQutritMixed` device does not have an operation to set the initial state as a density matrix. This would be a useful operation to have.

**Description of the Change:**
Adds QutritDensityMatrix operation to the `DefaultQutritMixed` device.
Modifies `qml.devices.qutrit_mixed.create_initial_state` so that it can create density matrix states along with vector states.
Fixes batching in `qml.devices.qutrit_mixed.create_initial_state`.

**Benefits:**
Allows for a density matrix state to be initialized on the `DefaultQutritMixed` device.
Should deal with https://github.com/PennyLaneAI/pennylane/issues/7220 occurring on the `DefaultQutritMixed` device.

**Possible Drawbacks:**
Adds an unnecessary operation: QubitDensityMatrix could be changed to DensityMatrix, allowing both Qubits and Qutrits to use the same operation.

**Related GitHub Issues:**
N/A
