### PR TITLE
Renaming PennyLane in `pyproject.toml`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -639,6 +639,10 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* `Pennylane` has been renamed `pennylane` in the `pyproject.toml` file 
+  to match the expected binary distribution format naming conventions.
+  [(#7689)](https://github.com/PennyLaneAI/pennylane/pull/7689)
+
 * The `qml.compiler.python_compiler` submodule has been restructured.
   [(#7645)](https://github.com/PennyLaneAI/pennylane/pull/7645)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -639,7 +639,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
-* `Pennylane` has been renamed `pennylane` in the `pyproject.toml` file 
+* `Pennylane` has been renamed to `pennylane` in the `pyproject.toml` file 
   to match the expected binary distribution format naming conventions.
   [(#7689)](https://github.com/PennyLaneAI/pennylane/pull/7689)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=75.8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "Pennylane"
+name = "pennylane"
 description = "PennyLane is a cross-platform Python library for quantum computing, quantum machine learning, and quantum chemistry. Train a quantum computer the same way as a neural network."
 readme = "README.md"
 license =  "Apache-2.0"


### PR DESCRIPTION
As explained in [this issue](https://github.com/PennyLaneAI/pennylane/issues/7660), the project name for PennyLane does not match with the expected binary distribution format naming conventions.

Therefore, we change the name in the `pyproject.toml` file before the next release, and this PR does precisely this.

**Related issues**: Fixes #7660 

[sc-93375]