### PR TITLE
Pinning `quimb` to previous version

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq!=0.45.0 ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.38 filecheck
+        pyzx matplotlib stim quimb==1.11.0 mitiq!=0.45.0 ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.38 filecheck
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}


### PR DESCRIPTION
`quimb` has released [another version 3 days ago](https://quimb.readthedocs.io/en/latest/changelog.html#v1-11-1-2025-06-20), and as usual this has broken `default.tensor`.

We'lll investigate this as soon as possible, but for now let's pin the `quimb` version in the CI.