### PR TITLE
unpin `mitiq` in CI

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -492,7 +492,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb==1.11.0 mitiq!=0.45.0 ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.38 filecheck
+        pyzx matplotlib stim quimb==1.11.0 mitiq ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.38 filecheck
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -845,6 +845,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Unpin `mitiq` in CI.
+  [(#7742)](https://github.com/PennyLaneAI/pennylane/pull/7742)
+
 * The `qml.measurements.Shots` class can now handle abstract numbers of shots.
   [(#7729)](https://github.com/PennyLaneAI/pennylane/pull/7729)
 


### PR DESCRIPTION
**Context:**

The problematic version was yanked,
<img width="824" alt="image" src="https://github.com/user-attachments/assets/befa8183-5888-4bb1-8786-f3a61349a2fe" />

**Description of the Change:**

Unpin `mitiq`.