### PR TITLE
Add warning to `qml.snapshots` and `qml.Snapshot` for transforms not preserving circuit structure

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -991,6 +991,10 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   disabling program capture.
   [(#7298)](https://github.com/PennyLaneAI/pennylane/pull/7298)
 
+* Added a warning to the documentation for `qml.snapshots`, clarifying that compilation transforms 
+may move operations across a `Snapshot`.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 <h3>Bug fixes 🐛</h3>
 
 * The `qml.ftqc.ParametricMidMeasureMP` class was unable to accept data from `jax.numpy.array` inputs

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -993,7 +993,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 * Added a warning to the documentation for `qml.snapshots`, clarifying that compilation transforms 
 may move operations across a `Snapshot`.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#7746)](https://github.com/PennyLaneAI/pennylane/pull/7746)
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -991,7 +991,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   disabling program capture.
   [(#7298)](https://github.com/PennyLaneAI/pennylane/pull/7298)
 
-* Added a warning to the documentation for `qml.snapshots`, clarifying that compilation transforms 
+* Added a warning to the documentation for `qml.snapshots` and `qml.Snapshot`, clarifying that compilation transforms 
 may move operations across a `Snapshot`.
   [(#7746)](https://github.com/PennyLaneAI/pennylane/pull/7746)
 

--- a/pennylane/debugging/snapshot.py
+++ b/pennylane/debugging/snapshot.py
@@ -90,6 +90,12 @@ def snapshots(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingFn
         For devices that do not support snapshots (e.g QPUs, external plug-in simulators), be mindful of
         additional costs that you might incur due to the 1 separate execution/snapshot behaviour.
 
+    .. warning::
+
+        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms 
+        (e.g., ``combine_global_phases``, ``merge_rotations``) may reorder or modify operations across the snapshot.
+        As a result, the captured state may differ from the original intent.
+
     **Example**
 
     .. code-block:: python3

--- a/pennylane/debugging/snapshot.py
+++ b/pennylane/debugging/snapshot.py
@@ -92,7 +92,7 @@ def snapshots(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingFn
 
     .. warning::
 
-        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms 
+        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms
         (e.g., ``combine_global_phases``, ``merge_rotations``) may reorder or modify operations across the snapshot.
         As a result, the captured state may differ from the original intent.
 

--- a/pennylane/ops/meta.py
+++ b/pennylane/ops/meta.py
@@ -179,6 +179,12 @@ class Snapshot(Operation):
         shots (Literal["workflow"], None, int, Sequence[int]): shots to use for the snapshot.
             ``"workflow"`` indicates the same number of shots as for the final measurement.
 
+    .. warning::
+
+        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms 
+        (e.g., ``combine_global_phases``, ``merge_rotations``) may reorder or modify operations across the snapshot.
+        As a result, the captured state may differ from the original intent.
+
     **Example**
 
     .. code-block:: python3

--- a/pennylane/ops/meta.py
+++ b/pennylane/ops/meta.py
@@ -181,7 +181,7 @@ class Snapshot(Operation):
 
     .. warning::
 
-        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms 
+        ``Snapshot`` captures the internal execution state at a point in the circuit, but compilation transforms
         (e.g., ``combine_global_phases``, ``merge_rotations``) may reorder or modify operations across the snapshot.
         As a result, the captured state may differ from the original intent.
 


### PR DESCRIPTION
**Context:**
Transformations like `combine_global_phases` can reorder or merge operations across a Snapshot, altering what the snapshot captures and potentially leading to confusing results.

**Description of the Change:**
Added a warning to the documentation for `qml.snapshots` noting that compilation transforms may move operations past a `Snapshot`, changing the state that is captured.

**Benefits:**
Clarifies expected behavior for users and avoids confusion when snapshots return unexpected results due to circuit transformations.

**Possible Drawbacks:**
N/A (doc update only)

**Related GitHub Issues:**
None