### PR TITLE
Optimize `BasisRotation` for real-valued inputs and extend theory in docstring

### DIFF
--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -14,6 +14,8 @@
 
 """Utility functions for decompositions are available from ``qml.math.decomposition``."""
 
+from functools import reduce
+
 import numpy as np
 
 from pennylane import math
@@ -351,8 +353,65 @@ def _givens_matrix(a, b, left=True, tol=1e-8):
     return math.array([[phase * sine, cosine], [-phase * cosine, sine]], like=interface)
 
 
+def _givens_matrix_real(a, b, left=True, tol=1e-8):
+    r"""Build a :math:`2 \times 2` Givens rotation matrix :math:`G`.
+
+    When the matrix :math:`G` is applied to a vector :math:`[a,\ b]^T` the following would happen:
+
+    .. math::
+
+            G \times \begin{bmatrix} a \\ b \end{bmatrix} = \begin{bmatrix} 0 \\ r \end{bmatrix} \quad \quad \quad \begin{bmatrix} a \\ b \end{bmatrix} \times G = \begin{bmatrix} r \\ 0 \end{bmatrix},
+
+    where :math:`r` is a complex number.
+
+    Args:
+        a (float or complex): first element of the vector for which the Givens matrix is being computed
+        b (float or complex): second element of the vector for which the Givens matrix is being computed
+        left (bool): determines if the Givens matrix is being applied from the left side or right side.
+        tol (float): determines tolerance limits for :math:`|a|` and :math:`|b|` under which they are considered as zero.
+
+    Returns:
+        tensor_like: Givens rotation matrix
+
+    Raises:
+        TypeError: if a and b have different interfaces
+
+    """
+
+    abs_a, abs_b = math.abs(a), math.abs(b)
+    interface_a, interface_b = math.get_interface(a), math.get_interface(b)
+
+    if interface_a != interface_b:
+        raise TypeError(
+            f"The interfaces of 'a' and 'b' do not match. Got {interface_a} and {interface_b}."
+        )
+
+    interface = interface_a
+
+    hypot = math.hypot(abs_a, abs_b) + 1e-15  # avoid division by zero
+
+    cosine = math.where(abs_b < tol, 0.0, abs_b / hypot)
+    cosine = math.where(abs_a < tol, 1.0, cosine)
+
+    sine = math.where(abs_b < tol, 1.0, abs_a / hypot)
+    sine = math.where(abs_a < tol, 0.0, sine)
+
+    sign = math.where((abs_a < tol) + (abs_b < tol), 1.0, math.sign(a * b))
+
+    if not left:
+        cosine, sine = sine, -cosine
+    return math.array([[cosine, -sign * sine], [sign * sine, cosine]], like=interface)
+
+
+def ___make_G(mat, i, j, n):
+    rotation_matrix = np.eye(n, dtype=float)
+    rotation_matrix[i, i], rotation_matrix[j, j] = mat[0, 0], mat[1, 1]
+    rotation_matrix[i, j], rotation_matrix[j, i] = mat[0, 1], mat[1, 0]
+    return rotation_matrix
+
+
 # pylint: disable=too-many-branches
-def givens_decomposition(unitary):
+def givens_decomposition(unitary, is_so=False):
     r"""Decompose a unitary into a sequence of Givens rotation gates with phase shifts and a diagonal phase matrix.
 
     This decomposition is based on the construction scheme given in `Optica, 3, 1460 (2016) <https://opg.optica.org/optica/fulltext.cfm?uri=optica-3-12-1460&id=355743>`_\ ,
@@ -442,54 +501,137 @@ def givens_decomposition(unitary):
 
     """
     interface = math.get_deep_interface(unitary)
-    unitary = math.copy(unitary) if interface == "jax" else math.toarray(unitary).copy()
-    M, N = math.shape(unitary)
+    if is_so:
+        givens_fn = _givens_matrix_real
+        assert math.isreal(unitary[0, 0])  # arrays have consistent dtypes, so it check just one
+    else:
+        givens_fn = _givens_matrix
 
-    if M != N:
-        raise ValueError(f"The unitary matrix should be of shape NxN, got {unitary.shape}")
+    unitary_copy = math.copy(unitary) if interface == "jax" else math.toarray(unitary).copy()
+    unitary = math.copy(unitary) if interface == "jax" else math.toarray(unitary).copy()
+    shape = math.shape(unitary)
+
+    if len(shape) != 2 or shape[0] != shape[1]:
+        raise ValueError(f"The unitary matrix should be of shape NxN, got {shape}")
+
+    N = shape[0]
 
     left_givens, right_givens = [], []
+    print(f"Have input matrix:\n{np.round(unitary, 4)}")
     for i in range(1, N):
+        print(f"{i=}")
         if i % 2:
             for j in range(0, i):
+                print(f"{j=}")
+                print(f"Attempt to eliminate U[{N-j-1}, {i-j-1}]")
                 indices = [i - j - 1, i - j]
-                grot_mat = _givens_matrix(*unitary[N - j - 1, indices].T, left=True)
-                unitary = _set_unitary_matrix(
-                    unitary, (Ellipsis, indices), unitary[:, indices] @ grot_mat.T, like=interface
-                )
+                grot_mat = givens_fn(*unitary[N - j - 1, indices].T, left=True)
+                # unitary = _set_unitary_matrix(
+                # unitary, (Ellipsis, indices), unitary[:, indices] @ grot_mat.T, like=interface
+                # )
+                unitary = unitary @ ___make_G(grot_mat.T, *indices, N)
                 right_givens.append((math.conj(grot_mat), indices))
+                print(f"U[{N-j-1}, {i-j-1}]={unitary[N-j-1, i-j-1]}")
+                if not np.isclose(unitary[N - j - 1, i - j - 1], 0.0):
+                    print("failed.")
+            if i == N - 1:
+                print("finishing with right")
         else:
             for j in range(1, i + 1):
+                print(f"{j=}")
+                print(f"Attempt to eliminate U[{N+j-i-1}, {j-1}]")
                 indices = [N + j - i - 2, N + j - i - 1]
-                grot_mat = _givens_matrix(*unitary[indices, j - 1], left=False)
-                unitary = _set_unitary_matrix(
-                    unitary, (indices, Ellipsis), grot_mat @ unitary[indices, :], like=interface
-                )
+                grot_mat = givens_fn(*unitary[indices, j - 1], left=False)
+                # unitary = _set_unitary_matrix(
+                # unitary, (indices, Ellipsis), grot_mat @ unitary[indices, :], like=interface
+                # )
+                unitary = ___make_G(grot_mat, *indices, N) @ unitary
                 left_givens.append((grot_mat, indices))
+                print(f"U[{N+j-i-1}, {j-1}]={unitary[N+j-i-1, j-1]}")
+                if not np.isclose(unitary[N + j - i - 1, j - 1], 0.0):
+                    print("failed.")
+            if i == N - 1:
+                print("finishing with left")
+        print(f"Have current matrix:\n{np.round(unitary, 4)}")
 
-    nleft_givens = []
-    for grot_mat, (i, j) in reversed(left_givens):
-        sphase_mat = math.diag(math.diag(unitary)[math.array([i, j])])
-        decomp_mat = math.conj(grot_mat).T @ sphase_mat
-        givens_mat = _givens_matrix(*decomp_mat[1, :].T)
-        nphase_mat = decomp_mat @ givens_mat.T
+    if is_so:
 
-        # check for T_{m,n}^{-1} x D = D x T.
-        if not math.is_abstract(decomp_mat) and not math.allclose(
-            nphase_mat @ math.conj(givens_mat), decomp_mat
-        ):  # pragma: no cover
-            raise ValueError("Failed to shift phase transposition.")
+        left_rots = [___make_G(mat, *ids, N) for mat, ids in reversed(left_givens)]
+        right_rots = [___make_G(mat.T, *ids, N) for mat, ids in right_givens]
+        reconstruction = reduce(np.dot, left_rots + [unitary_copy] + right_rots)
+        assert np.allclose(unitary, reconstruction), f"{reconstruction}"
+        assert np.allclose(np.eye(N), np.dot(unitary, reconstruction)), f"{reconstruction}"
+        __recon_ = left_rots + [unitary_copy] + right_rots
 
-        for diag_idx, diag_val in zip([(i, i), (j, j)], math.diag(nphase_mat)):
-            unitary = _set_unitary_matrix(unitary, diag_idx, diag_val, like=interface)
-        nleft_givens.append((math.conj(givens_mat), (i, j)))
+        if N % 2:
+            last_rotations = left_givens
+            for k in range(len(last_rotations) - 1, len(last_rotations) - N, -1):
+                grot_mat, (i, j) = last_rotations[k]
+                if unitary[j, j] < 0:
+                    # print(f"flipping Givens matrix on {i=} and {j=}")
+                    unitary = _set_unitary_matrix(unitary, (i, i), -unitary[i, i], like=interface)
+                    unitary = _set_unitary_matrix(unitary, (j, j), -unitary[j, j], like=interface)
+                    if unitary[i, i] < 0:
+                        last_rotations[k] = (grot_mat.T * (-1.0), (i, j))
+                    else:
+                        last_rotations[k] = (grot_mat * (-1.0), (i, j))
+                elif unitary[i, i] < 0:
+                    last_rotations[k] = (grot_mat.T, (i, j))
+        else:
+            last_rotations = right_givens
+            for k in range(len(last_rotations) - 1, len(last_rotations) - N, -1):
+                grot_mat, (i, j) = last_rotations[k]
+                if unitary[i, i] < 0:
+                    unitary = _set_unitary_matrix(unitary, (i, i), -unitary[i, i], like=interface)
+                    unitary = _set_unitary_matrix(unitary, (j, j), -unitary[j, j], like=interface)
+                    if unitary[j, j] < 0:
+                        last_rotations[k] = (grot_mat.T * (-1.0), (i, j))
+                    else:
+                        last_rotations[k] = (grot_mat * (-1.0), (i, j))
+                elif unitary[j, j] < 0:
+                    last_rotations[k] = (grot_mat.T, (i, j))
 
-    phases, ordered_rotations = math.diag(unitary), []
-    for grot_mat, (i, j) in list(reversed(nleft_givens)) + list(reversed(right_givens)):
-        if not math.is_abstract(grot_mat) and not math.all(
-            math.isreal(grot_mat[0, 1]) and math.isreal(grot_mat[1, 1])
-        ):  # pragma: no cover
-            raise ValueError(f"Incorrect Givens Rotation encountered, {grot_mat}")
-        ordered_rotations.append((grot_mat, (i, j)))
+        phases = math.diag(unitary)
+
+        left_rots = [___make_G(mat, *ids, N) for mat, ids in reversed(left_givens)]
+        right_rots = [___make_G(mat.T, *ids, N) for mat, ids in right_givens]
+        reconstruction_ = reduce(np.dot, left_rots + [unitary_copy] + right_rots)
+        assert np.allclose(np.eye(N), reconstruction_), f"{np.round(reconstruction_, 4)}"
+
+        left_givens = [(mat.T, indices) for mat, indices in left_givens]
+        ordered_rotations = left_givens + list(reversed(right_givens))
+
+        recon_rotations = [___make_G(mat, *ids, N) for mat, ids in ordered_rotations]
+        reconstruction = reduce(np.dot, recon_rotations)
+        assert np.allclose(unitary_copy, reconstruction)
+
+    else:
+        nleft_givens = []
+        for grot_mat, (i, j) in reversed(left_givens):
+            sphase_mat = math.diag(math.diag(unitary)[math.array([i, j])])
+            decomp_mat = math.conj(grot_mat).T @ sphase_mat
+            givens_mat = givens_fn(*decomp_mat[1, :].T)
+            nphase_mat = decomp_mat @ givens_mat.T
+
+            # check for T_{m,n}^{-1} x D = D x T.
+            if not math.is_abstract(decomp_mat) and not math.allclose(
+                nphase_mat @ math.conj(givens_mat), decomp_mat
+            ):  # pragma: no cover
+                raise ValueError("Failed to shift phase transposition.")
+
+            for diag_idx, diag_val in zip([(i, i), (j, j)], math.diag(nphase_mat)):
+                unitary = _set_unitary_matrix(unitary, diag_idx, diag_val, like=interface)
+            nleft_givens.append((math.conj(givens_mat), (i, j)))
+        print(*left_givens, sep="\n")
+        print(*nleft_givens, sep="\n")
+
+        phases, ordered_rotations = math.diag(unitary), []
+
+        for grot_mat, (i, j) in list(reversed(nleft_givens)) + list(reversed(right_givens)):
+            if not math.is_abstract(grot_mat) and not math.all(
+                math.isreal(grot_mat[0, 1]) and math.isreal(grot_mat[1, 1])
+            ):  # pragma: no cover
+                raise ValueError(f"Incorrect Givens Rotation encountered, {grot_mat}")
+            ordered_rotations.append((grot_mat, (i, j)))
 
     return phases, ordered_rotations


### PR DESCRIPTION
**Context:**
`qml.BasisRotation` implements a basis rotation in the space of orbitals, mapped to quantum circuits.
In general, the decomposition contains `PhaseShift` and `SingleExcitation` gates.
If the rotation matrix is real-valued, and thus orthogonal, the decomposition can be simplified to Givens rotations (`SingleExcitation`) only (for special orthogonal, i.e., determinant $1$), or Givens rotations and a single `PhaseShift` (determinant $-1$).
In addition, we recently gained some insight in how to understand the mapping from orbital rotations to qubits.

**Description of the Change:**
Add a branch to the decomposition of `qml.BasisRotation` that is triggered if the rotation matrix has a real number data type. It uses zero or one `PhaseShift` operations instead of up to $(N^2+N)/2$ phase shifts, and the same number of `SingleExcitation` gates as the complex-valued decomposition.

The second major change is an extension of the theory part of the docstring of `BasisRotation`, including a Lie algebraic explanation for the mapping.

**Benefits:**
Cheaper decomposition. More math context in docs.

**Possible Drawbacks:**
More complex decomposition logic.

**Related GitHub Issues:**
