### PR TITLE
Registers not yet supported

### DIFF
--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -668,6 +668,9 @@ class QasmInterpreter:
             node (QASMNode): The QubitDeclaration QASMNode.
             context (Context): The current context.
         """
+        if isinstance(node.size, ast.IntegerLiteral):
+            raise TypeError("Qubit registers are not yet supported, "
+                            "please declare each qubit individually.")
         context.wires.append(node.qubit.name)
 
     @visit.register(ast.ClassicalAssignment)

--- a/tests/io/qasm_interpreter/test_interpreter.py
+++ b/tests/io/qasm_interpreter/test_interpreter.py
@@ -595,11 +595,26 @@ class TestVariables:
         ):
             QasmInterpreter().interpret(ast, context={"wire_map": None, "name": "mutate-error"})
 
+    def test_declare_register(self):
+        # parse the QASM
+        ast = parse(
+            """
+            qubit[2] q;
+            """,
+            permissive=True,
+        )
+
+        with pytest.raises(TypeError, match="Qubit registers are not yet supported, "
+                                             "please declare each qubit individually."):
+            QasmInterpreter().interpret(
+                ast, context={"wire_map": None, "name": "qubit-register"}
+            )
+
     def test_retrieve_wire(self):
         # parse the QASM
         ast = parse(
             """
-            qubit[0] q;
+            qubit q;
             let s = q;
             """,
             permissive=True,


### PR DESCRIPTION


------------------------------------------------------------------------------------------------------------

**Context:** Qubit register declarations were treated as single qubit declarations in previous commits.

**Description of the Change:** Raises an error when a qubit register declaration is encountered, saying registers are not yet supported. Until we are able to add support for registers in a coming PR.

**Benefits:** Incorrect behaviour avoided.

**Possible Drawbacks:** Just a temporary band-aid.

**Related ShortCut Stories:** [sc-94195]
