### PR TITLE
Usability improvement to evolve

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -597,6 +597,8 @@
 
 <h4>Other improvements</h4>
 
+* `qml.evolve` now errors out if the first argument is not a valid type.
+
 * Caching with finite shots now always warns about the lack of expected noise.
   [(#7644)](https://github.com/PennyLaneAI/pennylane/pull/7644)
 

--- a/pennylane/ops/functions/evolve.py
+++ b/pennylane/ops/functions/evolve.py
@@ -164,6 +164,9 @@ def evolve(*args, **kwargs):  # pylint: disable=unused-argument
         will be significantly faster, see the jax docs on jitting. JIT-compiling is optional, and one can remove
         the decorator when only single executions are of interest.
     """
+    raise ValueError(
+        f"No dispatch rule for first argument of type {type(args[0])}. Options are Operator and ParametrizedHamiltonian"
+    )
 
 
 # pylint: disable=missing-docstring

--- a/tests/ops/functions/test_evolve.py
+++ b/tests/ops/functions/test_evolve.py
@@ -21,6 +21,13 @@ from pennylane.ops import Evolution
 from pennylane.pulse import ParametrizedEvolution, ParametrizedHamiltonian
 
 
+def test_error_for_unsupported_input():
+    """Test an error is raised for an unsupported input type."""
+
+    with pytest.raises(ValueError, match="No dispatch rule for first argument of type"):
+        qml.evolve(0.5)
+
+
 @pytest.mark.jax
 class TestEvolveConstructor:
     """Unit tests for the evolve function"""


### PR DESCRIPTION
**Context:**

It's easy to forget the call signature for `evolve` and switch the positions of the operator and coefficient. This just makes it so you actually get an error instead of it silently returning nothing.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
