### PR TITLE
Improved decompositions of `SingleExcitation`, `SingleExcitationMinus` and `SingleExcitationPlus`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,11 @@
 
 <h4>State-of-the-art templates and decompositions 🐝</h4>
 
+* The decompositions of `SingleExcitation`, `SingleExcitationMinus` and `SingleExcitationPlus`
+  have been reduced to fewer rotations and/or (CNOT|CZ|CY) gates. This leads to lower circuit cost
+  when decomposing these gates, both when focusing on two-qubit gates or on non-Clifford gates.
+  [(#7771)](https://github.com/PennyLaneAI/pennylane/pull/7771)
+
 * A new decomposition based on *unary iteration* has been added to :class:`qml.Select`.
   This decomposition reduces the :class:`T` count significantly, and uses :math:`c-1`
   auxiliary wires for a :class:`qml.Select` operation with :math:`c` control wires.

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -232,45 +232,24 @@ class SingleExcitation(Operation):
         **Example:**
 
         >>> qml.SingleExcitation.compute_decomposition(1.23, wires=(0,1))
-        [Adjoint(T(0)),
-         H(0),
-         S(0),
-         Adjoint(T(1)),
-         Adjoint(S(1)),
-         H(1),
-         CNOT(wires=[1, 0]),
-         RZ(-0.615, wires=[0]),
-         RY(0.615, wires=[1]),
-         CNOT(wires=[1, 0]),
-         Adjoint(S(0)),
-         H(0),
-         T(0),
-         H(1),
-         S(1),
-         T(1)]
+        [H(0),
+         CNOT(wires=[0, 1]),
+         RY(-0.615, wires=[0]),
+         RY(-0.615, wires=[1]),
+         CNOT(wires=[0, 1]),
+         H(0)]
 
         """
-        # This decomposition was found by plugging the matrix representation
-        # into transforms.two_qubit_decomposition and post-processing some of
-        # the resulting single-qubit gates.
+        # This decomposition is reported, e.g., in Fig. 2 of https://arxiv.org/pdf/2104.05695
         decomp_ops = [
-            qml.adjoint(qml.T)(wires=wires[0]),
-            qml.Hadamard(wires=wires[0]),
-            qml.S(wires=wires[0]),
-            qml.adjoint(qml.T)(wires=wires[1]),
-            qml.adjoint(qml.S)(wires=wires[1]),
-            qml.Hadamard(wires=wires[1]),
-            qml.CNOT(wires=[wires[1], wires[0]]),
-            qml.RZ(-phi / 2, wires=wires[0]),
-            qml.RY(phi / 2, wires=wires[1]),
-            qml.CNOT(wires=[wires[1], wires[0]]),
-            qml.adjoint(qml.S)(wires=wires[0]),
-            qml.Hadamard(wires=wires[0]),
-            qml.T(wires=wires[0]),
-            qml.Hadamard(wires=wires[1]),
-            qml.S(wires=wires[1]),
-            qml.T(wires=wires[1]),
+            qml.Hadamard(wires[0]),
+            qml.CNOT(wires),
+            qml.RY(-phi / 2, wires[0]),
+            qml.RY(-phi / 2, wires[1]),
+            qml.CNOT(wires),
+            qml.Hadamard(wires[0]),
         ]
+
         return decomp_ops
 
     def adjoint(self) -> "SingleExcitation":
@@ -291,35 +270,20 @@ class SingleExcitation(Operation):
 
 def _single_excitation_resources():
     return {
-        qml.decomposition.adjoint_resource_rep(qml.T, {}): 2,
-        qml.decomposition.adjoint_resource_rep(qml.S, {}): 2,
-        qml.Hadamard: 4,
-        qml.S: 2,
+        qml.Hadamard: 2,
         qml.CNOT: 2,
-        qml.RZ: 1,
-        qml.RY: 1,
-        qml.T: 2,
+        qml.RY: 2,
     }
 
 
 @register_resources(_single_excitation_resources)
 def _single_excitation_decomp(phi, wires, **__):
-    qml.adjoint(qml.T)(wires=wires[0])
-    qml.Hadamard(wires=wires[0])
-    qml.S(wires=wires[0])
-    qml.adjoint(qml.T)(wires=wires[1])
-    qml.adjoint(qml.S)(wires=wires[1])
-    qml.Hadamard(wires=wires[1])
-    qml.CNOT(wires=[wires[1], wires[0]])
-    qml.RZ(-phi / 2, wires=wires[0])
-    qml.RY(phi / 2, wires=wires[1])
-    qml.CNOT(wires=[wires[1], wires[0]])
-    qml.adjoint(qml.S)(wires=wires[0])
-    qml.Hadamard(wires=wires[0])
-    qml.T(wires=wires[0])
-    qml.Hadamard(wires=wires[1])
-    qml.S(wires=wires[1])
-    qml.T(wires=wires[1])
+    qml.Hadamard(wires[0])
+    qml.CNOT(wires)
+    qml.RY(-phi / 2, wires[0])
+    qml.RY(-phi / 2, wires[1])
+    qml.CNOT(wires)
+    qml.Hadamard(wires[0])
 
 
 add_decomps(SingleExcitation, _single_excitation_decomp)
@@ -429,27 +393,29 @@ class SingleExcitationMinus(Operation):
         **Example:**
 
         >>> qml.SingleExcitationMinus.compute_decomposition(1.23, wires=(0,1))
-        [X(0),
-        X(1),
-        ControlledPhaseShift(-0.615, wires=[1, 0]),
-        X(0),
-        X(1),
-        ControlledPhaseShift(-0.615, wires=[0, 1]),
-        CNOT(wires=[0, 1]),
-        CRY(1.23, wires=[1, 0]),
-        CNOT(wires=[0, 1])]
+        [H(1),
+         CNOT(wires=[1, 0]),
+         RY(0.615, wires=[0]),
+         RY(0.615, wires=[1]),
+         CY(wires=[1, 0]),
+         S(1),
+         H(1),
+         RZ(0.615, wires=[1]),
+         CNOT(wires=[0, 1]),
+         GlobalPhase(0.3075, wires=[])]
 
         """
         decomp_ops = [
-            qml.X(wires[0]),
-            qml.X(wires[1]),
-            qml.ControlledPhaseShift(-phi / 2, wires=[wires[1], wires[0]]),
-            qml.X(wires[0]),
-            qml.X(wires[1]),
-            qml.ControlledPhaseShift(-phi / 2, wires=[wires[0], wires[1]]),
-            qml.CNOT(wires=[wires[0], wires[1]]),
-            qml.CRY(phi, wires=[wires[1], wires[0]]),
-            qml.CNOT(wires=[wires[0], wires[1]]),
+            qml.Hadamard(wires[1]),
+            qml.CNOT([wires[1], wires[0]]),
+            qml.RY(phi / 2, wires[0]),
+            qml.RY(phi / 2, wires[1]),
+            qml.CY([wires[1], wires[0]]),
+            qml.S(wires[1]),
+            qml.Hadamard(wires[1]),
+            qml.RZ(phi / 2, wires[1]),
+            qml.CNOT(wires),
+            qml.GlobalPhase(phi / 4),
         ]
         return decomp_ops
 
@@ -467,20 +433,29 @@ class SingleExcitationMinus(Operation):
 
 
 def _single_excitation_minus_decomp_resources():
-    return {qml.X: 4, qml.ControlledPhaseShift: 2, qml.CNOT: 2, qml.CRY: 1}
+    return {
+        qml.Hadamard: 2,
+        qml.CY: 1,
+        qml.CNOT: 2,
+        qml.RY: 2,
+        qml.S: 1,
+        qml.RZ: 1,
+        qml.GlobalPhase: 1,
+    }
 
 
 @register_resources(_single_excitation_minus_decomp_resources)
 def _single_excitation_minus_decomp(phi, wires: WiresLike, **__):
-    qml.X(wires[0])
-    qml.X(wires[1])
-    qml.ControlledPhaseShift(-phi / 2, wires=[wires[1], wires[0]])
-    qml.X(wires[0])
-    qml.X(wires[1])
-    qml.ControlledPhaseShift(-phi / 2, wires=[wires[0], wires[1]])
-    qml.CNOT(wires=[wires[0], wires[1]])
-    qml.CRY(phi, wires=[wires[1], wires[0]])
-    qml.CNOT(wires=[wires[0], wires[1]])
+    qml.Hadamard(wires[1])
+    qml.CNOT([wires[1], wires[0]])
+    qml.RY(phi / 2, wires[0])
+    qml.RY(phi / 2, wires[1])
+    qml.CY([wires[1], wires[0]])
+    qml.S(wires[1])
+    qml.Hadamard(wires[1])
+    qml.RZ(phi / 2, wires[1])
+    qml.CNOT(wires)
+    qml.GlobalPhase(phi / 4)
 
 
 add_decomps(SingleExcitationMinus, _single_excitation_minus_decomp)
@@ -590,27 +565,29 @@ class SingleExcitationPlus(Operation):
         **Example:**
 
         >>> qml.SingleExcitationPlus.compute_decomposition(1.23, wires=(0,1))
-        [X(0),
-        X(1),
-        ControlledPhaseShift(0.615, wires=[1, 0]),
-        X(0),
-        X(1),
-        ControlledPhaseShift(0.615, wires=[0, 1]),
-        CNOT(wires=[0, 1]),
-        CRY(1.23, wires=[1, 0]),
-        CNOT(wires=[0, 1])]
+        [H(1),
+         CNOT(wires=[1, 0]),
+         RY(0.615, wires=[0]),
+         RY(0.615, wires=[1]),
+         CY(wires=[1, 0]),
+         S(1),
+         H(1),
+         RZ(0.615, wires=[1]),
+         CNOT(wires=[0, 1]),
+         GlobalPhase(-0.3075, wires=[])]
 
         """
         decomp_ops = [
-            qml.X(wires[0]),
-            qml.X(wires[1]),
-            qml.ControlledPhaseShift(phi / 2, wires=[wires[1], wires[0]]),
-            qml.X(wires[0]),
-            qml.X(wires[1]),
-            qml.ControlledPhaseShift(phi / 2, wires=[wires[0], wires[1]]),
-            qml.CNOT(wires=[wires[0], wires[1]]),
-            qml.CRY(phi, wires=[wires[1], wires[0]]),
-            qml.CNOT(wires=[wires[0], wires[1]]),
+            qml.Hadamard(wires[1]),
+            qml.CNOT([wires[1], wires[0]]),
+            qml.RY(phi / 2, wires[0]),
+            qml.RY(phi / 2, wires[1]),
+            qml.CY([wires[1], wires[0]]),
+            qml.S(wires[1]),
+            qml.Hadamard(wires[1]),
+            qml.RZ(-phi / 2, wires[1]),
+            qml.CNOT(wires),
+            qml.GlobalPhase(-phi / 4),
         ]
         return decomp_ops
 
@@ -628,20 +605,29 @@ class SingleExcitationPlus(Operation):
 
 
 def _single_excitation_plus_decomp_resources():
-    return {qml.X: 4, qml.ControlledPhaseShift: 2, qml.CNOT: 2, qml.CRY: 1}
+    return {
+        qml.Hadamard: 2,
+        qml.CY: 1,
+        qml.CNOT: 2,
+        qml.RY: 2,
+        qml.S: 1,
+        qml.RZ: 1,
+        qml.GlobalPhase: 1,
+    }
 
 
 @register_resources(_single_excitation_plus_decomp_resources)
 def _single_excitation_plus_decomp(phi, wires: WiresLike, **__):
-    qml.X(wires[0])
-    qml.X(wires[1])
-    qml.ControlledPhaseShift(phi / 2, wires=[wires[1], wires[0]])
-    qml.X(wires[0])
-    qml.X(wires[1])
-    qml.ControlledPhaseShift(phi / 2, wires=[wires[0], wires[1]])
-    qml.CNOT(wires=[wires[0], wires[1]])
-    qml.CRY(phi, wires=[wires[1], wires[0]])
-    qml.CNOT(wires=[wires[0], wires[1]])
+    qml.Hadamard(wires[1])
+    qml.CNOT([wires[1], wires[0]])
+    qml.RY(phi / 2, wires[0])
+    qml.RY(phi / 2, wires[1])
+    qml.CY([wires[1], wires[0]])
+    qml.S(wires[1])
+    qml.Hadamard(wires[1])
+    qml.RZ(-phi / 2, wires[1])
+    qml.CNOT(wires)
+    qml.GlobalPhase(-phi / 4)
 
 
 add_decomps(SingleExcitationPlus, _single_excitation_plus_decomp)

--- a/tests/ops/qubit/test_qchem_ops.py
+++ b/tests/ops/qubit/test_qchem_ops.py
@@ -80,32 +80,11 @@ class TestDecomposition:
         control and target wires.)"""
         decomp1 = qml.SingleExcitationPlus(phi, wires=[0, 1]).decomposition()
         decomp2 = qml.SingleExcitationPlus.compute_decomposition(phi, wires=[0, 1])
-
+        exp = SingleExcitationPlus(phi)
         for decomp in [decomp1, decomp2]:
-            mats = []
-            for i in reversed(decomp):
-                if i.wires.tolist() == [0]:
-                    mats.append(np.kron(i.matrix(), np.eye(2)))
-                elif i.wires.tolist() == [1]:
-                    mats.append(np.kron(np.eye(2), i.matrix()))
-                elif i.wires.tolist() == [1, 0] and isinstance(i, qml.CRY):
-                    new_mat = np.array(
-                        [
-                            [1, 0, 0, 0],
-                            [0, np.cos(phi / 2), 0, -np.sin(phi / 2)],
-                            [0, 0, 1, 0],
-                            [0, np.sin(phi / 2), 0, np.cos(phi / 2)],
-                        ]
-                    )
+            decomp_mat = qml.matrix(qml.tape.QuantumScript(decomp), wire_order=[0, 1])
 
-                    mats.append(new_mat)
-                else:
-                    mats.append(i.matrix())
-
-            decomposed_matrix = np.linalg.multi_dot(mats)
-            exp = SingleExcitationPlus(phi)
-
-            assert np.allclose(decomposed_matrix, exp)
+            assert np.allclose(decomp_mat, exp)
 
     @pytest.mark.parametrize("phi", [-0.1, 0.2, 0.5])
     def test_single_excitation_minus_decomp(self, phi):
@@ -117,32 +96,11 @@ class TestDecomposition:
         control and target wires.)"""
         decomp1 = qml.SingleExcitationMinus(phi, wires=[0, 1]).decomposition()
         decomp2 = qml.SingleExcitationMinus.compute_decomposition(phi, wires=[0, 1])
-
+        exp = SingleExcitationMinus(phi)
         for decomp in [decomp1, decomp2]:
-            mats = []
-            for i in reversed(decomp):
-                if i.wires.tolist() == [0]:
-                    mats.append(np.kron(i.matrix(), np.eye(2)))
-                elif i.wires.tolist() == [1]:
-                    mats.append(np.kron(np.eye(2), i.matrix()))
-                elif i.wires.tolist() == [1, 0] and isinstance(i, qml.CRY):
-                    new_mat = np.array(
-                        [
-                            [1, 0, 0, 0],
-                            [0, np.cos(phi / 2), 0, -np.sin(phi / 2)],
-                            [0, 0, 1, 0],
-                            [0, np.sin(phi / 2), 0, np.cos(phi / 2)],
-                        ]
-                    )
+            decomp_mat = qml.matrix(qml.tape.QuantumScript(decomp), wire_order=[0, 1])
 
-                    mats.append(new_mat)
-                else:
-                    mats.append(i.matrix())
-
-            decomposed_matrix = np.linalg.multi_dot(mats)
-            exp = SingleExcitationMinus(phi)
-
-            assert np.allclose(decomposed_matrix, exp)
+            assert np.allclose(decomp_mat, exp)
 
 
 class TestSingleExcitation:


### PR DESCRIPTION
**Context:**
There are qchem ops `SingleExcitation`, `SingleExcitationPlus` and `SingleExcitationMinus`. 

**Description of the Change:**
Improve their decompositions, requiring fewer static entanglers (i.e. CNOT, CY or CZ) and sometimes fewer `T` gates/varying-angle rotations.

The decomposition for `SingleExcitation` already was given in [Anselmetti et al.](https://arxiv.org/pdf/2104.05695)

Some (non-tight) lower bounds for static entangler count and rotation count are given here:
```python
import pennylane as qml
from pennylane.ops.op_math.decompositions.unitary_decompositions import _compute_num_cnots

for cls in [qml.SingleExcitation, qml.SingleExcitationMinus, qml.SingleExcitationPlus]:
    op0 = cls(np.random.random(), [0, 1])
    n0 = _compute_num_cnots(op0.matrix())
    f0 = len(op0.parameter_frequencies[0])
    print(f"{cls.__name__} requires at least {n0} CNOT gates and {f0} rotation gates.")
```
The structure of the generator of `SingleExcitationPlus` (and `Minus`) suggests that we actually will need at least three rotations for those gates, which is what we achieve in this PR. Up do conjugation by an `S` gate, `SingleExcitationPlus` is generated by a SWAP gate:

```pycon
>>> op = qml.SingleExcitationPlus(theta, [0, 1])
>>> g = qml.generator(op)[0]
>>> qml.simplify(qml.S(0) @ g @ qml.adjoint(qml.S(0)))
(
    I([0, 1])
  + Y(0) @ Y(1)
  + X(0) @ X(1)
  + Z(0) @ Z(1)
)
>>> qml.pauli_decompose(qml.SWAP([0, 1]).matrix())
(
    0.5 * (I(0) @ I(1))
  + 0.5 * (X(0) @ X(1))
  + 0.5 * (Y(0) @ Y(1))
  + 0.5 * (Z(0) @ Z(1))
)
```

**Benefits:**
Cheaper decompositions

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
[sc-94396]