### PR TITLE
[Python Compiler] Do not use AnyAttr in AnyOf

### DIFF
--- a/pennylane/compiler/python_compiler/quantum_dialect.py
+++ b/pennylane/compiler/python_compiler/quantum_dialect.py
@@ -29,7 +29,6 @@ from typing import Sequence, TypeAlias
 
 from xdsl.dialects.builtin import (
     AnyAttr,
-    AnyOf,
     BaseAttr,
     Float64Type,
     IntegerAttr,
@@ -469,7 +468,7 @@ class HamiltonianOp(IRDLOperation):
         `(` $coeffs `:` type($coeffs) `)` $terms attr-dict `:` type(results)
     """
 
-    coeffs = operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    coeffs = operand_def(AnyAttr())
 
     terms = var_operand_def(BaseAttr(ObservableType))
 
@@ -486,7 +485,7 @@ class HermitianOp(IRDLOperation):
         `(` $matrix `:` type($matrix) `)` $qubits attr-dict `:` type(results)
     """
 
-    matrix = operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    matrix = operand_def(AnyAttr())
 
     qubits = var_operand_def(BaseAttr(QubitType))
 
@@ -683,7 +682,7 @@ class QubitUnitaryOp(IRDLOperation):
         AttrSizedResultSegments(as_property=True),
     ]
 
-    matrix = operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    matrix = operand_def(AnyAttr())
 
     in_qubits = var_operand_def(BaseAttr(QubitType))
 
@@ -716,9 +715,9 @@ class SampleOp(IRDLOperation):
 
     dynamic_shape = var_operand_def(EqAttrConstraint(IntegerType(64)))
 
-    in_data = opt_operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    in_data = opt_operand_def(AnyAttr())
 
-    samples = opt_result_def(AnyOf((AnyAttr(), AnyAttr())))
+    samples = opt_result_def(AnyAttr())
 
 
 @irdl_op_definition
@@ -731,7 +730,7 @@ class SetBasisStateOp(IRDLOperation):
         `(` $basis_state`)` $in_qubits attr-dict `:` functional-type(operands, results)
     """
 
-    basis_state = operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    basis_state = operand_def(AnyAttr())
 
     in_qubits = var_operand_def(BaseAttr(QubitType))
 
@@ -748,7 +747,7 @@ class SetStateOp(IRDLOperation):
         `(` $in_state `)` $in_qubits attr-dict `:` functional-type(operands, results)
     """
 
-    in_state = operand_def(AnyOf((AnyAttr(), AnyAttr())))
+    in_state = operand_def(AnyAttr())
 
     in_qubits = var_operand_def(BaseAttr(QubitType))
 


### PR DESCRIPTION
**Context:** Recent changes in xDSL restrict the use of AnyAttr in AnyOf. See PR [here](https://github.com/xdslproject/xdsl/pull/4510)

**Description of the Change:** We don't need to say `AnyOf(AnyAttr(), AnyAttr())`. We can just say `AnyAttr()` and it means the same thing. We could make this check stricter by using the correct types which in most of the cases are TensorTypes or MemrefTypes, but I think this is ok for now.

**Benefits:** The latest version of xDSL works with the Python compiler.

**Possible Drawbacks:** None.

**Related GitHub Issues:**
