### PR TITLE
Template refactoring

### DIFF
--- a/pennylane/templates/subroutines/adder.py
+++ b/pennylane/templates/subroutines/adder.py
@@ -102,6 +102,8 @@ class Adder(Operation):
 
     grad_method = None
 
+    resource_keys = {"num_x_wires", "mod"}
+
     def __init__(
         self, k, x_wires: WiresLike, mod=None, work_wires: WiresLike = (), id=None
     ):  # pylint: disable=too-many-arguments


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:** We would like to refactor our templates to use quantum functions in their decompositions in order to make them compatible with the new decompositions system.

**Description of the Change:** Base branch for template refactoring, starting with Arithmetic templates.

**Benefits:** Allows us to decompose using decompositions that are program capture compatible. Tape based decompositions are still available as a backwards compatible fallback.

**Possible Drawbacks:** Work in progress, there are many templates to refactor.

**Related ShortCut Epic:**  [sc-89709]
