### PR TITLE
Add validation for `gradient_kwargs` during `QNode` construction

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -870,8 +870,8 @@
 
 <h3>Breaking changes 💔</h3>
 
-* Support for gradient keyword arguments as QNode keyword arguments has been removed. Instead please use the
-  new `gradient_kwargs` keyword argument accordingly.
+* Support for gradient keyword arguments as additional `QNode` keyword arguments has been removed. 
+  Instead, they should be provided as a `dict` via the new `gradient_kwargs` keyword argument.
   [(#7648)](https://github.com/PennyLaneAI/pennylane/pull/7648)
   [(#7782)](https://github.com/PennyLaneAI/pennylane/pull/7782)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -873,6 +873,7 @@
 * Support for gradient keyword arguments as QNode keyword arguments has been removed. Instead please use the
   new `gradient_kwargs` keyword argument accordingly.
   [(#7648)](https://github.com/PennyLaneAI/pennylane/pull/7648)
+  [(#7782)](https://github.com/PennyLaneAI/pennylane/pull/7782)
 
 * The default value of `cache` is now `"auto"` with `qml.execute`. Like `QNode`, `"auto"` only turns on caching
   when `max_diff > 1`.

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -559,6 +559,13 @@ class QNode:
             device = qml.devices.LegacyDeviceFacade(device)
 
         gradient_kwargs = gradient_kwargs or {}
+        invalid_gradient_kwargs = set(gradient_kwargs) - qml.gradients.SUPPORTED_GRADIENT_KWARGS
+        if invalid_gradient_kwargs:
+            warnings.warn(
+                f"Unrecognized gradient keyword argument(s): {invalid_gradient_kwargs}. "
+                f"Supported gradient keyword arguments are: {qml.gradients.SUPPORTED_GRADIENT_KWARGS}.",
+                UserWarning,
+            )
 
         if "shots" in inspect.signature(func).parameters:
             warnings.warn(

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -232,7 +232,7 @@ class TestValidation:
     def test_invalid_gradient_kwarg_warning(self):
         """Test that a warning is raised for an invalid gradient keyword argument"""
         dev = qml.device("default.qubit", wires=1)
-        expected_warning = "Unrecognized gradient keyword argument\(s\): {'invalid_kwarg'}"
+        expected_warning = r"Unrecognized gradient keyword argument\(s\): {'invalid_kwarg'}"
 
         with pytest.warns(UserWarning, match=expected_warning):
             QNode(dummyfunc, dev, gradient_kwargs={"invalid_kwarg": 1})

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -229,6 +229,14 @@ class TestInitialization:
 class TestValidation:
     """Tests for QNode creation and validation"""
 
+    def test_invalid_gradient_kwarg_warning(self):
+        """Test that a warning is raised for an invalid gradient keyword argument"""
+        dev = qml.device("default.qubit", wires=1)
+        expected_warning = "Unrecognized gradient keyword argument\(s\): {'invalid_kwarg'}"
+
+        with pytest.warns(UserWarning, match=expected_warning):
+            QNode(dummyfunc, dev, gradient_kwargs={"invalid_kwarg": 1})
+
     @pytest.mark.parametrize("return_type", (tuple, list))
     def test_return_behaviour_consistency(self, return_type):
         """Test that the QNode return typing stays consistent"""


### PR DESCRIPTION
**Context:**

Validation was dropped by accident after https://github.com/PennyLaneAI/pennylane/pull/7648. 

[sc-94503]