### PR TITLE
Return a quantum function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -237,7 +237,7 @@
   
   @qml.qnode(dev)
   def my_circuit():
-      qml.from_qasm3("qubit q0; qubit q1; ry(0.2) q0; rx(1.0) q1; pow(2) @ x q0;", {'q0': 0, 'q1': 1})
+      qml.from_qasm3("qubit q0; qubit q1; ry(0.2) q0; rx(1.0) q1; pow(2) @ x q0;", {'q0': 0, 'q1': 1})()
       return qml.expval(qml.Z(0))
   ```
 

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -861,13 +861,13 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         qubit_mapping Optional[dict]:  the mapping from OpenQASM 3.0 qubit names to PennyLane wires.
 
     Returns:
-        dict: the context resulting from the execution.
+        function: A quantum function that will execute the program.
 
     >>> import pennylane as qml
     >>> dev = qml.device("default.qubit", wires=[0, 1])
     >>> @qml.qnode(dev)
     >>> def my_circuit():
-    ...     qml.from_qasm3("qubit q0; qubit q1; ry(0.2) q0; rx(1.0) q1; pow(2) @ x q0;", {'q0': 0, 'q1': 1})
+    ...     qml.from_qasm3("qubit q0; qubit q1; ry(0.2) q0; rx(1.0) q1; pow(2) @ x q0;", {'q0': 0, 'q1': 1})()
     ...     return qml.expval(qml.Z(0))
     >>> print(qml.draw(my_circuit)())
     0: ──RY(0.20)──X²─┤  <Z>
@@ -886,6 +886,8 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         raise ImportError(
             "antlr4-python3-runtime is required to interpret openqasm3 in addition to the openqasm3 package"
         ) from e  # pragma: no cover
-    context = QasmInterpreter().interpret(ast, context={"name": "global", "wire_map": wire_map})
 
-    return context
+    def interpret_function():
+        QasmInterpreter().interpret(ast, context={"name": "global", "wire_map": wire_map})
+
+    return interpret_function

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -226,7 +226,7 @@ class TestOpenQasm:
         visit = mocker.spy(QasmInterpreter, "interpret")
 
         # call the method
-        from_qasm3(circuit)
+        from_qasm3(circuit)()
 
         # assertions
         parse.assert_called_with(circuit, permissive=True)


### PR DESCRIPTION

------------------------------------------------------------------------------------------------------------

**Context:** A tiny change to return a quantum function instead of the context for executing a QASM program.

**Description of the Change:** Small interface change recommended by @astralcai .

**Benefits:** We can call it!

**Possible Drawbacks:** We can't access the context.
