### PR TITLE
update incorrect PR number in changelog entry

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -536,6 +536,7 @@
 * A new QNode transform called :func:`~.transforms.set_shots` has been added to set or update the number of shots to be performed, overriding shots specified in the device.
   [(#7337)](https://github.com/PennyLaneAI/pennylane/pull/7337)
   [(#7358)](https://github.com/PennyLaneAI/pennylane/pull/7358)
+  [(#7415)](https://github.com/PennyLaneAI/pennylane/pull/7415)
   [(#7500)](https://github.com/PennyLaneAI/pennylane/pull/7500)
   [(#7627)](https://github.com/PennyLaneAI/pennylane/pull/7627)
 


### PR DESCRIPTION
**Context:**

As I was preparing the QA tasks, I noticed that PR #7363 is missing from the changelog somehow. Looks like it was clobbered somewhere along the way.

**Description of the Change:**

Updates the relevant entry.
