### PR TITLE
Implement group-by-sums optimization for perturbation_error function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -949,6 +949,9 @@
   parts of the algorithm.
   [(#7681)](https://github.com/PennyLaneAI/pennylane/pull/7681)
 
+* Optimization for :func`pertrubation_error` which groups commutators by linearity.
+  [(#7790)][https://github.com/PennyLaneAI/pennylane/pull/7790]
+
 * Fixed missing table descriptions for :class:`qml.FromBloq <pennylane.FromBloq>`,
   :func:`qml.qchem.two_particle <pennylane.qchem.two_particle>`,
   and :class:`qml.ParticleConservingU2 <pennylane.ParticleConservingU2>`.

--- a/pennylane/labs/tests/trotter_error/product_formulas/test_error.py
+++ b/pennylane/labs/tests/trotter_error/product_formulas/test_error.py
@@ -22,6 +22,7 @@ from pennylane.labs.trotter_error import (
     perturbation_error,
     vibrational_fragments,
 )
+from pennylane.labs.trotter_error.product_formulas.error import _group_sums
 
 
 @pytest.mark.parametrize(
@@ -97,3 +98,21 @@ def test_perturbation_error_invalid_parallel_mode():
             backend="mp_pool",
             parallel_mode="invalid_mode",
         )
+
+
+@pytest.mark.parametrize(
+    "term_dict, expected",
+    [
+        (
+            [{("A",): 5}, {("X", "A", "B"): 4, ("Y", "A", "B"): 3}],
+            [(frozenset({("X", 4), ("Y", 3)}), "A", "B")],
+        ),
+        (
+            [{("A",): 5}, {("X", "A", "B"): 4, ("Y", "A", "C"): 3}],
+            [(frozenset({("X", 4)}), "A", "B"), (frozenset({("Y", 3)}), "A", "C")],
+        ),
+    ],
+)
+def test_group_sums(term_dict, expected):
+    """Test the private _group_sums method"""
+    assert _group_sums(term_dict) == expected

--- a/pennylane/labs/tests/trotter_error/product_formulas/test_pt_integration.py
+++ b/pennylane/labs/tests/trotter_error/product_formulas/test_pt_integration.py
@@ -115,13 +115,14 @@ def test_perturbation_error(backend, num_workers, parallel_mode, n_states, mpi4p
     if backend in {"mpi4py_pool", "mpi4py_comm"} and not mpi4py_support:
         pytest.skip(f"Skipping test: '{backend}' requires mpi4py, which is not installed.")
 
-    pf = ProductFormula(frag_labels, coeffs=frag_coeffs)(h)
+    pf = ProductFormula(frag_labels, coeffs=frag_coeffs)
     states = [state] * n_states
     actual = perturbation_error(
         pf,
         fragments,
         states,
         order=order,
+        timestep=h,
         backend=backend,
         num_workers=num_workers,
         parallel_mode=parallel_mode,

--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from collections.abc import Hashable
 from functools import cache
 from itertools import permutations, product
-from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Set, Tuple
+from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Tuple
 
 import numpy as np
 

--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def bch_expansion(
-    product_formula: ProductFormula, order: int, group_sums: bool = False
+    product_formula: ProductFormula, order: int
 ) -> List[Dict[Tuple[Hashable], complex]]:
     r"""Compute the Baker-Campbell-Hausdorff expansion of a :class:`~.pennylane.labs.trotter_error.ProductFormula` object.
 
@@ -65,11 +65,7 @@ def bch_expansion(
                   ('C', 'A', 'C'): (-0.08333333333333333+0j),
                   ('C', 'B', 'C'): (-0.08333333333333333+0j)})]
     """
-    return (
-        _group_sums(_drop_zeros(_bch_expansion(product_formula, order, {})))
-        if group_sums
-        else _drop_zeros(_bch_expansion(product_formula, order, {}))
-    )
+    return _drop_zeros(_bch_expansion(product_formula, order, {}))
 
 
 def _bch_expansion(
@@ -495,24 +491,3 @@ def _drop_zeros(
             del terms[commutator]
 
     return term_dicts
-
-
-def _group_sums(
-    term_dicts: List[Dict[Tuple[Hashable], complex]],
-) -> List[Tuple[Hashable | Set]]:
-    return [_group_sums_in_dict(term_dict) for term_dict in term_dicts]
-
-
-def _group_sums_in_dict(term_dict: Dict[Tuple[Hashable], complex]) -> List[Tuple[Hashable | Set]]:
-    grouped_comms = defaultdict(set)
-    for commutator, coeff in term_dict.items():
-        head, *tail = commutator
-        tail = tuple(tail)
-        grouped_comms[tail].add((head, coeff))
-
-    grouped_term_list = []
-    for tail, head in grouped_comms.items():
-        commutator = (frozenset(head), *tail)
-        grouped_term_list.append(commutator)
-
-    return grouped_term_list

--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -499,5 +499,19 @@ def _drop_zeros(
 
 def _group_sums(
     term_dicts: List[Dict[Tuple[Hashable], complex]],
-) -> List[Dict[Tuple[Hashable | Set], complex]]:
-    grouped_dicts = []
+) -> List[Tuple[Hashable | Set]]:
+    return [_group_sums_in_dict(term_dict) for term_dict in term_dicts]
+
+def _group_sums_in_dict(term_dict: Dict[Tuple[Hashable], complex]) -> List[Tuple[Hashable | Set]]:
+    grouped_comms = defaultdict(set)
+    for commutator, coeff in term_dict.items():
+        head, *tail = commutator
+        tail = tuple(tail)
+        grouped_comms[tail].add((head, coeff))
+
+    grouped_term_dict = []
+    for tail, head in grouped_comms.items():
+        commutator = (head, *tail)
+        grouped_term_dict.append(commutator)
+
+    return grouped_term_dict

--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -502,6 +502,7 @@ def _group_sums(
 ) -> List[Tuple[Hashable | Set]]:
     return [_group_sums_in_dict(term_dict) for term_dict in term_dicts]
 
+
 def _group_sums_in_dict(term_dict: Dict[Tuple[Hashable], complex]) -> List[Tuple[Hashable | Set]]:
     grouped_comms = defaultdict(set)
     for commutator, coeff in term_dict.items():
@@ -509,9 +510,9 @@ def _group_sums_in_dict(term_dict: Dict[Tuple[Hashable], complex]) -> List[Tuple
         tail = tuple(tail)
         grouped_comms[tail].add((head, coeff))
 
-    grouped_term_dict = []
+    grouped_term_list = []
     for tail, head in grouped_comms.items():
-        commutator = (head, *tail)
-        grouped_term_dict.append(commutator)
+        commutator = (frozenset(head), *tail)
+        grouped_term_list.append(commutator)
 
-    return grouped_term_dict
+    return grouped_term_list

--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from collections.abc import Hashable
 from functools import cache
 from itertools import permutations, product
-from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, Generator, List, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def bch_expansion(
-    product_formula: ProductFormula, order: int
+    product_formula: ProductFormula, order: int, group_sums: bool = False
 ) -> List[Dict[Tuple[Hashable], complex]]:
     r"""Compute the Baker-Campbell-Hausdorff expansion of a :class:`~.pennylane.labs.trotter_error.ProductFormula` object.
 
@@ -65,7 +65,11 @@ def bch_expansion(
                   ('C', 'A', 'C'): (-0.08333333333333333+0j),
                   ('C', 'B', 'C'): (-0.08333333333333333+0j)})]
     """
-    return _drop_zeros(_bch_expansion(product_formula, order, {}))
+    return (
+        _group_sums(_drop_zeros(_bch_expansion(product_formula, order, {})))
+        if group_sums
+        else _drop_zeros(_bch_expansion(product_formula, order, {}))
+    )
 
 
 def _bch_expansion(
@@ -478,7 +482,7 @@ def _right_nest_two_comms(commutator: Tuple[Tuple | Hashable]) -> Dict[Tuple[Has
 
 
 def _drop_zeros(
-    term_dicts: List[Dict[Tuple[Hashable], float]],
+    term_dicts: List[Dict[Tuple[Hashable], complex]],
 ) -> List[Dict[Tuple[Hashable], float]]:
     """Remove any terms whose coefficient is close to zero"""
     for terms in term_dicts:
@@ -491,3 +495,9 @@ def _drop_zeros(
             del terms[commutator]
 
     return term_dicts
+
+
+def _group_sums(
+    term_dicts: List[Dict[Tuple[Hashable], complex]],
+) -> List[Dict[Tuple[Hashable | Set], complex]]:
+    grouped_dicts = []

--- a/pennylane/labs/trotter_error/product_formulas/error.py
+++ b/pennylane/labs/trotter_error/product_formulas/error.py
@@ -14,6 +14,7 @@
 """Functions for retreiving effective error from fragments"""
 
 import copy
+import math
 from collections import Counter
 from collections.abc import Hashable
 from typing import Dict, List, Sequence, Tuple
@@ -101,7 +102,7 @@ def _insert_fragments(
     )
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-positional-arguments
 def perturbation_error(
     product_formula: ProductFormula,
     fragments: Dict[Hashable, Fragment],
@@ -171,18 +172,20 @@ def perturbation_error(
     if not product_formula.fragments.issubset(fragments.keys()):
         raise ValueError("Fragments do not match product formula")
 
-    bch = bch_expansion(product_formula(1j * timestep), order)
-    commutators = {
-        commutator: coeff for comm_dict in bch[1:] for commutator, coeff in comm_dict.items()
-    }
+    commutators = [
+        x
+        for xs in bch_expansion(product_formula(1j * timestep), order, group_sums=True)[1:]
+        for x in xs
+    ]
 
     if backend == "serial":
         assert num_workers == 1, "num_workers must be set to 1 for serial execution."
         expectations = []
         for state in states:
             new_state = _AdditiveIdentity()
-            for commutator, coeff in commutators.items():
-                new_state += coeff * _apply_commutator(commutator, fragments, state)
+            for commutator in commutators:
+                new_state += _apply_commutator(commutator, fragments, state)
+
             expectations.append(state.dot(new_state))
 
         return expectations
@@ -203,11 +206,8 @@ def perturbation_error(
         for state in states:
             with executor(max_workers=num_workers) as ex:
                 applied_commutators = ex.starmap(
-                    _apply_commutator_coeff,
-                    [
-                        (commutator, coeff, fragments, state)
-                        for commutator, coeff in commutators.items()
-                    ],
+                    _apply_commutator,
+                    [(commutator, fragments, state) for commutator in commutators],
                 )
 
             new_state = _AdditiveIdentity()
@@ -225,8 +225,8 @@ def _get_expval_state(commutators, fragments, state: AbstractState) -> float:
     """Returns the expectation value of ``state`` with respect to the operator obtained by substituting ``fragments`` into ``commutators``."""
 
     new_state = _AdditiveIdentity()
-    for commutator, coeff in commutators.items():
-        new_state += coeff * _apply_commutator(commutator, fragments, state)
+    for commutator in commutators:
+        new_state += _apply_commutator(commutator, fragments, state)
 
     return state.dot(new_state)
 
@@ -240,28 +240,19 @@ def _apply_commutator(
 
     for term, coeff in _op_list(commutator).items():
         tmp_state = copy.copy(state)
-        for frag in reversed([fragments[x] for x in term]):
+        for frag in reversed(term):
+            if isinstance(frag, frozenset):
+                frag = sum(
+                    (frag_coeff * fragments[x] for x, frag_coeff in frag), _AdditiveIdentity()
+                )
+            else:
+                frag = fragments[frag]
+
             tmp_state = frag.apply(tmp_state)
 
         new_state += coeff * tmp_state
 
     return new_state
-
-
-def _apply_commutator_coeff(
-    commutator: Tuple[Hashable], coeff, fragments: Dict[Hashable, Fragment], state: AbstractState
-) -> AbstractState:
-    """Returns the state obtained from applying ``commutator`` to ``state`` and multiplying by the scalar ``coeff``."""
-
-    new_state = _AdditiveIdentity()
-
-    for term, co in _op_list(commutator).items():
-        tmp_state = None
-        for frag in reversed([fragments[x] for x in term]):
-            tmp_state = frag.apply(tmp_state) if tmp_state is not None else frag.apply(state)
-        new_state += co * tmp_state
-
-    return coeff * new_state
 
 
 def _op_list(commutator) -> Dict[Tuple[Hashable], complex]:

--- a/pennylane/labs/trotter_error/product_formulas/error.py
+++ b/pennylane/labs/trotter_error/product_formulas/error.py
@@ -14,7 +14,6 @@
 """Functions for retreiving effective error from fragments"""
 
 import copy
-import math
 from collections import Counter
 from collections.abc import Hashable
 from typing import Dict, List, Sequence, Tuple


### PR DESCRIPTION
This PR implements the "group-by-sums" method for reducing the number of commutators returned by BCH for perturbation theory.