### PR TITLE
Fix missing `method` change in changelog

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -221,6 +221,7 @@
   [(#7611)](https://github.com/PennyLaneAI/pennylane/pull/7611)
   [(#7711)](https://github.com/PennyLaneAI/pennylane/pull/7711)
   [(#7770)](https://github.com/PennyLaneAI/pennylane/pull/7770)
+  [(#7791)](https://github.com/PennyLaneAI/pennylane/pull/7791)
 
   The Ross-Selinger algorithm can drastically outperform the Solovay-Kitaev algorithm in many cases.
   Consider this simple circuit:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -235,7 +235,7 @@
 
       return qml.expval(qml.Z(0))
 
-  rs_circuit = qml.clifford_t_decomposition(circuit, method="rs")
+  rs_circuit = qml.clifford_t_decomposition(circuit, method="gridsynth")
   sk_circuit = qml.clifford_t_decomposition(circuit, method="sk")
 
   x, y = 0.12, 0.34

--- a/pennylane/ops/op_math/decompositions/rings.py
+++ b/pennylane/ops/op_math/decompositions/rings.py
@@ -241,8 +241,10 @@ class ZOmega:
     def __sub__(self, other):
         return self + (-other)
 
+    def __rsub__(self, other):
+        return other + (-self)
+
     __radd__ = __add__
-    __rsub__ = __sub__
     __rmul__ = __mul__
 
     def __neg__(self: ZOmega) -> ZOmega:

--- a/tests/ops/op_math/decompositions/test_rings.py
+++ b/tests/ops/op_math/decompositions/test_rings.py
@@ -138,6 +138,7 @@ class TestZOmega:
         assert z1.parity() == 0 and z2.parity() == 0  # Both z1 and z2 have even parity
         assert z2.norm() == abs(complex(z2)) * abs(complex(z2.conj()))
         assert (z1 - ZOmega(a=2, b=2, c=2)).to_sqrt_two() == ZSqrtTwo(a=4, b=1)
+        assert 1 - ZOmega() == ZOmega(d=1)
 
     def test_arithmetic_errors(self):
         """Test that arithmetic operations raise errors for invalid types."""


### PR DESCRIPTION
**Context:** Missed a change in the changelog.

**Description of the Change:** `method="gridsynth"` in the changelog example. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
