### PR TITLE
[v0.42.0 release] bump dev version to `v0.43.0`

### DIFF
--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -71,4 +71,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout ${{ env.tmp_branch }}
-          gh pr create --title "Daily rc sync to master" --body "" --reviewer "PietropaoloFrisoni,albi3ro"
+          gh pr create --title "Daily rc sync to master" --body "" --reviewer "andrijapau,albi3ro"

--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.42.0.md
 
 .. mdinclude:: ../releases/changelog-0.41.1.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.43.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0"
+__version__ = "0.43.0-dev0"

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0rc0"
+__version__ = "0.42.0"


### PR DESCRIPTION
**Context:**

By-product PR that is created after the `sh ./pennylane_version_bump.sh <your github username>` step in the release guide.

**Description of the Change:**

Same changes as the last release: https://github.com/PennyLaneAI/pennylane/pull/7216/files

[sc-94600]
