### PR TITLE
Raise an understandable error in place of openqasm3's mysterious ones

### DIFF
--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -71,4 +71,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git checkout ${{ env.tmp_branch }}
-          gh pr create --title "Daily rc sync to master" --body "" --reviewer "PietropaoloFrisoni,albi3ro"
+          gh pr create --title "Daily rc sync to master" --body "" --reviewer "andrijapau,albi3ro"

--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.42.0.md
 
 .. mdinclude:: ../releases/changelog-0.41.1.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.43.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0rc0"
+__version__ = "0.43.0-dev0"

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -932,6 +932,11 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         raise ImportError(
             "antlr4-python3-runtime is required to interpret openqasm3 in addition to the openqasm3 package"
         ) from e  # pragma: no cover
+    except Exception as e:
+        raise SyntaxError(
+            "Something went wrong when parsing the provided OpenQASM 3.0 code. "
+            f"Please ensure the code is valid OpenQASM 3.0 syntax. {str(e)}",
+        ) from e
 
     def interpret_function():
         QasmInterpreter().interpret(ast, context={"name": "global", "wire_map": wire_map})

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -213,6 +213,21 @@ class TestOpenQasm:
     dev = qml.device("default.qubit", wires=2, shots=100)
 
     @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
+    def test_invalid_qasm3(self):
+        circuit = """\
+            OPENQASM 3.0;
+            qubit q0;
+            bit output = "0";
+            rz(0.9) q0;
+            measure q0 -> output;
+            """
+
+        with pytest.raises(
+            SyntaxError, match="Something went wrong when parsing the provided OpenQASM 3.0 code"
+        ):
+            from_qasm3(circuit)()
+
+    @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
     def test_from_qasm3(self, mocker):
         circuit = """\
             OPENQASM 3.0;


### PR DESCRIPTION


------------------------------------------------------------------------------------------------------------

**Context:** When provided with incorrect QASM syntax, the parser library does not provide helpful error messages. They are mysterious, saying for example that NoneType has no len() or there are no viable candidates, etc.

**Description of the Change:** Catch all errors from the parser and wrap them with an understandable message.

**Benefits:** More clarity for users.

**Possible Drawbacks:** We still don't have very particular or specific error messages that can help us debug.
