### PR TITLE
Raise an understandable error in place of openqasm3's mysterious ones

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -271,6 +271,8 @@
   [(#7543)](https://github.com/PennyLaneAI/pennylane/pull/7543)
   [(#7783)](https://github.com/PennyLaneAI/pennylane/pull/7783)
   [(#7789)](https://github.com/PennyLaneAI/pennylane/pull/7789)
+  [(#7802)](https://github.com/PennyLaneAI/pennylane/pull/7802)
+
   ```python
   import pennylane as qml
 

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -932,6 +932,11 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         raise ImportError(
             "antlr4-python3-runtime is required to interpret openqasm3 in addition to the openqasm3 package"
         ) from e  # pragma: no cover
+    except Exception as e:
+        raise SyntaxError(
+            "Something went wrong when parsing the provided OpenQASM 3.0 code. "
+            f"Please ensure the code is valid OpenQASM 3.0 syntax. {str(e)}",
+        ) from e
 
     def interpret_function():
         QasmInterpreter().interpret(ast, context={"name": "global", "wire_map": wire_map})

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -934,7 +934,7 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         ) from e  # pragma: no cover
     except Exception as e:
         raise SyntaxError(
-            "Something went wrong when parsing the provided OpenQASM 3.0 code. "
+            f"Something went wrong when parsing the provided OpenQASM 3.0 code. "
             f"Please ensure the code is valid OpenQASM 3.0 syntax. {str(e)}",
         ) from e
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -213,6 +213,21 @@ class TestOpenQasm:
     dev = qml.device("default.qubit", wires=2, shots=100)
 
     @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
+    def test_invalid_qasm3(self):
+        circuit = """\
+            OPENQASM 3.0;
+            qubit q0;
+            bit output = "0";
+            rz(0.9) q0;
+            measure q0 -> output;
+            """
+
+        with pytest.raises(
+            SyntaxError, match="Something went wrong when parsing the provided OpenQASM 3.0 code"
+        ):
+            from_qasm3(circuit)()
+
+    @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
     def test_from_qasm3(self, mocker):
         circuit = """\
             OPENQASM 3.0;


### PR DESCRIPTION


------------------------------------------------------------------------------------------------------------

**Context:** When provided with incorrect QASM syntax, the parser library does not provide helpful error messages. They are mysterious, saying for example that NoneType has no len() or there are no viable candidates, etc.

**Description of the Change:** Catch all errors from the parser and wrap them with an understandable message.

**Benefits:** More clarity for users.

**Possible Drawbacks:** We still don't have very particular or specific error messages that can help us debug.

