### PR TITLE
mudit/0.42 fixes

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -271,6 +271,8 @@
   [(#7543)](https://github.com/PennyLaneAI/pennylane/pull/7543)
   [(#7783)](https://github.com/PennyLaneAI/pennylane/pull/7783)
   [(#7789)](https://github.com/PennyLaneAI/pennylane/pull/7789)
+  [(#7802)](https://github.com/PennyLaneAI/pennylane/pull/7802)
+
   ```python
   import pennylane as qml
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0rc0"
+__version__ = "0.42.0"

--- a/pennylane/allocation.py
+++ b/pennylane/allocation.py
@@ -24,6 +24,9 @@ from pennylane.wires import Wires
 has_jax = True
 try:
     import jax
+
+    # pylint: disable=ungrouped-imports
+    from pennylane.capture import QmlPrimitive
 except ImportError:
     jax = None
     has_jax = False
@@ -33,7 +36,7 @@ if not has_jax:
     allocate_prim = None
     deallocate_prim = None
 else:
-    allocate_prim = jax.extend.core.Primitive("allocate")
+    allocate_prim = QmlPrimitive("allocate")
     allocate_prim.multiple_results = True
 
     # pylint: disable=unused-argument
@@ -46,7 +49,7 @@ else:
     def _(*, num_wires, require_zeros=True, restored=False):
         return [jax.core.ShapedArray((), dtype=int) for _ in range(num_wires)]
 
-    deallocate_prim = jax.extend.core.Primitive("deallocate")
+    deallocate_prim = QmlPrimitive("deallocate")
     deallocate_prim.multiple_results = True
 
     # pylint: disable=unused-argument

--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -932,6 +932,11 @@ def from_qasm3(quantum_circuit: str, wire_map: dict = None):
         raise ImportError(
             "antlr4-python3-runtime is required to interpret openqasm3 in addition to the openqasm3 package"
         ) from e  # pragma: no cover
+    except Exception as e:
+        raise SyntaxError(
+            f"Something went wrong when parsing the provided OpenQASM 3.0 code. "
+            f"Please ensure the code is valid OpenQASM 3.0 syntax. {str(e)}",
+        ) from e
 
     def interpret_function():
         QasmInterpreter().interpret(ast, context={"name": "global", "wire_map": wire_map})

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -213,6 +213,21 @@ class TestOpenQasm:
     dev = qml.device("default.qubit", wires=2, shots=100)
 
     @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
+    def test_invalid_qasm3(self):
+        circuit = """\
+            OPENQASM 3.0;
+            qubit q0;
+            bit output = "0";
+            rz(0.9) q0;
+            measure q0 -> output;
+            """
+
+        with pytest.raises(
+            SyntaxError, match="Something went wrong when parsing the provided OpenQASM 3.0 code"
+        ):
+            from_qasm3(circuit)()
+
+    @pytest.mark.skipif(not has_openqasm, reason="requires openqasm3")
     def test_from_qasm3(self, mocker):
         circuit = """\
             OPENQASM 3.0;


### PR DESCRIPTION
- **Remove rc0 from version number**
- **Raise an understandable error in place of openqasm3's mysterious ones (#7802)**
- **Mudit's QA fixes for 0.42 release**
- **Allocate/deallocate primitives use QmlPrimitive instead of JAX's Primitive**
