### PR TITLE
Jax jit givens decomposition

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1038,6 +1038,9 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
+* Jax jit the `givens_matrix` for BasisRotation decomposition.
+  [(#7823)](https://github.com/PennyLaneAI/pennylane/pull/7823)
+
 * Move private code in the `TransformProgram` onto the `CotransformCache` class.
   [(#7750)](https://github.com/PennyLaneAI/pennylane/pull/7750)
 
@@ -1369,8 +1372,10 @@ Simone Gasperini,
 Soran Jahangiri,
 Korbinian Kottmann,
 Christina Lee,
+Joseph Lee,
 Austin Huang,
 Anton Naim Ibrahim,
+Erick Ochoa Lopez,
 William Maxwell
 Luis Alfredo Nuñez Meneses
 Oumarou Oumarou,

--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1376,8 +1376,8 @@ Joseph Lee,
 Austin Huang,
 Anton Naim Ibrahim,
 Erick Ochoa Lopez,
-William Maxwell
-Luis Alfredo Nuñez Meneses
+William Maxwell,
+Luis Alfredo Nuñez Meneses,
 Oumarou Oumarou,
 Lee J. O'Riordan,
 Mudit Pandey,

--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1038,7 +1038,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
 
 <h3>Internal changes ⚙️</h3>
 
-* Jax jit the `givens_matrix` for BasisRotation decomposition.
+* Jits the `givens_matrix` computation from `BasisRotation` when it is within a jit context, which significantly reduces the program size and compilation time of workflows.
   [(#7823)](https://github.com/PennyLaneAI/pennylane/pull/7823)
 
 * Move private code in the `TransformProgram` onto the `CotransformCache` class.

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -352,7 +352,7 @@ def _givens_matrix_core(a, b, left=True, tol=1e-8):
     phase = math.where(abs_b < tol, 1.0, (1.0 * b * math.conj(a)) / (aprod + 1e-15))
     phase = math.where(abs_a < tol, 1.0, phase)
 
-    if interface_a == "jax":
+    if interface == "jax":
         return jax.lax.cond(
             left,
             lambda phase, cosine, sine: math.array(

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -22,6 +22,7 @@ from pennylane import math
 
 try:
     import jax
+    import jax.numpy as jnp
 except ModuleNotFoundError:  # pragma: no cover
     ...
 
@@ -384,9 +385,9 @@ def _givens_matrix_jax():
 
 def _givens_matrix(a, b, left=True, tol=1e-8):
     interface = math.get_interface(a)
-    if interface != "jax":
-        return _givens_matrix_core(a, b, left=left, tol=tol)
-    return _givens_matrix_jax()(a, b, left=left, tol=tol)
+    if interface == "jax" and isinstance(jnp.array(0), jax.core.Tracer):
+        return _givens_matrix_jax()(a, b, left=left, tol=tol)
+    return _givens_matrix_core(a, b, left=left, tol=tol)
 
 
 def _right_givens_core(indices, unitary, N, j):
@@ -410,9 +411,9 @@ def _right_givens_jax():
 
 def _right_givens(indices, unitary, N, j):
     interface = math.get_interface(unitary)
-    if interface != "jax":
-        return _right_givens_core(indices, unitary, N, j)
-    return _right_givens_jax()(indices, unitary, N, j)
+    if interface == "jax" and isinstance(jnp.array(0), jax.core.Tracer):
+        return _right_givens_jax()(indices, unitary, N, j)
+    return _right_givens_core(indices, unitary, N, j)
 
 
 def _left_givens_core(indices, unitary, j):
@@ -436,9 +437,9 @@ def _left_givens_jax():
 
 def _left_givens(indices, unitary, j):
     interface = math.get_interface(unitary)
-    if interface != "jax":
-        return _left_givens_core(indices, unitary, j)
-    return _left_givens_jax()(indices, unitary, j)
+    if interface == "jax" and isinstance(jnp.array(0), jax.core.Tracer):
+        return _left_givens_jax()(indices, unitary, j)
+    return _left_givens_core(indices, unitary, j)
 
 
 # pylint: disable=too-many-branches

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -399,7 +399,7 @@ def _right_givens_core(indices, unitary, N, j):
 
 
 @functools.lru_cache
-def _right_givens_jax(indices, unitary, N, j):
+def _right_givens_jax():
 
     @jax.jit
     def _right_givens_jax(indices, unitary, N, j):
@@ -412,7 +412,7 @@ def _right_givens(indices, unitary, N, j):
     interface = math.get_interface(unitary)
     if interface != "jax":
         return _right_givens_core(indices, unitary, N, j)
-    return _right_givens_jax(indices, unitary, N, j)
+    return _right_givens_jax()(indices, unitary, N, j)
 
 
 def _left_givens_core(indices, unitary, j):
@@ -425,7 +425,7 @@ def _left_givens_core(indices, unitary, j):
 
 
 @functools.lru_cache
-def _left_givens_jax(indices, unitary, j):
+def _left_givens_jax():
 
     @jax.jit
     def _left_givens_jax(indices, unitary, j):
@@ -438,7 +438,7 @@ def _left_givens(indices, unitary, j):
     interface = math.get_interface(unitary)
     if interface != "jax":
         return _left_givens_core(indices, unitary, j)
-    return _left_givens_jax(indices, unitary, j)
+    return _left_givens_jax()(indices, unitary, j)
 
 
 # pylint: disable=too-many-branches

--- a/tests/math/test_givens_rotations.py
+++ b/tests/math/test_givens_rotations.py
@@ -142,6 +142,18 @@ def test_givens_matrix_exceptions():
         _givens_matrix(a, b)
 
 
+@pytest.mark.jax
+def test_givens_matrix_jaxpr():
+    """Verify the JAXPR representation includes a function"""
+    import jax.numpy as jnp
+    from jax import make_jaxpr
+
+    a = jnp.array(1.2)
+    b = jnp.array(2.3)
+
+    assert "givens_matrix_jax" in str(make_jaxpr(_givens_matrix)(a, b))
+
+
 # pylint:disable = too-many-arguments
 @pytest.mark.parametrize(
     ("jax", "unitary_matrix", "index", "value", "like", "expected_matrix"),


### PR DESCRIPTION
**Context:**
This PR is a combination of @erick-xanadu's previous [PR1](https://github.com/PennyLaneAI/pennylane/pull/7013) and [PR2](https://github.com/PennyLaneAI/pennylane/pull/7014).

**Description of the Change:**
 It jax jits the `givens_matrix` from `BasisRotation` when it is within a jit context, which significantly reduces the program size and compilation time of workflows, e.g. the XAS benchmark.

**Benefits:**
This significantly reduces the time for XAS with compilation benchmark ([~5-6x](https://github.com/PennyLaneAI/pennylane-benchmarks/actions/runs/16158349592/job/45616094304#step:10:104)). This undoes most of the performance degradation coming from the bufferization updates in catalyst.

**Possible Drawbacks:**
Jax jitting is now part of the Pennylane internals

**Related GitHub Issues:**

[sc-94738]