### PR TITLE
Fix queuing with mappable operations within `partial_wires`

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1348,6 +1348,9 @@ may move operations across a `Snapshot`.
   in the :doc:`/introduction/dynamic_quantum_circuits` page.
   [(#7691)](https://github.com/PennyLaneAI/pennylane/pull/7691)
 
+* Fixes a bug where an operation wrapped in `partial_wires` does not get queued.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -24,6 +24,7 @@ from pennylane.boolean_fn import BooleanFn
 from pennylane.operation import Operation
 from pennylane.ops import Adjoint, Controlled, Exp, LinearCombination, adjoint, ctrl
 from pennylane.ops.functions import simplify
+from pennylane.queuing import QueuingManager, apply
 from pennylane.templates import ControlledSequence
 from pennylane.wires import WireError, Wires
 
@@ -757,7 +758,11 @@ def partial_wires(operation, *args, **kwargs):
                     return tuple(operation(**op_args, wires=wire) for wire in op_wires)
 
         if is_mappable and operation.wires is not None:
-            return operation.map_wires(dict(zip(operation.wires, op_args.pop("wires"))))
+            with QueuingManager.stop_recording():
+                mapped_op = operation.map_wires(dict(zip(operation.wires, op_args.pop("wires"))))
+            if QueuingManager.recording():
+                apply(mapped_op)
+            return mapped_op
 
         if "wires" not in parameters or (
             "MeasFunc" in op_type and any(x in op_args for x in ["obs", "H"])

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -23,8 +23,8 @@ from pennylane import ops as qops
 from pennylane.boolean_fn import BooleanFn
 from pennylane.operation import Operation
 from pennylane.ops import Adjoint, Controlled, Exp, LinearCombination, adjoint, ctrl
-from pennylane.ops.functions import simplify
-from pennylane.queuing import QueuingManager, apply
+from pennylane.ops.functions import map_wires, simplify
+from pennylane.queuing import QueuingManager
 from pennylane.templates import ControlledSequence
 from pennylane.wires import WireError, Wires
 
@@ -758,11 +758,8 @@ def partial_wires(operation, *args, **kwargs):
                     return tuple(operation(**op_args, wires=wire) for wire in op_wires)
 
         if is_mappable and operation.wires is not None:
-            with QueuingManager.stop_recording():
-                mapped_op = operation.map_wires(dict(zip(operation.wires, op_args.pop("wires"))))
-            if QueuingManager.recording():
-                apply(mapped_op)
-            return mapped_op
+            wire_map = dict(zip(operation.wires, op_args.pop("wires")))
+            return map_wires(operation, wire_map, queue=QueuingManager.recording())
 
         if "wires" not in parameters or (
             "MeasFunc" in op_type and any(x in op_args for x in ["obs", "H"])

--- a/tests/noise/test_conditionals.py
+++ b/tests/noise/test_conditionals.py
@@ -378,6 +378,21 @@ class TestNoiseFunctions:
         mp = qml.noise.partial_wires(qml.counts)(qml.X("light"))
         qml.assert_equal(mp, qml.counts(wires=["light"]))
 
+    def test_partial_wires_queuing(self):
+        """Test for checking partial_wires correctly queue operations"""
+
+        op1 = qml.X(2)
+        qs1 = qml.tape.make_qscript(qml.noise.partial_wires(qml.DepolarizingChannel, 0.01))
+        qs2 = qml.tape.make_qscript(qml.noise.partial_wires(qml.DepolarizingChannel(0.01, [0])))
+        assert qs1(op1).operations == qs2(op1).operations and len(qs1(op1).operations) == 1
+
+        op1 = qml.CNOT(["a", "b"])
+        d1, d2 = [-0.9486833] * 4, [-0.31622777] * 2
+        krs = [qml.math.diag(d1), qml.math.diag(d2, k=2) + qml.math.diag(d2, k=-2)]
+        qs1 = qml.tape.make_qscript(qml.noise.partial_wires(qml.QubitChannel, krs))
+        qs2 = qml.tape.make_qscript(qml.noise.partial_wires(qml.QubitChannel(krs, [0, 1])))
+        assert qs1(op1).operations == qs2(op1).operations and len(qs1(op1).operations) == 1
+
     def test_partial_wires_error(self):
         """Test for checking partial_wires raise correct error when args are given"""
 


### PR DESCRIPTION
**Context:** Fixes queuing with mappable operations within `partial_wires`

**Description of the Change:** 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** [#636](https://github.com/PennyLaneAI/pennylane-qiskit/issues/636)

