### PR TITLE
Simone's QA doc fixes for v0.42 release

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1113,6 +1113,7 @@ Here's a list of deprecations made this release. For a more detailed breakdown o
   [(#7226)](https://github.com/PennyLaneAI/pennylane/pull/7226)
   [(#7372)](https://github.com/PennyLaneAI/pennylane/pull/7372)
   [(#7392)](https://github.com/PennyLaneAI/pennylane/pull/7392)
+  [(#7813)](https://github.com/PennyLaneAI/pennylane/pull/7813)
 
 * A new internal module, `qml.concurrency`, is added to support internal use of multiprocess and multithreaded execution of workloads. This also migrates the use of `concurrent.futures` in `default.qubit` to this new design.
   [(#7303)](https://github.com/PennyLaneAI/pennylane/pull/7303)

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.0rc0"
+__version__ = "0.42.0"

--- a/pennylane/devices/null_qubit.py
+++ b/pennylane/devices/null_qubit.py
@@ -190,7 +190,11 @@ class NullQubit(Device):
             (``['aux_wire', 'q1', 'q2']``). Default ``None`` if not specified.
         shots (int, Sequence[int], Sequence[Union[int, Sequence[int]]]): The default number of shots
             to use in executions involving this device.
-        track_resources (bool): If True, track the number of resources used by the device and save them to a JSON file. This argument is experimental and subject to change.
+        track_resources (bool): If True, track the number of resources used by the device and save them to a JSON file.
+            The filename will match ``__pennylane_resources_data_*.json`` where the wildcard (asterisk) is replaced by
+            the timestamp of when execution began in nanoseconds since Unix EPOCH. This argument is experimental and
+            subject to change.
+
     **Example:**
 
     .. code-block:: python


### PR DESCRIPTION
- Add missing argument `sort` to the docstrings of a few `CircuitGraph` methods