### PR TITLE
Update README image paths for PyPI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Get up and running quickly with PennyLane by following our [quickstart guide](ht
 
 Whether you're exploring quantum machine learning (QML), quantum computing, or quantum chemistry, PennyLane offers a wide range of tools and resources to support your research:
 
-<img src="./doc/_static/readme/research.png" align="right" width="350px">
+<img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/research.png" align="right" width="350px">
 
 ### Key Resources:
 
@@ -106,7 +106,7 @@ quantum device.
 Take a deeper dive into quantum computing by exploring cutting-edge algorithms using PennyLane and quantum hardware. [Explore PennyLane demos](https://pennylane.ai/qml/demonstrations.html).
 
 <a href="https://pennylane.ai/qml/demonstrations">
-  <img src="./doc/_static/readme/demos.png" width="900px">
+  <img src="https://raw.githubusercontent.com/PennyLaneAI/pennylane/master/doc/_static/readme/demos.png" width="900px">
 </a>
 
 If you would like to contribute your own demo, see our [demo submission


### PR DESCRIPTION
**Context:**
Some images in the `README.md` are not rendering properly on [PyPI](https://pypi.org/project/PennyLane/) because PyPI does not support relative image paths.

**Description of the Change:**
This PR updates image references in `README.md` to use absolute URLs pointing to raw GitHub content to ensure images render correctly on both GitHub and PyPI.


**Notes:**
Please note that we had decided to use a relative path for certain images in the past to support GitHub’s dark mode rendering. See https://github.com/PennyLaneAI/pennylane/pull/2341 for more details.


