### PR TITLE
Seed `test_split_to_single_terms`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Seeded tests for the `split_to_single_terms` transformation.
+  [(#7851)](https://github.com/PennyLaneAI/pennylane/pull/7851)
+
 * Upgrade `rc_sync.yml` to work with latest `pyproject.toml` changes.
   [(#7808)](https://github.com/PennyLaneAI/pennylane/pull/7808)
   [(#7818)](https://github.com/PennyLaneAI/pennylane/pull/7818)

--- a/tests/transforms/test_split_to_single_terms.py
+++ b/tests/transforms/test_split_to_single_terms.py
@@ -291,13 +291,13 @@ class TestIntegration:
             ),
         ],
     )
-    def test_single_expval(self, shots, params, expected_results):
+    def test_single_expval(self, shots, params, expected_results, seed):
         """Tests that a QNode with a single expval measurement is executed correctly"""
 
         coeffs = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
         obs = single_term_obs_list + [qml.I()]  # test constant offset
 
-        dev = NoTermsDevice(wires=2, shots=shots)
+        dev = NoTermsDevice(wires=2, shots=shots, seed=seed)
 
         @qml.qnode(dev)
         def circuit(angles):
@@ -363,10 +363,10 @@ class TestIntegration:
             ),
         ],
     )
-    def test_multiple_expval(self, shots, params, expected_results):
+    def test_multiple_expval(self, shots, params, expected_results, seed):
         """Tests that a QNode with multiple expval measurements is executed correctly"""
 
-        dev = NoTermsDevice(wires=2, shots=shots)
+        dev = NoTermsDevice(wires=2, shots=shots, seed=seed)
 
         obs_list = complex_obs_list
 
@@ -429,10 +429,10 @@ class TestIntegration:
             ),
         ],
     )
-    def test_mixed_measurement_types(self, shots, params, expected_results):
+    def test_mixed_measurement_types(self, shots, params, expected_results, seed):
         """Tests that a QNode with mixed measurement types is executed correctly"""
 
-        dev = NoTermsDevice(wires=2, shots=shots)
+        dev = NoTermsDevice(wires=2, shots=shots, seed=seed)
 
         obs_list = complex_obs_list
 
@@ -493,11 +493,11 @@ class TestIntegration:
             assert qml.math.allclose(expval_res, expected_results, atol=0.05)
 
     @pytest.mark.parametrize("shots", [None, 20000, [20000, 30000, 40000]])
-    def test_sum_with_only_identity(self, shots):
+    def test_sum_with_only_identity(self, shots, seed):
         """Tests that split_to_single_terms can handle Identity observables (these
         are treated separately as offsets in the transform)"""
 
-        dev = NoTermsDevice(wires=2, shots=shots)
+        dev = NoTermsDevice(wires=2, shots=shots, seed=seed)
         H = qml.Hamiltonian([1.5, 2.5], [qml.I(), qml.I()])
 
         @split_to_single_terms
@@ -509,11 +509,11 @@ class TestIntegration:
         assert qml.math.allclose(res, 1.5 + 2.5)
 
     @pytest.mark.parametrize("shots", [None, 20000, [20000, 30000, 40000]])
-    def test_sum_with_identity_and_observable(self, shots):
+    def test_sum_with_identity_and_observable(self, shots, seed):
         """Tests that split_to_single_terms can handle a combination Identity observables (these
         are treated separately as offsets in the transform) and other observables"""
 
-        dev = NoTermsDevice(wires=2, shots=shots)
+        dev = NoTermsDevice(wires=2, shots=shots, seed=seed)
         H = qml.Hamiltonian([1.5, 2.5], [qml.I(0), qml.Y(0)])
 
         @split_to_single_terms
@@ -546,12 +546,12 @@ class TestDifferentiability:
     """Tests the differentiability of the ``split_to_single_terms`` transform"""
 
     @pytest.mark.autograd
-    def test_trainable_hamiltonian_autograd(self):
+    def test_trainable_hamiltonian_autograd(self, seed):
         """Tests that measurements of trainable Hamiltonians are differentiable"""
 
         import pennylane.numpy as pnp
 
-        dev = NoTermsDevice(wires=2, shots=50000)
+        dev = NoTermsDevice(wires=2, shots=50000, seed=seed)
 
         @split_to_single_terms
         @qml.qnode(dev)
@@ -567,13 +567,13 @@ class TestDifferentiability:
 
     @pytest.mark.jax
     @pytest.mark.parametrize("use_jit", [False, True])
-    def test_trainable_hamiltonian_jax(self, use_jit):
+    def test_trainable_hamiltonian_jax(self, use_jit, seed):
         """Tests that measurements of trainable Hamiltonians are differentiable with jax"""
 
         import jax
         import jax.numpy as jnp
 
-        dev = NoTermsDevice(wires=2, shots=50000)
+        dev = NoTermsDevice(wires=2, shots=50000, seed=seed)
 
         @partial(split_to_single_terms)
         @qml.qnode(dev)
@@ -591,13 +591,13 @@ class TestDifferentiability:
         assert qml.math.allclose(actual, [-0.5, np.cos(np.pi / 4)], rtol=0.05)
 
     @pytest.mark.torch
-    def test_trainable_hamiltonian_torch(self):
+    def test_trainable_hamiltonian_torch(self, seed):
         """Tests that measurements of trainable Hamiltonians are differentiable with torch"""
 
         import torch
         from torch.autograd.functional import jacobian
 
-        dev = NoTermsDevice(wires=2, shots=50000)
+        dev = NoTermsDevice(wires=2, shots=50000, seed=seed)
 
         @split_to_single_terms
         @qml.qnode(dev)
@@ -612,12 +612,12 @@ class TestDifferentiability:
         assert qml.math.allclose(actual, [-0.5, np.cos(np.pi / 4)], rtol=0.05)
 
     @pytest.mark.tf
-    def test_trainable_hamiltonian_tensorflow(self):
+    def test_trainable_hamiltonian_tensorflow(self, seed):
         """Tests that measurements of trainable Hamiltonians are differentiable with tensorflow"""
 
         import tensorflow as tf
 
-        dev = NoTermsDevice(wires=2, shots=50000)
+        dev = NoTermsDevice(wires=2, shots=50000, seed=seed)
 
         @qml.qnode(dev)
         def circuit(coeff1, coeff2):


### PR DESCRIPTION
**Context:**
`tests/transform/test_split_to_single_terms` somehow escaped our global seeding system. It caused multiple stochastic failure during the release week 07July~11July 2025. Therefore here we seed them.

**Description of the Change:**
Whoever involves finite-shot experiments and checks stochastic results shall be seeded.

**Benefits:**
CI stability and reliability.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-90216]