### PR TITLE
Update pytest version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pre-commit>=2.19.0
-pytest>=7.1.2
+pytest>=8.4.1
 pytest-cov>=3.0.0
 pytest-mock>=3.7.0
 pytest-xdist>=2.5.0


### PR DESCRIPTION
**Context:**
Old pytest versions cause unit test failures in PennyLane and Lightning.

**Description of the Change:**
Updates the requirements files to only use versions of pytest which are properly supported.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95292]