### PR TITLE
Deprecate `shots` setting from devices

### DIFF
--- a/pennylane/ftqc/pauli_tracker.py
+++ b/pennylane/ftqc/pauli_tracker.py
@@ -415,8 +415,9 @@ def get_byproduct_corrections(tape: QuantumScript, mid_meas: List, measurement_v
 
 
             num_shots = 1000
-            dev = qml.device("lightning.qubit", shots=num_shots)
+            dev = qml.device("lightning.qubit")
 
+            @partial(qml.set_shots, shots=num_shots)
             @diagonalize_mcms
             @qml.qnode(dev, mcm_method="one-shot")
             def circ(start_state):

--- a/pennylane/templates/subroutines/semi_adder.py
+++ b/pennylane/templates/subroutines/semi_adder.py
@@ -84,8 +84,9 @@ class SemiAdder(Operation):
 
         wires = qml.registers({"x":3, "y":6, "work":5})
 
-        dev = qml.device("default.qubit", shots=1)
+        dev = qml.device("default.qubit")
 
+        @partial(qml.set_shots, shots=1)
         @qml.qnode(dev)
         def circuit():
             qml.BasisEmbedding(x, wires=wires["x"])
@@ -109,8 +110,9 @@ class SemiAdder(Operation):
 
         wires = qml.registers({"x":3, "y":2, "work":1})
 
-        dev = qml.device("default.qubit", shots=1)
+        dev = qml.device("default.qubit")
 
+        @partial(qml.set_shots, shots=1)
         @qml.qnode(dev)
         def circuit():
             qml.BasisEmbedding(x, wires=wires["x"])

--- a/pennylane/templates/subroutines/temporary_and.py
+++ b/pennylane/templates/subroutines/temporary_and.py
@@ -58,7 +58,8 @@ class TemporaryAND(Operation):
 
     .. code-block::
 
-        dev = qml.device("default.qubit", shots=1)
+        dev = qml.device("default.qubit")
+        @partial(qml.set_shots, shots=1)
         @qml.qnode(dev)
         def circuit():
             # |0000⟩

--- a/tests/device_shots_to_analytic.py
+++ b/tests/device_shots_to_analytic.py
@@ -26,7 +26,8 @@ def shots_to_analytic(dev: qml.devices.Device) -> qml.devices.Device:
 
     .. code-block:: python
 
-        @qml.qnode(shots_to_analytic(qml.device('default.qubit', shots=(1,1,1))))
+        @partial(qml.set_shots, shots=(1,1,1))
+        @qml.qnode(shots_to_analytic(qml.device('default.qubit')))
         def f(x):
             qml.RX(2*x, 0)
             return qml.expval(qml.Z(0))


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**
Question:
Shall we deprecate legacy devices `shots` as well? I wonder how large engineering it would be if we proceed

**Related GitHub Issues:**
