### PR TITLE
Use `TemporaryAND` for `MultiControlledX` decomposition with many clean aux wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* Improved the decomposition of `MultiControlledX` with many clean auxiliary wires to leverage
+  `TemporaryAND` gates. This reduces the gate counts upon further decomposition.
+  [(#7859)](https://github.com/PennyLaneAI/pennylane/pull/7859)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * Added state of the art resources for the `ResourceSelectPauliRot` template and the
@@ -32,3 +36,4 @@ This release contains contributions from (in alphabetical order):
 
 Andrija Paurevic,
 Jay Soni,
+David Wierichs,

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -15,13 +15,13 @@ r"""
 Contains the AmplitudeEmbedding template.
 """
 # pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
-from pennylane.ops import StatePrep
+from pennylane import ops
 
 # tolerance for normalization
 TOLERANCE = 1e-10
 
 
-class AmplitudeEmbedding(StatePrep):
+class AmplitudeEmbedding(ops.StatePrep):
     r"""Encodes :math:`2^n` features into the amplitude vector of :math:`n` qubits.
 
     By setting ``pad_with`` to a real or complex number, ``features`` is automatically padded to dimension
@@ -109,7 +109,7 @@ class AmplitudeEmbedding(StatePrep):
 
     def __init__(
         self, features, wires, pad_with=None, normalize=False, id=None, validate_norm=True
-    ):
+    ):  # pylint: disable=too-many-positional-arguments
         super().__init__(
             features,
             wires=wires,

--- a/pennylane/templates/subroutines/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/approx_time_evolution.py
@@ -18,8 +18,8 @@ Contains the ApproxTimeEvolution template.
 import copy
 
 import pennylane as qml
+from pennylane import ops
 from pennylane.operation import Operation
-from pennylane.ops import PauliRot
 from pennylane.wires import Wires
 
 
@@ -215,7 +215,7 @@ class ApproxTimeEvolution(Operation):
                 theta = 2 * time * coeff / n
                 term_str = "".join(pw.values())
                 wires = qml.wires.Wires(pw.keys())
-                single_round.append(PauliRot(theta, term_str, wires=wires))
+                single_round.append(ops.PauliRot(theta, term_str, wires=wires))
 
         full_decomp = single_round * n
         if qml.QueuingManager.recording():

--- a/pennylane/templates/subroutines/arbitrary_unitary.py
+++ b/pennylane/templates/subroutines/arbitrary_unitary.py
@@ -14,9 +14,8 @@
 r"""
 Contains the ArbitraryUnitary template.
 """
-import pennylane as qml
+from pennylane import math, ops
 from pennylane.operation import Operation
-from pennylane.ops import PauliRot
 
 _PAULIS = ["I", "X", "Y", "Z"]
 
@@ -97,7 +96,7 @@ class ArbitraryUnitary(Operation):
     ndim_params = (1,)
 
     def __init__(self, weights, wires, id=None):
-        shape = qml.math.shape(weights)
+        shape = math.shape(weights)
         dim = 4 ** len(wires) - 1
         if len(shape) not in (1, 2) or shape[-1] != dim:
             raise ValueError(
@@ -128,7 +127,7 @@ class ArbitraryUnitary(Operation):
         op_list = []
 
         for i, pauli_word in enumerate(_all_pauli_words_but_identity(len(wires))):
-            op_list.append(PauliRot(weights[..., i], pauli_word, wires=wires))
+            op_list.append(ops.PauliRot(weights[..., i], pauli_word, wires=wires))
 
         return op_list
 

--- a/pennylane/templates/subroutines/fermionic_double_excitation.py
+++ b/pennylane/templates/subroutines/fermionic_double_excitation.py
@@ -14,14 +14,14 @@
 r"""
 Contains the FermionicDoubleExcitation template.
 """
-# pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
+# pylint: disable=too-many-branches,too-many-arguments,protected-access,too-many-positional-arguments
 import copy
 
 import numpy as np
 
 import pennylane as qml
+from pennylane import ops
 from pennylane.operation import Operation
-from pennylane.ops import CNOT, RX, RZ, Hadamard
 from pennylane.wires import Wires
 
 
@@ -47,24 +47,29 @@ def _layer1(weight, s, r, q, p, set_cnot_wires):
           list[.Operator]: sequence of operators defined by this function
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
-    op_list = [Hadamard(wires=s), Hadamard(wires=r), RX(-np.pi / 2, wires=q), Hadamard(wires=p)]
+    op_list = [
+        ops.Hadamard(wires=s),
+        ops.Hadamard(wires=r),
+        ops.RX(-np.pi / 2, wires=q),
+        ops.Hadamard(wires=p),
+    ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(weight / 8, wires=p))
+    op_list.append(ops.RZ(weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(Hadamard(wires=s))
-    op_list.append(Hadamard(wires=r))
-    op_list.append(RX(np.pi / 2, wires=q))
-    op_list.append(Hadamard(wires=p))
+    op_list.append(ops.Hadamard(wires=s))
+    op_list.append(ops.Hadamard(wires=r))
+    op_list.append(ops.RX(np.pi / 2, wires=q))
+    op_list.append(ops.Hadamard(wires=p))
     return op_list
 
 
@@ -91,28 +96,28 @@ def _layer2(weight, s, r, q, p, set_cnot_wires):
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
     op_list = [
-        RX(-np.pi / 2, wires=s),
-        Hadamard(wires=r),
-        RX(-np.pi / 2, wires=q),
-        RX(-np.pi / 2, wires=p),
+        ops.RX(-np.pi / 2, wires=s),
+        ops.Hadamard(wires=r),
+        ops.RX(-np.pi / 2, wires=q),
+        ops.RX(-np.pi / 2, wires=p),
     ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(weight / 8, wires=p))
+    op_list.append(ops.RZ(weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(RX(np.pi / 2, wires=s))
-    op_list.append(Hadamard(wires=r))
-    op_list.append(RX(np.pi / 2, wires=q))
-    op_list.append(RX(np.pi / 2, wires=p))
+    op_list.append(ops.RX(np.pi / 2, wires=s))
+    op_list.append(ops.Hadamard(wires=r))
+    op_list.append(ops.RX(np.pi / 2, wires=q))
+    op_list.append(ops.RX(np.pi / 2, wires=p))
     return op_list
 
 
@@ -139,28 +144,28 @@ def _layer3(weight, s, r, q, p, set_cnot_wires):
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
     op_list = [
-        Hadamard(wires=s),
-        RX(-np.pi / 2, wires=r),
-        RX(-np.pi / 2, wires=q),
-        RX(-np.pi / 2, wires=p),
+        ops.Hadamard(wires=s),
+        ops.RX(-np.pi / 2, wires=r),
+        ops.RX(-np.pi / 2, wires=q),
+        ops.RX(-np.pi / 2, wires=p),
     ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(weight / 8, wires=p))
+    op_list.append(ops.RZ(weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(Hadamard(wires=s))
-    op_list.append(RX(np.pi / 2, wires=r))
-    op_list.append(RX(np.pi / 2, wires=q))
-    op_list.append(RX(np.pi / 2, wires=p))
+    op_list.append(ops.Hadamard(wires=s))
+    op_list.append(ops.RX(np.pi / 2, wires=r))
+    op_list.append(ops.RX(np.pi / 2, wires=q))
+    op_list.append(ops.RX(np.pi / 2, wires=p))
     return op_list
 
 
@@ -186,24 +191,29 @@ def _layer4(weight, s, r, q, p, set_cnot_wires):
         list[.Operator]: sequence of operators defined by this function
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
-    op_list = [Hadamard(wires=s), Hadamard(wires=r), Hadamard(wires=q), RX(-np.pi / 2, wires=p)]
+    op_list = [
+        ops.Hadamard(wires=s),
+        ops.Hadamard(wires=r),
+        ops.Hadamard(wires=q),
+        ops.RX(-np.pi / 2, wires=p),
+    ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(weight / 8, wires=p))
+    op_list.append(ops.RZ(weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(Hadamard(wires=s))
-    op_list.append(Hadamard(wires=r))
-    op_list.append(Hadamard(wires=q))
-    op_list.append(RX(np.pi / 2, wires=p))
+    op_list.append(ops.Hadamard(wires=s))
+    op_list.append(ops.Hadamard(wires=r))
+    op_list.append(ops.Hadamard(wires=q))
+    op_list.append(ops.RX(np.pi / 2, wires=p))
     return op_list
 
 
@@ -229,24 +239,29 @@ def _layer5(weight, s, r, q, p, set_cnot_wires):
         list[.Operator]: sequence of operators defined by this function
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
-    op_list = [RX(-np.pi / 2, wires=s), Hadamard(wires=r), Hadamard(wires=q), Hadamard(wires=p)]
+    op_list = [
+        ops.RX(-np.pi / 2, wires=s),
+        ops.Hadamard(wires=r),
+        ops.Hadamard(wires=q),
+        ops.Hadamard(wires=p),
+    ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(-weight / 8, wires=p))
+    op_list.append(ops.RZ(-weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(RX(np.pi / 2, wires=s))
-    op_list.append(Hadamard(wires=r))
-    op_list.append(Hadamard(wires=q))
-    op_list.append(Hadamard(wires=p))
+    op_list.append(ops.RX(np.pi / 2, wires=s))
+    op_list.append(ops.Hadamard(wires=r))
+    op_list.append(ops.Hadamard(wires=q))
+    op_list.append(ops.Hadamard(wires=p))
     return op_list
 
 
@@ -272,24 +287,29 @@ def _layer6(weight, s, r, q, p, set_cnot_wires):
         list[.Operator]: sequence of operators defined by this function
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
-    op_list = [Hadamard(wires=s), RX(-np.pi / 2, wires=r), Hadamard(wires=q), Hadamard(wires=p)]
+    op_list = [
+        ops.Hadamard(wires=s),
+        ops.RX(-np.pi / 2, wires=r),
+        ops.Hadamard(wires=q),
+        ops.Hadamard(wires=p),
+    ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(-weight / 8, wires=p))
+    op_list.append(ops.RZ(-weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(Hadamard(wires=s))
-    op_list.append(RX(np.pi / 2, wires=r))
-    op_list.append(Hadamard(wires=q))
-    op_list.append(Hadamard(wires=p))
+    op_list.append(ops.Hadamard(wires=s))
+    op_list.append(ops.RX(np.pi / 2, wires=r))
+    op_list.append(ops.Hadamard(wires=q))
+    op_list.append(ops.Hadamard(wires=p))
     return op_list
 
 
@@ -316,28 +336,28 @@ def _layer7(weight, s, r, q, p, set_cnot_wires):
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
     op_list = [
-        RX(-np.pi / 2, wires=s),
-        RX(-np.pi / 2, wires=r),
-        RX(-np.pi / 2, wires=q),
-        Hadamard(wires=p),
+        ops.RX(-np.pi / 2, wires=s),
+        ops.RX(-np.pi / 2, wires=r),
+        ops.RX(-np.pi / 2, wires=q),
+        ops.Hadamard(wires=p),
     ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(-weight / 8, wires=p))
+    op_list.append(ops.RZ(-weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(RX(np.pi / 2, wires=s))
-    op_list.append(RX(np.pi / 2, wires=r))
-    op_list.append(RX(np.pi / 2, wires=q))
-    op_list.append(Hadamard(wires=p))
+    op_list.append(ops.RX(np.pi / 2, wires=s))
+    op_list.append(ops.RX(np.pi / 2, wires=r))
+    op_list.append(ops.RX(np.pi / 2, wires=q))
+    op_list.append(ops.Hadamard(wires=p))
     return op_list
 
 
@@ -364,28 +384,28 @@ def _layer8(weight, s, r, q, p, set_cnot_wires):
     """
     # U_1, U_2, U_3, U_4 acting on wires 's', 'r', 'q' and 'p'
     op_list = [
-        RX(-np.pi / 2, wires=s),
-        RX(-np.pi / 2, wires=r),
-        Hadamard(wires=q),
-        RX(-np.pi / 2, wires=p),
+        ops.RX(-np.pi / 2, wires=s),
+        ops.RX(-np.pi / 2, wires=r),
+        ops.Hadamard(wires=q),
+        ops.RX(-np.pi / 2, wires=p),
     ]
 
     # Applying CNOTs
     for cnot_wires in set_cnot_wires:
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # Z rotation acting on wire 'p'
-    op_list.append(RZ(-weight / 8, wires=p))
+    op_list.append(ops.RZ(-weight / 8, wires=p))
 
     # Applying CNOTs in reverse order
     for cnot_wires in reversed(set_cnot_wires):
-        op_list.append(CNOT(wires=cnot_wires))
+        op_list.append(ops.CNOT(wires=cnot_wires))
 
     # U_1^+, U_2^+, U_3^+, U_4^+ acting on wires 's', 'r', 'q' and 'p'
-    op_list.append(RX(np.pi / 2, wires=s))
-    op_list.append(RX(np.pi / 2, wires=r))
-    op_list.append(Hadamard(wires=q))
-    op_list.append(RX(np.pi / 2, wires=p))
+    op_list.append(ops.RX(np.pi / 2, wires=s))
+    op_list.append(ops.RX(np.pi / 2, wires=r))
+    op_list.append(ops.Hadamard(wires=q))
+    op_list.append(ops.RX(np.pi / 2, wires=p))
     return op_list
 
 

--- a/pennylane/templates/subroutines/fermionic_single_excitation.py
+++ b/pennylane/templates/subroutines/fermionic_single_excitation.py
@@ -18,8 +18,8 @@ Contains the FermionicSingleExcitation template.
 import numpy as np
 
 import pennylane as qml
+from pennylane import ops
 from pennylane.operation import Operation
-from pennylane.ops import CNOT, RX, RZ, Hadamard
 
 
 class FermionicSingleExcitation(Operation):
@@ -160,44 +160,44 @@ class FermionicSingleExcitation(Operation):
         # Apply the first layer
 
         # U_1, U_2 acting on wires 'r' and 'p'
-        op_list.append(RX(-np.pi / 2, wires=r))
-        op_list.append(Hadamard(wires=p))
+        op_list.append(ops.RX(-np.pi / 2, wires=r))
+        op_list.append(ops.Hadamard(wires=p))
 
         # Applying CNOTs between wires 'r' and 'p'
         for cnot_wires in set_cnot_wires:
-            op_list.append(CNOT(wires=cnot_wires))
+            op_list.append(ops.CNOT(wires=cnot_wires))
 
         # Z rotation acting on wire 'p'
-        op_list.append(RZ(weight / 2, wires=p))
+        op_list.append(ops.RZ(weight / 2, wires=p))
 
         # Applying CNOTs in reverse order
         for cnot_wires in reversed(set_cnot_wires):
-            op_list.append(CNOT(wires=cnot_wires))
+            op_list.append(ops.CNOT(wires=cnot_wires))
 
         # U_1^+, U_2^+ acting on wires 'r' and 'p'
-        op_list.append(RX(np.pi / 2, wires=r))
-        op_list.append(Hadamard(wires=p))
+        op_list.append(ops.RX(np.pi / 2, wires=r))
+        op_list.append(ops.Hadamard(wires=p))
 
         # ------------------------------------------------------------------
         # Apply the second layer
 
         # U_1, U_2 acting on wires 'r' and 'p'
-        op_list.append(Hadamard(wires=r))
-        op_list.append(RX(-np.pi / 2, wires=p))
+        op_list.append(ops.Hadamard(wires=r))
+        op_list.append(ops.RX(-np.pi / 2, wires=p))
 
         # Applying CNOTs between wires 'r' and 'p'
         for cnot_wires in set_cnot_wires:
-            op_list.append(CNOT(wires=cnot_wires))
+            op_list.append(ops.CNOT(wires=cnot_wires))
 
         # Z rotation acting on wire 'p'
-        op_list.append(RZ(-weight / 2, wires=p))
+        op_list.append(ops.RZ(-weight / 2, wires=p))
 
         # Applying CNOTs in reverse order
         for cnot_wires in reversed(set_cnot_wires):
-            op_list.append(CNOT(wires=cnot_wires))
+            op_list.append(ops.CNOT(wires=cnot_wires))
 
         # U_1^+, U_2^+ acting on wires 'r' and 'p'
-        op_list.append(Hadamard(wires=r))
-        op_list.append(RX(np.pi / 2, wires=p))
+        op_list.append(ops.Hadamard(wires=r))
+        op_list.append(ops.RX(np.pi / 2, wires=p))
 
         return op_list

--- a/pennylane/templates/subroutines/permute.py
+++ b/pennylane/templates/subroutines/permute.py
@@ -16,8 +16,8 @@ Contains the Permute template.
 """
 import copy
 
+from pennylane import ops
 from pennylane.operation import Operation
-from pennylane.ops import SWAP
 from pennylane.wires import Wires
 
 
@@ -208,7 +208,7 @@ class Permute(Operation):
                 idx_there = working_order.index(permutation[idx_here])
 
                 # SWAP based on the labels of the wires
-                op_list.append(SWAP(wires=wires.subset([idx_here, idx_there])))
+                op_list.append(ops.SWAP(wires=wires.subset([idx_here, idx_there])))
 
                 # Update the working order to account for the SWAP
                 working_order[idx_here], working_order[idx_there] = (

--- a/pennylane/templates/subroutines/temporary_and.py
+++ b/pennylane/templates/subroutines/temporary_and.py
@@ -17,8 +17,8 @@ Contains the TemporaryAND template, which also is known as Elbow.
 
 from functools import lru_cache
 
-import pennylane as qml
-from pennylane.decomposition import add_decomps, register_resources
+from pennylane import math, ops
+from pennylane.decomposition import add_decomps, adjoint_resource_rep, register_resources
 from pennylane.operation import Operation
 from pennylane.wires import Wires, WiresLike
 
@@ -143,7 +143,7 @@ class TemporaryAND(Operation):
         if control_values[1] == 0:
             mask ^= 2
 
-        result_matrix = qml.math.array(
+        result_matrix = math.array(
             [
                 [1, 0, 0, 0, 0, 0, 0, 0],
                 [0, -1j, 0, 0, 0, 0, 0, 0],
@@ -157,7 +157,7 @@ class TemporaryAND(Operation):
             dtype=complex,
         )
 
-        perm = qml.math.arange(8) ^ mask
+        perm = math.arange(8) ^ mask
         result_matrix = result_matrix[perm][:, perm]
 
         return result_matrix
@@ -199,22 +199,22 @@ class TemporaryAND(Operation):
 
         list_decomp = []
 
-        list_decomp.extend([qml.X(wires[idx]) for idx in [0, 1] if control_values[idx] == 0])
+        list_decomp.extend([ops.X(wires[idx]) for idx in [0, 1] if control_values[idx] == 0])
 
         list_decomp += [
-            qml.Hadamard(wires=wires[2]),
-            qml.T(wires=wires[2]),
-            qml.CNOT(wires=[wires[1], wires[2]]),
-            qml.adjoint(qml.T(wires=wires[2])),
-            qml.CNOT(wires=[wires[0], wires[2]]),
-            qml.T(wires=wires[2]),
-            qml.CNOT(wires=[wires[1], wires[2]]),
-            qml.adjoint(qml.T(wires=wires[2])),
-            qml.Hadamard(wires=wires[2]),
-            qml.adjoint(qml.S(wires=wires[2])),
+            ops.Hadamard(wires=wires[2]),
+            ops.T(wires=wires[2]),
+            ops.CNOT(wires=[wires[1], wires[2]]),
+            ops.adjoint(ops.T(wires=wires[2])),
+            ops.CNOT(wires=[wires[0], wires[2]]),
+            ops.T(wires=wires[2]),
+            ops.CNOT(wires=[wires[1], wires[2]]),
+            ops.adjoint(ops.T(wires=wires[2])),
+            ops.Hadamard(wires=wires[2]),
+            ops.adjoint(ops.S(wires=wires[2])),
         ]
 
-        list_decomp.extend([qml.X(wires[idx]) for idx in [0, 1] if control_values[idx] == 0])
+        list_decomp.extend([ops.X(wires[idx]) for idx in [0, 1] if control_values[idx] == 0])
 
         return list_decomp
 
@@ -222,12 +222,12 @@ class TemporaryAND(Operation):
 def _temporary_and_resources():
     number_xs = 4  # worst case scenario
     return {
-        qml.X: number_xs,
-        qml.Hadamard: 2,
-        qml.CNOT: 3,
-        qml.T: 2,
-        qml.decomposition.adjoint_resource_rep(qml.T, {}): 2,
-        qml.decomposition.adjoint_resource_rep(qml.S, {}): 1,
+        ops.X: number_xs,
+        ops.Hadamard: 2,
+        ops.CNOT: 3,
+        ops.T: 2,
+        adjoint_resource_rep(ops.T, {}): 2,
+        adjoint_resource_rep(ops.S, {}): 1,
     }
 
 
@@ -235,27 +235,27 @@ def _temporary_and_resources():
 def _temporary_and(wires: WiresLike, **kwargs):
     control_values = kwargs["control_values"]
     if control_values[0] == 0:
-        qml.X(wires[0])
+        ops.X(wires[0])
 
     if control_values[1] == 0:
-        qml.X(wires[1])
+        ops.X(wires[1])
 
-    qml.Hadamard(wires=wires[2])
-    qml.T(wires=wires[2])
-    qml.CNOT(wires=[wires[1], wires[2]])
-    qml.adjoint(qml.T(wires=wires[2]))
-    qml.CNOT(wires=[wires[0], wires[2]])
-    qml.T(wires=wires[2])
-    qml.CNOT(wires=[wires[1], wires[2]])
-    qml.adjoint(qml.T(wires=wires[2]))
-    qml.Hadamard(wires=wires[2])
-    qml.adjoint(qml.S(wires=wires[2]))
+    ops.Hadamard(wires=wires[2])
+    ops.T(wires=wires[2])
+    ops.CNOT(wires=[wires[1], wires[2]])
+    ops.adjoint(ops.T(wires=wires[2]))
+    ops.CNOT(wires=[wires[0], wires[2]])
+    ops.T(wires=wires[2])
+    ops.CNOT(wires=[wires[1], wires[2]])
+    ops.adjoint(ops.T(wires=wires[2]))
+    ops.Hadamard(wires=wires[2])
+    ops.adjoint(ops.S(wires=wires[2]))
 
     if control_values[0] == 0:
-        qml.X(wires[0])
+        ops.X(wires[0])
 
     if control_values[1] == 0:
-        qml.X(wires[1])
+        ops.X(wires[1])
 
 
 add_decomps(TemporaryAND, _temporary_and)

--- a/pennylane/templates/subroutines/uccsd.py
+++ b/pennylane/templates/subroutines/uccsd.py
@@ -14,14 +14,14 @@
 r"""
 Contains the UCCSD template.
 """
-# pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
+# pylint: disable=too-many-branches,too-many-arguments,protected-access,too-many-positional-arguments
 import copy
 
 import numpy as np
 
 import pennylane as qml
+from pennylane import ops
 from pennylane.operation import Operation
-from pennylane.ops import BasisState
 from pennylane.wires import Wires
 
 
@@ -266,7 +266,7 @@ class UCCSD(Operation):
         """
         op_list = []
 
-        op_list.append(BasisState(init_state, wires=wires))
+        op_list.append(ops.BasisState(init_state, wires=wires))
 
         if n_repeats == 1 and len(qml.math.shape(weights)) == 1:
             weights = qml.math.expand_dims(weights, 0)


### PR DESCRIPTION
**Context:**
We can decompose `MultiControlledX` with many aux wires (number of control wires minus two many), and PL already does that. This decomposition consists of `Toffoli` gates only.

**Description of the Change:**
If the auxiliary wires are clean, the `Toffoli` gates appearing in this decomposition can be replaced by `TemporaryAND` gates, which ultimately will reduce the gate count (already now but even more so once we have the 0-T gate decomposition for `adjoint(TemporaryAND)`.

**Benefits:**
Cheaper decomposition

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-95311]