### PR TITLE
Remove warning in the `qml.FlipSign` operation

### DIFF
--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -14,8 +14,6 @@
 r"""
 Contains the FlipSign template.
 """
-import warnings
-
 import pennylane as qml
 from pennylane.operation import Operation
 
@@ -34,12 +32,6 @@ class FlipSign(Operation):
     Args:
         n (array[int] or int): binary array or integer value representing the state on which to flip the sign
         wires (array[int] or int): wires that the template acts on
-
-    .. warning::
-
-        Passing an integer `m` as the wires argument is now interpreted as a single wire (i.e. wires=[`m`]).
-        This is different from the previous interpretation of wires=range(`m`). This may lead to unexpected errors.
-
 
     **Example**
 
@@ -80,10 +72,6 @@ class FlipSign(Operation):
             raise ValueError("At least one valid wire is required.")
 
         if isinstance(wires, int):
-            warnings.warn(
-                "Passing an integer `m` as the wires argument is now interpreted as a single wire (i.e. wires=[`m`])."
-                "This is different from the previous interpretation of wires=range(`m`). This may lead to unexpected errors."
-            )
             wires = [wires]
 
         if isinstance(n, int):


### PR DESCRIPTION
A warning is currently raised when creating an instance of the `qml.FlipSign` operation passing an integer number as the `wires` argument. This was introduced by [this PR](https://github.com/PennyLaneAI/pennylane/pull/7647) to warn users about the new `qml.FlipSign` behaviour fixing the previous wrong interpretation of that argument.

The aim of this PR is to remove the warning.

[sc-93136]