### PR TITLE
Fix error in Code Blocks

### DIFF
--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -325,7 +325,7 @@ solver.
   ```pycon
   >>> gridsynth_circuit = qml.clifford_t_decomposition(circuit, method="gridsynth")
   >>> sk_circuit = qml.clifford_t_decomposition(circuit, method="sk")
-  >>> gridsynth_specs = qml.specs(rs_circuit)()["resources"]
+  >>> gridsynth_specs = qml.specs(gridsynth_circuit)()["resources"]
   >>> sk_specs = qml.specs(sk_circuit)()["resources"]
   >>> print(gridsynth_specs.num_gates, sk_specs.num_gates)
   239 47942


### PR DESCRIPTION
**Context:**
There was an error in the the code example of the resource-efficient Clifford-T decompositions section of the changelog

**Description of the Change:**
Renamed an erroneous call of `rs_circuit` to `gridsynth_circuit`

**Benefits:**
No errors in release notes codeblocks

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
