### PR TITLE
Bug fix/shots warning

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -60,6 +60,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug with `QNode.update` where unnecessary `_set_shots` was being called.
+  This caused unnecessary warnings when no `QNode._shots` are really updated.
+
 * Fixes attributes and types in the quantum dialect.
   This allows for types to be inferred correctly when parsing.
   [(#7825)](https://github.com/PennyLaneAI/pennylane/pull/7825)

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -734,7 +734,9 @@ class QNode:
 
         original_init_args.update(kwargs)
         updated_qn = QNode(**original_init_args)
-        updated_qn._set_shots(old_shots)  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        if updated_qn._shots != old_shots:
+            updated_qn._set_shots(old_shots)
 
         # pylint: disable=protected-access
         updated_qn._transform_program = qml.transforms.core.TransformProgram(self.transform_program)


### PR DESCRIPTION
**Context:**
`QNode.update` calls `_set_shots` with the old `_shots` no matter the new `_shots` chnaged or not. This caused unnecessary warnings to come up e.g.:
```python
@qml.qnode(qml.device('default.qubit'))
def c():
    return qml.state()

c.update(diff_method="parameter-shift")(shots=50)
```
to get
```bash
UserWarning: Both 'shots=' parameter and 'set_shots' transform are specified. The transform will take precedence over 'shots=50.'
  return func(*args, **kwargs)
```

**Description of the Change:**
If not actual shots update happenning just skip `_set_shots`

**Benefits:**
Fixed the bug; now the logic is closer to reality

**Possible Drawbacks:**

**Related GitHub Issues:**
