### PR TITLE
mcm_method="device" resolves to tree-traversal for default.qubit

### DIFF
--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -655,8 +655,13 @@ class DefaultQubit(Device):
             if option not in updated_values["device_options"]:
                 updated_values["device_options"][option] = getattr(self, f"_{option}")
 
+        mcm_config = config.mcm_config
+
+        if mcm_config.mcm_method == "device":
+            mcm_config = replace(mcm_config, mcm_method="tree-traversal")
+
         if qml.capture.enabled():
-            mcm_config = config.mcm_config
+
             mcm_updated_values = {}
             mcm_method = mcm_config.mcm_method
 
@@ -669,8 +674,9 @@ class DefaultQubit(Device):
                 mcm_updated_values["postselect_mode"] = None
             if mcm_method is None:
                 mcm_updated_values["mcm_method"] = "deferred"
-            updated_values["mcm_config"] = replace(mcm_config, **mcm_updated_values)
+            mcm_config = replace(mcm_config, **mcm_updated_values)
 
+        updated_values["mcm_config"] = mcm_config
         return replace(config, **updated_values)
 
     @debug_logger

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 from pennylane.devices import DefaultQubit, ExecutionConfig
 from pennylane.devices.default_qubit import stopping_condition
+from pennylane.devices.execution_config import MCMConfig
 from pennylane.exceptions import DeviceError
 from pennylane.operation import classproperty
 
@@ -191,6 +192,13 @@ class TestConfigSetup:
         dev = qml.device("default.qubit")
         processed = dev.setup_execution_config(config)
         assert processed.convert_to_numpy
+
+    def test_resolve_native_mcm_method(self):
+        """Tests that mcm_method="device" resolves to tree-traversal"""
+        config = ExecutionConfig(mcm_config=MCMConfig(mcm_method="device"))
+        dev = qml.device("default.qubit")
+        processed = dev.setup_execution_config(config)
+        assert processed.mcm_config.mcm_method == "tree-traversal"
 
 
 # pylint: disable=too-few-public-methods


### PR DESCRIPTION
**Context:**
It was previously determined that `mcm_method="device"` is the convention for using the device-native mcm method, one that does not require any transforms on the PL side.

**Description of the Change:**
Update `default.qubit` to resolve `mcm_method="device"` to tree-traversal.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95418]