### PR TITLE
LinearCombination can be used in a `PlxprInterpeter`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,9 @@
   [(#7808)](https://github.com/PennyLaneAI/pennylane/pull/7808)
   [(#7818)](https://github.com/PennyLaneAI/pennylane/pull/7818)
 
+* `LinearCombination` instances can be created with `_primitive.impl` when
+  capture is enabled and tracing is active.
+
 <h3>Documentation 📝</h3>
 
 <h3>Bug fixes 🐛</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -61,6 +61,7 @@
 
 * `LinearCombination` instances can be created with `_primitive.impl` when
   capture is enabled and tracing is active.
+  [(#7893)](https://github.com/PennyLaneAI/pennylane/pull/7893)
 
 <h3>Documentation 📝</h3>
 

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -25,6 +25,7 @@ from typing import Union
 import pennylane as qml
 from pennylane.operation import Operator
 
+from .sprod import SProd
 from .sum import Sum
 
 
@@ -151,7 +152,8 @@ class LinearCombination(Sum):
         self._hyperparameters = {"ops": self._ops}
 
         with qml.QueuingManager.stop_recording():
-            operands = tuple(qml.s_prod(c, op) for c, op in zip(coeffs, observables))
+            # type.__call__ valid when capture is enabled and creating an instance
+            operands = tuple(type.__call__(SProd, c, op) for c, op in zip(coeffs, observables))
 
         super().__init__(
             *operands,

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -2000,3 +2000,17 @@ class TestLinearCombinationDifferentiation:
             match="not supported on adjoint",
         ):
             grad_fn(coeffs, param)
+
+
+# pylint: disable=protected-access
+@pytest.mark.capture
+def test_create_instance_while_tracing():
+    """Test that a LinearCombination instance can be created while tracing."""
+
+    def f(a, b):
+        op1 = qml.X._primitive.impl(0, n_wires=1)
+        op2 = qml.Y._primitive.impl(0, n_wires=1)
+        op = qml.ops.LinearCombination._primitive.impl(a, b, op1, op2, n_obs=2)
+        assert isinstance(op, qml.ops.LinearCombination)
+
+    jax.make_jaxpr(f)(1, 2)


### PR DESCRIPTION
**Context:**

Found in https://github.com/PennyLaneAI/catalyst/pull/1889

The `SProd` instances created during initialization were preventing concrete `LinearCombination` instances from being created.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-95516]