### PR TITLE
P1 Subroutine Qfunc Decompositions

### DIFF
--- a/pennylane/templates/subroutines/reflection.py
+++ b/pennylane/templates/subroutines/reflection.py
@@ -16,10 +16,19 @@
 This submodule contains the template for the Reflection operation.
 """
 import copy
+from collections import Counter
 
 import numpy as np
+from jax.tools.jax_to_ir import set_up_flags
 
 import pennylane as qml
+from pennylane.decomposition import (
+    add_decomps,
+    adjoint_resource_rep,
+    controlled_resource_rep,
+    register_resources,
+    resource_rep,
+)
 from pennylane.operation import Operation
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires
@@ -106,6 +115,8 @@ class Reflection(Operation):
 
     grad_method = None
 
+    resource_keys = {"base_class", "base_params", "num_wires", "num_reflection_wires"}
+
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):
         return cls._primitive.bind(*args, **kwargs)
@@ -139,6 +150,15 @@ class Reflection(Operation):
         }
 
         super().__init__(alpha, *U.data, wires=wires, id=id)
+
+    @property
+    def resource_params(self) -> dict:
+        return {
+            "base_class": self.hyperparameters["base"].__class__,
+            "base_params": self.hyperparameters["base"].resource_params,
+            "num_wires": None,
+            "num_reflection_wires": len(self.hyperparameters["reflection_wires"]),
+        }
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access
@@ -198,3 +218,65 @@ class Reflection(Operation):
         ops.append(U)
 
         return ops
+
+
+def _reflection_decomposition_resources(
+    base_class, base_params, num_wires, num_reflection_wires=None
+) -> dict:
+
+    num_wires = num_reflection_wires if num_reflection_wires is not None else num_wires
+
+    resources = Counter(
+        {resource_rep(qml.GlobalPhase): 1, adjoint_resource_rep(base_class, base_params): 1}
+    )
+
+    if num_wires > 1:
+        resources[resource_rep(qml.PauliX)] = 2
+        resources[
+            controlled_resource_rep(
+                qml.PhaseShift,
+                {},
+                num_control_wires=num_wires - 1,
+                num_zero_control_values=num_wires - 1,
+            )
+        ] = 1
+    else:
+        resources[resource_rep(qml.PauliX)] = 2
+        resources[resource_rep(qml.PhaseShift)] = 1
+
+    resources[resource_rep(base_class, **base_params)] = 1
+
+    return resources
+
+
+@register_resources(_reflection_decomposition_resources)
+def _reflection_decomposition(*parameters, wires=None, **hyperparameters):
+    alpha = parameters[0]
+    U = hyperparameters["base"]
+    reflection_wires = hyperparameters["reflection_wires"]
+
+    wires = qml.wires.Wires(reflection_wires) if reflection_wires is not None else wires
+
+    qml.GlobalPhase(np.pi)
+    qml.adjoint(U)
+
+    if len(wires) > 1:
+        qml.PauliX(wires=wires[-1])
+
+        qml.ctrl(
+            qml.PhaseShift(alpha, wires=wires[-1]),
+            control=wires[:-1],
+            control_values=[0] * (len(wires) - 1),
+        )
+
+        qml.PauliX(wires=wires[-1])
+
+    else:
+        qml.PauliX(wires=wires)
+        qml.PhaseShift(alpha, wires=wires)
+        qml.PauliX(wires=wires)
+
+    U.__class__(*U.parameters, wires=U.wires)
+
+
+add_decomps(Reflection, _reflection_decomposition)

--- a/tests/templates/test_subroutines/test_reflection.py
+++ b/tests/templates/test_subroutines/test_reflection.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
 @qml.prod
@@ -80,6 +81,19 @@ def test_decomposition(op, expected):
     """Test that the decomposition of the Reflection operator is correct"""
     decomp = op.decomposition()
     assert decomp == expected
+
+
+@pytest.mark.parametrize(
+    ("op"),
+    [
+        qml.Reflection(qml.Hadamard(wires=0), 0.5, reflection_wires=[0]),
+        qml.Reflection(qml.QFT(wires=[0, 1]), 0.5),
+    ],
+)
+def test_decomposition_new(op):
+    """Tests the decomposition rule implemented with the new system."""
+    for rule in qml.list_decomps(qml.Reflection):
+        _test_decomposition_rule(op, rule)
 
 
 def test_default_values():


### PR DESCRIPTION


------------------------------------------------------------------------------------------------------------

**Context:** We would like to refactor our P1 subroutine templates to use quantum functions in their decompositions in order to make them compatible with the new decompositions system.

**Description of the Change:** Branch for subroutine template refactoring.

**Benefits:** Allows us to decompose using decompositions that are program capture compatible. Tape based decompositions are still available as a backwards compatible fallback.

**Possible Drawbacks:**

**Related ShortCut Stories:** [sc-95702]
