### PR TITLE
Fix double mapping in resolve_dynamic_wires

### DIFF
--- a/pennylane/transforms/resolve_dynamic_wires.py
+++ b/pennylane/transforms/resolve_dynamic_wires.py
@@ -216,12 +216,12 @@ def resolve_dynamic_wires(
                 deallocated.add(w)
                 manager.return_wire(wire_map.pop(w))
         else:
-            op = op.map_wires(wire_map)
-            if intersection := deallocated.intersection(set(op.wires)):
+            mapped_op = op.map_wires(wire_map)
+            if intersection := deallocated.intersection(set(mapped_op.wires)):
                 raise ValueError(
-                    f"Encountered deallocated wires {intersection} in {op}. Dynamic wires cannot be used after deallocation."
+                    f"Encountered deallocated wires {intersection} in {mapped_op}. Dynamic wires cannot be used after deallocation."
                 )
-            new_ops.append(op.map_wires(wire_map))
+            new_ops.append(mapped_op)
 
     mps = [mp.map_wires(wire_map) for mp in tape.measurements]
     for mp in mps:


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

The double call to map_wires in resolve_dynamic_wires was removed.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
