### PR TITLE
[Python Compiler] Add AllocQubitOp and DeallocQubitOp to quantum dialect

### DIFF
--- a/pennylane/compiler/python_compiler/dialects/quantum.py
+++ b/pennylane/compiler/python_compiler/dialects/quantum.py
@@ -369,6 +369,35 @@ class DeviceReleaseOp(IRDLOperation):
 
 
 @irdl_op_definition
+class AllocQubitOp(IRDLOperation):
+    name = "quantum.alloc_qb"
+
+    assembly_format = " attr-dict `:` type(results)"
+
+    qubit = result_def(QubitType)
+
+    def __init__(self):
+        super().__init__(
+            result_types=(QubitType(),),
+        )
+
+
+@irdl_op_definition
+class DeallocQubitOp(IRDLOperation):
+    name = "quantum.dealloc_qb"
+
+    assembly_format = " $qubit attr-dict `:` type(operands)"
+
+    qubit = operand_def(QubitType)
+
+    def __init__(self, qubit: QubitSSAValue | Operation):
+        super().__init__(
+            operands=(qubit,),
+            result_types=(QubitType(),),
+        )
+
+
+@irdl_op_definition
 class ExpvalOp(IRDLOperation):
     """Compute the expectation value of the given observable for the current state"""
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

Add [AllocQubitOp](https://github.com/PennyLaneAI/catalyst/blob/34145fd52c3eff19b3f290937e38475f86155b82/mlir/include/Quantum/IR/QuantumOps.td#L153C31-L153C39) and [DeallocQubitOp](https://github.com/PennyLaneAI/catalyst/blob/34145fd52c3eff19b3f290937e38475f86155b82/mlir/include/Quantum/IR/QuantumOps.td#L183) to quantum dialect in python compler 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
