### PR TITLE
Improve error message for incorrect use of compiler transforms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -18,6 +18,10 @@
 
 <h4>Other improvements</h4>
 
+* The error message raised when using Python compiler transforms with :func:`pennylane.qjit` has been updated
+  with suggested fixes.
+  [(#)]()
+
 * A new `qml.transforms.resolve_dynamic_wires` transform can allocate concrete wire values for dynamic
   qubit allocation.
   [(#7678)](https://github.com/PennyLaneAI/pennylane/pull/7678)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,7 +20,7 @@
 
 * The error message raised when using Python compiler transforms with :func:`pennylane.qjit` has been updated
   with suggested fixes.
-  [(#)]()
+  [(#7916)](https://github.com/PennyLaneAI/pennylane/pull/7916)
 
 * A new `qml.transforms.resolve_dynamic_wires` transform can allocate concrete wire values for dynamic
   qubit allocation.

--- a/pennylane/compiler/python_compiler/transforms/api/compiler_transform.py
+++ b/pennylane/compiler/python_compiler/transforms/api/compiler_transform.py
@@ -27,7 +27,11 @@ def _create_null_transform(name: str) -> Callable:
     """Create a dummy tape transform. The tape transform raises an error if used."""
 
     def null_transform(_):
-        raise RuntimeError(f"Cannot apply the {name} pass without 'qml.qjit'.")
+        raise RuntimeError(
+            f"Cannot apply the {name} pass without '@qml.qjit'. Additionally, program capture "
+            "must be enabled using 'qml.capture.enable()'. Otherwise, the pass must be applied "
+            f"using the '@catalyst.passes.apply_pass(\"{name}\")' decorator."
+        )
 
     return null_transform
 


### PR DESCRIPTION
[sc-95008]

The error message raised when using compiler transforms with program capture disabled was very cryptic. This PR makes the error message clearer.