### PR TITLE
Update xdsl version

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -533,7 +533,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb==1.11.0 mitiq ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.44 filecheck
+        pyzx matplotlib stim quimb==1.11.0 mitiq ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.45 filecheck
         jax==0.6.0 jaxlib==0.6.0
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -142,6 +142,9 @@
 * The `TensorLike` type is now compatible with static type checkers.
   [(#7905)](https://github.com/PennyLaneAI/pennylane/pull/7905)
 
+* Update xDSL supported version to `0.45`.
+  [(#7923)](https://github.com/PennyLaneAI/pennylane/pull/7923)
+
 <h3>Documentation 📝</h3>
 
 * Updated the code example in the documentation for :func:`~.transforms.split_non_commuting`.

--- a/pennylane/compiler/python_compiler/compiler.py
+++ b/pennylane/compiler/python_compiler/compiler.py
@@ -21,7 +21,7 @@ from jaxlib.mlir.dialects import stablehlo
 from jaxlib.mlir.ir import Context as jaxContext  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Module as jaxModule  # pylint: disable=no-name-in-module
 from xdsl.context import Context as xContext
-from xdsl.passes import PipelinePass
+from xdsl.passes import PassPipeline
 from xdsl.printer import Printer
 
 from .jax_utils import QuantumParser
@@ -46,7 +46,7 @@ class Compiler:
         ctx = xContext(allow_unregistered=True)
         parser = QuantumParser(ctx, gentxtmod)
         xmod = parser.parse_module()
-        pipeline = PipelinePass((ApplyTransformSequence(),))
+        pipeline = PassPipeline((ApplyTransformSequence(),))
         # xmod is modified in place
         pipeline.apply(ctx, xmod)
 

--- a/pennylane/compiler/python_compiler/jax_utils.py
+++ b/pennylane/compiler/python_compiler/jax_utils.py
@@ -17,8 +17,8 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, TypeAlias
 
-import jaxlib
 from catalyst import QJIT
+from jax._src.lib import _jax
 from jaxlib.mlir.dialects import stablehlo as jstablehlo  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Context as jContext  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Module as jModule  # pylint: disable=no-name-in-module
@@ -36,7 +36,7 @@ from xdsl.traits import SymbolTable as xSymbolTable
 
 from .dialects import MBQC, Quantum
 
-JaxJittedFunction: TypeAlias = jaxlib.xla_extension.PjitFunction
+JaxJittedFunction: TypeAlias = _jax.PjitFunction  # pylint: disable=c-extension-no-member
 
 
 class QuantumParser(xParser):  # pylint: disable=abstract-method,too-few-public-methods

--- a/pennylane/compiler/python_compiler/jax_utils.py
+++ b/pennylane/compiler/python_compiler/jax_utils.py
@@ -17,8 +17,8 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, TypeAlias
 
+import jaxlib
 from catalyst import QJIT
-from jax._src.lib import _jax
 from jaxlib.mlir.dialects import stablehlo as jstablehlo  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Context as jContext  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Module as jModule  # pylint: disable=no-name-in-module
@@ -36,7 +36,7 @@ from xdsl.traits import SymbolTable as xSymbolTable
 
 from .dialects import MBQC, Quantum
 
-JaxJittedFunction: TypeAlias = _jax.PjitFunction  # pylint: disable=c-extension-no-member
+JaxJittedFunction: TypeAlias = jaxlib.xla_extension.PjitFunction
 
 
 class QuantumParser(xParser):  # pylint: disable=abstract-method,too-few-public-methods

--- a/pennylane/compiler/python_compiler/transforms/api/apply_transform_sequence.py
+++ b/pennylane/compiler/python_compiler/transforms/api/apply_transform_sequence.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 
 from xdsl.context import Context
 from xdsl.dialects import builtin
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass, PassPipeline
 
 from .transform_interpreter import TransformInterpreterPass  # pylint: disable=no-name-in-module
 
@@ -54,7 +54,7 @@ class ApplyTransformSequence(ModulePass):
                     if isinstance(op, builtin.ModuleOp):
                         nested_modules.append(op)
 
-        pipeline = PipelinePass(
+        pipeline = PassPipeline(
             # pylint: disable-next=unexpected-keyword-arg
             (TransformInterpreterPass(passes=available_passes),)
         )

--- a/pennylane/compiler/python_compiler/transforms/api/transform_interpreter.py
+++ b/pennylane/compiler/python_compiler/transforms/api/transform_interpreter.py
@@ -27,10 +27,9 @@ from xdsl.dialects import builtin, transform
 from xdsl.interpreter import Interpreter, PythonValues, impl, register_impls
 from xdsl.interpreters.transform import TransformFunctions
 from xdsl.parser import Parser
-from xdsl.passes import ModulePass, PipelinePass
+from xdsl.passes import ModulePass, PassPipeline
 from xdsl.printer import Printer
 from xdsl.rewriter import Rewriter
-from xdsl.utils import parse_pipeline
 from xdsl.utils.exceptions import PassFailedException
 
 
@@ -56,11 +55,8 @@ class TransformFunctionsExt(TransformFunctions):
         pass_name = op.pass_name.data  # pragma: no cover
         if pass_name in self.passes:
             # pragma: no cover
-            pipeline = PipelinePass(
-                tuple(
-                    PipelinePass.iter_passes(self.passes, parse_pipeline.parse_pipeline(pass_name))
-                )
-            )
+            pass_class = self.passes[pass_name]()
+            pipeline = PassPipeline((pass_class(),))
             pipeline.apply(self.ctx, args[0])
             return (args[0],)
 

--- a/tests/python_compiler/conftest.py
+++ b/tests/python_compiler/conftest.py
@@ -27,7 +27,7 @@ try:
     from filecheck.parser import Parser, pattern_for_opts
     from xdsl.context import Context
     from xdsl.dialects import test
-    from xdsl.passes import PipelinePass
+    from xdsl.passes import PassPipeline
 
     from pennylane.compiler.python_compiler import Compiler
     from pennylane.compiler.python_compiler.jax_utils import (
@@ -47,7 +47,7 @@ def _run_filecheck_impl(program_str, pipeline=()):
     ctx = Context(allow_unregistered=True)
     xdsl_module = QuantumParser(ctx, program_str, extra_dialects=(test.Test,)).parse_module()
 
-    pipeline = PipelinePass(pipeline)
+    pipeline = PassPipeline(pipeline)
     pipeline.apply(ctx, xdsl_module)
 
     opts = parse_argv_options(["filecheck", __file__])

--- a/tests/python_compiler/test_python_compiler.py
+++ b/tests/python_compiler/test_python_compiler.py
@@ -199,7 +199,7 @@ def test_integration_for_transform_interpreter(capsys):
     ctx.load_dialect(builtin.Builtin)
     ctx.load_dialect(transform.Transform)
 
-    pipeline = xdsl.passes.PipelinePass((ApplyTransformSequence(),))
+    pipeline = xdsl.passes.PassPipeline((ApplyTransformSequence(),))
     pipeline.apply(ctx, program())
     captured = capsys.readouterr()
     assert captured.out.strip() == "hello world"


### PR DESCRIPTION
**Context:** Updates needed for the Python Compiler to be compatible with the new version of xDSL

**Description of the Change:** Renamed PassPipeline with PipelinePass

**Benefits:** Compatible with the newer version.

**Possible Drawbacks:** None.

**Related GitHub Issues:**

[sc-95842]
