### PR TITLE
update jax for interface-unit-tests

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -534,7 +534,7 @@ jobs:
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
         pyzx matplotlib stim quimb==1.11.0 mitiq ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime xdsl==0.44 filecheck
-        jax==0.6.0 jaxlib==0.6.0
+        jax==0.6.3 jaxlib==0.6.3
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.tensorflow-version }}
         ${{ needs.default-dependency-versions.outputs.catalyst-nightly }}

--- a/pennylane/compiler/python_compiler/jax_utils.py
+++ b/pennylane/compiler/python_compiler/jax_utils.py
@@ -17,8 +17,8 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, TypeAlias
 
-import jaxlib
 from catalyst import QJIT
+from jax._src.lib import _jax
 from jaxlib.mlir.dialects import stablehlo as jstablehlo  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Context as jContext  # pylint: disable=no-name-in-module
 from jaxlib.mlir.ir import Module as jModule  # pylint: disable=no-name-in-module
@@ -36,7 +36,7 @@ from xdsl.traits import SymbolTable as xSymbolTable
 
 from .dialects import MBQC, Quantum
 
-JaxJittedFunction: TypeAlias = jaxlib.xla_extension.PjitFunction
+JaxJittedFunction: TypeAlias = _jax.PjitFunction  # pylint: disable=c-extension-no-member
 
 
 class QuantumParser(xParser):  # pylint: disable=abstract-method,too-few-public-methods


### PR DESCRIPTION
**Context:** Updating jax to version 0.6.3 in some external tests.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
