### PR TITLE
improve type hints in measurements module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,6 +170,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Improves type hints in the `measurements` module.
+
 * Refactored the codebase to adopt modern type hint syntax for Python 3.11+ language features.
   [(#7860)](https://github.com/PennyLaneAI/pennylane/pull/7860)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -171,6 +171,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Improves type hints in the `measurements` module.
+  [(#7938)](https://github.com/PennyLaneAI/pennylane/pull/7938)
 
 * Refactored the codebase to adopt modern type hint syntax for Python 3.11+ language features.
   [(#7860)](https://github.com/PennyLaneAI/pennylane/pull/7860)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -27,194 +27,6 @@ from pennylane.wires import Wires, WiresLike
 from .measurements import MeasurementShapeError, MeasurementTransform
 
 
-def shadow_expval(H, k=1, seed=None):
-    r"""Compute expectation values using classical shadows in a differentiable manner.
-
-    The canonical way of computing expectation values is to simply average the expectation values for each local snapshot, :math:`\langle O \rangle = \sum_t \text{tr}(\rho^{(t)}O) / T`.
-    This corresponds to the case ``k=1``. In the original work, `2002.08953 <https://arxiv.org/abs/2002.08953>`_, it has been proposed to split the ``T`` measurements into ``k`` equal
-    parts to compute the median of means. For the case of Pauli measurements and Pauli observables, there is no advantage expected from setting ``k>1``.
-
-    Args:
-        H (Union[Iterable[Operator], Operator]): Observable or
-            iterable of observables to compute the expectation value over.
-        k (int): Number of equal parts to split the shadow's measurements to compute the median of means. ``k=1`` (default) corresponds to simply taking the mean over all measurements.
-        seed (Union[None, int]):  Seed used to randomly sample Pauli measurements during the
-            classical shadows protocol. If None, a random seed will be generated. If a tape with
-            a ``shadow_expval`` measurement is copied, the seed will also be copied.
-            Different seeds are still generated for different constructed tapes.
-
-    Returns:
-        ShadowExpvalMP: Measurement process instance
-
-    .. note::
-
-        This measurement uses the measurement :func:`~.pennylane.classical_shadow` and the class :class:`~.pennylane.ClassicalShadow` for post-processing
-        internally to compute expectation values. In order to compute correct gradients using PennyLane's automatic differentiation,
-        you need to use this measurement.
-
-    **Example**
-
-    .. code-block:: python3
-
-        from functools import partial
-        H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
-
-        dev = qml.device("default.qubit", wires=range(2))
-        @partial(qml.set_shots, shots=10000)
-        @qml.qnode(dev)
-        def circuit(x, obs):
-            qml.Hadamard(0)
-            qml.CNOT((0,1))
-            qml.RX(x, wires=0)
-            return qml.shadow_expval(obs)
-
-        x = np.array(0.5, requires_grad=True)
-
-    We can compute the expectation value of H as well as its gradient in the usual way.
-
-    >>> circuit(x, H)
-    array(1.8774)
-    >>> qml.grad(circuit)(x, H)
-    -0.44999999999999984
-
-    In ``shadow_expval``, we can pass a list of observables. Note that each qnode execution internally performs one quantum measurement, so be sure
-    to include all observables that you want to estimate from a single measurement in the same execution.
-
-    >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
-    >>> circuit(x, Hs)
-    array([ 1.881 , -0.0312, -0.0027, -0.0087])
-    >>> qml.jacobian(circuit)(x, Hs)
-    array([-0.4518,  0.0174, -0.0216, -0.0063])
-    """
-    seed = seed or np.random.randint(2**30)
-    return ShadowExpvalMP(H=H, seed=seed, k=k)
-
-
-def classical_shadow(wires: WiresLike, seed=None):
-    """
-    The classical shadow measurement protocol.
-
-    The protocol is described in detail in the paper `Predicting Many Properties of a Quantum System from Very Few Measurements <https://arxiv.org/abs/2002.08953>`_.
-    This measurement process returns the randomized Pauli measurements (the ``recipes``)
-    that are performed for each qubit and snapshot as an integer:
-
-    - 0 for Pauli X,
-    - 1 for Pauli Y, and
-    - 2 for Pauli Z.
-
-    It also returns the measurement results (the ``bits``); 0 if the 1 eigenvalue
-    is sampled, and 1 if the -1 eigenvalue is sampled.
-
-    The device shots are used to specify the number of snapshots. If ``T`` is the number
-    of shots and ``n`` is the number of qubits, then both the measured bits and the
-    Pauli measurements have shape ``(T, n)``.
-
-    Args:
-        wires (Sequence[int]): the wires to perform Pauli measurements on
-        seed (Union[None, int]):  Seed used to randomly sample Pauli measurements during the
-            classical shadows protocol. If None, a random seed will be generated. If a tape with
-            a ``classical_shadow`` measurement is copied, the seed will also be copied.
-            Different seeds are still generated for different constructed tapes.
-
-    Returns:
-        ClassicalShadowMP: measurement process instance
-
-    **Example**
-
-    Consider the following QNode that prepares a Bell state and performs a classical
-    shadow measurement:
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=5)
-        @qml.qnode(dev)
-        def circuit():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.classical_shadow(wires=[0, 1])
-
-    Executing this QNode produces the sampled bits and the Pauli measurements used:
-
-    >>> bits, recipes = circuit()
-    >>> bits
-    tensor([[0, 0],
-            [1, 0],
-            [1, 0],
-            [0, 0],
-            [0, 1]], dtype=uint8, requires_grad=True)
-    >>> recipes
-    tensor([[2, 2],
-            [0, 2],
-            [1, 0],
-            [0, 2],
-            [0, 2]], dtype=uint8, requires_grad=True)
-
-    .. details::
-        :title: Usage Details
-
-        Consider again the QNode in the above example. Since the Pauli observables are
-        randomly sampled, executing this QNode again would produce different bits and Pauli recipes:
-
-        >>> bits, recipes = circuit()
-        >>> bits
-        tensor([[0, 1],
-                [0, 1],
-                [0, 0],
-                [0, 1],
-                [1, 1]], dtype=uint8, requires_grad=True)
-        >>> recipes
-        tensor([[1, 0],
-                [2, 1],
-                [2, 2],
-                [1, 0],
-                [0, 0]], dtype=uint8, requires_grad=True)
-
-        To use the same Pauli recipes for different executions, the :class:`~.tape.QuantumTape`
-        interface should be used instead:
-
-        .. code-block:: python3
-
-            dev = qml.device("default.qubit", wires=2)
-
-            ops = [qml.Hadamard(wires=0), qml.CNOT(wires=(0,1))]
-            measurements = [qml.classical_shadow(wires=(0,1))]
-            tape = qml.tape.QuantumTape(ops, measurements, shots=5)
-
-        >>> bits1, recipes1 = qml.execute([tape], device=dev, diff_method=None)[0]
-        >>> bits2, recipes2 = qml.execute([tape], device=dev, diff_method=None)[0]
-        >>> np.all(recipes1 == recipes2)
-        True
-        >>> np.all(bits1 == bits2)
-        False
-
-        If using different Pauli recipes is desired for the :class:`~.tape.QuantumTape` interface,
-        different seeds should be used for the classical shadow:
-
-        .. code-block:: python3
-
-            dev = qml.device("default.qubit", wires=2)
-
-            measurements1 = [qml.classical_shadow(wires=(0,1), seed=10)]
-            tape1 = qml.tape.QuantumTape(ops, measurements1, shots=5)
-
-            measurements2 = [qml.classical_shadow(wires=(0,1), seed=15)]
-            tape2 = qml.tape.QuantumTape(ops, measurements2, shots=5)
-
-        >>> bits1, recipes1 = qml.execute([tape1], device=dev, diff_method=None)[0]
-        >>> bits2, recipes2 = qml.execute([tape2], device=dev, diff_method=None)[0]
-        >>> np.all(recipes1 == recipes2)
-        False
-        >>> np.all(bits1 == bits2)
-        False
-    """
-    wires = Wires(wires)
-    seed = seed or np.random.randint(2**30)
-    return ClassicalShadowMP(wires=wires, seed=seed)
-
-
 class ClassicalShadowMP(MeasurementTransform):
     """Represents a classical shadow measurement process occurring at the end of a
     quantum variational circuit.
@@ -752,6 +564,194 @@ class ShadowExpvalMP(MeasurementTransform):
             k=self.k,
             seed=self.seed,
         )
+
+
+def shadow_expval(H, k=1, seed=None) -> ShadowExpvalMP:
+    r"""Compute expectation values using classical shadows in a differentiable manner.
+
+    The canonical way of computing expectation values is to simply average the expectation values for each local snapshot, :math:`\langle O \rangle = \sum_t \text{tr}(\rho^{(t)}O) / T`.
+    This corresponds to the case ``k=1``. In the original work, `2002.08953 <https://arxiv.org/abs/2002.08953>`_, it has been proposed to split the ``T`` measurements into ``k`` equal
+    parts to compute the median of means. For the case of Pauli measurements and Pauli observables, there is no advantage expected from setting ``k>1``.
+
+    Args:
+        H (Union[Iterable[Operator], Operator]): Observable or
+            iterable of observables to compute the expectation value over.
+        k (int): Number of equal parts to split the shadow's measurements to compute the median of means. ``k=1`` (default) corresponds to simply taking the mean over all measurements.
+        seed (Union[None, int]):  Seed used to randomly sample Pauli measurements during the
+            classical shadows protocol. If None, a random seed will be generated. If a tape with
+            a ``shadow_expval`` measurement is copied, the seed will also be copied.
+            Different seeds are still generated for different constructed tapes.
+
+    Returns:
+        ShadowExpvalMP: Measurement process instance
+
+    .. note::
+
+        This measurement uses the measurement :func:`~.pennylane.classical_shadow` and the class :class:`~.pennylane.ClassicalShadow` for post-processing
+        internally to compute expectation values. In order to compute correct gradients using PennyLane's automatic differentiation,
+        you need to use this measurement.
+
+    **Example**
+
+    .. code-block:: python3
+
+        from functools import partial
+        H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+
+        dev = qml.device("default.qubit", wires=range(2))
+        @partial(qml.set_shots, shots=10000)
+        @qml.qnode(dev)
+        def circuit(x, obs):
+            qml.Hadamard(0)
+            qml.CNOT((0,1))
+            qml.RX(x, wires=0)
+            return qml.shadow_expval(obs)
+
+        x = np.array(0.5, requires_grad=True)
+
+    We can compute the expectation value of H as well as its gradient in the usual way.
+
+    >>> circuit(x, H)
+    array(1.8774)
+    >>> qml.grad(circuit)(x, H)
+    -0.44999999999999984
+
+    In ``shadow_expval``, we can pass a list of observables. Note that each qnode execution internally performs one quantum measurement, so be sure
+    to include all observables that you want to estimate from a single measurement in the same execution.
+
+    >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
+    >>> circuit(x, Hs)
+    array([ 1.881 , -0.0312, -0.0027, -0.0087])
+    >>> qml.jacobian(circuit)(x, Hs)
+    array([-0.4518,  0.0174, -0.0216, -0.0063])
+    """
+    seed = seed or np.random.randint(2**30)
+    return ShadowExpvalMP(H=H, seed=seed, k=k)
+
+
+def classical_shadow(wires: WiresLike, seed=None) -> ClassicalShadowMP:
+    """
+    The classical shadow measurement protocol.
+
+    The protocol is described in detail in the paper `Predicting Many Properties of a Quantum System from Very Few Measurements <https://arxiv.org/abs/2002.08953>`_.
+    This measurement process returns the randomized Pauli measurements (the ``recipes``)
+    that are performed for each qubit and snapshot as an integer:
+
+    - 0 for Pauli X,
+    - 1 for Pauli Y, and
+    - 2 for Pauli Z.
+
+    It also returns the measurement results (the ``bits``); 0 if the 1 eigenvalue
+    is sampled, and 1 if the -1 eigenvalue is sampled.
+
+    The device shots are used to specify the number of snapshots. If ``T`` is the number
+    of shots and ``n`` is the number of qubits, then both the measured bits and the
+    Pauli measurements have shape ``(T, n)``.
+
+    Args:
+        wires (Sequence[int]): the wires to perform Pauli measurements on
+        seed (Union[None, int]):  Seed used to randomly sample Pauli measurements during the
+            classical shadows protocol. If None, a random seed will be generated. If a tape with
+            a ``classical_shadow`` measurement is copied, the seed will also be copied.
+            Different seeds are still generated for different constructed tapes.
+
+    Returns:
+        ClassicalShadowMP: measurement process instance
+
+    **Example**
+
+    Consider the following QNode that prepares a Bell state and performs a classical
+    shadow measurement:
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=5)
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            return qml.classical_shadow(wires=[0, 1])
+
+    Executing this QNode produces the sampled bits and the Pauli measurements used:
+
+    >>> bits, recipes = circuit()
+    >>> bits
+    tensor([[0, 0],
+            [1, 0],
+            [1, 0],
+            [0, 0],
+            [0, 1]], dtype=uint8, requires_grad=True)
+    >>> recipes
+    tensor([[2, 2],
+            [0, 2],
+            [1, 0],
+            [0, 2],
+            [0, 2]], dtype=uint8, requires_grad=True)
+
+    .. details::
+        :title: Usage Details
+
+        Consider again the QNode in the above example. Since the Pauli observables are
+        randomly sampled, executing this QNode again would produce different bits and Pauli recipes:
+
+        >>> bits, recipes = circuit()
+        >>> bits
+        tensor([[0, 1],
+                [0, 1],
+                [0, 0],
+                [0, 1],
+                [1, 1]], dtype=uint8, requires_grad=True)
+        >>> recipes
+        tensor([[1, 0],
+                [2, 1],
+                [2, 2],
+                [1, 0],
+                [0, 0]], dtype=uint8, requires_grad=True)
+
+        To use the same Pauli recipes for different executions, the :class:`~.tape.QuantumTape`
+        interface should be used instead:
+
+        .. code-block:: python3
+
+            dev = qml.device("default.qubit", wires=2)
+
+            ops = [qml.Hadamard(wires=0), qml.CNOT(wires=(0,1))]
+            measurements = [qml.classical_shadow(wires=(0,1))]
+            tape = qml.tape.QuantumTape(ops, measurements, shots=5)
+
+        >>> bits1, recipes1 = qml.execute([tape], device=dev, diff_method=None)[0]
+        >>> bits2, recipes2 = qml.execute([tape], device=dev, diff_method=None)[0]
+        >>> np.all(recipes1 == recipes2)
+        True
+        >>> np.all(bits1 == bits2)
+        False
+
+        If using different Pauli recipes is desired for the :class:`~.tape.QuantumTape` interface,
+        different seeds should be used for the classical shadow:
+
+        .. code-block:: python3
+
+            dev = qml.device("default.qubit", wires=2)
+
+            measurements1 = [qml.classical_shadow(wires=(0,1), seed=10)]
+            tape1 = qml.tape.QuantumTape(ops, measurements1, shots=5)
+
+            measurements2 = [qml.classical_shadow(wires=(0,1), seed=15)]
+            tape2 = qml.tape.QuantumTape(ops, measurements2, shots=5)
+
+        >>> bits1, recipes1 = qml.execute([tape1], device=dev, diff_method=None)[0]
+        >>> bits2, recipes2 = qml.execute([tape2], device=dev, diff_method=None)[0]
+        >>> np.all(recipes1 == recipes2)
+        False
+        >>> np.all(bits1 == bits2)
+        False
+    """
+    wires = Wires(wires)
+    seed = seed or np.random.randint(2**30)
+    return ClassicalShadowMP(wires=wires, seed=seed)
 
 
 if ShadowExpvalMP._obs_primitive is not None:  # pylint: disable=protected-access

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -27,147 +27,6 @@ from .measurements import SampleMeasurement
 from .mid_measure import MeasurementValue
 
 
-def counts(
-    op=None,
-    wires=None,
-    all_outcomes=False,
-) -> "CountsMP":
-    r"""Sample from the supplied observable, with the number of shots
-    determined from the ``dev.shots`` attribute of the corresponding device,
-    returning the number of counts for each sample. If no observable is provided then basis state
-    samples are returned directly from the device.
-
-    Note that the output shape of this measurement process depends on the shots
-    specified on the device.
-
-    Args:
-        op (Operator or MeasurementValue or None): a quantum observable object. To get counts
-            for mid-circuit measurements, ``op`` should be a ``MeasurementValue``.
-        wires (Sequence[int] or int or None): the wires we wish to sample from, ONLY set wires if
-            op is None
-        all_outcomes(bool): determines whether the returned dict will contain only the observed
-            outcomes (default), or whether it will display all possible outcomes for the system
-
-    Returns:
-        CountsMP: Measurement process instance
-
-    Raises:
-        ValueError: Cannot set wires if an observable is provided
-
-    The samples are drawn from the eigenvalues :math:`\{\lambda_i\}` of the observable.
-    The probability of drawing eigenvalue :math:`\lambda_i` is given by
-    :math:`p(\lambda_i) = |\langle \xi_i | \psi \rangle|^2`, where :math:`| \xi_i \rangle`
-    is the corresponding basis state from the observable's eigenbasis.
-
-    .. note::
-
-        Differentiation of QNodes that return ``counts`` is currently not supported. Please refer to
-        :func:`~.pennylane.sample` if differentiability is required.
-
-    **Example**
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=4)
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.counts(qml.Y(0))
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    {-1: 2, 1: 2}
-
-    If no observable is provided, then the raw basis state samples obtained
-    from device are returned (e.g., for a qubit device, samples from the
-    computational device are returned). In this case, ``wires`` can be specified
-    so that sample results only include measurement results of the qubits of interest.
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=4)
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.counts()
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    {'00': 3, '01': 1}
-
-    By default, outcomes that were not observed will not be included in the dictionary.
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=4)
-        @qml.qnode(dev)
-        def circuit():
-            qml.X(0)
-            return qml.counts()
-
-    Executing this QNode shows only the observed outcomes:
-
-    >>> circuit()
-    {'10': 4}
-
-    Passing all_outcomes=True will create a dictionary that displays all possible outcomes:
-
-    .. code-block:: python3
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.X(0)
-            return qml.counts(all_outcomes=True)
-
-    Executing this QNode shows counts for all states:
-
-    >>> circuit()
-    {'00': 0, '01': 0, '10': 4, '11': 0}
-
-    """
-    if isinstance(op, MeasurementValue):
-        return CountsMP(obs=op, all_outcomes=all_outcomes)
-
-    if isinstance(op, Sequence):
-        if not all(
-            qml.math.is_abstract(o)
-            or (isinstance(o, MeasurementValue) and len(o.measurements) == 1)
-            for o in op
-        ):
-            raise QuantumFunctionError(
-                "Only sequences of single MeasurementValues can be passed with the op argument. "
-                "MeasurementValues manipulated using arithmetic operators cannot be used when "
-                "collecting statistics for a sequence of mid-circuit measurements."
-            )
-
-        return CountsMP(obs=op, all_outcomes=all_outcomes)
-
-    if wires is not None:
-        if op is not None:
-            raise ValueError(
-                "Cannot specify the wires to sample if an observable is provided. The wires "
-                "to sample will be determined directly from the observable."
-            )
-        wires = Wires(wires)
-
-    return CountsMP(obs=op, wires=wires, all_outcomes=all_outcomes)
-
-
 class CountsMP(SampleMeasurement):
     """Measurement process that samples from the supplied observable and returns the number of
     counts for each sample.
@@ -439,6 +298,147 @@ class CountsMP(SampleMeasurement):
             outcome_binary = binary_pattern.format(outcome)
             if outcome_binary not in outcome_counts:
                 outcome_counts[outcome_binary] = 0
+
+
+def counts(
+    op=None,
+    wires=None,
+    all_outcomes=False,
+) -> CountsMP:
+    r"""Sample from the supplied observable, with the number of shots
+    determined from the ``dev.shots`` attribute of the corresponding device,
+    returning the number of counts for each sample. If no observable is provided then basis state
+    samples are returned directly from the device.
+
+    Note that the output shape of this measurement process depends on the shots
+    specified on the device.
+
+    Args:
+        op (Operator or MeasurementValue or None): a quantum observable object. To get counts
+            for mid-circuit measurements, ``op`` should be a ``MeasurementValue``.
+        wires (Sequence[int] or int or None): the wires we wish to sample from, ONLY set wires if
+            op is None
+        all_outcomes(bool): determines whether the returned dict will contain only the observed
+            outcomes (default), or whether it will display all possible outcomes for the system
+
+    Returns:
+        CountsMP: Measurement process instance
+
+    Raises:
+        ValueError: Cannot set wires if an observable is provided
+
+    The samples are drawn from the eigenvalues :math:`\{\lambda_i\}` of the observable.
+    The probability of drawing eigenvalue :math:`\lambda_i` is given by
+    :math:`p(\lambda_i) = |\langle \xi_i | \psi \rangle|^2`, where :math:`| \xi_i \rangle`
+    is the corresponding basis state from the observable's eigenbasis.
+
+    .. note::
+
+        Differentiation of QNodes that return ``counts`` is currently not supported. Please refer to
+        :func:`~.pennylane.sample` if differentiability is required.
+
+    **Example**
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=4)
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.counts(qml.Y(0))
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    {-1: 2, 1: 2}
+
+    If no observable is provided, then the raw basis state samples obtained
+    from device are returned (e.g., for a qubit device, samples from the
+    computational device are returned). In this case, ``wires`` can be specified
+    so that sample results only include measurement results of the qubits of interest.
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=4)
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.counts()
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    {'00': 3, '01': 1}
+
+    By default, outcomes that were not observed will not be included in the dictionary.
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=4)
+        @qml.qnode(dev)
+        def circuit():
+            qml.X(0)
+            return qml.counts()
+
+    Executing this QNode shows only the observed outcomes:
+
+    >>> circuit()
+    {'10': 4}
+
+    Passing all_outcomes=True will create a dictionary that displays all possible outcomes:
+
+    .. code-block:: python3
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.X(0)
+            return qml.counts(all_outcomes=True)
+
+    Executing this QNode shows counts for all states:
+
+    >>> circuit()
+    {'00': 0, '01': 0, '10': 4, '11': 0}
+
+    """
+    if isinstance(op, MeasurementValue):
+        return CountsMP(obs=op, all_outcomes=all_outcomes)
+
+    if isinstance(op, Sequence):
+        if not all(
+            qml.math.is_abstract(o)
+            or (isinstance(o, MeasurementValue) and len(o.measurements) == 1)
+            for o in op
+        ):
+            raise QuantumFunctionError(
+                "Only sequences of single MeasurementValues can be passed with the op argument. "
+                "MeasurementValues manipulated using arithmetic operators cannot be used when "
+                "collecting statistics for a sequence of mid-circuit measurements."
+            )
+
+        return CountsMP(obs=op, all_outcomes=all_outcomes)
+
+    if wires is not None:
+        if op is not None:
+            raise ValueError(
+                "Cannot specify the wires to sample if an observable is provided. The wires "
+                "to sample will be determined directly from the observable."
+            )
+        wires = Wires(wires)
+
+    return CountsMP(obs=op, wires=wires, all_outcomes=all_outcomes)
 
 
 def _remove_unobserved_outcomes(outcome_counts: dict):

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -25,55 +25,6 @@ from .mid_measure import MeasurementValue
 from .sample import SampleMP
 
 
-def expval(
-    op: Operator | MeasurementValue,
-):
-    r"""Expectation value of the supplied observable.
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.Y(0))
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    -0.4794255386042029
-
-    Args:
-        op (Union[Operator, MeasurementValue]): a quantum observable object. To
-            get expectation values for mid-circuit measurements, ``op`` should be
-            a ``MeasurementValue``.
-
-    Returns:
-        ExpectationMP: measurement process instance
-    """
-    if isinstance(op, MeasurementValue):
-        return ExpectationMP(obs=op)
-
-    if isinstance(op, Sequence):
-        raise ValueError(
-            "qml.expval does not support measuring sequences of measurements or observables"
-        )
-
-    if isinstance(op, qml.Identity) and len(op.wires) == 0:
-        # temporary solution to merge https://github.com/PennyLaneAI/pennylane/pull/5106
-        # allow once we have testing and confidence in qml.expval(I())
-        raise NotImplementedError(
-            "Expectation values of qml.Identity() without wires are currently not allowed."
-        )
-
-    return ExpectationMP(obs=op)
-
-
 class ExpectationMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the expectation value of the supplied observable.
 
@@ -160,3 +111,52 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             probabilities (array): the probabilities of collapsing to eigen states
         """
         return qml.math.dot(probabilities, self.eigvals())
+
+
+def expval(
+    op: Operator | MeasurementValue,
+) -> ExpectationMP:
+    r"""Expectation value of the supplied observable.
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.Y(0))
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    -0.4794255386042029
+
+    Args:
+        op (Union[Operator, MeasurementValue]): a quantum observable object. To
+            get expectation values for mid-circuit measurements, ``op`` should be
+            a ``MeasurementValue``.
+
+    Returns:
+        ExpectationMP: measurement process instance
+    """
+    if isinstance(op, MeasurementValue):
+        return ExpectationMP(obs=op)
+
+    if isinstance(op, Sequence):
+        raise ValueError(
+            "qml.expval does not support measuring sequences of measurements or observables"
+        )
+
+    if isinstance(op, qml.Identity) and len(op.wires) == 0:
+        # temporary solution to merge https://github.com/PennyLaneAI/pennylane/pull/5106
+        # allow once we have testing and confidence in qml.expval(I())
+        raise NotImplementedError(
+            "Expectation values of qml.Identity() without wires are currently not allowed."
+        )
+
+    return ExpectationMP(obs=op)

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -26,197 +26,6 @@ from pennylane.wires import Wires
 from .measurements import MeasurementProcess
 
 
-def measure(wires: Hashable | Wires, reset: bool = False, postselect: int | None = None):
-    r"""Perform a mid-circuit measurement in the computational basis on the
-    supplied qubit.
-
-    Computational basis measurements are performed using the 0, 1 convention
-    rather than the ±1 convention.
-    Measurement outcomes can be used to conditionally apply operations, and measurement
-    statistics can be gathered and returned by a quantum function.
-
-    If a device doesn't support mid-circuit measurements natively, then the
-    QNode will apply the :func:`defer_measurements` transform.
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=3)
-
-        @qml.qnode(dev)
-        def func(x, y):
-            qml.RY(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            m_0 = qml.measure(1)
-
-            qml.cond(m_0, qml.RY)(y, wires=0)
-            return qml.probs(wires=[0])
-
-    Executing this QNode:
-
-    >>> pars = np.array([0.643, 0.246], requires_grad=True)
-    >>> func(*pars)
-    tensor([0.90165331, 0.09834669], requires_grad=True)
-
-    Wires can be reused after measurement. Moreover, measured wires can be reset
-    to the :math:`|0 \rangle` state by setting ``reset=True``.
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=3)
-
-        @qml.qnode(dev)
-        def func():
-            qml.X(1)
-            m_0 = qml.measure(1, reset=True)
-            return qml.probs(wires=[1])
-
-    Executing this QNode:
-
-    >>> func()
-    tensor([1., 0.], requires_grad=True)
-
-    Mid-circuit measurements can be manipulated using the following arithmetic operators:
-    ``+``, ``-``, ``*``, ``/``, ``~`` (not), ``&`` (and), ``|`` (or), ``==``, ``<=``,
-    ``>=``, ``<``, ``>`` with other mid-circuit measurements or scalars.
-
-    .. Note ::
-
-        Python ``not``, ``and``, ``or``, do not work since these do not have dunder methods.
-        Instead use ``~``, ``&``, ``|``.
-
-    Mid-circuit measurement results can be processed with the usual measurement functions such as
-    :func:`~.expval`. For QNodes with finite shots, :func:`~.sample` applied to a mid-circuit measurement
-    result will return a binary sequence of samples.
-    See :ref:`here <mid_circuit_measurements_statistics>` for more details.
-
-    .. Note ::
-
-        Computational basis measurements are performed using the 0, 1 convention rather than the ±1 convention.
-        So, for example, ``expval(qml.measure(0))`` and ``expval(qml.Z(0))`` will give different answers.
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit")
-
-        @qml.qnode(dev)
-        def circuit(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            m0 = qml.measure(1)
-            return (
-                qml.sample(m0), qml.expval(m0), qml.var(m0), qml.probs(op=m0), qml.counts(op=m0),
-            )
-
-    >>> circuit(1.0, 2.0, shots=1000)
-    (array([0, 1, 1, ..., 1, 1, 1])), 0.702, 0.20919600000000002, array([0.298, 0.702]), {0: 298, 1: 702})
-
-    Args:
-        wires (Wires): The wire to measure.
-        reset (Optional[bool]): Whether to reset the wire to the :math:`|0 \rangle`
-            state after measurement.
-        postselect (Optional[int]): Which basis state to postselect after a mid-circuit
-            measurement. None by default. If postselection is requested, only the post-measurement
-            state that is used for postselection will be considered in the remaining circuit.
-
-    Returns:
-        MidMeasureMP: measurement process instance
-
-    Raises:
-        QuantumFunctionError: if multiple wires were specified
-
-    .. details::
-        :title: Postselection
-
-        Postselection discards outcomes that do not meet the criteria provided by the ``postselect``
-        argument. For example, specifying ``postselect=1`` on wire 0 would be equivalent to projecting
-        the state vector onto the :math:`|1\rangle` state on wire 0:
-
-        .. code-block:: python3
-
-            dev = qml.device("default.qubit")
-
-            @qml.qnode(dev)
-            def func(x):
-                qml.RX(x, wires=0)
-                m0 = qml.measure(0, postselect=1)
-                qml.cond(m0, qml.X)(wires=1)
-                return qml.sample(wires=1)
-
-        By postselecting on ``1``, we only consider the ``1`` measurement outcome on wire 0. So, the probability of
-        measuring ``1`` on wire 1 after postselection should also be 1. Executing this QNode with 10 shots:
-
-        >>> func(np.pi / 2, shots=10)
-        array([1, 1, 1, 1, 1, 1, 1])
-
-        Note that only 7 samples are returned. This is because samples that do not meet the postselection criteria are
-        thrown away.
-
-        If postselection is requested on a state with zero probability of being measured, the result may contain ``NaN``
-        or ``Inf`` values:
-
-        .. code-block:: python3
-
-            dev = qml.device("default.qubit")
-
-            @qml.qnode(dev)
-            def func(x):
-                qml.RX(x, wires=0)
-                m0 = qml.measure(0, postselect=1)
-                qml.cond(m0, qml.X)(wires=1)
-                return qml.probs(wires=1)
-
-        >>> func(0.0)
-        tensor([nan, nan], requires_grad=True)
-
-        In the case of ``qml.sample``, an empty array will be returned:
-
-        .. code-block:: python3
-
-            dev = qml.device("default.qubit")
-
-            @qml.qnode(dev)
-            def func(x):
-                qml.RX(x, wires=0)
-                m0 = qml.measure(0, postselect=1)
-                qml.cond(m0, qml.X)(wires=1)
-                return qml.sample(wires=[0, 1])
-
-        >>> func(0.0, shots=[10, 10])
-        (array([], shape=(0, 2), dtype=int64), array([], shape=(0, 2), dtype=int64))
-
-        .. note::
-
-            Currently, postselection support is only available on ``default.qubit``. Using postselection
-            on other devices will raise an error.
-
-        .. warning::
-
-            All measurements are supported when using postselection. However, postselection on a zero probability
-            state can cause some measurements to break:
-
-            * With finite shots, one must be careful when measuring ``qml.probs`` or ``qml.counts``, as these
-              measurements will raise errors if there are no valid samples after postselection. This will occur
-              with postselection states that have zero or close to zero probability.
-
-            * With analytic execution, ``qml.mutual_info`` will raise errors when using any interfaces except
-              ``jax``, and ``qml.vn_entropy`` will raise an error with the ``tensorflow`` interface when the
-              postselection state has zero probability.
-
-            * When using JIT, ``QNode``'s may have unexpected behaviour when postselection on a zero
-              probability state is performed. Due to floating point precision, the zero probability may not be
-              detected, thus letting execution continue as normal without ``NaN`` or ``Inf`` values or empty
-              samples, leading to unexpected or incorrect results.
-
-    """
-    if qml.capture.enabled():
-        primitive = _create_mid_measure_primitive()
-        return primitive.bind(wires, reset=reset, postselect=postselect)
-
-    return _measure_impl(wires, reset=reset, postselect=postselect)
-
-
 def _measure_impl(
     wires: Hashable | Wires, reset: bool | None = False, postselect: int | None = None
 ):
@@ -613,3 +422,196 @@ def find_post_processed_mcms(circuit):
         elif m.mv is not None:
             post_processed_mcms = post_processed_mcms | set(m.mv.measurements)
     return post_processed_mcms
+
+
+def measure(
+    wires: Hashable | Wires, reset: bool = False, postselect: int | None = None
+) -> MeasurementValue:
+    r"""Perform a mid-circuit measurement in the computational basis on the
+    supplied qubit.
+
+    Computational basis measurements are performed using the 0, 1 convention
+    rather than the ±1 convention.
+    Measurement outcomes can be used to conditionally apply operations, and measurement
+    statistics can be gathered and returned by a quantum function.
+
+    If a device doesn't support mid-circuit measurements natively, then the
+    QNode will apply the :func:`defer_measurements` transform.
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def func(x, y):
+            qml.RY(x, wires=0)
+            qml.CNOT(wires=[0, 1])
+            m_0 = qml.measure(1)
+
+            qml.cond(m_0, qml.RY)(y, wires=0)
+            return qml.probs(wires=[0])
+
+    Executing this QNode:
+
+    >>> pars = np.array([0.643, 0.246], requires_grad=True)
+    >>> func(*pars)
+    tensor([0.90165331, 0.09834669], requires_grad=True)
+
+    Wires can be reused after measurement. Moreover, measured wires can be reset
+    to the :math:`|0 \rangle` state by setting ``reset=True``.
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def func():
+            qml.X(1)
+            m_0 = qml.measure(1, reset=True)
+            return qml.probs(wires=[1])
+
+    Executing this QNode:
+
+    >>> func()
+    tensor([1., 0.], requires_grad=True)
+
+    Mid-circuit measurements can be manipulated using the following arithmetic operators:
+    ``+``, ``-``, ``*``, ``/``, ``~`` (not), ``&`` (and), ``|`` (or), ``==``, ``<=``,
+    ``>=``, ``<``, ``>`` with other mid-circuit measurements or scalars.
+
+    .. Note ::
+
+        Python ``not``, ``and``, ``or``, do not work since these do not have dunder methods.
+        Instead use ``~``, ``&``, ``|``.
+
+    Mid-circuit measurement results can be processed with the usual measurement functions such as
+    :func:`~.expval`. For QNodes with finite shots, :func:`~.sample` applied to a mid-circuit measurement
+    result will return a binary sequence of samples.
+    See :ref:`here <mid_circuit_measurements_statistics>` for more details.
+
+    .. Note ::
+
+        Computational basis measurements are performed using the 0, 1 convention rather than the ±1 convention.
+        So, for example, ``expval(qml.measure(0))`` and ``expval(qml.Z(0))`` will give different answers.
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit")
+
+        @qml.qnode(dev)
+        def circuit(x, y):
+            qml.RX(x, wires=0)
+            qml.RY(y, wires=1)
+            m0 = qml.measure(1)
+            return (
+                qml.sample(m0), qml.expval(m0), qml.var(m0), qml.probs(op=m0), qml.counts(op=m0),
+            )
+
+    >>> circuit(1.0, 2.0, shots=1000)
+    (array([0, 1, 1, ..., 1, 1, 1])), 0.702, 0.20919600000000002, array([0.298, 0.702]), {0: 298, 1: 702})
+
+    Args:
+        wires (Wires): The wire to measure.
+        reset (Optional[bool]): Whether to reset the wire to the :math:`|0 \rangle`
+            state after measurement.
+        postselect (Optional[int]): Which basis state to postselect after a mid-circuit
+            measurement. None by default. If postselection is requested, only the post-measurement
+            state that is used for postselection will be considered in the remaining circuit.
+
+    Returns:
+        MidMeasureMP: measurement process instance
+
+    Raises:
+        QuantumFunctionError: if multiple wires were specified
+
+    .. details::
+        :title: Postselection
+
+        Postselection discards outcomes that do not meet the criteria provided by the ``postselect``
+        argument. For example, specifying ``postselect=1`` on wire 0 would be equivalent to projecting
+        the state vector onto the :math:`|1\rangle` state on wire 0:
+
+        .. code-block:: python3
+
+            dev = qml.device("default.qubit")
+
+            @qml.qnode(dev)
+            def func(x):
+                qml.RX(x, wires=0)
+                m0 = qml.measure(0, postselect=1)
+                qml.cond(m0, qml.X)(wires=1)
+                return qml.sample(wires=1)
+
+        By postselecting on ``1``, we only consider the ``1`` measurement outcome on wire 0. So, the probability of
+        measuring ``1`` on wire 1 after postselection should also be 1. Executing this QNode with 10 shots:
+
+        >>> func(np.pi / 2, shots=10)
+        array([1, 1, 1, 1, 1, 1, 1])
+
+        Note that only 7 samples are returned. This is because samples that do not meet the postselection criteria are
+        thrown away.
+
+        If postselection is requested on a state with zero probability of being measured, the result may contain ``NaN``
+        or ``Inf`` values:
+
+        .. code-block:: python3
+
+            dev = qml.device("default.qubit")
+
+            @qml.qnode(dev)
+            def func(x):
+                qml.RX(x, wires=0)
+                m0 = qml.measure(0, postselect=1)
+                qml.cond(m0, qml.X)(wires=1)
+                return qml.probs(wires=1)
+
+        >>> func(0.0)
+        tensor([nan, nan], requires_grad=True)
+
+        In the case of ``qml.sample``, an empty array will be returned:
+
+        .. code-block:: python3
+
+            dev = qml.device("default.qubit")
+
+            @qml.qnode(dev)
+            def func(x):
+                qml.RX(x, wires=0)
+                m0 = qml.measure(0, postselect=1)
+                qml.cond(m0, qml.X)(wires=1)
+                return qml.sample(wires=[0, 1])
+
+        >>> func(0.0, shots=[10, 10])
+        (array([], shape=(0, 2), dtype=int64), array([], shape=(0, 2), dtype=int64))
+
+        .. note::
+
+            Currently, postselection support is only available on ``default.qubit``. Using postselection
+            on other devices will raise an error.
+
+        .. warning::
+
+            All measurements are supported when using postselection. However, postselection on a zero probability
+            state can cause some measurements to break:
+
+            * With finite shots, one must be careful when measuring ``qml.probs`` or ``qml.counts``, as these
+              measurements will raise errors if there are no valid samples after postselection. This will occur
+              with postselection states that have zero or close to zero probability.
+
+            * With analytic execution, ``qml.mutual_info`` will raise errors when using any interfaces except
+              ``jax``, and ``qml.vn_entropy`` will raise an error with the ``tensorflow`` interface when the
+              postselection state has zero probability.
+
+            * When using JIT, ``QNode``'s may have unexpected behaviour when postselection on a zero
+              probability state is performed. Due to floating point precision, the zero probability may not be
+              detected, thus letting execution continue as normal without ``NaN`` or ``Inf`` values or empty
+              samples, leading to unexpected or incorrect results.
+
+    """
+    if qml.capture.enabled():
+        primitive = _create_mid_measure_primitive()
+        return primitive.bind(wires, reset=reset, postselect=postselect)
+
+    return _measure_impl(wires, reset=reset, postselect=postselect)

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -25,68 +25,6 @@ from pennylane.wires import Wires
 from .measurements import StateMeasurement
 
 
-def mutual_info(wires0, wires1, log_base=None):
-    r"""Mutual information between the subsystems prior to measurement:
-
-    .. math::
-
-        I(A, B) = S(\rho^A) + S(\rho^B) - S(\rho^{AB})
-
-    where :math:`S` is the von Neumann entropy.
-
-    The mutual information is a measure of correlation between two subsystems.
-    More specifically, it quantifies the amount of information obtained about
-    one system by measuring the other system.
-
-    Args:
-        wires0 (Sequence[int] or int): the wires of the first subsystem
-        wires1 (Sequence[int] or int): the wires of the second subsystem
-        log_base (float): Base for the logarithm.
-
-    Returns:
-        MutualInfoMP: measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit_mutual(x):
-            qml.IsingXX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
-
-    Executing this QNode:
-
-    >>> circuit_mutual(np.pi/2)
-    1.3862943611198906
-
-    It is also possible to get the gradient of the previous QNode:
-
-    >>> param = np.array(np.pi/4, requires_grad=True)
-    >>> qml.grad(circuit_mutual)(param)
-    tensor(1.24645048, requires_grad=True)
-
-    .. note::
-
-        Calculating the derivative of :func:`~.mutual_info` is currently supported when
-        using the classical backpropagation differentiation method (``diff_method="backprop"``)
-        with a compatible device and finite differences (``diff_method="finite-diff"``).
-
-    .. seealso:: :func:`~pennylane.vn_entropy`, :func:`pennylane.math.mutual_info`
-    """
-    wires0 = qml.wires.Wires(wires0)
-    wires1 = qml.wires.Wires(wires1)
-
-    # the subsystems cannot overlap
-    if not any(qml.math.is_abstract(w) for w in wires0 + wires1) and [
-        wire for wire in wires0 if wire in wires1
-    ]:
-        raise QuantumFunctionError("Subsystems for computing mutual information must not overlap.")
-    return MutualInfoMP(wires=(wires0, wires1), log_base=log_base)
-
-
 class MutualInfoMP(StateMeasurement):
     """Measurement process that computes the mutual information between the provided wires.
 
@@ -182,3 +120,65 @@ if MutualInfoMP._wires_primitive is not None:
         wires0 = all_wires[:n_wires0]
         wires1 = all_wires[n_wires0:]
         return type.__call__(MutualInfoMP, wires=(wires0, wires1), **kwargs)
+
+
+def mutual_info(wires0, wires1, log_base=None) -> MutualInfoMP:
+    r"""Mutual information between the subsystems prior to measurement:
+
+    .. math::
+
+        I(A, B) = S(\rho^A) + S(\rho^B) - S(\rho^{AB})
+
+    where :math:`S` is the von Neumann entropy.
+
+    The mutual information is a measure of correlation between two subsystems.
+    More specifically, it quantifies the amount of information obtained about
+    one system by measuring the other system.
+
+    Args:
+        wires0 (Sequence[int] or int): the wires of the first subsystem
+        wires1 (Sequence[int] or int): the wires of the second subsystem
+        log_base (float): Base for the logarithm.
+
+    Returns:
+        MutualInfoMP: measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit_mutual(x):
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.mutual_info(wires0=[0], wires1=[1])
+
+    Executing this QNode:
+
+    >>> circuit_mutual(np.pi/2)
+    1.3862943611198906
+
+    It is also possible to get the gradient of the previous QNode:
+
+    >>> param = np.array(np.pi/4, requires_grad=True)
+    >>> qml.grad(circuit_mutual)(param)
+    tensor(1.24645048, requires_grad=True)
+
+    .. note::
+
+        Calculating the derivative of :func:`~.mutual_info` is currently supported when
+        using the classical backpropagation differentiation method (``diff_method="backprop"``)
+        with a compatible device and finite differences (``diff_method="finite-diff"``).
+
+    .. seealso:: :func:`~pennylane.vn_entropy`, :func:`pennylane.math.mutual_info`
+    """
+    wires0 = qml.wires.Wires(wires0)
+    wires1 = qml.wires.Wires(wires1)
+
+    # the subsystems cannot overlap
+    if not any(qml.math.is_abstract(w) for w in wires0 + wires1) and [
+        wire for wire in wires0 if wire in wires1
+    ]:
+        raise QuantumFunctionError("Subsystems for computing mutual information must not overlap.")
+    return MutualInfoMP(wires=(wires0, wires1), log_base=log_base)

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -27,113 +27,6 @@ from .measurements import SampleMeasurement, StateMeasurement
 from .mid_measure import MeasurementValue
 
 
-def probs(wires=None, op=None) -> "ProbabilityMP":
-    r"""Probability of each computational basis state.
-
-    This measurement function accepts either a wire specification or
-    an observable. Passing wires to the function
-    instructs the QNode to return a flat array containing the
-    probabilities :math:`|\langle i | \psi \rangle |^2` of measuring
-    the computational basis state :math:`| i \rangle` given the current
-    state :math:`| \psi \rangle`.
-
-    Marginal probabilities may also be requested by restricting
-    the wires to a subset of the full system; the size of the
-    returned array will be ``[2**len(wires)]``.
-
-    .. Note::
-        If no wires or observable are given, the probability of all wires is returned.
-
-    Args:
-        wires (Sequence[int] or int): the wire the operation acts on
-        op (Operator or MeasurementValue or Sequence[MeasurementValue]): Observable (with a ``diagonalizing_gates``
-            attribute) that rotates the computational basis, or a  ``MeasurementValue``
-            corresponding to mid-circuit measurements.
-
-    Returns:
-        ProbabilityMP: Measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.Hadamard(wires=1)
-            return qml.probs(wires=[0, 1])
-
-    Executing this QNode:
-
-    >>> circuit()
-    array([0.5, 0.5, 0. , 0. ])
-
-    The returned array is in lexicographic order, so corresponds
-    to a :math:`50\%` chance of measuring either :math:`|00\rangle`
-    or :math:`|01\rangle`.
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        H = 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.Z(0)
-            qml.X(1)
-            return qml.probs(op=qml.Hermitian(H, wires=0))
-
-    >>> circuit()
-    array([0.14644661 0.85355339])
-
-    The returned array is in lexicographic order, so corresponds
-    to a :math:`14.6\%` chance of measuring the rotated :math:`|0\rangle` state
-    and :math:`85.4\%` of measuring the rotated :math:`|1\rangle` state.
-
-    Note that the output shape of this measurement process depends on whether
-    the device simulates qubit or continuous variable quantum systems.
-    """
-    if isinstance(op, MeasurementValue):
-        if len(op.measurements) > 1:
-            raise ValueError(
-                "Cannot use qml.probs() when measuring multiple mid-circuit measurements collected "
-                "using arithmetic operators. To collect probabilities for multiple mid-circuit "
-                "measurements, use a list of mid-circuit measurements with qml.probs()."
-            )
-        return ProbabilityMP(obs=op)
-
-    if isinstance(op, Sequence):
-        if not qml.math.is_abstract(op[0]) and not all(
-            isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in op
-        ):
-            raise QuantumFunctionError(
-                "Only sequences of single MeasurementValues can be passed with the op argument. "
-                "MeasurementValues manipulated using arithmetic operators cannot be used when "
-                "collecting statistics for a sequence of mid-circuit measurements."
-            )
-
-        return ProbabilityMP(obs=op)
-
-    if isinstance(op, qml.ops.LinearCombination):
-        raise QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
-
-    if op is not None and not qml.math.is_abstract(op) and not op.has_diagonalizing_gates:
-        raise QuantumFunctionError(
-            f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
-        )
-
-    if wires is not None:
-        if op is not None:
-            raise QuantumFunctionError(
-                "Cannot specify the wires to probs if an observable is "
-                "provided. The wires for probs will be determined directly from the observable."
-            )
-        wires = Wires(wires)
-    return ProbabilityMP(obs=op, wires=wires)
-
-
 class ProbabilityMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the probability of each computational basis state.
 
@@ -306,3 +199,110 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
             like=interface,
         )
         return probabilities / bin_size
+
+
+def probs(wires=None, op=None) -> ProbabilityMP:
+    r"""Probability of each computational basis state.
+
+    This measurement function accepts either a wire specification or
+    an observable. Passing wires to the function
+    instructs the QNode to return a flat array containing the
+    probabilities :math:`|\langle i | \psi \rangle |^2` of measuring
+    the computational basis state :math:`| i \rangle` given the current
+    state :math:`| \psi \rangle`.
+
+    Marginal probabilities may also be requested by restricting
+    the wires to a subset of the full system; the size of the
+    returned array will be ``[2**len(wires)]``.
+
+    .. Note::
+        If no wires or observable are given, the probability of all wires is returned.
+
+    Args:
+        wires (Sequence[int] or int): the wire the operation acts on
+        op (Operator or MeasurementValue or Sequence[MeasurementValue]): Observable (with a ``diagonalizing_gates``
+            attribute) that rotates the computational basis, or a  ``MeasurementValue``
+            corresponding to mid-circuit measurements.
+
+    Returns:
+        ProbabilityMP: Measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=1)
+            return qml.probs(wires=[0, 1])
+
+    Executing this QNode:
+
+    >>> circuit()
+    array([0.5, 0.5, 0. , 0. ])
+
+    The returned array is in lexicographic order, so corresponds
+    to a :math:`50\%` chance of measuring either :math:`|00\rangle`
+    or :math:`|01\rangle`.
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        H = 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Z(0)
+            qml.X(1)
+            return qml.probs(op=qml.Hermitian(H, wires=0))
+
+    >>> circuit()
+    array([0.14644661 0.85355339])
+
+    The returned array is in lexicographic order, so corresponds
+    to a :math:`14.6\%` chance of measuring the rotated :math:`|0\rangle` state
+    and :math:`85.4\%` of measuring the rotated :math:`|1\rangle` state.
+
+    Note that the output shape of this measurement process depends on whether
+    the device simulates qubit or continuous variable quantum systems.
+    """
+    if isinstance(op, MeasurementValue):
+        if len(op.measurements) > 1:
+            raise ValueError(
+                "Cannot use qml.probs() when measuring multiple mid-circuit measurements collected "
+                "using arithmetic operators. To collect probabilities for multiple mid-circuit "
+                "measurements, use a list of mid-circuit measurements with qml.probs()."
+            )
+        return ProbabilityMP(obs=op)
+
+    if isinstance(op, Sequence):
+        if not qml.math.is_abstract(op[0]) and not all(
+            isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in op
+        ):
+            raise QuantumFunctionError(
+                "Only sequences of single MeasurementValues can be passed with the op argument. "
+                "MeasurementValues manipulated using arithmetic operators cannot be used when "
+                "collecting statistics for a sequence of mid-circuit measurements."
+            )
+
+        return ProbabilityMP(obs=op)
+
+    if isinstance(op, qml.ops.LinearCombination):
+        raise QuantumFunctionError("Hamiltonians are not supported for rotating probabilities.")
+
+    if op is not None and not qml.math.is_abstract(op) and not op.has_diagonalizing_gates:
+        raise QuantumFunctionError(
+            f"{op} does not define diagonalizing gates : cannot be used to rotate the probability"
+        )
+
+    if wires is not None:
+        if op is not None:
+            raise QuantumFunctionError(
+                "Cannot specify the wires to probs if an observable is "
+                "provided. The wires for probs will be determined directly from the observable."
+            )
+        wires = Wires(wires)
+    return ProbabilityMP(obs=op, wires=wires)

--- a/pennylane/measurements/purity.py
+++ b/pennylane/measurements/purity.py
@@ -23,45 +23,6 @@ from pennylane.wires import Wires
 from .measurements import StateMeasurement
 
 
-def purity(wires) -> "PurityMP":
-    r"""The purity of the system prior to measurement.
-
-    .. math::
-        \gamma = \text{Tr}(\rho^2)
-
-    where :math:`\rho` is the density matrix. The purity of a normalized quantum state satisfies
-    :math:`\frac{1}{d} \leq \gamma \leq 1`, where :math:`d` is the dimension of the Hilbert space.
-    A pure state has a purity of 1.
-
-    Args:
-        wires (Sequence[int] or int): The wires of the subsystem
-
-    Returns:
-        PurityMP: Measurement process instance
-
-    **Example**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.mixed", wires=2)
-
-        @qml.qnode(dev)
-        def circuit_purity(p):
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.BitFlip(p, wires=0)
-            qml.BitFlip(p, wires=1)
-            return qml.purity(wires=[0,1])
-
-    >>> circuit_purity(0.1)
-    array(0.7048)
-
-    .. seealso:: :func:`pennylane.math.purity`
-    """
-    wires = Wires(wires)
-    return PurityMP(wires=wires)
-
-
 class PurityMP(StateMeasurement):
     """Measurement process that computes the purity of the system prior to measurement.
 
@@ -98,3 +59,42 @@ class PurityMP(StateMeasurement):
         wire_map = dict(zip(wire_order, list(range(len(wire_order)))))
         indices = [wire_map[w] for w in self.wires]
         return qml.math.purity(density_matrix, indices=indices, c_dtype=density_matrix.dtype)
+
+
+def purity(wires) -> PurityMP:
+    r"""The purity of the system prior to measurement.
+
+    .. math::
+        \gamma = \text{Tr}(\rho^2)
+
+    where :math:`\rho` is the density matrix. The purity of a normalized quantum state satisfies
+    :math:`\frac{1}{d} \leq \gamma \leq 1`, where :math:`d` is the dimension of the Hilbert space.
+    A pure state has a purity of 1.
+
+    Args:
+        wires (Sequence[int] or int): The wires of the subsystem
+
+    Returns:
+        PurityMP: Measurement process instance
+
+    **Example**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.mixed", wires=2)
+
+        @qml.qnode(dev)
+        def circuit_purity(p):
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.BitFlip(p, wires=0)
+            qml.BitFlip(p, wires=1)
+            return qml.purity(wires=[0,1])
+
+    >>> circuit_purity(0.1)
+    array(0.7048)
+
+    .. seealso:: :func:`pennylane.math.purity`
+    """
+    wires = Wires(wires)
+    return PurityMP(wires=wires)

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -27,124 +27,6 @@ from .measurements import MeasurementShapeError, SampleMeasurement
 from .mid_measure import MeasurementValue
 
 
-def sample(
-    op: Operator | MeasurementValue | Sequence[MeasurementValue] | None = None,
-    wires=None,
-) -> "SampleMP":
-    r"""Sample from the supplied observable, with the number of shots
-    determined from the ``dev.shots`` attribute of the corresponding device,
-    returning raw samples. If no observable is provided then basis state samples are returned
-    directly from the device.
-
-    Note that the output shape of this measurement process depends on the shots
-    specified on the device.
-
-    Args:
-        op (Operator or MeasurementValue): a quantum observable object. To get samples
-            for mid-circuit measurements, ``op`` should be a ``MeasurementValue``.
-        wires (Sequence[int] or int or None): the wires we wish to sample from; ONLY set wires if
-            op is ``None``.
-
-    Returns:
-        SampleMP: Measurement process instance
-
-    Raises:
-        ValueError: Cannot set wires if an observable is provided
-
-    The samples are drawn from the eigenvalues :math:`\{\lambda_i\}` of the observable.
-    The probability of drawing eigenvalue :math:`\lambda_i` is given by
-    :math:`p(\lambda_i) = |\langle \xi_i | \psi \rangle|^2`, where :math:`| \xi_i \rangle`
-    is the corresponding basis state from the observable's eigenbasis.
-
-    .. note::
-
-        QNodes that return samples cannot, in general, be differentiated, since the derivative
-        with respect to a sample --- a stochastic process --- is ill-defined. An alternative
-        approach would be to use single-shot expectation values. For example, instead of this:
-
-        .. code-block:: python
-
-            from functools import partial
-            dev = qml.device("default.qubit")
-
-            @partial(qml.set_shots, shots=10)
-            @qml.qnode(dev, diff_method="parameter-shift")
-            def circuit(angle):
-                qml.RX(angle, wires=0)
-                return qml.sample(qml.PauliX(0))
-
-            angle = qml.numpy.array(0.1)
-            res = qml.jacobian(circuit)(angle)
-
-        Consider using :func:`~pennylane.expval` and a sequence of single shots, like this:
-
-        .. code-block:: python
-
-            from functools import partial
-            dev = qml.device("default.qubit")
-
-            @partial(qml.set_shots, shots=[(1, 10)])
-            @qml.qnode(dev, diff_method="parameter-shift")
-            def circuit(angle):
-                qml.RX(angle, wires=0)
-                return qml.expval(qml.PauliX(0))
-
-            def cost(angle):
-                return qml.math.hstack(circuit(angle))
-
-            angle = qml.numpy.array(0.1)
-            res = qml.jacobian(cost)(angle)
-
-    **Example**
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=4)
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample(qml.Y(0))
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    array([ 1.,  1.,  1., -1.])
-
-    If no observable is provided, then the raw basis state samples obtained
-    from device are returned (e.g., for a qubit device, samples from the
-    computational device are returned). In this case, ``wires`` can be specified
-    so that sample results only include measurement results of the qubits of interest.
-
-    .. code-block:: python3
-
-        from functools import partial
-        dev = qml.device("default.qubit", wires=2)
-
-        @partial(qml.set_shots, shots=4)
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample()
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    array([[0, 1],
-           [0, 0],
-           [1, 1],
-           [0, 0]])
-
-    """
-    return SampleMP(obs=op, wires=None if wires is None else qml.wires.Wires(wires))
-
-
 class SampleMP(SampleMeasurement):
     """Measurement process that returns the samples of a given observable. If no observable is
     provided then basis state samples are returned directly from the device.
@@ -344,3 +226,121 @@ class SampleMP(SampleMeasurement):
             return eigvals[int(outcome, 2)]
 
         return [int(bit) for bit in outcome]
+
+
+def sample(
+    op: Operator | MeasurementValue | Sequence[MeasurementValue] | None = None,
+    wires=None,
+) -> SampleMP:
+    r"""Sample from the supplied observable, with the number of shots
+    determined from the ``dev.shots`` attribute of the corresponding device,
+    returning raw samples. If no observable is provided then basis state samples are returned
+    directly from the device.
+
+    Note that the output shape of this measurement process depends on the shots
+    specified on the device.
+
+    Args:
+        op (Operator or MeasurementValue): a quantum observable object. To get samples
+            for mid-circuit measurements, ``op`` should be a ``MeasurementValue``.
+        wires (Sequence[int] or int or None): the wires we wish to sample from; ONLY set wires if
+            op is ``None``.
+
+    Returns:
+        SampleMP: Measurement process instance
+
+    Raises:
+        ValueError: Cannot set wires if an observable is provided
+
+    The samples are drawn from the eigenvalues :math:`\{\lambda_i\}` of the observable.
+    The probability of drawing eigenvalue :math:`\lambda_i` is given by
+    :math:`p(\lambda_i) = |\langle \xi_i | \psi \rangle|^2`, where :math:`| \xi_i \rangle`
+    is the corresponding basis state from the observable's eigenbasis.
+
+    .. note::
+
+        QNodes that return samples cannot, in general, be differentiated, since the derivative
+        with respect to a sample --- a stochastic process --- is ill-defined. An alternative
+        approach would be to use single-shot expectation values. For example, instead of this:
+
+        .. code-block:: python
+
+            from functools import partial
+            dev = qml.device("default.qubit")
+
+            @partial(qml.set_shots, shots=10)
+            @qml.qnode(dev, diff_method="parameter-shift")
+            def circuit(angle):
+                qml.RX(angle, wires=0)
+                return qml.sample(qml.PauliX(0))
+
+            angle = qml.numpy.array(0.1)
+            res = qml.jacobian(circuit)(angle)
+
+        Consider using :func:`~pennylane.expval` and a sequence of single shots, like this:
+
+        .. code-block:: python
+
+            from functools import partial
+            dev = qml.device("default.qubit")
+
+            @partial(qml.set_shots, shots=[(1, 10)])
+            @qml.qnode(dev, diff_method="parameter-shift")
+            def circuit(angle):
+                qml.RX(angle, wires=0)
+                return qml.expval(qml.PauliX(0))
+
+            def cost(angle):
+                return qml.math.hstack(circuit(angle))
+
+            angle = qml.numpy.array(0.1)
+            res = qml.jacobian(cost)(angle)
+
+    **Example**
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=4)
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample(qml.Y(0))
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    array([ 1.,  1.,  1., -1.])
+
+    If no observable is provided, then the raw basis state samples obtained
+    from device are returned (e.g., for a qubit device, samples from the
+    computational device are returned). In this case, ``wires`` can be specified
+    so that sample results only include measurement results of the qubits of interest.
+
+    .. code-block:: python3
+
+        from functools import partial
+        dev = qml.device("default.qubit", wires=2)
+
+        @partial(qml.set_shots, shots=4)
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.sample()
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    array([[0, 1],
+           [0, 0],
+           [1, 1],
+           [0, 0]])
+
+    """
+    return SampleMP(obs=op, wires=None if wires is None else qml.wires.Wires(wires))

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -23,109 +23,6 @@ from pennylane.wires import WireError, Wires
 from .measurements import StateMeasurement
 
 
-def state() -> "StateMP":
-    r"""Quantum state in the computational basis.
-
-    This function accepts no observables and instead instructs the QNode to return its state. A
-    ``wires`` argument should *not* be provided since ``state()`` always returns a pure state
-    describing all wires in the device.
-
-    Note that the output shape of this measurement process depends on the
-    number of wires defined for the device.
-
-    Returns:
-        StateMP: Measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.Hadamard(wires=1)
-            return qml.state()
-
-    Executing this QNode:
-
-    >>> circuit()
-    array([0.70710678+0.j, 0.70710678+0.j, 0.        +0.j, 0.        +0.j])
-
-    The returned array is in lexicographic order. Hence, we have a :math:`1/\sqrt{2}` amplitude
-    in both :math:`|00\rangle` and :math:`|01\rangle`.
-
-    .. note::
-
-        Differentiating :func:`~pennylane.state` is currently only supported when using the
-        classical backpropagation differentiation method (``diff_method="backprop"``) with a
-        compatible device.
-
-    .. details::
-        :title: Usage Details
-
-        A QNode with the ``qml.state`` output can be used in a cost function which
-        is then differentiated:
-
-        >>> dev = qml.device('default.qubit', wires=2)
-        >>> @qml.qnode(dev, diff_method="backprop")
-        ... def test(x):
-        ...     qml.RY(x, wires=[0])
-        ...     return qml.state()
-        >>> def cost(x):
-        ...     return np.abs(test(x)[0])
-        >>> cost(x)
-        0.9987502603949663
-        >>> qml.grad(cost)(x)
-        tensor(-0.02498958, requires_grad=True)
-    """
-    return StateMP()
-
-
-def density_matrix(wires) -> "DensityMatrixMP":
-    r"""Quantum density matrix in the computational basis.
-
-    This function accepts no observables and instead instructs the QNode to return its density
-    matrix or reduced density matrix. The ``wires`` argument gives the possibility
-    to trace out a part of the system. It can result in obtaining a mixed state, which can be
-    only represented by the reduced density matrix.
-
-    Args:
-        wires (Sequence[int] or int): the wires of the subsystem
-
-    Returns:
-        DensityMatrixMP: Measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.Y(0)
-            qml.Hadamard(wires=1)
-            return qml.density_matrix([0])
-
-    Executing this QNode:
-
-    >>> circuit()
-    array([[0.+0.j 0.+0.j]
-        [0.+0.j 1.+0.j]])
-
-    The returned matrix is the reduced density matrix, where system 1 is traced out.
-
-    .. note::
-
-        Calculating the derivative of :func:`~pennylane.density_matrix` is currently only supported when
-        using the classical backpropagation differentiation method (``diff_method="backprop"``)
-        with a compatible device.
-    """
-    wires = Wires(wires)
-    return DensityMatrixMP(wires=wires)
-
-
 class StateMP(StateMeasurement):
     """Measurement process that returns the quantum state in the computational basis.
 
@@ -258,3 +155,106 @@ class DensityMatrixMP(StateMP):
         ):
             kwargs["c_dtype"] = density_matrix.dtype
         return qml.math.reduce_dm(density_matrix, **kwargs)
+
+
+def state() -> StateMP:
+    r"""Quantum state in the computational basis.
+
+    This function accepts no observables and instead instructs the QNode to return its state. A
+    ``wires`` argument should *not* be provided since ``state()`` always returns a pure state
+    describing all wires in the device.
+
+    Note that the output shape of this measurement process depends on the
+    number of wires defined for the device.
+
+    Returns:
+        StateMP: Measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=1)
+            return qml.state()
+
+    Executing this QNode:
+
+    >>> circuit()
+    array([0.70710678+0.j, 0.70710678+0.j, 0.        +0.j, 0.        +0.j])
+
+    The returned array is in lexicographic order. Hence, we have a :math:`1/\sqrt{2}` amplitude
+    in both :math:`|00\rangle` and :math:`|01\rangle`.
+
+    .. note::
+
+        Differentiating :func:`~pennylane.state` is currently only supported when using the
+        classical backpropagation differentiation method (``diff_method="backprop"``) with a
+        compatible device.
+
+    .. details::
+        :title: Usage Details
+
+        A QNode with the ``qml.state`` output can be used in a cost function which
+        is then differentiated:
+
+        >>> dev = qml.device('default.qubit', wires=2)
+        >>> @qml.qnode(dev, diff_method="backprop")
+        ... def test(x):
+        ...     qml.RY(x, wires=[0])
+        ...     return qml.state()
+        >>> def cost(x):
+        ...     return np.abs(test(x)[0])
+        >>> cost(x)
+        0.9987502603949663
+        >>> qml.grad(cost)(x)
+        tensor(-0.02498958, requires_grad=True)
+    """
+    return StateMP()
+
+
+def density_matrix(wires) -> DensityMatrixMP:
+    r"""Quantum density matrix in the computational basis.
+
+    This function accepts no observables and instead instructs the QNode to return its density
+    matrix or reduced density matrix. The ``wires`` argument gives the possibility
+    to trace out a part of the system. It can result in obtaining a mixed state, which can be
+    only represented by the reduced density matrix.
+
+    Args:
+        wires (Sequence[int] or int): the wires of the subsystem
+
+    Returns:
+        DensityMatrixMP: Measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.Y(0)
+            qml.Hadamard(wires=1)
+            return qml.density_matrix([0])
+
+    Executing this QNode:
+
+    >>> circuit()
+    array([[0.+0.j 0.+0.j]
+        [0.+0.j 1.+0.j]])
+
+    The returned matrix is the reduced density matrix, where system 1 is traced out.
+
+    .. note::
+
+        Calculating the derivative of :func:`~pennylane.density_matrix` is currently only supported when
+        using the classical backpropagation differentiation method (``diff_method="backprop"``)
+        with a compatible device.
+    """
+    wires = Wires(wires)
+    return DensityMatrixMP(wires=wires)

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -26,46 +26,6 @@ from .mid_measure import MeasurementValue
 from .sample import SampleMP
 
 
-def var(op: Operator | MeasurementValue) -> "VarianceMP":
-    r"""Variance of the supplied observable.
-
-    Args:
-        op (Union[Operator, MeasurementValue]): a quantum observable object.
-            To get variances for mid-circuit measurements, ``op`` should be a
-            ``MeasurementValue``.
-
-    Returns:
-        VarianceMP: Measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.var(qml.Y(0))
-
-    Executing this QNode:
-
-    >>> circuit(0.5)
-    0.7701511529340698
-    """
-    if isinstance(op, MeasurementValue):
-        return VarianceMP(obs=op)
-
-    if isinstance(op, Sequence):
-        raise ValueError(
-            "qml.var does not support measuring sequences of measurements or observables"
-        )
-
-    return VarianceMP(obs=op)
-
-
 class VarianceMP(SampleMeasurement, StateMeasurement):
     """Measurement process that computes the variance of the supplied observable.
 
@@ -152,3 +112,43 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
         """
         eigvals = qml.math.asarray(self.eigvals(), dtype="float64")
         return qml.math.dot(probabilities, (eigvals**2)) - qml.math.dot(probabilities, eigvals) ** 2
+
+
+def var(op: Operator | MeasurementValue) -> VarianceMP:
+    r"""Variance of the supplied observable.
+
+    Args:
+        op (Union[Operator, MeasurementValue]): a quantum observable object.
+            To get variances for mid-circuit measurements, ``op`` should be a
+            ``MeasurementValue``.
+
+    Returns:
+        VarianceMP: Measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            qml.Hadamard(wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.Y(0))
+
+    Executing this QNode:
+
+    >>> circuit(0.5)
+    0.7701511529340698
+    """
+    if isinstance(op, MeasurementValue):
+        return VarianceMP(obs=op)
+
+    if isinstance(op, Sequence):
+        raise ValueError(
+            "qml.var does not support measuring sequences of measurements or observables"
+        )
+
+    return VarianceMP(obs=op)

--- a/pennylane/measurements/vn_entropy.py
+++ b/pennylane/measurements/vn_entropy.py
@@ -23,58 +23,6 @@ from pennylane.wires import Wires
 from .measurements import StateMeasurement
 
 
-def vn_entropy(wires, log_base=None) -> "VnEntropyMP":
-    r"""Von Neumann entropy of the system prior to measurement.
-
-    .. math::
-        S( \rho ) = -\text{Tr}( \rho \log ( \rho ))
-
-    Args:
-        wires (Sequence[int] or int): The wires of the subsystem
-        log_base (float): Base for the logarithm.
-
-    Returns:
-        VnEntropyMP: Measurement process instance
-
-    **Example:**
-
-    .. code-block:: python3
-
-        dev = qml.device("default.qubit", wires=2)
-
-        @qml.qnode(dev)
-        def circuit_entropy(x):
-            qml.IsingXX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=[0])
-
-    Executing this QNode:
-
-    >>> circuit_entropy(np.pi/2)
-    0.6931472
-
-    It is also possible to get the gradient of the previous QNode:
-
-    >>> param = np.array(np.pi/4, requires_grad=True)
-    >>> qml.grad(circuit_entropy)(param)
-    tensor(0.62322524, requires_grad=True)
-
-    .. note::
-
-        Calculating the derivative of :func:`~pennylane.vn_entropy` is currently supported when
-        using the classical backpropagation differentiation method (``diff_method="backprop"``)
-        with a compatible device and finite differences (``diff_method="finite-diff"``).
-
-    .. note::
-
-        ``qml.vn_entropy`` can also be used to compute the entropy of entanglement between two
-        subsystems by computing the Von Neumann entropy of either of the subsystems.
-
-    .. seealso:: :func:`pennylane.math.vn_entropy`, :func:`pennylane.math.vn_entanglement_entropy`
-    """
-    wires = Wires(wires)
-    return VnEntropyMP(wires=wires, log_base=log_base)
-
-
 class VnEntropyMP(StateMeasurement):
     """Measurement process that computes the Von Neumann entropy of the system prior to measurement.
 
@@ -130,3 +78,55 @@ class VnEntropyMP(StateMeasurement):
         return qml.math.vn_entropy(
             density_matrix, indices=self.wires, c_dtype=density_matrix.dtype, base=self.log_base
         )
+
+
+def vn_entropy(wires, log_base=None) -> VnEntropyMP:
+    r"""Von Neumann entropy of the system prior to measurement.
+
+    .. math::
+        S( \rho ) = -\text{Tr}( \rho \log ( \rho ))
+
+    Args:
+        wires (Sequence[int] or int): The wires of the subsystem
+        log_base (float): Base for the logarithm.
+
+    Returns:
+        VnEntropyMP: Measurement process instance
+
+    **Example:**
+
+    .. code-block:: python3
+
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def circuit_entropy(x):
+            qml.IsingXX(x, wires=[0, 1])
+            return qml.vn_entropy(wires=[0])
+
+    Executing this QNode:
+
+    >>> circuit_entropy(np.pi/2)
+    0.6931472
+
+    It is also possible to get the gradient of the previous QNode:
+
+    >>> param = np.array(np.pi/4, requires_grad=True)
+    >>> qml.grad(circuit_entropy)(param)
+    tensor(0.62322524, requires_grad=True)
+
+    .. note::
+
+        Calculating the derivative of :func:`~pennylane.vn_entropy` is currently supported when
+        using the classical backpropagation differentiation method (``diff_method="backprop"``)
+        with a compatible device and finite differences (``diff_method="finite-diff"``).
+
+    .. note::
+
+        ``qml.vn_entropy`` can also be used to compute the entropy of entanglement between two
+        subsystems by computing the Von Neumann entropy of either of the subsystems.
+
+    .. seealso:: :func:`pennylane.math.vn_entropy`, :func:`pennylane.math.vn_entanglement_entropy`
+    """
+    wires = Wires(wires)
+    return VnEntropyMP(wires=wires, log_base=log_base)


### PR DESCRIPTION
**Context:**

**Description of the Change:**

Moves the constructor below the class definition so we can properly type-hint the constructor without quotation marks.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
