### PR TITLE
fixing 1 qubit-size SemiAdder

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -259,7 +259,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Guillermo Alonso 
+Guillermo Alonso,
 Utkarsh Azad,
 Joey Carter,
 Yushao Chen,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -252,10 +252,14 @@
   This allows for types to be inferred correctly when parsing.
   [(#7825)](https://github.com/PennyLaneAI/pennylane/pull/7825)
 
+* Fixes `SemiAdder` to work when inputs are defined with a single wire.
+  [(#7940)](https://github.com/PennyLaneAI/pennylane/pull/7940)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Guillermo Alonso 
 Utkarsh Azad,
 Joey Carter,
 Yushao Chen,

--- a/pennylane/templates/subroutines/semi_adder.py
+++ b/pennylane/templates/subroutines/semi_adder.py
@@ -142,8 +142,6 @@ class SemiAdder(Operation):
         y_wires = qml.wires.Wires(y_wires)
         if work_wires:
             work_wires = qml.wires.Wires(work_wires)
-
-        if work_wires:
             if len(work_wires) < len(y_wires) - 1:
                 raise ValueError(f"At least {len(y_wires)-1} work_wires should be provided.")
             if work_wires.intersection(x_wires):

--- a/pennylane/templates/subroutines/semi_adder.py
+++ b/pennylane/templates/subroutines/semi_adder.py
@@ -140,14 +140,16 @@ class SemiAdder(Operation):
 
         x_wires = qml.wires.Wires(x_wires)
         y_wires = qml.wires.Wires(y_wires)
-        work_wires = qml.wires.Wires(work_wires)
+        if work_wires:
+            work_wires = qml.wires.Wires(work_wires)
 
-        if len(work_wires) < len(y_wires) - 1:
-            raise ValueError(f"At least {len(y_wires)-1} work_wires should be provided.")
-        if work_wires.intersection(x_wires):
-            raise ValueError("None of the wires in work_wires should be included in x_wires.")
-        if work_wires.intersection(y_wires):
-            raise ValueError("None of the wires in work_wires should be included in y_wires.")
+        if work_wires:
+            if len(work_wires) < len(y_wires) - 1:
+                raise ValueError(f"At least {len(y_wires)-1} work_wires should be provided.")
+            if work_wires.intersection(x_wires):
+                raise ValueError("None of the wires in work_wires should be included in x_wires.")
+            if work_wires.intersection(y_wires):
+                raise ValueError("None of the wires in work_wires should be included in y_wires.")
         if x_wires.intersection(y_wires):
             raise ValueError("None of the wires in y_wires should be included in x_wires.")
 
@@ -155,7 +157,10 @@ class SemiAdder(Operation):
         self.hyperparameters["y_wires"] = y_wires
         self.hyperparameters["work_wires"] = work_wires
 
-        all_wires = qml.wires.Wires.all_wires([x_wires, y_wires, work_wires])
+        if work_wires:
+            all_wires = qml.wires.Wires.all_wires([x_wires, y_wires, work_wires])
+        else:
+            all_wires = qml.wires.Wires.all_wires([x_wires, y_wires])
 
         super().__init__(wires=all_wires, id=id)
 
@@ -242,6 +247,10 @@ def _semiadder(x_wires, y_wires, work_wires, **_):
 
     num_y_wires = len(y_wires)
     num_x_wires = len(x_wires)
+
+    if num_y_wires == 1:
+        qml.CNOT([x_wires[-1], y_wires[0]])
+        return
 
     x_wires_pl = x_wires[::-1][:num_y_wires]
     y_wires_pl = y_wires[::-1]

--- a/tests/templates/test_subroutines/test_semi_adder.py
+++ b/tests/templates/test_subroutines/test_semi_adder.py
@@ -37,6 +37,13 @@ class TestSemiAdder:
     @pytest.mark.parametrize(
         ("x_wires", "y_wires", "work_wires", "x", "y"),
         [
+            ([0], [1], None, 1, 0),
+            ([0], [1], None, 1, 1),
+            ([0, 1], [2], None, 0, 1),
+            ([0, 1], [2], None, 1, 1),
+            ([0, 1], [2], None, 1, 0),
+            ([0, 1], [2, 3], [4], 2, 0),
+            ([0, 1], [2, 3], [4], 1, 2),
             ([0, 1, 2], [3, 4, 5], [6, 7], 1, 2),
             ([0, 1, 2], [3, 4, 5], [6, 7], 5, 6),
             ([0, 1], [2, 3, 4], [5, 6], 3, 2),
@@ -63,15 +70,21 @@ class TestSemiAdder:
 
         output = circuit(x, y)
 
+        if len(y_wires) == 1:
+            sample = [output[0]]
+        else:
+            sample = output[0]
+
         #  check that the output sample is the binary representation of x + y mod 2^len(y_wires)
         # pylint: disable=bad-reversed-sequence
         assert np.allclose(
-            sum(bit * (2**i) for i, bit in enumerate(reversed(output[0]))),
+            sum(bit * (2**i) for i, bit in enumerate(reversed(sample))),
             (x + y) % 2 ** len(y_wires),
         )
 
-        # check work_wires are in state |0>
-        assert np.isclose(output[1][0], 1.0)
+        if work_wires:
+            # check work_wires are in state |0>
+            assert np.isclose(output[1][0], 1.0)
 
     @pytest.mark.parametrize(
         ("x_wires", "y_wires", "work_wires", "msg_match"),


### PR DESCRIPTION
**Context:**

the SemiAdder was not working in the edge case of x + y defined with a single qubit. This PR covers this situation

**Description of the Change:**

In this scenario, the semiAdder is a CNOT.
Note that in this case work_wires are not needed. So I had to change the logic that was assuming we always have work wires

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
