### PR TITLE
Deprecate `QuantumScript.shape` and `QuantumScript.numeric_type`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -10,7 +10,7 @@ Pending deprecations
 --------------------
 
 * ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` are deprecated and will be removed in version v0.44.
-  Instead, the correspoding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
+  Instead, the corresponding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
 
   - Deprecated in v0.43
   - Will be removed in v0.44

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,12 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` are deprecated and will be removed in version v0.44.
+  Instead, the correspoding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
+
+  - Deprecated in v0.43
+  - Will be removed in v0.44
+
 * Some unnecessary methods of the ``qml.CircuitGraph`` class are deprecated and will be removed in version v0.44:
 
     - ``print_contents`` in favor of ``print(obj)``

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -169,6 +169,10 @@
 
 <h3>Deprecations 👋</h3>
 
+* ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` are deprecated and will be removed in version v0.44.
+  Instead, the correspoding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
+  [(#7950)](https://github.com/PennyLaneAI/pennylane/pull/7950)
+
 * Some unnecessary methods of the `qml.CircuitGraph` class are deprecated and will be removed in version v0.44:
   [(#7904)](https://github.com/PennyLaneAI/pennylane/pull/7904)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,7 +170,7 @@
 <h3>Deprecations 👋</h3>
 
 * ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` are deprecated and will be removed in version v0.44.
-  Instead, the correspoding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
+  Instead, the corresponding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
   [(#7950)](https://github.com/PennyLaneAI/pennylane/pull/7950)
 
 * Some unnecessary methods of the `qml.CircuitGraph` class are deprecated and will be removed in version v0.44:

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -768,6 +768,11 @@ class QuantumScript:
         Returns:
             Union[tuple[int], tuple[tuple[int]]]: the output shape(s) of the quantum script result
 
+        .. warning::
+
+            The ``QuantumScript.shape`` method is deprecated and will be removed in v0.44.
+            "Instead, please use ``MeasurementProcess.shape``.
+
         **Examples**
 
         .. code-block:: pycon
@@ -812,6 +817,11 @@ class QuantumScript:
         Returns:
             Union[type, Tuple[type]]: The numeric type corresponding to the result type of the
             quantum script, or a tuple of such types if the script contains multiple measurements
+
+        .. warning::
+
+            The ``QuantumScript.numeric_type`` method is deprecated and will be removed in v0.44.
+            "Instead, please use ``MeasurementProcess.numeric_type``.
 
         **Example:**
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -771,7 +771,7 @@ class QuantumScript:
         .. warning::
 
             The ``QuantumScript.shape`` method is deprecated and will be removed in v0.44.
-            "Instead, please use ``MeasurementProcess.shape``.
+            Instead, please use ``MeasurementProcess.shape``.
 
         **Examples**
 
@@ -821,7 +821,7 @@ class QuantumScript:
         .. warning::
 
             The ``QuantumScript.numeric_type`` method is deprecated and will be removed in v0.44.
-            "Instead, please use ``MeasurementProcess.numeric_type``.
+            Instead, please use ``MeasurementProcess.numeric_type``.
 
         **Example:**
 

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -781,6 +781,12 @@ class QuantumScript:
             >>> qs.shape(dev)
             ((4,), (), (4,))
         """
+        warnings.warn(
+            "``QuantumScript.shape`` is deprecated and will be removed in v0.44. "
+            "Instead, please use ``MeasurementProcess.shape``.",
+            PennyLaneDeprecationWarning,
+        )
+
         num_device_wires = len(device.wires) if device.wires else len(self.wires)
 
         def get_shape(mp, _shots):

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -816,6 +816,12 @@ class QuantumScript:
             >>> qs.numeric_type
             complex
         """
+        warnings.warn(
+            "``QuantumScript.numeric_type`` is deprecated and will be removed in v0.44. "
+            "Instead, please use ``MeasurementProcess.numeric_type``.",
+            PennyLaneDeprecationWarning,
+        )
+
         types = tuple(observable.numeric_type for observable in self.measurements)
 
         return types[0] if len(types) == 1 else types

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -39,12 +39,12 @@ def test_to_openqasm_deprecation():
 
 def test_numeric_type_deprecation():
     """Test deprecation of the ``QuantumScript.numeric_type`` property."""
-    circuit = QuantumScript(measurements=qml.Z(0))
+    circuit = QuantumScript(measurements=[qml.sample()])
 
     with pytest.warns(
         PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
     ):
-        assert circuit.numeric_type == float
+        assert circuit.numeric_type == int
 
 
 class TestInitialization:

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -1679,8 +1679,7 @@ class TestNumericType:
         )
         herm = np.outer(arr, arr)
 
-        ret = qml.sample(qml.Hermitian(herm, wires=0))
-        qs = QuantumScript([qml.RY(0.4, 0)], [ret], shots=5)
+        qs = QuantumScript([qml.RY(0.4, 0)], [qml.sample(qml.Hermitian(herm, wires=0))], shots=5)
 
         result = qml.execute([qs], dev, diff_method=None)[0]
 

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -1651,8 +1651,7 @@ class TestNumericType:
         """Test that the tape can correctly determine the output domain for a
         sampling measurement returning samples"""
         dev = qml.device("default.qubit", wires=3, shots=5)
-        ret = qml.sample()
-        qs = QuantumScript([qml.RY(0.4, 0)], [ret], shots=5)
+        qs = QuantumScript([qml.RY(0.4, 0)], [qml.sample()], shots=5)
 
         result = qml.execute([qs], dev, diff_method=None)[0]
 

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -37,16 +37,6 @@ def test_to_openqasm_deprecation():
         circuit.to_openqasm()
 
 
-def test_numeric_type_deprecation():
-    """Test deprecation of the ``QuantumScript.numeric_type`` property."""
-    circuit = QuantumScript(measurements=[qml.sample()])
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
-    ):
-        assert circuit.numeric_type == int
-
-
 class TestInitialization:
     """Test the non-update components of intialization."""
 
@@ -1629,7 +1619,11 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert all(np.issubdtype(res.dtype, float) for res in result)
-        assert ret.numeric_type is float
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert qs.numeric_type is float
 
     @pytest.mark.parametrize(
         "ret", [qml.state(), qml.density_matrix(wires=[0, 1]), qml.density_matrix(wires=[2, 0])]
@@ -1647,7 +1641,11 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, complex)
-        assert ret.numeric_type is complex
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert qs.numeric_type is complex
 
     def test_sample_int_eigvals(self):
         """Test that the tape can correctly determine the output domain for a
@@ -1660,7 +1658,11 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, np.int64)
-        assert ret.numeric_type is int
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert qs.numeric_type is int
 
     # TODO: add cases for each interface once qml.Hermitian supports other
     # interfaces
@@ -1684,7 +1686,11 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, float)
-        assert ret.numeric_type is float
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert qs.numeric_type is float
 
     @pytest.mark.autograd
     def test_sample_real_and_int_eigvals(self):
@@ -1706,8 +1712,11 @@ class TestNumericType:
         # Double-check the domain of the QNode output
         assert np.issubdtype(result[0].dtype, float)
         assert np.issubdtype(result[1].dtype, np.int64)
-        assert m[0].numeric_type == float
-        assert m[1].numeric_type == int
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert qs.numeric_type == (float, int)
 
 
 class TestDiagonalizingGates:

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -1378,7 +1378,7 @@ class TestOutputShape:
         expectation value, variance and probability measurements with a shot
         vector."""
         if isinstance(measurements[0], qml.measurements.ProbabilityMP):
-            num_wires = set(len(m.wires) for m in measurements)
+            num_wires = {len(m.wires) for m in measurements}
             if len(num_wires) > 1:
                 pytest.skip(
                     "Multi-probs with varying number of varies when using a shot vector is to be updated in PennyLane."
@@ -1586,7 +1586,7 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert all(np.issubdtype(res.dtype, float) for res in result)
-        assert qs.numeric_type is float
+        assert ret.numeric_type is float
 
     @pytest.mark.parametrize(
         "ret", [qml.state(), qml.density_matrix(wires=[0, 1]), qml.density_matrix(wires=[2, 0])]
@@ -1604,19 +1604,20 @@ class TestNumericType:
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, complex)
-        assert qs.numeric_type is complex
+        assert ret.numeric_type is complex
 
     def test_sample_int_eigvals(self):
         """Test that the tape can correctly determine the output domain for a
         sampling measurement returning samples"""
         dev = qml.device("default.qubit", wires=3, shots=5)
-        qs = QuantumScript([qml.RY(0.4, 0)], [qml.sample()], shots=5)
+        ret = qml.sample()
+        qs = QuantumScript([qml.RY(0.4, 0)], [ret], shots=5)
 
         result = qml.execute([qs], dev, diff_method=None)[0]
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, np.int64)
-        assert qs.numeric_type is int
+        assert ret.numeric_type is int
 
     # TODO: add cases for each interface once qml.Hermitian supports other
     # interfaces
@@ -1633,13 +1634,14 @@ class TestNumericType:
         )
         herm = np.outer(arr, arr)
 
-        qs = QuantumScript([qml.RY(0.4, 0)], [qml.sample(qml.Hermitian(herm, wires=0))], shots=5)
+        ret = qml.sample(qml.Hermitian(herm, wires=0))
+        qs = QuantumScript([qml.RY(0.4, 0)], [ret], shots=5)
 
         result = qml.execute([qs], dev, diff_method=None)[0]
 
         # Double-check the domain of the QNode output
         assert np.issubdtype(result.dtype, float)
-        assert qs.numeric_type is float
+        assert ret.numeric_type is float
 
     @pytest.mark.autograd
     def test_sample_real_and_int_eigvals(self):
@@ -1661,7 +1663,8 @@ class TestNumericType:
         # Double-check the domain of the QNode output
         assert np.issubdtype(result[0].dtype, float)
         assert np.issubdtype(result[1].dtype, np.int64)
-        assert qs.numeric_type == (float, int)
+        assert m[0].numeric_type == float
+        assert m[1].numeric_type == int
 
 
 class TestDiagonalizingGates:

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -1328,7 +1328,11 @@ class TestOutputShape:
 
             else:
                 expected_shape = () if shots == 1 else (shots,)
-        assert qs.shape(dev) == expected_shape
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert qs.shape(dev) == expected_shape
 
     @pytest.mark.parametrize("measurement, expected_shape", measures)
     @pytest.mark.parametrize("shots", [None, 1, 10, (1, 2, 5, 3)])
@@ -1356,7 +1360,10 @@ class TestOutputShape:
         else:
             res_shape = res.shape
 
-        assert qs.shape(dev) == res_shape
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert qs.shape(dev) == res_shape
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("measurements, expected", multi_measurements)
@@ -1372,7 +1379,10 @@ class TestOutputShape:
             expected[1] = shots
             expected = tuple(expected)
 
-        res = qs.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = qs.shape(dev)
         assert res == expected
 
         # TODO: test diff_method is not None when the interface `execute` functions are implemented
@@ -1404,7 +1414,11 @@ class TestOutputShape:
 
         # Update expected as we're using a shotvector
         expected = tuple(expected for _ in shots)
-        res = qs.shape(dev)
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = qs.shape(dev)
         assert res == expected
 
         # TODO: test diff_method is not None when the interface `execute` functions are implemented
@@ -1431,7 +1445,10 @@ class TestOutputShape:
 
         expected = tuple(() if shots == 1 else (shots,) for _ in range(num_samples))
 
-        res = qs.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = qs.shape(dev)
         assert res == expected
 
         res = qml.execute([qs], dev, diff_method=None)[0]
@@ -1471,7 +1488,10 @@ class TestOutputShape:
             0
         ].shape
 
-        assert tape.shape(dev) == expected_shape
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == expected_shape
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("measurement, expected", measures)
@@ -1499,7 +1519,11 @@ class TestOutputShape:
         tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
         program = dev.preprocess_transforms()
         expected = qml.execute([tape], dev, diff_method=None, transform_program=program)[0]
-        actual = tape.shape(dev)
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            actual = tape.shape(dev)
 
         for exp, act in zip(expected, actual):
             assert exp.shape == act
@@ -1522,7 +1546,10 @@ class TestOutputShape:
 
         expected = tuple(tuple(() if s == 1 else (s,) for _ in range(num_samples)) for s in shots)
 
-        res = qs.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = qs.shape(dev)
         assert res == expected
 
         expected = qml.execute([qs], dev, diff_method=None)[0]
@@ -1545,7 +1572,10 @@ class TestOutputShape:
             tuple((3,) if s == 1 else (s, 3) for _ in range(num_samples)) for s in shots
         )
 
-        res = qs.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = qs.shape(dev)
         assert res == expected
 
         program = dev.preprocess_transforms()
@@ -1562,7 +1592,10 @@ class TestOutputShape:
         y = np.array([0.1, 0.2])
         tape = qml.tape.QuantumScript([qml.RY(y, 0)], [qml.expval(qml.Z(0))], shots=(1, 2, 3))
 
-        assert tape.shape(dev) == ((2,), (2,), (2,))
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == ((2,), (2,), (2,))
 
 
 class TestNumericType:

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -37,6 +37,16 @@ def test_to_openqasm_deprecation():
         circuit.to_openqasm()
 
 
+def test_numeric_type_deprecation():
+    """Test deprecation of the ``QuantumScript.numeric_type`` property."""
+    circuit = QuantumScript(measurements=qml.Z(0))
+
+    with pytest.warns(
+        PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+    ):
+        assert circuit.numeric_type == float
+
+
 class TestInitialization:
     """Test the non-update components of intialization."""
 

--- a/tests/tape/test_tape.py
+++ b/tests/tape/test_tape.py
@@ -21,7 +21,7 @@ import pytest
 
 import pennylane as qml
 from pennylane import CircuitGraph
-from pennylane.exceptions import QuantumFunctionError
+from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
 from pennylane.measurements import (
     ExpectationMP,
     MeasurementProcess,
@@ -1223,6 +1223,7 @@ class TestExecution:
             qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
 
         res = dev.execute(tape)
+
         assert res.shape == ()
 
         expected = np.sin(y) * np.cos(x)
@@ -1765,7 +1766,10 @@ class TestOutputShape:
             else:
                 expected_shape = (shots, num_wires) if shots != 1 else (num_wires,)
 
-        assert tape.shape(dev) == expected_shape
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == expected_shape
 
     @pytest.mark.parametrize("measurement, _", measures)
     @pytest.mark.parametrize("shots", [None, 1, 10, (1, 2, 5, 3)])
@@ -1809,7 +1813,11 @@ class TestOutputShape:
             res_shape = res.shape
 
         res_shape = res_shape if res_shape != tuple() else ()
-        assert tape.shape(dev) == res_shape
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == res_shape
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("measurements, expected", multi_measurements)
@@ -1833,7 +1841,10 @@ class TestOutputShape:
             expected[1] = shots
             expected = tuple(expected)
 
-        res = tape.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = tape.shape(dev)
         assert res == expected
 
         execution_results = cost(tape, dev)
@@ -1849,7 +1860,7 @@ class TestOutputShape:
         expectation value, variance and probability measurements with a shot
         vector."""
         if isinstance(measurements[0], qml.measurements.ProbabilityMP):
-            num_wires = set(len(m.wires) for m in measurements)
+            num_wires = {len(m.wires) for m in measurements}
             if len(num_wires) > 1:
                 pytest.skip(
                     "Multi-probs with varying number of varies when using a shot vector is to be updated in PennyLane."
@@ -1870,7 +1881,11 @@ class TestOutputShape:
         tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
         # Modify expected to account for shot vector
         expected = tuple(expected for _ in shots)
-        res = tape.shape(dev)
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = tape.shape(dev)
         assert res == expected
 
     @pytest.mark.autograd
@@ -1896,7 +1911,10 @@ class TestOutputShape:
         else:
             expected = tuple((shots,) for _ in range(num_samples))
 
-        res = tape.shape(dev)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = tape.shape(dev)
         assert res == expected
 
     @pytest.mark.autograd
@@ -1925,7 +1943,11 @@ class TestOutputShape:
                 expected.append(tuple((s,) for _ in range(num_samples)))
 
         expected = tuple(expected)
-        res = tape.shape(dev)
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            res = tape.shape(dev)
 
         for r, e in zip(res, expected):
             assert r == e
@@ -1956,7 +1978,11 @@ class TestOutputShape:
         tape = qml.tape.QuantumScript.from_queue(q, shots=shots)
         program = dev.preprocess_transforms()
         expected = qml.execute([tape], dev, diff_method=None, transform_program=program)[0]
-        assert tape.shape(dev) == expected.shape
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == expected.shape
 
     @pytest.mark.autograd
     @pytest.mark.parametrize("measurement, expected", measures)
@@ -1985,7 +2011,11 @@ class TestOutputShape:
         program = dev.preprocess_transforms()
         expected = qml.execute([tape], dev, diff_method=None, transform_program=program)[0]
         expected = tuple(i.shape for i in expected)
-        assert tape.shape(dev) == expected
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.shape`` is deprecated"
+        ):
+            assert tape.shape(dev) == expected
 
 
 class TestNumericType:
@@ -2015,7 +2045,11 @@ class TestNumericType:
             assert np.issubdtype(result.dtype, float)
 
         tape = qml.workflow.construct_tape(circuit)(0.3, 0.2)
-        assert tape.numeric_type is float
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type is float
 
     @pytest.mark.parametrize(
         "ret", [qml.state(), qml.density_matrix(wires=[0, 1]), qml.density_matrix(wires=[2, 0])]
@@ -2037,7 +2071,11 @@ class TestNumericType:
         assert np.issubdtype(result.dtype, complex)
 
         tape = qml.workflow.construct_tape(circuit)(0.3, 0.2)
-        assert tape.numeric_type is complex
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type is complex
 
     def test_sample_int(self):
         """Test that the tape can correctly determine the output domain for a
@@ -2055,7 +2093,11 @@ class TestNumericType:
         assert np.issubdtype(result.dtype, int)
 
         tape = qml.workflow.construct_tape(circuit)()
-        assert tape.numeric_type is int
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type is int
 
     # TODO: add cases for each interface once qml.Hermitian supports other
     # interfaces
@@ -2084,7 +2126,11 @@ class TestNumericType:
         assert np.issubdtype(result[0].dtype, float)
 
         tape = qml.workflow.construct_tape(circuit)(0.3, 0.2)
-        assert tape.numeric_type is float
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type is float
 
     @pytest.mark.autograd
     def test_sample_real_and_int_eigvals(self):
@@ -2114,7 +2160,11 @@ class TestNumericType:
         assert result[1].dtype == int
 
         tape = qml.workflow.construct_tape(circuit)(0, 3)
-        assert tape.numeric_type == (float, int)
+
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type == (float, int)
 
     def test_multi_type_measurements_numeric_type_error(self):
         """Test that querying the numeric type of a tape with several types of
@@ -2130,7 +2180,10 @@ class TestNumericType:
 
         tape = qml.tape.QuantumScript.from_queue(q)
 
-        assert tape.numeric_type == (float, float)
+        with pytest.warns(
+            PennyLaneDeprecationWarning, match="``QuantumScript.numeric_type`` is deprecated"
+        ):
+            assert tape.numeric_type == (float, float)
 
 
 class TestTapeDraw:


### PR DESCRIPTION
We don't use `QuantumScript.shape` method and `QuantumScript.numeric_type` property anymore. Much cleaner to use the corresponding method/property of the `MeasurementProcess` class instead.

[sc-95548]