### PR TITLE
Use opaque syntax for the measurement-plane attribute of the mbqc dialect

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -281,6 +281,11 @@
 * Update JAX version used in tests to `0.6.2`
   [(#7925)](https://github.com/PennyLaneAI/pennylane/pull/7925)
 
+* The measurement-plane attribute of the Python compiler `mbqc` dialect now uses the "opaque syntax"
+  format when printing in the generic IR format. This enables usage of this attribute when IR needs
+  to be passed from the python compiler to Catalyst.
+  [(#7957)](https://github.com/PennyLaneAI/pennylane/pull/7957)
+
 <h3>Documentation 📝</h3>
 
 * Improved the docstrings of all optimizers for consistency and legibility.

--- a/pennylane/compiler/python_compiler/dialects/mbqc.py
+++ b/pennylane/compiler/python_compiler/dialects/mbqc.py
@@ -24,7 +24,7 @@ catalyst/mlir/include/MBQC/IR/MBQCDialect.td file in the catalyst repository.
 from typing import TypeAlias
 
 from xdsl.dialects.builtin import I32, Float64Type, IntegerAttr, IntegerType
-from xdsl.ir import Dialect, EnumAttribute, Operation, SSAValue
+from xdsl.ir import Dialect, EnumAttribute, Operation, SpacedOpaqueSyntaxAttribute, SSAValue
 from xdsl.irdl import (
     IRDLOperation,
     irdl_attr_definition,
@@ -53,7 +53,7 @@ class MeasurementPlaneEnum(StrEnum):
 
 
 @irdl_attr_definition
-class MeasurementPlaneAttr(EnumAttribute[MeasurementPlaneEnum]):
+class MeasurementPlaneAttr(EnumAttribute[MeasurementPlaneEnum], SpacedOpaqueSyntaxAttribute):
     """Planes in the Bloch sphere representation with support for arbitrary-basis measurements"""
 
     # pylint: disable=too-few-public-methods

--- a/tests/python_compiler/dialects/test_mbqc_dialect.py
+++ b/tests/python_compiler/dialects/test_mbqc_dialect.py
@@ -86,6 +86,9 @@ def test_assembly_format(run_filecheck):
 
     // CHECK: [[mres4:%.+]], [[out_qubit4:%.+]] = mbqc.measure_in_basis{{\s*}}[XY, [[angle]]] [[qubit]] postselect 1 : i1, !quantum.bit
     %mres4, %out_qubit4 = mbqc.measure_in_basis [XY, %angle] %qubit postselect 1 : i1, !quantum.bit
+
+    // COM: Check generic format
+    %res:2 = "mbqc.measure_in_basis"(%qubit, %angle) <{plane = #mbqc<measurement_plane XY>, postselect = 0 : i32}> : (!quantum.bit, f64) -> (i1, !quantum.bit)
     """
 
     run_filecheck(program)

--- a/tests/python_compiler/dialects/test_mbqc_dialect.py
+++ b/tests/python_compiler/dialects/test_mbqc_dialect.py
@@ -88,6 +88,7 @@ def test_assembly_format(run_filecheck):
     %mres4, %out_qubit4 = mbqc.measure_in_basis [XY, %angle] %qubit postselect 1 : i1, !quantum.bit
 
     // COM: Check generic format
+    // CHECK: {{%.+}}, {{%.+}} = mbqc.measure_in_basis[XY, [[angle]]] [[qubit]] postselect 0 : i1, !quantum.bit
     %res:2 = "mbqc.measure_in_basis"(%qubit, %angle) <{plane = #mbqc<measurement_plane XY>, postselect = 0 : i32}> : (!quantum.bit, f64) -> (i1, !quantum.bit)
     """
 


### PR DESCRIPTION
**Context:** The generic format of attributes in xDSL and in MLIR need to agree in order for the output of a Python compiler pass to be used as input to Catalyst. As such, the measurement-plane attribute of the `mbqc` dialect needs to be output in the "opaque" format. For example, the generic format of an `mbqc.measure_in_basis` op should be

```mlir
%res:2 = "mbqc.measure_in_basis"(%qbit, %angle) <{plane = #mbqc<measurement_plane XY>, postselect = 0 : i32}> : (!quantum.bit, f64) -> (i1, !quantum.bit)
```

Previously, without the opaque format, the `plane` attribute was output as

```mlir
<{plane = #mbqc.measurement_planeXY}>
```

which is incompatible with the attribute as defined in Catalyst.

**Description of the Change:** The class `MeasurementPlaneAttr` now also inherits from the `SpacedOpaqueSyntaxAttribute` class so that it uses the opaque format for its generic output.

**Benefits:** Unblocks usage of `mbqc.measure_in_basis` ops in the python compiler and in Catalyst.