### PR TITLE
sc-96250-orphan-directive-showing-up-on-release-pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -138,7 +138,7 @@ today_fmt = "%Y-%m-%d"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "releases/*.md"]
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.

--- a/doc/releases/changelog-0.1.0.md
+++ b/doc/releases/changelog-0.1.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.1.0
 

--- a/doc/releases/changelog-0.1.0.md
+++ b/doc/releases/changelog-0.1.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.1.0
 

--- a/doc/releases/changelog-0.1.0.md
+++ b/doc/releases/changelog-0.1.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.1.0
 

--- a/doc/releases/changelog-0.10.0.md
+++ b/doc/releases/changelog-0.10.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.10.0
 

--- a/doc/releases/changelog-0.10.0.md
+++ b/doc/releases/changelog-0.10.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.10.0
 

--- a/doc/releases/changelog-0.10.0.md
+++ b/doc/releases/changelog-0.10.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.10.0
 

--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.11.0
 

--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.11.0
 

--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.11.0
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.12.0
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.12.0
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.12.0
 

--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.13.0
 

--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.13.0
 

--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.13.0
 

--- a/doc/releases/changelog-0.14.0.md
+++ b/doc/releases/changelog-0.14.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.14.0
 

--- a/doc/releases/changelog-0.14.0.md
+++ b/doc/releases/changelog-0.14.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.14.0
 

--- a/doc/releases/changelog-0.14.0.md
+++ b/doc/releases/changelog-0.14.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.14.0
 

--- a/doc/releases/changelog-0.14.1.md
+++ b/doc/releases/changelog-0.14.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.14.1
 

--- a/doc/releases/changelog-0.14.1.md
+++ b/doc/releases/changelog-0.14.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.14.1
 

--- a/doc/releases/changelog-0.14.1.md
+++ b/doc/releases/changelog-0.14.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.14.1
 

--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.15.0
 

--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.15.0
 

--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.15.0
 

--- a/doc/releases/changelog-0.15.1.md
+++ b/doc/releases/changelog-0.15.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.15.1
 

--- a/doc/releases/changelog-0.15.1.md
+++ b/doc/releases/changelog-0.15.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.15.1
 

--- a/doc/releases/changelog-0.15.1.md
+++ b/doc/releases/changelog-0.15.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.15.1
 

--- a/doc/releases/changelog-0.16.0.md
+++ b/doc/releases/changelog-0.16.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.16.0
 

--- a/doc/releases/changelog-0.16.0.md
+++ b/doc/releases/changelog-0.16.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.16.0
 

--- a/doc/releases/changelog-0.16.0.md
+++ b/doc/releases/changelog-0.16.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.16.0
 

--- a/doc/releases/changelog-0.17.0.md
+++ b/doc/releases/changelog-0.17.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.17.0
 

--- a/doc/releases/changelog-0.17.0.md
+++ b/doc/releases/changelog-0.17.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.17.0
 

--- a/doc/releases/changelog-0.17.0.md
+++ b/doc/releases/changelog-0.17.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.17.0
 

--- a/doc/releases/changelog-0.18.0.md
+++ b/doc/releases/changelog-0.18.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.18.0
 

--- a/doc/releases/changelog-0.18.0.md
+++ b/doc/releases/changelog-0.18.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.18.0
 

--- a/doc/releases/changelog-0.18.0.md
+++ b/doc/releases/changelog-0.18.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.18.0
 

--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.19.0
 

--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.19.0
 

--- a/doc/releases/changelog-0.19.0.md
+++ b/doc/releases/changelog-0.19.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.19.0
 

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.19.1
 

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.19.1
 

--- a/doc/releases/changelog-0.19.1.md
+++ b/doc/releases/changelog-0.19.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.19.1
 

--- a/doc/releases/changelog-0.2.0.md
+++ b/doc/releases/changelog-0.2.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.2.0
 

--- a/doc/releases/changelog-0.2.0.md
+++ b/doc/releases/changelog-0.2.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.2.0
 

--- a/doc/releases/changelog-0.2.0.md
+++ b/doc/releases/changelog-0.2.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.2.0
 

--- a/doc/releases/changelog-0.20.0.md
+++ b/doc/releases/changelog-0.20.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.20.0
 

--- a/doc/releases/changelog-0.20.0.md
+++ b/doc/releases/changelog-0.20.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.20.0
 

--- a/doc/releases/changelog-0.20.0.md
+++ b/doc/releases/changelog-0.20.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.20.0
 

--- a/doc/releases/changelog-0.21.0.md
+++ b/doc/releases/changelog-0.21.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.21.0
 

--- a/doc/releases/changelog-0.21.0.md
+++ b/doc/releases/changelog-0.21.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.21.0
 

--- a/doc/releases/changelog-0.21.0.md
+++ b/doc/releases/changelog-0.21.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.21.0
 

--- a/doc/releases/changelog-0.22.0.md
+++ b/doc/releases/changelog-0.22.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.22.0
 

--- a/doc/releases/changelog-0.22.0.md
+++ b/doc/releases/changelog-0.22.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.22.0
 

--- a/doc/releases/changelog-0.22.0.md
+++ b/doc/releases/changelog-0.22.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.22.0
 

--- a/doc/releases/changelog-0.22.1.md
+++ b/doc/releases/changelog-0.22.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.22.1
 

--- a/doc/releases/changelog-0.22.1.md
+++ b/doc/releases/changelog-0.22.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.22.1
 

--- a/doc/releases/changelog-0.22.1.md
+++ b/doc/releases/changelog-0.22.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.22.1
 

--- a/doc/releases/changelog-0.22.2.md
+++ b/doc/releases/changelog-0.22.2.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.22.2
 

--- a/doc/releases/changelog-0.22.2.md
+++ b/doc/releases/changelog-0.22.2.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.22.2
 

--- a/doc/releases/changelog-0.22.2.md
+++ b/doc/releases/changelog-0.22.2.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.22.2
 

--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.23.0
 

--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.23.0
 

--- a/doc/releases/changelog-0.23.0.md
+++ b/doc/releases/changelog-0.23.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.23.0
 

--- a/doc/releases/changelog-0.23.1.md
+++ b/doc/releases/changelog-0.23.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.23.1
 

--- a/doc/releases/changelog-0.23.1.md
+++ b/doc/releases/changelog-0.23.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.23.1
 

--- a/doc/releases/changelog-0.23.1.md
+++ b/doc/releases/changelog-0.23.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.23.1
 

--- a/doc/releases/changelog-0.24.0.md
+++ b/doc/releases/changelog-0.24.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.24.0
 

--- a/doc/releases/changelog-0.24.0.md
+++ b/doc/releases/changelog-0.24.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.24.0
 

--- a/doc/releases/changelog-0.24.0.md
+++ b/doc/releases/changelog-0.24.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.24.0
 

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.25.0
 

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.25.0
 

--- a/doc/releases/changelog-0.25.0.md
+++ b/doc/releases/changelog-0.25.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.25.0
 

--- a/doc/releases/changelog-0.25.1.md
+++ b/doc/releases/changelog-0.25.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.25.1
 

--- a/doc/releases/changelog-0.25.1.md
+++ b/doc/releases/changelog-0.25.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.25.1
 

--- a/doc/releases/changelog-0.25.1.md
+++ b/doc/releases/changelog-0.25.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.25.1
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.26.0
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.26.0
 

--- a/doc/releases/changelog-0.26.0.md
+++ b/doc/releases/changelog-0.26.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.26.0
 

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.27.0
 

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.27.0
 

--- a/doc/releases/changelog-0.27.0.md
+++ b/doc/releases/changelog-0.27.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.27.0
 

--- a/doc/releases/changelog-0.28.0.md
+++ b/doc/releases/changelog-0.28.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.28.0
 

--- a/doc/releases/changelog-0.28.0.md
+++ b/doc/releases/changelog-0.28.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.28.0
 

--- a/doc/releases/changelog-0.28.0.md
+++ b/doc/releases/changelog-0.28.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.28.0
 

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.29.0
 

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.29.0
 

--- a/doc/releases/changelog-0.29.0.md
+++ b/doc/releases/changelog-0.29.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.29.0
 

--- a/doc/releases/changelog-0.3.0.md
+++ b/doc/releases/changelog-0.3.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.3.0
 

--- a/doc/releases/changelog-0.3.0.md
+++ b/doc/releases/changelog-0.3.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.3.0
 

--- a/doc/releases/changelog-0.3.0.md
+++ b/doc/releases/changelog-0.3.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.3.0
 

--- a/doc/releases/changelog-0.3.1.md
+++ b/doc/releases/changelog-0.3.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.3.1
 

--- a/doc/releases/changelog-0.3.1.md
+++ b/doc/releases/changelog-0.3.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.3.1
 

--- a/doc/releases/changelog-0.3.1.md
+++ b/doc/releases/changelog-0.3.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.3.1
 

--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.30.0
 

--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.30.0
 

--- a/doc/releases/changelog-0.30.0.md
+++ b/doc/releases/changelog-0.30.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.30.0
 

--- a/doc/releases/changelog-0.31.0.md
+++ b/doc/releases/changelog-0.31.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.31.0
 

--- a/doc/releases/changelog-0.31.0.md
+++ b/doc/releases/changelog-0.31.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.31.0
 

--- a/doc/releases/changelog-0.31.0.md
+++ b/doc/releases/changelog-0.31.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.31.0
 

--- a/doc/releases/changelog-0.31.1.md
+++ b/doc/releases/changelog-0.31.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.31.1
 

--- a/doc/releases/changelog-0.31.1.md
+++ b/doc/releases/changelog-0.31.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.31.1
 

--- a/doc/releases/changelog-0.31.1.md
+++ b/doc/releases/changelog-0.31.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.31.1
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.32.0
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.32.0
 

--- a/doc/releases/changelog-0.32.0.md
+++ b/doc/releases/changelog-0.32.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.32.0
 

--- a/doc/releases/changelog-0.33.0.md
+++ b/doc/releases/changelog-0.33.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.33.0
 

--- a/doc/releases/changelog-0.33.0.md
+++ b/doc/releases/changelog-0.33.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.33.0
 

--- a/doc/releases/changelog-0.33.0.md
+++ b/doc/releases/changelog-0.33.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.33.0
 

--- a/doc/releases/changelog-0.33.1.md
+++ b/doc/releases/changelog-0.33.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.33.1
 

--- a/doc/releases/changelog-0.33.1.md
+++ b/doc/releases/changelog-0.33.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.33.1
 

--- a/doc/releases/changelog-0.33.1.md
+++ b/doc/releases/changelog-0.33.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.33.1
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.34.0
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.34.0
 

--- a/doc/releases/changelog-0.34.0.md
+++ b/doc/releases/changelog-0.34.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.34.0
 

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.35.0
 

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.35.0
 

--- a/doc/releases/changelog-0.35.0.md
+++ b/doc/releases/changelog-0.35.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.35.0
 

--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.35.1
 

--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.35.1
 

--- a/doc/releases/changelog-0.35.1.md
+++ b/doc/releases/changelog-0.35.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.35.1
 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.36.0
 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.36.0
 

--- a/doc/releases/changelog-0.36.0.md
+++ b/doc/releases/changelog-0.36.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.36.0
 

--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.37.0
 

--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.37.0
 

--- a/doc/releases/changelog-0.37.0.md
+++ b/doc/releases/changelog-0.37.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.37.0
 

--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.38.0
 

--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.38.0
 

--- a/doc/releases/changelog-0.38.0.md
+++ b/doc/releases/changelog-0.38.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.38.0
 

--- a/doc/releases/changelog-0.39.0.md
+++ b/doc/releases/changelog-0.39.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.39.0
 

--- a/doc/releases/changelog-0.39.0.md
+++ b/doc/releases/changelog-0.39.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.39.0
 

--- a/doc/releases/changelog-0.39.0.md
+++ b/doc/releases/changelog-0.39.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.39.0
 

--- a/doc/releases/changelog-0.4.0.md
+++ b/doc/releases/changelog-0.4.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.4.0
 

--- a/doc/releases/changelog-0.4.0.md
+++ b/doc/releases/changelog-0.4.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.4.0
 

--- a/doc/releases/changelog-0.4.0.md
+++ b/doc/releases/changelog-0.4.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.4.0
 

--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.40.0
 

--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.40.0
 

--- a/doc/releases/changelog-0.40.0.md
+++ b/doc/releases/changelog-0.40.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.40.0
 

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.41.0
 

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.41.0
 

--- a/doc/releases/changelog-0.41.0.md
+++ b/doc/releases/changelog-0.41.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.41.0
 

--- a/doc/releases/changelog-0.41.1.md
+++ b/doc/releases/changelog-0.41.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.41.1
 

--- a/doc/releases/changelog-0.41.1.md
+++ b/doc/releases/changelog-0.41.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.41.1
 

--- a/doc/releases/changelog-0.41.1.md
+++ b/doc/releases/changelog-0.41.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.41.1
 

--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.42.0 (current release)
 

--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.42.0 (current release)
 

--- a/doc/releases/changelog-0.42.0.md
+++ b/doc/releases/changelog-0.42.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.42.0 (current release)
 

--- a/doc/releases/changelog-0.5.0.md
+++ b/doc/releases/changelog-0.5.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.5.0
 

--- a/doc/releases/changelog-0.5.0.md
+++ b/doc/releases/changelog-0.5.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.5.0
 

--- a/doc/releases/changelog-0.5.0.md
+++ b/doc/releases/changelog-0.5.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.5.0
 

--- a/doc/releases/changelog-0.6.0.md
+++ b/doc/releases/changelog-0.6.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.6.0
 

--- a/doc/releases/changelog-0.6.0.md
+++ b/doc/releases/changelog-0.6.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.6.0
 

--- a/doc/releases/changelog-0.6.0.md
+++ b/doc/releases/changelog-0.6.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.6.0
 

--- a/doc/releases/changelog-0.6.1.md
+++ b/doc/releases/changelog-0.6.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.6.1
 

--- a/doc/releases/changelog-0.6.1.md
+++ b/doc/releases/changelog-0.6.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.6.1
 

--- a/doc/releases/changelog-0.6.1.md
+++ b/doc/releases/changelog-0.6.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.6.1
 

--- a/doc/releases/changelog-0.7.0.md
+++ b/doc/releases/changelog-0.7.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.7.0
 

--- a/doc/releases/changelog-0.7.0.md
+++ b/doc/releases/changelog-0.7.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.7.0
 

--- a/doc/releases/changelog-0.7.0.md
+++ b/doc/releases/changelog-0.7.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.7.0
 

--- a/doc/releases/changelog-0.8.0.md
+++ b/doc/releases/changelog-0.8.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.8.0
 

--- a/doc/releases/changelog-0.8.0.md
+++ b/doc/releases/changelog-0.8.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.8.0
 

--- a/doc/releases/changelog-0.8.0.md
+++ b/doc/releases/changelog-0.8.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.8.0
 

--- a/doc/releases/changelog-0.8.1.md
+++ b/doc/releases/changelog-0.8.1.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.8.1
 

--- a/doc/releases/changelog-0.8.1.md
+++ b/doc/releases/changelog-0.8.1.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.8.1
 

--- a/doc/releases/changelog-0.8.1.md
+++ b/doc/releases/changelog-0.8.1.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.8.1
 

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.9.0
 

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.9.0
 

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.9.0
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,4 +1,3 @@
-:orphan:
 
 # Release 0.43.0-dev (development release)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,4 +1,3 @@
-<!-- orphan: true -->
 
 # Release 0.43.0-dev (development release)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,3 +1,4 @@
+<!-- orphan: true -->
 
 # Release 0.43.0-dev (development release)
 


### PR DESCRIPTION
## Ticket
- [sc-96250-orphan-directive-showing-up-on-release-pages](https://app.shortcut.com/xanaduai/story/96250/orphan-directive-showing-up-on-release-pages)

## Issue
- `:orphan:` directive is not working as expected (could be with the sphinx upgrade), Therefore its showing up on release pages as text.
<img width="974" height="262" alt="Screenshot 2025-07-24 at 4 57 46 PM" src="https://github.com/user-attachments/assets/473337b1-36a0-47f9-8541-7f0ce15c60ef" />


## Fix
-  Since these pages are included using `mdinclude::` directive they are part of `toctree` but not recognized by sphinx which throws a warning when `orphan` directive is used.
- To prevent warnings when removing `:orphan:` directive from `.md` pages, added it to config in `exclude_patterns`since we are manually including them.

## Testing
- Check that Release Notes on PR preview work as expected
- https://xanaduai-pennylane--7958.com.readthedocs.build/en/7958/development/release_notes.html

<img width="940" height="313" alt="Screenshot 2025-07-24 at 5 01 38 PM" src="https://github.com/user-attachments/assets/6b951235-419e-4bb3-a254-af5a9fe1d20e" />
