### PR TITLE
Update how submodules are import top-level

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -232,7 +232,7 @@
 
 * Update PennyLane's top-level `__init__.py` file imports to improve Python language server support for finding
   PennyLane submodules.
-  [(#)]()
+  [(#7959)](https://github.com/PennyLaneAI/pennylane/pull/7959)
 
 * Adds `measurements` as a "core" module in the tach specification.
  [(#7945)](https://github.com/PennyLaneAI/pennylane/pull/7945)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,6 +230,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Update PennyLane's top-level `__init__.py` file imports to improve Python language server support for finding
+  PennyLane submodules.
+  [(#)]()
+
 * Adds `measurements` as a "core" module in the tach specification.
  [(#7945)](https://github.com/PennyLaneAI/pennylane/pull/7945)
 

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -17,21 +17,21 @@ PennyLane can be directly imported.
 """
 import warnings
 
-import pennylane.exceptions
+from pennylane import exceptions
 from pennylane.boolean_fn import BooleanFn
-import pennylane.numpy
+from pennylane import numpy
 from pennylane.queuing import QueuingManager, apply
 
-import pennylane.compiler
+from pennylane import compiler
 from pennylane.compiler import qjit
-import pennylane.capture
-import pennylane.control_flow
+from pennylane import capture
+from pennylane import control_flow
 from pennylane.control_flow import for_loop, while_loop
-import pennylane.kernels
-import pennylane.math
-import pennylane.operation
-import pennylane.allocation
-import pennylane.decomposition
+from pennylane import kernels
+from pennylane import math
+from pennylane import operation
+from pennylane import allocation
+from pennylane import decomposition
 from pennylane.decomposition import (
     register_resources,
     register_condition,
@@ -39,12 +39,12 @@ from pennylane.decomposition import (
     list_decomps,
     resource_rep,
 )
-import pennylane.templates
-import pennylane.pauli
+from pennylane import templates
+from pennylane import pauli
 from pennylane.pauli import pauli_decompose
 from pennylane.resource import specs
-import pennylane.resource
-import pennylane.qchem
+from pennylane import resource
+from pennylane import qchem
 from pennylane.fermi import (
     FermiC,
     FermiA,
@@ -103,6 +103,7 @@ from pennylane.templates.state_preparations import *
 from pennylane.templates.subroutines import *
 from pennylane import qaoa
 from pennylane.workflow import QNode, qnode, execute, set_shots
+from pennylane import workflow
 from pennylane.io import (
     from_pyquil,
     from_qasm,
@@ -170,29 +171,29 @@ from pennylane.debugging import (
 )
 from pennylane.shadows import ClassicalShadow
 from pennylane.qcut import cut_circuit, cut_circuit_mc
-import pennylane.pulse
+from pennylane import pulse
 
-import pennylane.fourier
+from pennylane import fourier
 from pennylane.gradients import metric_tensor, adjoint_metric_tensor
-import pennylane.gradients  # pylint:disable=wrong-import-order
+from pennylane import gradients  # pylint:disable=wrong-import-order
 from pennylane.drawer import draw, draw_mpl
 
 # pylint:disable=wrong-import-order
-import pennylane.logging  # pylint:disable=wrong-import-order
+from pennylane import logging  # pylint:disable=wrong-import-order
 
-import pennylane.data
+from pennylane import data
 
-import pennylane.noise
+from pennylane import noise
 from pennylane.noise import NoiseModel
 
 from pennylane.devices import Tracker
 from pennylane.devices.device_constructor import device, refresh_devices
 
-import pennylane.spin
+from pennylane import spin
 
-import pennylane.liealg
+from pennylane import liealg
 from pennylane.liealg import lie_closure, structure_constants, center
-import pennylane.qnn
+from pennylane import qnn
 
 # Look for an existing configuration file
 default_config = Configuration("config.toml")
@@ -201,7 +202,10 @@ default_config = Configuration("config.toml")
 def __getattr__(name):
 
     if name == "plugin_devices":
-        return pennylane.devices.device_constructor.plugin_devices
+        # pylint: disable=import-outside-toplevel
+        from pennylane.devices.device_constructor import plugin_devices
+
+        return plugin_devices
 
     raise AttributeError(f"module 'pennylane' has no attribute '{name}'")
 


### PR DESCRIPTION
Going to class/function definitions using language servers such as Pylance on VSCode does not work well in PennyLane because of the style we use for importing submodules. This PR changes the import style from `import pennylane.potato` to `from pennylane import potato`. This makes `potato` discoverable to language servers, drastically improving developer experience with PennyLane.

**Breaking change:**
`qml.pennylane` is no longer accessible. On `master`:
```pycon
>>> import pennylane as qml
>>> qml.pennylane
<module 'pennylane' from '/Users/mudit.pandey/repos/pennylane/pennylane/__init__.py'>
```

On this branch:
```pycon
>>> import pennylane as qml
>>> qml.pennylane
AttributeError: module 'pennylane' has no attribute 'pennylane'
```

There are many PL submodules that are missing from the top-level init file, listed below. They may or may not be added to the `__init__` file.

- [ ] qml.bose
- [ ] qml.concurrency
- [ ] qml.debugging
- [ ] qml.devices
- [ ] qml.drawer
- [ ] qml.fermi
- [ ] qml.io
- [ ] qml.measurements
- [ ] qml.ops
- [ ] qml.optimize
- [ ] qml.pytrees
- [ ] qml.qcut
- [ ] qml.shadows
- [ ] qml.tape
- [ ] qml.transforms
- [ ] qml.workflow
- [ ] qml.queuing
- [ ] qml.typing
- [ ] qml.wires

[sc-96255]