### PR TITLE
Add `isort` and `black` to use config from `pyproject.toml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,8 @@ repos:
     - id: black
       name: "🐍 black · Format code"
       args: [
-              "--line-length=100",
-              "-t", "py311",
-              "-t", "py312",
-              "-t", "py313",
+              "--config",
+              "./pyproject.toml",
             ]
       exclude: ^doc/
 -   repo: https://github.com/PyCQA/isort
@@ -23,19 +21,8 @@ repos:
       name: "🐍 isort · Sort imports"
       args:
         [
-          "--py",
-          "311",
-          "--profile",
-          "black",
-          "-l",
-          "100",
-          "-o",
-          "autoray",
-          "-p",
-          "./pennylane",
-          "--skip",
-          "__init__.py",
-          "--filter-files",
+          "--settings-path",
+          "./pyproject.toml",
         ]
       files: ^(pennylane/|tests/)
 -   repo: https://github.com/gauge-sh/tach-pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,16 @@ pennylane = ["devices/tests/pytest.ini", "drawer/plot.mplstyle"]
 line-length = 100
 include = '\.pyi?$'
 
+[tool.isort]
+py_version = 311
+profile = "black"
+line_length = 100
+known_third_party = ["autoray"]
+known_first_party = ["pennylane"]
+skip = ["__init__.py"]
+filter_files = true
+include = '\.pyi?$'
+
 [tool.bandit]
 targets = "pennylane"
 exclude_dirs = ["tests", "pennylane/labs/tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ pennylane = ["devices/tests/pytest.ini", "drawer/plot.mplstyle"]
 
 [tool.black]
 line-length = 100
+target-version = ["py311", "py312", "py313"]
 include = '\.pyi?$'
 
 [tool.isort]
@@ -98,7 +99,6 @@ known_third_party = ["autoray"]
 known_first_party = ["pennylane"]
 skip = ["__init__.py"]
 filter_files = true
-include = '\.pyi?$'
 
 [tool.bandit]
 targets = "pennylane"


### PR DESCRIPTION
We want to have a single source of truth for the config of our tooling.

* Update `pyproject.toml` with `isort` and `black` config
* Update `pre-commit-config.yaml` to use `pyproject.toml` as the source of truth for the config for `isort` and `black`

I confirmed locally that the updated pre-commit hook is able to pull the config from `pyproject.toml` correctly.

[sc-96260]