### PR TITLE
Small refactor of `queue` method for `ResourceOperators`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -165,6 +165,10 @@
 * Added state of the art resources for the `ResourceQFT` and `ResourceAQFT` templates.
   [(#7920)](https://github.com/PennyLaneAI/pennylane/pull/7920)
 
+* Added an internal `dequeue()` method to the `ResourceOperator` class to simplify the 
+  instantiation of resource operators which require resource operators as input.
+  [(#7974)](https://github.com/PennyLaneAI/pennylane/pull/7974)
+
 * The `catalyst` xDSL dialect has been added to the Python compiler, which contains data structures that support core compiler functionality.
   [(#7901)](https://github.com/PennyLaneAI/pennylane/pull/7901)
 

--- a/pennylane/labs/resource_estimation/ops/op_math/symbolic.py
+++ b/pennylane/labs/resource_estimation/ops/op_math/symbolic.py
@@ -92,7 +92,8 @@ class ResourceAdjoint(ResourceOperator):
     resource_keys = {"base_cmpr_op"}
 
     def __init__(self, base_op: ResourceOperator, wires=None) -> None:
-        self.queue(remove_op=base_op)
+        self.dequeue(op_to_remove=base_op)
+        self.queue()
         base_cmpr_op = base_op.resource_rep_from_op()
 
         self.base_op = base_cmpr_op
@@ -103,12 +104,6 @@ class ResourceAdjoint(ResourceOperator):
         else:
             self.wires = None or base_op.wires
             self.num_wires = base_op.num_wires
-
-    def queue(self, remove_op, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        context.remove(remove_op)
-        context.append(self)
-        return self
 
     @property
     def resource_params(self) -> dict:
@@ -301,7 +296,8 @@ class ResourceControlled(ResourceOperator):
         num_ctrl_values: int,
         wires=None,
     ) -> None:
-        self.queue(remove_base_op=base_op)
+        self.dequeue(op_to_remove=base_op)
+        self.queue()
         base_cmpr_op = base_op.resource_rep_from_op()
 
         self.base_op = base_cmpr_op
@@ -315,12 +311,6 @@ class ResourceControlled(ResourceOperator):
             self.wires = None
             num_base_wires = base_op.num_wires
             self.num_wires = num_ctrl_wires + num_base_wires
-
-    def queue(self, remove_base_op, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        context.remove(remove_base_op)
-        context.append(self)
-        return self
 
     @property
     def resource_params(self) -> dict:
@@ -569,7 +559,8 @@ class ResourcePow(ResourceOperator):
     resource_keys = {"base_cmpr_op", "z"}
 
     def __init__(self, base_op: ResourceOperator, z: int, wires=None) -> None:
-        self.queue(remove_op=base_op)
+        self.dequeue(op_to_remove=base_op)
+        self.queue()
         base_cmpr_op = base_op.resource_rep_from_op()
 
         self.z = z
@@ -581,12 +572,6 @@ class ResourcePow(ResourceOperator):
         else:
             self.wires = None or base_op.wires
             self.num_wires = base_op.num_wires
-
-    def queue(self, remove_op, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        context.remove(remove_op)
-        context.append(self)
-        return self
 
     @property
     def resource_params(self) -> dict:
@@ -782,7 +767,8 @@ class ResourceProd(ResourceOperator):
             ops.append(op)
             counts.append(count)
 
-        self.queue(ops)
+        self.dequeue(op_to_remove=ops)
+        self.queue()
 
         try:
             cmpr_ops = tuple(op.resource_rep_from_op() for op in ops)
@@ -804,13 +790,6 @@ class ResourceProd(ResourceOperator):
             else:
                 self.wires = Wires.all_wires(ops_wires)
                 self.num_wires = len(self.wires)
-
-    def queue(self, ops_to_remove, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        for op in ops_to_remove:
-            context.remove(op)
-        context.append(self)
-        return self
 
     @property
     def resource_params(self) -> dict:
@@ -962,7 +941,8 @@ class ResourceChangeBasisOp(ResourceOperator):
         uncompute_op = uncompute_op or ResourceAdjoint(compute_op)
         ops_to_remove = [compute_op, base_op, uncompute_op]
 
-        self.queue(ops_to_remove)
+        self.dequeue(op_to_remove=ops_to_remove)
+        self.queue()
 
         try:
             self.cmpr_compute_op = compute_op.resource_rep_from_op()
@@ -985,13 +965,6 @@ class ResourceChangeBasisOp(ResourceOperator):
             else:
                 self.wires = Wires.all_wires(ops_wires)
                 self.num_wires = len(self.wires)
-
-    def queue(self, ops_to_remove, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        for op in ops_to_remove:
-            context.remove(op)
-        context.append(self)
-        return self
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/labs/resource_estimation/ops/op_math/symbolic.py
+++ b/pennylane/labs/resource_estimation/ops/op_math/symbolic.py
@@ -24,7 +24,6 @@ from pennylane.labs.resource_estimation.resource_operator import (
     ResourcesNotDefined,
     resource_rep,
 )
-from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires
 
 # pylint: disable=too-many-ancestors,arguments-differ,protected-access,too-many-arguments,too-many-positional-arguments,super-init-not-called

--- a/pennylane/labs/resource_estimation/resource_operator.py
+++ b/pennylane/labs/resource_estimation/resource_operator.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Iterable
 from inspect import signature
+from typing import Union
 
 import numpy as np
 
@@ -210,6 +211,18 @@ class ResourceOperator(ABC):
         """Append the operator to the Operator queue."""
         context.append(self)
         return self
+
+    @staticmethod
+    def dequeue(
+        op_to_remove: Union["ResourceOperator", Iterable],
+        context: QueuingManager = QueuingManager,
+    ):
+        """Remove the given resource operator(s) from the Operator queue."""
+        if not isinstance(op_to_remove, Iterable):
+            op_to_remove = [op_to_remove]
+
+        for op in op_to_remove:
+            context.remove(op)
 
     @classproperty
     @classmethod

--- a/pennylane/labs/resource_estimation/templates/subroutines.py
+++ b/pennylane/labs/resource_estimation/templates/subroutines.py
@@ -24,7 +24,6 @@ from pennylane.labs.resource_estimation.resource_operator import (
     ResourceOperator,
     resource_rep,
 )
-from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires
 
 # pylint: disable=arguments-differ,protected-access,too-many-arguments,unused-argument,super-init-not-called

--- a/pennylane/labs/resource_estimation/templates/subroutines.py
+++ b/pennylane/labs/resource_estimation/templates/subroutines.py
@@ -914,7 +914,8 @@ class ResourceSelect(ResourceOperator):
     resource_keys = {"cmpr_ops"}
 
     def __init__(self, select_ops, wires=None) -> None:
-        self.queue(select_ops)
+        self.dequeue(op_to_remove=select_ops)
+        self.queue()
         num_select_ops = len(select_ops)
         num_ctrl_wires = math.ceil(math.log2(num_select_ops))
 
@@ -937,13 +938,6 @@ class ResourceSelect(ResourceOperator):
             else:
                 self.wires = Wires.all_wires(ops_wires)
                 self.num_wires = len(self.wires) + num_ctrl_wires
-
-    def queue(self, ops_to_remove, context: QueuingManager = QueuingManager):
-        """Append the operator to the Operator queue."""
-        for op in ops_to_remove:
-            context.remove(op)
-        context.append(self)
-        return self
 
     @classmethod
     def default_resource_decomp(cls, cmpr_ops, **kwargs):  # pylint: disable=unused-argument

--- a/pennylane/labs/tests/resource_estimation/test_resource_operator.py
+++ b/pennylane/labs/tests/resource_estimation/test_resource_operator.py
@@ -184,14 +184,17 @@ class DummyOp(ResourceOperator):
 
     @property
     def resource_params(self):
+        """dummy resource params method"""
         return {"x": self.x}
 
     @classmethod
     def resource_rep(cls, x):
+        """dummy resource rep method"""
         return DummyCmprsRep(cls.__name__, param=x)
 
     @classmethod
     def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
         return [x]
 
 
@@ -204,10 +207,12 @@ class DummyOp_no_resource_rep(ResourceOperator):
 
     @property
     def resource_params(self):
+        """dummy resource params method"""
         return DummyCmprsRep({"x": self.x})
 
     @classmethod
     def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
         return [x]
 
 
@@ -220,10 +225,12 @@ class DummyOp_no_resource_params(ResourceOperator):
 
     @classmethod
     def resource_rep(cls, x):
+        """dummy resource rep method"""
         return DummyCmprsRep(cls.__name__, param=x)
 
     @classmethod
     def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
         return [x]
 
 
@@ -236,10 +243,12 @@ class DummyOp_no_resource_decomp(ResourceOperator):
 
     @classmethod
     def resource_rep(cls, x):
+        """dummy resource rep method"""
         return DummyCmprsRep(cls.__name__, param=x)
 
     @property
     def resource_params(self):
+        """dummy resource params method"""
         return DummyCmprsRep({"x": self.x})
 
 
@@ -497,6 +506,7 @@ def test_set_adj_decomp():
 
         @classmethod
         def default_adjoint_resource_decomp(cls, x):
+            """dummy adjoint resource decomp method"""
             return cls.default_resource_decomp(x=x)
 
     op1 = DummyAdjOp(x=5)
@@ -524,6 +534,7 @@ def test_set_ctrl_decomp():
 
         @classmethod
         def default_controlled_resource_decomp(cls, ctrl_num_ctrl_wires, ctrl_num_ctrl_values, x):
+            """dummy control resource decomp method"""
             return cls.default_resource_decomp(x=x + ctrl_num_ctrl_values)
 
     op1 = DummyCtrlOp(x=5)
@@ -551,6 +562,7 @@ def test_set_pow_decomp():
 
         @classmethod
         def default_pow_resource_decomp(cls, pow_z, x):
+            """dummy adjoint resource decomp method"""
             return cls.default_resource_decomp(x=x)
 
     op1 = DummyPowOp(x=5)
@@ -650,6 +662,7 @@ def test_resource_rep():
 
         @classmethod
         def default_resource_decomp(cls, num_wires, continuous_param, bool_param):
+            """dummy default resource decomp method"""
             raise NotImplementedError
 
     class ResourceOpB(ResourceOperator):
@@ -669,6 +682,7 @@ def test_resource_rep():
 
         @classmethod
         def default_resource_decomp(cls, **kwargs):
+            """dummy default resource decomp method"""
             raise NotImplementedError
 
     expected_resource_rep_A = CompressedResourceOp(

--- a/pennylane/labs/tests/resource_estimation/test_resource_operator.py
+++ b/pennylane/labs/tests/resource_estimation/test_resource_operator.py
@@ -37,7 +37,7 @@ from pennylane.labs.resource_estimation.resource_operator import (
     _make_hashable,
     resource_rep,
 )
-from pennylane.queuing import AnnotatedQueue, QueuingManager
+from pennylane.queuing import AnnotatedQueue
 from pennylane.wires import Wires
 
 # pylint: disable=protected-access, too-few-public-methods, no-self-use, unused-argument, arguments-differ, no-member, comparison-with-itself

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -318,7 +318,9 @@ class QueuingManager:
         Args:
             obj: the object to be removed
         """
+        print("in remove")
         if cls.recording():
+            print("is recording")
             cls.active_context().remove(obj)
 
     @classmethod

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -318,9 +318,7 @@ class QueuingManager:
         Args:
             obj: the object to be removed
         """
-        print("in remove")
         if cls.recording():
-            print("is recording")
             cls.active_context().remove(obj)
 
     @classmethod


### PR DESCRIPTION
**Context:**
Resource operators are tracked using the queuing architecture. The default `queue()` method adds an instance of the Resource operator to the active queuing context. 

In some cases operators consume other operators and thus those inputs need to be removed from the queue. This responsibility was being absorbed into the `queue()` leading to diverging implementations for the various Resource operators depending on their inputs. In this PR we move that responsibility to a more general, separate method called `dequeue`. 

**Description of the Change:**
- Refactored the diverging `queue()` method implementations 
- Add a new `dequeue()` method to remove from the queue. 
