### PR TITLE
Stop queuing due to decompositions from within `qml.matrix`.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -361,6 +361,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug that caused operators to be queued from within :func:`~.matrix` if it required
+  decomposition of an operator that in turn queues its constituents in its decomposition method.
+  [(#7975)](https://github.com/PennyLaneAI/pennylane/pull/7975)
+
 * An error is now raised if an `end` statement is found in a measurement conditioned branch in a QASM string being imported into PennyLane.
   [(#7872)](https://github.com/PennyLaneAI/pennylane/pull/7872)
 
@@ -402,4 +406,5 @@ Mudit Pandey,
 Andrija Paurevic,
 Shuli Shu,
 Jay Soni,
+David Wierichs,
 Jake Zaia

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -374,8 +374,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixes a bug that caused operators to be queued from within :func:`~.matrix` if it required
-  decomposition of an operator that in turn queues its constituents in its decomposition method.
+* Fixes a bug in :func:`~.matrix` where an operator's
+  constituents were incorrectly queued if its decomposition was requested.
   [(#7975)](https://github.com/PennyLaneAI/pennylane/pull/7975)
 
 * An error is now raised if an `end` statement is found in a measurement conditioned branch in a QASM string being imported into PennyLane.

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -21,6 +21,7 @@ from pennylane import transform
 from pennylane.exceptions import MatrixUndefinedError, TransformError
 from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence, PauliWord
+from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.typing import PostprocessingFn, TensorLike
 
@@ -234,7 +235,9 @@ def matrix(op: Operator | PauliWord | PauliSentence, wire_order=None) -> TensorL
     if op.has_sparse_matrix:
         return op.sparse_matrix(wire_order=wire_order).todense()
     if op.has_decomposition:
-        return matrix(QuantumScript(op.decomposition()), wire_order=wire_order or op.wires)
+        with QueuingManager.stop_recording():
+            ops = op.decomposition()
+        return matrix(QuantumScript(ops), wire_order=wire_order or op.wires)
     raise MatrixUndefinedError(
         "Operator must define a matrix, sparse matrix, or decomposition for use with qml.matrix."
     )

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -566,7 +566,9 @@ class TestTemplates:
 
         weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         op = CustomOp(weights, wires=[0, 1])
-        res = qml.matrix(op)
+        with qml.queuing.AnnotatedQueue() as q_test:
+            res = qml.matrix(op)
+        assert len(q_test) == 0  # Test that no operators were leaked
 
         op = qml.StronglyEntanglingLayers(weights, wires=[0, 1])
         with qml.queuing.AnnotatedQueue() as q:

--- a/tests/ops/functions/test_matrix.py
+++ b/tests/ops/functions/test_matrix.py
@@ -593,7 +593,10 @@ class TestTemplates:
 
         weights = np.array([[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]])
         x = 0.54
-        res = qml.matrix(circuit, wire_order=[0, 1])(weights, x)
+        with qml.queuing.AnnotatedQueue() as q_test:
+            res = qml.matrix(circuit, wire_order=[0, 1])(weights, x)
+
+        assert len(q_test) == 0  # Test that no operators were leaked
 
         op = qml.StronglyEntanglingLayers(weights, wires=[0, 1])
 


### PR DESCRIPTION
**Context:**
`qml.matrix` leaks queued ops from decompositions.

**Description of the Change:**
Fix the leak.

**Benefits:**
No leak.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#7975 
[sc-96525]