### PR TITLE
fix tree-traversal with non-standard wire ordering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -401,7 +401,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixes an issue with tree-traversal and non-standard wire orders.
+* Fixes an issue with tree-traversal and non-sequential wire orders.
   [(#7991)](https://github.com/PennyLaneAI/pennylane/pull/7991)
 
 * Fixes a bug in :func:`~.matrix` where an operator's

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -396,6 +396,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes an issue with tree-traversal and non-standard wire orders.
+
 * Fixes a bug in :func:`~.matrix` where an operator's
   constituents were incorrectly queued if its decomposition was requested.
   [(#7975)](https://github.com/PennyLaneAI/pennylane/pull/7975)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -402,6 +402,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fixes an issue with tree-traversal and non-standard wire orders.
+  [(#7991)](https://github.com/PennyLaneAI/pennylane/pull/7991)
 
 * Fixes a bug in :func:`~.matrix` where an operator's
   constituents were incorrectly queued if its decomposition was requested.

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -539,7 +539,10 @@ def simulate_tree_mcm(
             else:
                 initial_state = branch_state(stack.states[depth], mcm_current[depth], mcms[depth])
             circtmp = circuits[depth].copy(shots=qml.measurements.shots.Shots(shots))
-            circtmp = prepend_state_prep(circtmp, initial_state, interface, circuit.wires)
+
+            circtmp = prepend_state_prep(
+                circtmp, initial_state, interface, sorted(circuit.op_wires)
+            )
             state, is_state_batched = get_final_state(
                 circtmp,
                 debugger=debugger,

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -540,9 +540,7 @@ def simulate_tree_mcm(
                 initial_state = branch_state(stack.states[depth], mcm_current[depth], mcms[depth])
             circtmp = circuits[depth].copy(shots=qml.measurements.shots.Shots(shots))
 
-            circtmp = prepend_state_prep(
-                circtmp, initial_state, interface, sorted(circuit.op_wires)
-            )
+            circtmp = prepend_state_prep(circtmp, initial_state, interface, sorted(circuit.wires))
             state, is_state_batched = get_final_state(
                 circtmp,
                 debugger=debugger,

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -1668,3 +1668,11 @@ class TestMidMeasurements:
         tape = qml.tape.QuantumScript(ops, [qml.probs(wires=(0, 1, 2))])
         res = simulate_tree_mcm(tape)
         assert qml.math.allclose(res, np.array([1, 0, 0, 0, 0, 0, 0, 0]))
+
+    def test_measurement_on_non_op_wire_with_nonstandard_order(self):
+        """Test that we can measure wires not present in the circuit."""
+
+        ops = [qml.measurements.MidMeasureMP(wires=1), qml.X(1)]
+        tape = qml.tape.QuantumScript(ops, [qml.probs(wires=(0, 1, 2))])
+        res = simulate_tree_mcm(tape)
+        assert qml.math.allclose(res, np.array([0, 0, 1, 0, 0, 0, 0, 0]))

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -1660,3 +1660,11 @@ class TestMidMeasurements:
         tape = qml.tape.QuantumScript(ops, [qml.expval(qml.Z(2))])
         res = simulate_tree_mcm(tape)
         assert qml.math.allclose(res, 0)
+
+    def test_measurement_on_non_op_wire(self):
+        """Test that we can measure wires not present in the circuit."""
+
+        ops = [qml.measurements.MidMeasureMP(wires=0)]
+        tape = qml.tape.QuantumScript(ops, [qml.probs(wires=(0, 1, 2))])
+        res = simulate_tree_mcm(tape)
+        assert qml.math.allclose(res, np.array([1, 0, 0, 0, 0, 0, 0, 0]))

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -1651,3 +1651,12 @@ class TestMidMeasurements:
             )
             expected_sample = simulate(equivalent_tape, rng=rng)
             fisher_exact_test(subset, expected_sample, outcomes=(-1, 1))
+
+    def test_tree_traversal_non_standard_wire_order(self):
+        """Test that tree-traversal still works with a non-standard wire order."""
+
+        ops = [qml.H(0), qml.CNOT((0, 2)), qml.measurements.MidMeasureMP(wires=0), qml.S(1)]
+
+        tape = qml.tape.QuantumScript(ops, [qml.expval(qml.Z(2))])
+        res = simulate_tree_mcm(tape)
+        assert qml.math.allclose(res, 0)


### PR DESCRIPTION
**Context:**

```
@qml.qnode(qml.device('default.qubit'))
def c():
    qml.H(0)
    qml.CNOT((0,2))
    qml.measure(0, reset=True)
    qml.CNOT((0,1))
    return qml.expval(qml.Z(2))

c.update(mcm_method="tree-traversal")(), c.update(mcm_method="deferred")(), qml.set_shots(c, 1000).update(mcm_method="one-shot")()
```
```
(1.0, 0.0, -0.002)
```

tree-traversal is giving incorrect answers with non-sequential wire orders.

**Description of the Change:**

Add a sorted to the wire order used in the `StatePrep`.

**Benefits:**

Correct results.

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #7990 [sc-96701]