### PR TITLE
Clarify uses of `Operator.adjoint` and `Operator.pow`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -407,6 +407,8 @@
 
 <h3>Documentation 📝</h3>
 
+* Clarifies the use case for `Operator.pow` and `Operator.adjoint`.
+
 * The docstring of the `is_hermitian` operator property has been updated to better describe its behaviour.
   [(#7946)](https://github.com/PennyLaneAI/pennylane/pull/7946)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -943,7 +943,7 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         A ``EigvalsUndefinedError`` is raised if the eigenvalues have not been defined and cannot be
         inferred from the matrix representation.
 
-        .. seealso:: :meth:`~.Operator.compute_eigvals`
+        .. seealso:: :meth:`~.Operator.compute_eigvals` and :func:`qml.eigvals() <pennylane.eigvals>`
 
         Returns:
             tensor_like: eigenvalues
@@ -1537,7 +1537,11 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         raise GeneratorUndefinedError(f"Operation {self.name} does not have a generator")
 
     def pow(self, z: float) -> list["Operator"]:
-        """A list of new operators equal to this one raised to the given power.
+        """A list of new operators equal to this one raised to the given power. This method is used to simplify
+        :class:`~.Pow` instances created by :func:`~.pow` or ``op ** power``.
+
+        ``Operator.pow`` can be optionally defined by Operator developers, while :func:`~.pow` or ``op ** power``
+        are the entry point for constructing generic powers to exponents.
 
         Args:
             z (float): exponent for the operator
@@ -1586,11 +1590,15 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         return cls.adjoint != Operator.adjoint
 
     def adjoint(self) -> "Operator":  # pylint:disable=no-self-use
-        """Create an operation that is the adjoint of this one.
+        """Create an operation that is the adjoint of this one. Used to simplify
+        :class:`~.Adjoint` operators constructed by :func:`~.adjoint`.
 
         Adjointed operations are the conjugated and transposed version of the
         original operation. Adjointed ops are equivalent to the inverted operation for unitary
         gates.
+
+        ``Operator.adjoint`` can be optionally defined by Operator developers, while :func:`~.adjoint`
+        is the entry point for constructing generic adjoint representations.
 
         Returns:
             The adjointed operation.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1549,6 +1549,18 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         Returns:
             list[:class:`~.operation.Operator`]
 
+        >>> class MyClass(qml.operation.Operator):
+        ...
+        ...     def pow(self, z):
+        ...         return [MyClass(self.data[0]*z, self.wires)]
+        >>> op = MyClass(0.5, 0) ** 2
+        >>> op
+        MyClass(0.5, wires=[0])**2
+        >>> op.decomposition()
+        [MyClass(1.0, wires=[0])]
+        >>> op.simplify()
+        MyClass(1.0, wires=[0])
+
         """
         # Child methods may call super().pow(z%period) where op**period = I
         # For example, PauliX**2 = I, SX**4 = I, TShift**3 = I (for qutrit)
@@ -1602,6 +1614,20 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
 
         Returns:
             The adjointed operation.
+
+        >>> class MyClass(qml.operation.Operator):
+        ...
+        ...     def adjoint(self):
+        ...         return self
+        >>> op = qml.adjoint(MyClass(wires=0))
+        >>> op
+        Adjoint(MyClass(wires=[0]))
+        >>> op.decomposition()
+        [MyClass(wires=[0])]
+        >>> op.simplify()
+        MyClass(wires=[0])
+
+
         """
         raise AdjointUndefinedError
 


### PR DESCRIPTION
**Context:**

**Description of the Change:**

Clearing up  that `Operator.adjoint` and `Operator.pow` are for defining decompositions and simplifications for `Pow` and `Adjoint` operators constructed via `qml.adjoint` and `qml.pow`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
