### PR TITLE
Fix typo in BCH algorithm

### DIFF
--- a/pennylane/labs/trotter_error/product_formulas/bch.py
+++ b/pennylane/labs/trotter_error/product_formulas/bch.py
@@ -463,12 +463,12 @@ def _right_nest_two_comms(commutator: tuple[tuple | Hashable]) -> dict[tuple[Has
     b = commutator[1][0]
     c = commutator[1][1:]
 
-    comm_bca = {(b,) + comm: coeff for comm, coeff in _right_nest_two_comms((a, c)).items()}
+    comm_bac = {(b,) + comm: coeff for comm, coeff in _right_nest_two_comms((a, c)).items()}
     comm_cab = {comm: -coeff for comm, coeff in _right_nest_two_comms(((b,) + a, c)).items()}
 
     commutators = defaultdict(int)
 
-    for comm, coeff in comm_bca.items():
+    for comm, coeff in comm_bac.items():
         commutators[comm] += coeff
 
     for comm, coeff in comm_cab.items():


### PR DESCRIPTION
Quick fix of a typo in a variable name