### PR TITLE
Fix dynamic one shot sample shapes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -444,6 +444,12 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a shape broadcasting bug in `dynamic_one_shot` transform that caused multi-wire sampling 
+  with `mcm_method="one-shot"` and `postselect_mode="fill-shots"` to fail with incompatible shapes 
+  for broadcasting error. The issue occurred when samples had shape `(shots, 1, wires)` but `is_valid` 
+  had shape `(shots,)`.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Fixes an issue with tree-traversal and non-sequential wire orders.
   [(#7991)](https://github.com/PennyLaneAI/pennylane/pull/7991)
 

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -450,8 +450,8 @@ def _gather_counts(measurement: CountsMP, samples, is_valid, postselect_mode=Non
 # pylint: disable=unused-argument
 @gather_non_mcm.register
 def _gather_samples(measurement: SampleMP, samples, is_valid, postselect_mode=None):
-    if postselect_mode == "pad-invalid-samples" and samples.ndim == 2:
-        is_valid = qml.math.reshape(is_valid, (-1, 1))
+    if postselect_mode == "pad-invalid-samples" and samples.ndim >= 2:
+        is_valid = qml.math.reshape(is_valid, (-1,) + (1,) * (samples.ndim - 1))
     if postselect_mode == "pad-invalid-samples":
         return qml.math.where(is_valid, samples, fill_in_value)
     if qml.math.shape(samples) == ():  # single shot case


### PR DESCRIPTION
**Context:**
Somehow after cleaning up dynamic one shot code the shapes of samples between PennyLane and Catalyst mismatch. And this cause misterious infinite hanging on any Latest/Latest with PL>dev17.

**Description of the Change:**
Fix the shape in a compatible way; extended the previous conditional pre-processing of `is_valid` tensor.

**Benefits:**
Unblock many PR's

**Possible Drawbacks:**

**Related GitHub Issues:**
