### PR TITLE
Refactor DecompositionGraph to two classes

### DIFF
--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -55,6 +55,18 @@ from .symbolic_decomposition import (
 from .utils import translate_op_alias
 
 
+@dataclass(frozen=True)
+class _DecompositionNode:
+    """A node that represents a decomposition rule."""
+
+    rule: DecompositionRule
+    decomp_resource: Resources
+
+    def count(self, op: CompressedResourceOp):
+        """Find the number of occurrences of an operator in the decomposition."""
+        return self.decomp_resource.gate_counts.get(op, 0)
+
+
 class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
     """A graph that models a decomposition problem.
 
@@ -117,10 +129,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
             operations=[op],
             gate_set={"RZ", "RX", "CNOT", "GlobalPhase"},
         )
-        graph.solve()
+        solution = graph.solve()
 
     >>> with qml.queuing.AnnotatedQueue() as q:
-    ...     graph.decomposition(op)(0.5, wires=[0, 1])
+    ...     solution.decomposition(op)(0.5, wires=[0, 1])
     >>> q.queue
     [RZ(1.5707963267948966, wires=[1]),
      RY(0.25, wires=[1]),
@@ -128,7 +140,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
      RY(-0.25, wires=[1]),
      CNOT(wires=[0, 1]),
      RZ(-1.5707963267948966, wires=[1])]
-    >>> graph.resource_estimate(op)
+    >>> solution.resource_estimate(op)
     <num_gates=10, gate_counts={RZ: 6, CNOT: 2, RX: 2}, weighted_cost=10.0>
 
     """
@@ -159,52 +171,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
 
         # Initializes the graph.
         self._graph = rx.PyDiGraph()
-        self._visitor = None
 
         # Construct the decomposition graph
         self._start = self._graph.add_node(None)
         self._construct_graph(operations)
-
-    def _get_decompositions(self, op_node: CompressedResourceOp) -> list[DecompositionRule]:
-        """Helper function to get a list of decomposition rules."""
-
-        op_name = _to_name(op_node)
-
-        if op_name in self._fixed_decomps:
-            return [self._fixed_decomps[op_name]]
-
-        decomps = self._alt_decomps.get(op_name, []) + list_decomps(op_name)
-
-        if (
-            issubclass(op_node.op_type, qml.ops.Adjoint)
-            and self_adjoint not in decomps
-            and adjoint_rotation not in decomps
-        ):
-            # In general, we decompose the adjoint of an operator by applying adjoint to the
-            # decompositions of the operator. However, this is not necessary if the operator
-            # is self-adjoint or if it has a single rotation angle which can be trivially
-            # inverted to obtain its adjoint. In this case, `self_adjoint` or `adjoint_rotation`
-            # would've already been retrieved as a potential decomposition rule for this
-            # operator, so there is no need to consider the general case.
-            decomps.extend(self._get_adjoint_decompositions(op_node))
-
-        elif (
-            issubclass(op_node.op_type, qml.ops.Pow)
-            and pow_rotation not in decomps
-            and pow_involutory not in decomps
-        ):
-            # Similar to the adjoint case, the `_get_pow_decompositions` contains the general
-            # approach we take to decompose powers of operators. However, if the operator is
-            # involutory or if it has a single rotation angle that can be trivially multiplied
-            # with the power, we would've already retrieved `pow_involutory` or `pow_rotation`
-            # as a potential decomposition rule for this operator, so there is no need to consider
-            # the general case.
-            decomps.extend(self._get_pow_decompositions(op_node))
-
-        elif op_node.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):
-            decomps.extend(self._get_controlled_decompositions(op_node))
-
-        return decomps
 
     def _construct_graph(self, operations):
         """Constructs the decomposition graph."""
@@ -253,6 +223,47 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
             op_node_idx = self._add_op_node(op)
             self._graph.add_edge(op_node_idx, d_node_idx, (op_node_idx, d_node_idx))
         self._graph.add_edge(d_node_idx, op_idx, 0)
+
+    def _get_decompositions(self, op_node: CompressedResourceOp) -> list[DecompositionRule]:
+        """Helper function to get a list of decomposition rules."""
+
+        op_name = _to_name(op_node)
+
+        if op_name in self._fixed_decomps:
+            return [self._fixed_decomps[op_name]]
+
+        decomps = self._alt_decomps.get(op_name, []) + list_decomps(op_name)
+
+        if (
+            issubclass(op_node.op_type, qml.ops.Adjoint)
+            and self_adjoint not in decomps
+            and adjoint_rotation not in decomps
+        ):
+            # In general, we decompose the adjoint of an operator by applying adjoint to the
+            # decompositions of the operator. However, this is not necessary if the operator
+            # is self-adjoint or if it has a single rotation angle which can be trivially
+            # inverted to obtain its adjoint. In this case, `self_adjoint` or `adjoint_rotation`
+            # would've already been retrieved as a potential decomposition rule for this
+            # operator, so there is no need to consider the general case.
+            decomps.extend(self._get_adjoint_decompositions(op_node))
+
+        elif (
+            issubclass(op_node.op_type, qml.ops.Pow)
+            and pow_rotation not in decomps
+            and pow_involutory not in decomps
+        ):
+            # Similar to the adjoint case, the `_get_pow_decompositions` contains the general
+            # approach we take to decompose powers of operators. However, if the operator is
+            # involutory or if it has a single rotation angle that can be trivially multiplied
+            # with the power, we would've already retrieved `pow_involutory` or `pow_rotation`
+            # as a potential decomposition rule for this operator, so there is no need to consider
+            # the general case.
+            decomps.extend(self._get_pow_decompositions(op_node))
+
+        elif op_node.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):
+            decomps.extend(self._get_controlled_decompositions(op_node))
+
+        return decomps
 
     def _get_adjoint_decompositions(self, op_node: CompressedResourceOp) -> list[DecompositionRule]:
         """Gets the decomposition rules for the adjoint of an operator."""
@@ -315,7 +326,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
 
         return rules
 
-    def solve(self, lazy=True):
+    def solve(self, lazy=True) -> DecompGraphSolution:
         """Solves the graph using the Dijkstra search algorithm.
 
         Args:
@@ -323,8 +334,11 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
                 found for all operations that the graph was initialized with. Otherwise, the
                 entire graph will be explored.
 
+        Returns:
+            DecompGraphSolution
+
         """
-        self._visitor = _DecompositionSearchVisitor(
+        visitor = _DecompositionSearchVisitor(
             self._graph,
             self._weights,
             self._original_ops_indices,
@@ -333,15 +347,30 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes
         rx.dijkstra_search(
             self._graph,
             source=[self._start],
-            weight_fn=self._visitor.edge_weight,
-            visitor=self._visitor,
+            weight_fn=visitor.edge_weight,
+            visitor=visitor,
         )
-        if self._visitor.unsolved_op_indices:
-            unsolved_ops = [self._graph[op_idx] for op_idx in self._visitor.unsolved_op_indices]
+        if visitor.unsolved_op_indices:
+            unsolved_ops = [self._graph[op_idx] for op_idx in visitor.unsolved_op_indices]
             op_names = {op.name for op in unsolved_ops}
             raise DecompositionError(
                 f"Decomposition not found for {op_names} to the gate set {set(self._weights)}"
             )
+        return DecompGraphSolution(visitor, self._graph, self._all_op_indices)
+
+
+class DecompGraphSolution:
+    """A solution to a decomposition graph."""
+
+    def __init__(
+        self,
+        visitor: _DecompositionSearchVisitor,
+        graph: rx.PyDiGraph,
+        all_op_indices: dict[CompressedResourceOp, int],
+    ) -> None:
+        self._visitor = visitor
+        self._graph = graph
+        self._all_op_indices = all_op_indices
 
     def is_solved_for(self, op):
         """Tests whether the decomposition graph is solved for a given operator."""
@@ -503,18 +532,6 @@ class _DecompositionSearchVisitor(DijkstraVisitor):
         elif isinstance(target_node, CompressedResourceOp):
             self.predecessors[target_idx] = src_idx
             self.distances[target_idx] = self.distances[src_idx]
-
-
-@dataclass(frozen=True)
-class _DecompositionNode:
-    """A node that represents a decomposition rule."""
-
-    rule: DecompositionRule
-    decomp_resource: Resources
-
-    def count(self, op: CompressedResourceOp):
-        """Find the number of occurrences of an operator in the decomposition."""
-        return self.decomp_resource.gate_counts.get(op, 0)
 
 
 def _to_name(op):

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -61,10 +61,10 @@ class TestDecompositionGraph:
             operations=[op],
             gate_set=gate_weights,
         )
-        graph.solve()
+        solution = graph.solve()
 
         expected_resource = to_resources({qml.CZ: 2, qml.RX: 2})
-        assert graph.resource_estimate(op) == expected_resource
+        assert solution.resource_estimate(op) == expected_resource
 
         # the RZ CZ RX CZ decomp is avoided when the CZ weight is large.
         gate_weights = {
@@ -80,12 +80,12 @@ class TestDecompositionGraph:
             operations=[op],
             gate_set=gate_weights,
         )
-        graph.solve()
+        solution = graph.solve()
 
         expected_resource = to_resources(
             {qml.RX: 2, qml.CNOT: 2, qml.RY: 4, qml.GlobalPhase: 4, qml.RZ: 4}
         )
-        assert graph.resource_estimate(op) == expected_resource
+        assert solution.resource_estimate(op) == expected_resource
 
     def test_get_decomp_rule(self, _):
         """Tests the internal method that gets the decomposition rules for an operator."""
@@ -237,13 +237,13 @@ class TestDecompositionGraph:
             operations=[op],
             gate_set={"RX", "RY", "RZ", "GlobalPhase"},
         )
-        graph.solve()
+        solution = graph.solve()
 
         # verify that the better decomposition rule is chosen when both are valid.
-        assert graph.resource_estimate(op) == to_resources(
+        assert solution.resource_estimate(op) == to_resources(
             {qml.RY: 1, qml.GlobalPhase: 1, qml.RZ: 1},
         )
-        assert graph.decomposition(op).compute_resources() == to_resources(
+        assert solution.decomposition(op).compute_resources() == to_resources(
             {qml.RY: 1, qml.GlobalPhase: 1, qml.RZ: 1},
         )
 
@@ -296,17 +296,17 @@ class TestDecompositionGraph:
                 AnotherOp: [_another_decomp],
             },
         )
-        graph.solve(lazy=True)
-        assert not graph.is_solved_for(AnotherOp(wires=[0, 1]))
+        solution = graph.solve(lazy=True)
+        assert not solution.is_solved_for(AnotherOp(wires=[0, 1]))
 
         with pytest.raises(DecompositionError, match="is unsolved in this decomposition graph."):
-            graph.resource_estimate(AnotherOp(wires=[0, 1]))
+            solution.resource_estimate(AnotherOp(wires=[0, 1]))
 
         with pytest.raises(DecompositionError, match="is unsolved in this decomposition graph."):
-            graph.decomposition(AnotherOp(wires=[0, 1]))
+            solution.decomposition(AnotherOp(wires=[0, 1]))
 
-        graph.solve(lazy=False)
-        assert graph.is_solved_for(AnotherOp(wires=[0, 1]))
+        solution = graph.solve(lazy=False)
+        assert solution.is_solved_for(AnotherOp(wires=[0, 1]))
 
     def test_decomposition_with_resource_params(self, _):
         """Tests operators with non-empty resource params."""
@@ -344,17 +344,17 @@ class TestDecompositionGraph:
         # and 4 edges from the dummy starting node to the target gate set
         assert len(graph._graph.edges()) == 27
 
-        graph.solve()
-        assert graph.resource_estimate(op) == to_resources(
+        solution = graph.solve()
+        assert solution.resource_estimate(op) == to_resources(
             {qml.CZ: 14, qml.RZ: 59, qml.RX: 28, qml.GlobalPhase: 28},
         )
-        assert graph.decomposition(op).compute_resources(**op.resource_params) == to_resources(
+        assert solution.decomposition(op).compute_resources(**op.resource_params) == to_resources(
             {
                 qml.resource_rep(qml.MultiRZ, num_wires=4): 1,
                 qml.resource_rep(qml.MultiRZ, num_wires=3): 2,
             },
         )
-        assert graph.decomposition(qml.Hadamard(wires=[0])).compute_resources() == to_resources(
+        assert solution.decomposition(qml.Hadamard(wires=[0])).compute_resources() == to_resources(
             {qml.RZ: 2, qml.RX: 1, qml.GlobalPhase: 1},
         )
 
@@ -380,10 +380,10 @@ class TestControlledDecompositions:
         assert len(graph._graph.edges()) == 6
 
         # Verify the decompositions
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
 
         assert q.queue == [
             qml.PhaseShift(-0.5, wires=[1]),
@@ -403,10 +403,10 @@ class TestControlledDecompositions:
         assert len(graph._graph.edges()) == 49
 
         # Verify the decompositions
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
 
         assert q.queue == [qml.CNOT(wires=[1, 0]), qml.CH(wires=[1, 0])]
 
@@ -474,24 +474,24 @@ class TestControlledDecompositions:
         # and 6 edge from the dummy starting node to the target gate set.
         assert len(graph._graph.edges()) == 58
 
-        graph.solve()
+        solution = graph.solve()
 
         # Check that decomposition rules are found for the necessary controlled operators.
-        assert graph.decomposition(op1)
-        assert graph.decomposition(op2)
-        assert graph.decomposition(op3)
-        assert graph.decomposition(qml.ctrl(qml.GlobalPhase(0.5), control=[1]))
-        assert graph.decomposition(qml.ctrl(qml.GlobalPhase(0.5), control=[1, 2]))
-        assert graph.decomposition(qml.ctrl(CustomOp(wires=[1]), control=[0, 2]))
+        assert solution.decomposition(op1)
+        assert solution.decomposition(op2)
+        assert solution.decomposition(op3)
+        assert solution.decomposition(qml.ctrl(qml.GlobalPhase(0.5), control=[1]))
+        assert solution.decomposition(qml.ctrl(qml.GlobalPhase(0.5), control=[1, 2]))
+        assert solution.decomposition(qml.ctrl(CustomOp(wires=[1]), control=[0, 2]))
 
     def test_flip_controlled_adjoint(self, _):
         """Tests that the controlled form of an adjoint operator is decomposed properly."""
 
         op = qml.ctrl(qml.adjoint(qml.U1(0.5, wires=0)), control=[1])
         graph = DecompositionGraph(operations=[op], gate_set={"ControlledPhaseShift"})
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
         assert q.queue == [qml.adjoint(qml.ops.Controlled(qml.U1(0.5, wires=0), control_wires=[1]))]
 
     def test_decompose_with_single_work_wire(self, _):
@@ -508,15 +508,15 @@ class TestControlledDecompositions:
             operations=[op],
             gate_set={"MultiControlledX", "CRot"},
         )
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
         assert q.queue == [
             qml.MultiControlledX(wires=[1, 2, 3, 4], work_wires=[5], work_wire_type="clean"),
             qml.CRot(0.123, 0.234, 0.345, wires=[4, 0]),
             qml.MultiControlledX(wires=[1, 2, 3, 4], work_wires=[5], work_wire_type="clean"),
         ]
-        assert graph.resource_estimate(op) == to_resources(
+        assert solution.resource_estimate(op) == to_resources(
             {
                 resource_rep(
                     qml.MultiControlledX,
@@ -548,12 +548,12 @@ class TestSymbolicDecompositions:
         assert len(graph._graph.nodes()) == 4
         assert len(graph._graph.edges()) == 3
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
 
         assert q.queue == [qml.RX(0.5, wires=[0])]
-        assert graph.resource_estimate(op) == to_resources({qml.RX: 1})
+        assert solution.resource_estimate(op) == to_resources({qml.RX: 1})
 
     def test_adjoint_custom(self, _):
         """Tests adjoint of an operator that defines its own adjoint."""
@@ -565,12 +565,12 @@ class TestSymbolicDecompositions:
         assert len(graph._graph.nodes()) == 4
         assert len(graph._graph.edges()) == 3
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
 
         assert q.queue == [qml.RX(-0.5, wires=[0])]
-        assert graph.resource_estimate(op) == to_resources({qml.RX: 1})
+        assert solution.resource_estimate(op) == to_resources({qml.RX: 1})
 
     def test_adjoint_general(self, _):
         """Tests decomposition of a generalized adjoint operation."""
@@ -606,9 +606,9 @@ class TestSymbolicDecompositions:
         # and 4 edges from the dummy starting node to the target gate set.
         assert len(graph._graph.edges()) == 19
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
 
         assert q.queue == [
             qml.adjoint(qml.T(2)),
@@ -617,7 +617,7 @@ class TestSymbolicDecompositions:
             qml.adjoint(qml.CNOT(wires=[0, 1])),
             qml.adjoint(qml.H(wires=0)),
         ]
-        assert graph.resource_estimate(op) == to_resources(
+        assert solution.resource_estimate(op) == to_resources(
             {qml.H: 1, qml.CNOT: 2, qml.RX: 1, qml.PhaseShift: 1},
         )
 
@@ -635,19 +635,19 @@ class TestSymbolicDecompositions:
         # H**6 decomposes to nothing, so H isn't counted.
         assert len(graph._graph.edges()) == 4
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
 
         assert q.queue == [qml.pow(qml.H(0), 6)]
-        assert graph.resource_estimate(op) == to_resources({})
+        assert solution.resource_estimate(op) == to_resources({})
 
         op2 = qml.pow(qml.H(0), 6)
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
 
         assert q.queue == []
-        assert graph.resource_estimate(op2) == to_resources({})
+        assert solution.resource_estimate(op2) == to_resources({})
 
     def test_custom_symbolic_decompositions(self, _):
         """Tests that custom symbolic decompositions are used."""
@@ -672,18 +672,18 @@ class TestSymbolicDecompositions:
         op3 = qml.ops.Controlled(qml.H(0), control_wires=1)
         op4 = qml.adjoint(qml.RX(0.5, wires=0))
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
-            graph.decomposition(op3)(*op3.parameters, wires=op3.wires, **op3.hyperparameters)
-            graph.decomposition(op4)(*op4.parameters, wires=op4.wires, **op4.hyperparameters)
+            solution.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op3)(*op3.parameters, wires=op3.wires, **op3.hyperparameters)
+            solution.decomposition(op4)(*op4.parameters, wires=op4.wires, **op4.hyperparameters)
 
         assert q.queue == [qml.H(0), qml.H(1), qml.CH(wires=[1, 0]), qml.RX(-0.5, wires=0)]
-        assert graph.resource_estimate(op1) == to_resources({qml.H: 1})
-        assert graph.resource_estimate(op2) == to_resources({qml.H: 1})
-        assert graph.resource_estimate(op3) == to_resources({qml.CH: 1})
-        assert graph.resource_estimate(op4) == to_resources({qml.RX: 1})
+        assert solution.resource_estimate(op1) == to_resources({qml.H: 1})
+        assert solution.resource_estimate(op2) == to_resources({qml.H: 1})
+        assert solution.resource_estimate(op3) == to_resources({qml.CH: 1})
+        assert solution.resource_estimate(op4) == to_resources({qml.RX: 1})
 
     def test_special_pow_decomps(self, _):
         """Tests special cases for decomposing a power."""
@@ -712,14 +712,14 @@ class TestSymbolicDecompositions:
         op1 = qml.pow(CustomOp(0), 0)
         op2 = qml.pow(CustomOp(1), 1)
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
 
         assert q.queue == [CustomOp(1)]
-        assert graph.resource_estimate(op1) == to_resources({})
-        assert graph.resource_estimate(op2) == to_resources({CustomOp: 1})
+        assert solution.resource_estimate(op1) == to_resources({})
+        assert solution.resource_estimate(op2) == to_resources({CustomOp: 1})
 
     def test_general_pow_decomps(self, _):
         """Tests the more general power decomposition rules."""
@@ -748,10 +748,10 @@ class TestSymbolicDecompositions:
         op1 = qml.pow(CustomOp(0), 2)
         op2 = qml.pow(qml.adjoint(CustomOp(1)), 2)
 
-        graph.solve()
+        solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
-            graph.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
-            graph.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+            solution.decomposition(op1)(*op1.parameters, wires=op1.wires, **op1.hyperparameters)
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
 
         assert q.queue == [
             CustomOp(0),


### PR DESCRIPTION
**Context:**

**Description of the Change:**
Splitting the solution part of a `DecompositionGraph` to a separate `DecompGraphSolution` class, returned by the `solve` method.

**Benefits:**
Cleaner code

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-97093]
