### PR TITLE
chore: fix path rendering in `deprecations` page

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -120,12 +120,12 @@ for details on how to port your legacy code to the new system. The following fun
   - Removed in v0.40
 
 * :meth:`pennylane.pauli.PauliSentence.hamiltonian` and :meth:`pennylane.pauli.PauliWord.hamiltonian` have been removed. Instead, please use
-  :meth:`pennylane.pauli.PauliSentence.operation` and :meth:`~pennylane.pauli.PauliWord.operation` respectively.
+  :meth:`pennylane.pauli.PauliSentence.operation` and :meth:`pennylane.pauli.PauliWord.operation` respectively.
 
   - Deprecated in v0.39
   - Removed in v0.40
 
-* :func:`pennylane.pauli.simplify` has been removed. Instead, please use :func:`pennylane.simplify` or :meth:`~pennylane.operation.Operator.simplify`.
+* :func:`pennylane.pauli.simplify` has been removed. Instead, please use :func:`pennylane.simplify` or :meth:`pennylane.operation.Operator.simplify`.
 
   - Deprecated in v0.39
   - Removed in v0.40

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -42,19 +42,19 @@ Pending deprecations
   - Deprecated in v0.43
   - Will be removed in a future version
 
-* `MeasurementProcess.expand` is deprecated. The relevant method can be replaced with 
-  `qml.tape.QuantumScript(mp.obs.diagonalizing_gates(), [type(mp)(eigvals=mp.obs.eigvals(), wires=mp.obs.wires)])`
+* ``MeasurementProcess.expand`` is deprecated. The relevant method can be replaced with 
+  ``qml.tape.QuantumScript(mp.obs.diagonalizing_gates(), [type(mp)(eigvals=mp.obs.eigvals(), wires=mp.obs.wires)])``.
   
   - Deprecated in v0.43
   - Will be removed in v0.44
 
-* ``shots=`` in ``QNode`` calls is deprecated and will be removed in v0.44.
+* The ``shots=`` kwarg in ``QNode`` calls is deprecated and will be removed in v0.44.
   Instead, please use the ``qml.workflow.set_shots`` transform to set the number of shots for a ``QNode``.
 
   - Deprecated in v0.43
   - Will be removed in v0.44
 
-* ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` are deprecated and will be removed in version v0.44.
+* The ``QuantumScript.shape`` and ``QuantumScript.numeric_type`` properties are deprecated and will be removed in version v0.44.
   Instead, the corresponding ``.shape`` or ``.numeric_type`` of the ``MeasurementProcess`` class should be used.
 
   - Deprecated in v0.43

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -112,15 +112,15 @@ In PennyLane v0.40, the legacy operator arithmetic system has been removed, and 
 operator arithmetic functionality that was introduced in v0.36. Check out the :ref:`Updated operators <new_opmath>` page
 for details on how to port your legacy code to the new system. The following functionality has been removed:
 
-* In PennyLane v0.40, legacy operator arithmetic has been removed. This includes :func:`~pennylane.operation.enable_new_opmath`,
-  :func:`~pennylane.operation.disable_new_opmath`, :class:`~pennylane.ops.Hamiltonian`, and :class:`~pennylane.operation.Tensor`. Note
-  that ``qml.Hamiltonian`` will continue to dispatch to :class:`~pennylane.ops.LinearCombination`.
+* In PennyLane v0.40, legacy operator arithmetic has been removed. This includes :func:`pennylane.operation.enable_new_opmath`,
+  :func:`pennylane.operation.disable_new_opmath`, :class:`pennylane.ops.Hamiltonian`, and :class:`pennylane.operation.Tensor`. Note
+  that ``qml.Hamiltonian`` will continue to dispatch to :class:`pennylane.ops.LinearCombination`.
 
   - Deprecated in v0.39
   - Removed in v0.40
 
-* :meth:`~pennylane.pauli.PauliSentence.hamiltonian` and :meth:`~pennylane.pauli.PauliWord.hamiltonian` has been removed. Instead, please use
-  :meth:`~pennylane.pauli.PauliSentence.operation` and :meth:`~pennylane.pauli.PauliWord.operation` respectively.
+* :meth:`pennylane.pauli.PauliSentence.hamiltonian` and :meth:`pennylane.pauli.PauliWord.hamiltonian` have been removed. Instead, please use
+  :meth:`pennylane.pauli.PauliSentence.operation` and :meth:`~pennylane.pauli.PauliWord.operation` respectively.
 
   - Deprecated in v0.39
   - Removed in v0.40

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -16,32 +16,28 @@ Pending deprecations
 
   As a concrete example, consider the following case:
 
-  ```python
-  coeffs = [0.5, -0.6]
-  ops = [qml.X(0), qml.X(0) @ qml.Y(1)]
-  H_flat = qml.dot(coeffs, ops)
-  ```
+  .. code-block:: python
+
+    coeffs = [0.5, -0.6]
+    ops = [qml.X(0), qml.X(0) @ qml.Y(1)]
+    H_flat = qml.dot(coeffs, ops)
 
   Instead of computing the Suzuki-Trotter product approximation as:
 
-  ```pycon
   >>> qml.evolve(H_flat, num_steps=2).decomposition()
   [RX(0.5, wires=[0]),
   PauliRot(-0.6, XY, wires=[0, 1]),
   RX(0.5, wires=[0]),
   PauliRot(-0.6, XY, wires=[0, 1])]
-  ```
 
   The same result can be obtained using :class:`~.TrotterProduct` as follows:
 
-  ```pycon
   >>> decomp_ops = qml.adjoint(qml.TrotterProduct(H_flat, time=1.0, n=2)).decomposition()
   >>> [simp_op for op in decomp_ops for simp_op in map(qml.simplify, op.decomposition())]
   [RX(0.5, wires=[0]),
   PauliRot(-0.6, XY, wires=[0, 1]),
   RX(0.5, wires=[0]),
   PauliRot(-0.6, XY, wires=[0, 1])]
-  ```
   
   - Deprecated in v0.43
   - Will be removed in a future version


### PR DESCRIPTION
**Context:**

A lot of our entries had weird rendering.

**Description of the Change:**

Cleaned up the sphinx directives to have better rendering. See https://xanaduai-pennylane--8034.com.readthedocs.build/en/8034/development/deprecations.html for renders.

[sc-97212]