### PR TITLE
Update `max_workers` for `qml.concurrency` with `mpi_comm` backend

### DIFF
--- a/pennylane/concurrency/executors/external/mpi.py
+++ b/pennylane/concurrency/executors/external/mpi.py
@@ -148,7 +148,7 @@ class MPICommExec(ExtExec):  # pragma: no cover
         from mpi4py import MPI  # Required to call MPI_Init
 
         self._comm = MPI.COMM_WORLD
-        self._size = MPI.COMM_WORLD.Get_size()
+        self._size = MPI.COMM_WORLD.Get_size() if max_workers is None else max_workers
 
         self._cfg = ExecBackendConfig(
             submit_fn="submit",


### PR DESCRIPTION
**Context:**
Using `qml.concurrency` with the `mpi_comm` backend doesn't allow specifying the number of workers inside the Python script

**Description of the Change:**
Set `self.size` with the number of workers for the backend `mpi_comm`

**Benefits:**
More control over the spawn workers

**Possible Drawbacks:**

**Related GitHub Issues:**
