### PR TITLE
feat: add `GradientConfig` frozen dataclass object

### DIFF
--- a/pennylane/devices/execution_config.py
+++ b/pennylane/devices/execution_config.py
@@ -155,7 +155,7 @@ class ExecutionConfig:
     mcm_config: MCMConfig | dict = field(default_factory=MCMConfig)
     """Configuration options for handling mid-circuit measurements"""
 
-    gradient_config: GradientConfig | dict | None = field(default_factory=GradientConfig)
+    gradient_config: GradientConfig | dict | None = None
     """Configuration options for handling mid-circuit measurements"""
 
     convert_to_numpy: bool = True


### PR DESCRIPTION
**Context:**

Our `ExecutionConfig` has too many fields. It's better to have a `GradientConfig` object that does all of the field handling for gradient related stuff.

[sc-]
