### PR TITLE
Fix dynamic one shot with squeezing and qjit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -387,6 +387,7 @@
 
 * Improves readability of `dynamic_one_shot` postprocessing to allow further modification.
   [(#7962)](https://github.com/PennyLaneAI/pennylane/pull/7962)
+  [(#8041)](https://github.com/PennyLaneAI/pennylane/pull/8041)
 
 * Update PennyLane's top-level `__init__.py` file imports to improve Python language server support for finding
   PennyLane submodules.

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -339,6 +339,7 @@ def _handle_measurement_qjit(
             qml.math.sum(result[1] * qml.math.reshape(is_valid, (-1, 1)), axis=0),
         )
         return res, m_count + 1
+    result = qml.math.squeeze(result)
     return gather_non_mcm(m, result, is_valid, postselect_mode=postselect_mode), m_count + 1
 
 


### PR DESCRIPTION
**Context:**

PR #7962 accidentally broke catalyst because I missed a squeeze statement.

**Description of the Change:**

Adds the squeeze statement back in.

**Benefits:**

Catalyst tests pass again.

**Possible Drawbacks:**

**Related GitHub Issues:**
