### PR TITLE
Partial wires docstring corrections

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -494,6 +494,9 @@
 
 <h3>Documentation 📝</h3>
 
+* Small typos in the docstring for `qml.noise.partial_wires` have been corrected.
+  [(#)]()
+
 * Updated the code examples in the documentation of :func:`~.specs`.
   [(#8003)](https://github.com/PennyLaneAI/pennylane/pull/8003)
 

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -664,32 +664,32 @@ def partial_wires(operation, *args, **kwargs):
 
     >>> func = qml.noise.partial_wires(qml.RX(1.2, [12]))
     >>> func(2)
-    qml.RX(1.2, wires=[2])
+    RX(1.2, wires=[2])
     >>> func(qml.RY(1.0, ["wires"]))
-    qml.RX(1.2, wires=["wires"])
+    RX(1.2, wires=["wires"])
 
     Additionally, an :class:`Operation <pennylane.operation.Operation>` class can
     also be provided, while providing required positional arguments via ``args``:
 
     >>> func = qml.noise.partial_wires(qml.RX, 3.2, [20])
     >>> func(qml.RY(1.0, [0]))
-    qml.RX(3.2, wires=[0])
+    RX(3.2, wires=[0])
 
     Moreover, one can use ``kwargs`` instead of positional arguments:
 
     >>> func = qml.noise.partial_wires(qml.RX, phi=1.2)
     >>> func(qml.RY(1.0, [2]))
-    qml.RX(1.2, wires=[2])
+    RX(1.2, wires=[2])
     >>> rfunc = qml.noise.partial_wires(qml.RX(1.2, [12]), phi=2.3)
     >>> rfunc(qml.RY(1.0, ["light"]))
-    qml.RX(2.3, wires=["light"])
+    RX(2.3, wires=["light"])
 
     Finally, one may also use this with an instance of
     :class:`MeasurementProcess <pennylane.measurement.MeasurementProcess>`
 
     >>> func = qml.noise.partial_wires(qml.expval(qml.Z(0)))
     >>> func(qml.RX(1.2, wires=[9]))
-    qml.expval(qml.Z(9))
+    expval(Z(9))
     """
     if callable(operation):
         op_class, op_type = _process_callable(operation)


### PR DESCRIPTION
**Context:** Typos

**Description of the Change:** Typos in docstrings

**Benefits:** yes

**Possible Drawbacks:** no

**Related GitHub Issues:**
