### PR TITLE
[Capture] `cond` can accept an operator `true_fn` with no `false_fn` provided

### DIFF
--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -781,6 +781,24 @@ the condition is ``False``, a ``false_fn`` must be provided:
 >>> circuit()
 Array(0., dtype=float32)
 
+Or the ``true_fn`` itself can be an operator type itself:
+
+.. code-block:: python
+
+    import pennylane as qml
+
+    qml.capture.enable()
+
+    @qml.qnode(qml.device("default.qubit", wires=2))
+    def circuit():
+        m0 = qml.measure(0)
+        qml.cond(m0, true_fn=qml.X)(0)
+
+        return qml.expval(qml.X(0))
+
+>>> circuit()
+Array(0., dtype=float32)
+
 while loops 
 -----------
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -116,6 +116,10 @@
   It validates that all executions are shot-based.
   [(#8037)](https://github.com/PennyLaneAI/pennylane/pull/8037)
 
+* With program capture, the `true_fn` can now be a subclass of `Operator` when no `false_fn` is provided.
+  `qml.cond(condition, qml.X)(0)` is now valid code and will return nothing, even though `qml.X` is
+  technically a callable that returns an `X` operator.
+
 <h4>OpenQASM-PennyLane interoperability</h4>
 
 * The :func:`qml.from_qasm3` function can now convert OpenQASM 3.0 circuits that contain

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -119,6 +119,7 @@
 * With program capture, the `true_fn` can now be a subclass of `Operator` when no `false_fn` is provided.
   `qml.cond(condition, qml.X)(0)` is now valid code and will return nothing, even though `qml.X` is
   technically a callable that returns an `X` operator.
+  [(#8060)](https://github.com/PennyLaneAI/pennylane/pull/8060)
 
 <h4>OpenQASM-PennyLane interoperability</h4>
 

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -65,6 +65,16 @@ def _add_abstract_shapes(f):
     return new_f
 
 
+def _no_return(fn):
+    if isinstance(fn, type) and issubclass(fn, Operator):
+
+        def new_fn(*args, **kwargs):
+            fn(*args, **kwargs)
+
+        return new_fn
+    return fn
+
+
 class Conditional(SymbolicOp, Operation):
     """A Conditional Operation.
 
@@ -257,7 +267,8 @@ class CondCallable:
             if len(self.orig_elifs) > 0 and not isinstance(self.orig_elifs[0], tuple)
             else list(self.orig_elifs)
         )
-        flat_true_fn = FlatFn(self.true_fn)
+        true_fn = _no_return(self.true_fn) if self.otherwise_fn is None else self.true_fn
+        flat_true_fn = FlatFn(true_fn)
         branches = [(self.preds[0], flat_true_fn), *elifs, (True, self.otherwise_fn)]
 
         end_const_ind = len(

--- a/tests/capture/test_capture_cond.py
+++ b/tests/capture/test_capture_cond.py
@@ -384,6 +384,23 @@ class TestCondReturns:
                 jax.numpy.array(1)
             )
 
+    def test_true_fn_operator_type_no_false_fn(self):
+        """Test that the true_fn can be an operator type when there is no false function. Instead,
+        the cond simply has no output."""
+
+        def f():
+            qml.cond(True, qml.X)(0)
+
+        jaxpr = jax.make_jaxpr(f)()
+        assert jaxpr.eqns[0].primitive == cond_prim
+        assert len(jaxpr.eqns[0].outvars) == 0
+
+        true_fn = jaxpr.eqns[0].params["jaxpr_branches"][0]
+        assert len(true_fn.outvars) == 0
+        assert true_fn.eqns[0].primitive == qml.X._primitive  # pylint: disable=protected-access
+
+        assert jaxpr.eqns[0].params["jaxpr_branches"][-1] is None
+
 
 dev = qml.device("default.qubit", wires=3)
 


### PR DESCRIPTION
**Context:**

One thing both core pennylane and current catalyst both support is:
```
qml.cond(True, qml.X)(0)
```

Capture currently forbids this, because the `true_fn` and `false_fn` have different outputs.  

If we make the assumption that the above syntax always means "queue an X operator" instead of "return an X operator", we can still consider it well defined.

So if no `false_fn` is provided and the input is a subclass of operator, we should just assume that the operator should be "queued" not necessarily returned.

**Description of the Change:**

Removes the output from `true_fn` if it's a subclass of `Operator` and no `false_fn` is provided.

**Benefits:**

Smoother change to using program capture as the new frontend.

**Possible Drawbacks:**

Someone might actually want the operator instance. This is more of a "patch" for a specific use case than generic behavior.

**Related GitHub Issues:**

[sc-97433]