### PR TITLE
[Bug Fix Release] fix recursion error when simplifying operators raised to integer powers

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-0.42.2.md
+
 .. mdinclude:: ../releases/changelog-0.42.1.md
 
 .. mdinclude:: ../releases/changelog-0.42.0.md

--- a/doc/releases/changelog-0.42.1.md
+++ b/doc/releases/changelog-0.42.1.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.42.1 (current release)
+# Release 0.42.1
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -11,7 +11,7 @@
   >>> (DummyOp(0) ** 2).simplify()
   DummyOp(0) @ DummyOp(0)
   ```
-  
+
   Previously, this would fail with a recursion error.
   [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
 
@@ -19,4 +19,5 @@
 
 This release contains contributions from (in alphabetical order):
 
-Andrija Paurevic
+Christina Lee,
+Andrija Paurevic.

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -4,12 +4,14 @@
 
 <h3>Bug fixes 🐛</h3>
 * Fixed a recursion error when simplifying operators that are raised to integer powers. For example,
+
   ```pycon
   >>> class DummyOp(qml.operation.Operator):
   ...     pass
   >>> (DummyOp(0) ** 2).simplify()
   DummyOp(0) @ DummyOp(0)
   ```
+  
   Previously, this would fail with a recursion error.
   [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
 

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -1,0 +1,14 @@
+:orphan:
+
+# Release 0.42.2 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* Simplifying operators raised to integer powers no longer causes recursion errors.
+  [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -3,8 +3,14 @@
 # Release 0.42.2 (current release)
 
 <h3>Bug fixes 🐛</h3>
-
-* Simplifying operators raised to integer powers no longer causes recursion errors.
+* Fixed a recursion error when simplifying operators that are raised to integer powers. For example,
+  ```pycon
+  >>> class DummyOp(qml.operation.Operator):
+  ...     pass
+  >>> (DummyOp(0) ** 2).simplify()
+  DummyOp(0) @ DummyOp(0)
+  ```
+  Previously, this would fail with a recursion error.
   [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
 
 <h3>Contributors ✍️</h3>

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.1"
+__version__ = "0.42.2"

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1778,7 +1778,7 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         """The negation operation of an Operator object."""
         return qml.s_prod(scalar=-1, operator=self, lazy=False)
 
-    def __pow__(self, other: TensorLike):
+    def __pow__(self, other: TensorLike) -> "Operator":
         r"""The power operation of an Operator object."""
         if isinstance(other, TensorLike):
             return qml.pow(self, z=other)

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -401,8 +401,9 @@ class Pow(ScalarSymbolicOp):
             ops = base.pow(z=self.z)
             if not ops:
                 return qml.Identity(self.wires)
-            op = qml.prod(*ops) if len(ops) > 1 else ops[0]
-            return op if qml.capture.enabled() else op.simplify()
+            if not qml.capture.enabled():
+                ops = [op.simplify() for op in ops]
+            return qml.prod(*ops) if len(ops) > 1 else ops[0]
         except PowUndefinedError:
             return Pow(base=base, z=self.z)
 

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -108,6 +108,15 @@ class TestConstructor:
 
         assert original_op not in q.queue
 
+    def test_simplify_squared(self):
+        """Test that an op without a special pow method can still be simplified when raised to an integer power."""
+
+        class DummyOp(qml.operation.Operator):
+            pass
+
+        simplified = (DummyOp(0) ** 2).simplify()
+        qml.assert_equal(simplified, DummyOp(0) @ DummyOp(0))
+
 
 @pytest.mark.parametrize("power_method", [Pow, pow_using_dunder_method, qml.pow])
 class TestInheritanceMixins:


### PR DESCRIPTION
**Context:**

A bug was found during `v0.43` development that causes recursion errors for an edge case.

**Description of the Change:**

Bug was fixed in `v0.43` development here: https://github.com/PennyLaneAI/pennylane/pull/8044/files. 

This PR just cherry picks that commit and updates any changelog / release notes files as necessary.

[sc-97369]
