### PR TITLE
[Bug Fix Release] fix: changelog entry in release notes

### DIFF
--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -15,6 +15,7 @@
 
   Previously, this would fail with a recursion error.
   [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
+  [(#8064)](https://github.com/PennyLaneAI/pennylane/pull/8064)
 
 <h3>Contributors ✍️</h3>
 

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -3,6 +3,7 @@
 # Release 0.42.2 (current release)
 
 <h3>Bug fixes 🐛</h3>
+
 * Fixed a recursion error when simplifying operators that are raised to integer powers. For example,
 
   ```pycon


### PR DESCRIPTION
**Context:**

Follow up to https://github.com/PennyLaneAI/pennylane/pull/8061 - there was a formatting error in the changelog entry of the release notes page.

<img width="1118" height="208" alt="image" src="https://github.com/user-attachments/assets/8431832d-9ee4-407d-959e-a6a6f9768f90" />


**Description of the Change:**

Renders properly in the release notes page (code block didn't render correctly),
<img width="802" height="314" alt="image" src="https://github.com/user-attachments/assets/0ca9ecdc-e0f2-4b37-8ad1-eb99d641e0be" />

[sc-97369]
