### PR TITLE
[Capture] Add error if `qml.cond` predicate is not a scalar

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -121,6 +121,8 @@
   technically a callable that returns an `X` operator.
   [(#8060)](https://github.com/PennyLaneAI/pennylane/pull/8060)
 
+* With program capture, an error is now raised if the conditional predicate is not a scalar.
+
 <h4>OpenQASM-PennyLane interoperability</h4>
 
 * The :func:`qml.from_qasm3` function can now convert OpenQASM 3.0 circuits that contain

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -282,6 +282,8 @@ class CondCallable:
         abstracted_axes, abstract_shapes = qml.capture.determine_abstracted_axes(args)
 
         for pred, fn in branches:
+            if (pred_shape := qml.math.shape(pred)) != ():
+                raise ValueError(f"Condition predicate must be a scalar. Got {pred_shape}.")
             conditions.append(pred)
             if fn is None:
                 jaxpr_branches.append(None)

--- a/tests/capture/test_capture_cond.py
+++ b/tests/capture/test_capture_cond.py
@@ -58,6 +58,16 @@ def testing_functions():
     return true_fn, false_fn, elif_fn1, elif_fn2, elif_fn3, elif_fn4
 
 
+def test_bad_predicate_shape():
+    """Test that an error is raised if the predicate is not a scalar."""
+
+    def f():
+        qml.cond(np.array([0, 0]), qml.X, qml.Z)(0)
+
+    with pytest.raises(ValueError, match="predicate must be a scalar"):
+        jax.make_jaxpr(f)()
+
+
 @pytest.mark.parametrize("decorator", [True, False])
 class TestCond:
     """Tests for conditional functions using qml.cond."""


### PR DESCRIPTION
**Context:**

While updating catalyst tests to run with both frontends, I was encountering this test:
```
    def test_array_conversion_failed(self):
        """Test failure at converting array to bool using Autograph."""

        @qjit(autograph=True)
        def workflow(x):
            n = jnp.array([[1], [2]])

            if n:
                y = x**2
            else:
                y = 0

            return y

        with pytest.raises(
            TypeError, match="Array with multiple elements is not a valid predicate"
        ):
            workflow(3)
```

Which made me realize we don't actually have a similar verification for program capture. This adds that verification in.

**Description of the Change:**

Checks that all the predicates are scalars.

**Benefits:**

Enhanced verification.

**Possible Drawbacks:**

More stuff to run.

**Related GitHub Issues:**

[sc-97523]