### PR TITLE
chore: merge `v0.42.2` bug fix release into `main`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -5,6 +5,8 @@ This page contains the release notes for PennyLane.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.42.2.md
+
 .. mdinclude:: ../releases/changelog-0.42.1.md
 
 .. mdinclude:: ../releases/changelog-0.42.0.md

--- a/doc/releases/changelog-0.42.1.md
+++ b/doc/releases/changelog-0.42.1.md
@@ -1,4 +1,4 @@
-# Release 0.42.1 (current release)
+# Release 0.42.1
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -1,0 +1,23 @@
+# Release 0.42.2 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* Fixed a recursion error when simplifying operators that are raised to integer powers. For example,
+
+  ```pycon
+  >>> class DummyOp(qml.operation.Operator):
+  ...     pass
+  >>> (DummyOp(0) ** 2).simplify()
+  DummyOp(0) @ DummyOp(0)
+  ```
+
+  Previously, this would fail with a recursion error.
+  [(#8061)](https://github.com/PennyLaneAI/pennylane/pull/8061)
+  [(#8064)](https://github.com/PennyLaneAI/pennylane/pull/8064)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Christina Lee,
+Andrija Paurevic.


### PR DESCRIPTION
**Context:**

v0.42.2 was released yesterday (https://github.com/PennyLaneAI/pennylane/pull/8061). The bug fix is already in main so we only need to update the changelog entries.

**Benefits:** Up to date code.

[sc-97524]
