### PR TITLE
[WIP] Make `qnode.shots` Public Again

### DIFF
--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -439,7 +439,7 @@ def construct_batch(
     _validate_level(level)
     is_torch_layer = type(qnode).__name__ == "TorchLayer"
     has_shots_param = "shots" in inspect.signature(qnode.func).parameters
-    default_shots = qnode._shots  # pylint:disable=protected-access
+    default_shots = qnode.shots
 
     user_program = qnode.transform_program
     num_user_transforms = len(user_program)


### PR DESCRIPTION
**Context:**
Note that long ago we abandoned the `shots` specification at `QNode`. However, now with many things and contexts changed drastically, we would like to bring back a public UI for convenience and friendliness.

**Description of the Change:**
 - [x] a new public property `shots` has been created. Its setter is blocked by errors due to exclusive access of `qml.set_shots`
 - [ ] 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-97581]