### PR TITLE
Add support for MCMs to the decomposition system.

### DIFF
--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -149,8 +149,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         self,
         operations: list[Operator | CompressedResourceOp],
         gate_set: set[type | str] | dict[type | str, float],
-        fixed_decomps: dict = None,
-        alt_decomps: dict = None,
+        fixed_decomps: dict | None = None,
+        alt_decomps: dict | None = None,
     ):
         if isinstance(gate_set, dict):
             # the gate_set is a dict
@@ -179,6 +179,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
     def _construct_graph(self, operations):
         """Constructs the decomposition graph."""
         for op in operations:
+            if isinstance(op, qml.measurements.MidMeasureMP):
+                continue  # cannot decompose a mid-circuit measurement
+            if isinstance(op, qml.ops.Conditional):
+                op = op.base  # decompose the base of a classically controlled operator.
             if isinstance(op, Operator):
                 op = resource_rep(type(op), **op.resource_params)
             idx = self._add_op_node(op)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -696,12 +696,7 @@ def _equal_measurements(
 
 @_equal_dispatch.register
 def _equal_mid_measure(op1: MidMeasureMP, op2: MidMeasureMP, **_):
-    return (
-        op1.wires == op2.wires
-        and op1.id == op2.id
-        and op1.reset == op2.reset
-        and op1.postselect == op2.postselect
-    )
+    return op1.wires == op2.wires and op1.reset == op2.reset and op1.postselect == op2.postselect
 
 
 @_equal_dispatch.register

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -95,7 +95,7 @@ class Conditional(SymbolicOp, Operation):
             can be useful for some applications where the instance has to be identified
     """
 
-    def __init__(self, expr, then_op: type[Operation], id=None):
+    def __init__(self, expr, then_op: Operation, id=None):
         self.hyperparameters["meas_val"] = expr
         self._name = f"Conditional({then_op.name})"
         super().__init__(then_op, id=id)


### PR DESCRIPTION
**Context:**

**Description of the Change:**
- The `qml.transforms.decompose` will decompose the base inside a `Conditional`

**Benefits:**
Decomposition rules can contain mid circuit measurements and conditional operators

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-96740]
[sc-96739]
