### PR TITLE
Remove mention of `use_style` in `MPLDrawer`

### DIFF
--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -123,20 +123,7 @@ class MPLDrawer:
 
     **Formatting**
 
-    PennyLane has inbuilt styles for controlling the appearance of the circuit drawings.
-    All available styles can be determined by evaluating ``qml.drawer.available_styles()``.
-    Any available string can then be passed to ``qml.drawer.use_style``.
-
-    .. code-block:: python
-
-        qml.drawer.use_style('black_white')
-
-    .. figure:: ../../_static/drawer/black_white_style.png
-            :align: center
-            :width: 60%
-            :target: javascript:void(0);
-
-    You can also control the appearance with matplotlib's provided tools, see the
+    You can control the appearance with matplotlib's provided tools, see the
     `matplotlib docs <https://matplotlib.org/stable/tutorials/introductory/customizing.html>`_ .
     For example, we can customize ``plt.rcParams``:
 


### PR DESCRIPTION
**Context:**
- `use_style` is not functional with `MPLDrawer`, therefore it's mention should be removed from the documentation.
See forum thread uncovering this issue: https://discuss.pennylane.ai/t/how-to-customize-the-text-in-the-quantum-gates-when-drawing-a-quantum-circuit-diagram/8897/4

**Description of the Change:**
- Remove mentions of `use_style` from `MPLDrawer` documentation page.

**Benefits:**
- Avoids user confusion regarding the use of `use_style` with `MPLDrawer`.

**Possible Drawbacks:**

**Related GitHub Issues:**
