### PR TITLE
capture counts

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -523,6 +523,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* `counts` can now be captured by program capture. `MeasurementProcess._abstract_eval` should now return a tuple
+  of `(shape, dtype)` tuples, instead of a single `(shape, dtype)` tuple.
+
 * Add capability for roundtrip testing and module verification to the Python compiler `run_filecheck` and
 `run_filecheck_qjit` fixtures.
   [(#8049)](https://github.com/PennyLaneAI/pennylane/pull/8049)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -525,6 +525,7 @@
 
 * `counts` can now be captured by program capture. `MeasurementProcess._abstract_eval` should now return a tuple
   of `(shape, dtype)` tuples, instead of a single `(shape, dtype)` tuple.
+  [(#8096)](https://github.com/PennyLaneAI/pennylane/pull/8096)
 
 * Add capability for roundtrip testing and module verification to the Python compiler `run_filecheck` and
 `run_filecheck_qjit` fixtures.

--- a/pennylane/measurements/capture_measurements.py
+++ b/pennylane/measurements/capture_measurements.py
@@ -49,11 +49,16 @@ def _get_abstract_measurement():
         """
 
         def __init__(
-            self, abstract_eval: Callable, n_wires: int | None = None, has_eigvals: bool = False
+            self,
+            abstract_eval: Callable,
+            n_wires: int | None = None,
+            has_eigvals: bool = False,
+            num_outputs: int = 1,
         ):
             self._abstract_eval = abstract_eval
             self._n_wires = n_wires
             self.has_eigvals: bool = has_eigvals
+            self.num_outputs = num_outputs
 
         def abstract_eval(self, num_device_wires: int, shots: int) -> tuple[tuple, type]:
             """Calculate the shape and dtype for an evaluation with specified number of device
@@ -220,6 +225,11 @@ def create_measurement_wires_primitive(
     def _(*args, has_eigvals=False, **_):
         abstract_eval = measurement_type._abstract_eval  # pylint: disable=protected-access
         n_wires = len(args) - 1 if has_eigvals else len(args)
-        return abstract_type(abstract_eval, n_wires=n_wires, has_eigvals=has_eigvals)
+        return abstract_type(
+            abstract_eval,
+            n_wires=n_wires,
+            has_eigvals=has_eigvals,
+            num_outputs=measurement_type._num_outputs,  # pylint: disable=protected-access
+        )
 
     return primitive

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -402,7 +402,7 @@ class ClassicalShadowMP(MeasurementTransform):
         shots: int | None = None,
         num_device_wires: int = 0,
     ) -> tuple:
-        return (2, shots, n_wires), np.int8
+        return (((2, shots, n_wires), np.int8),)
 
     def shape(self, shots: int | None = None, num_device_wires: int = 0) -> tuple[int, int, int]:
         # otherwise, the return type requires a device

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -50,6 +50,7 @@ class CountsMP(SampleMeasurement):
     """
 
     _shortname = "counts"
+    _num_outputs = 2
 
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(
@@ -88,9 +89,11 @@ class CountsMP(SampleMeasurement):
         shots: int | None = None,
         num_device_wires: int = 0,
     ) -> tuple:
-        raise NotImplementedError(
-            "CountsMP returns a dictionary, which is not compatible with capture."
-        )
+        if shots is None:
+            raise ValueError("finite shots are required to use Counts")
+        dim = num_device_wires if n_wires == 0 else n_wires
+        arr1 = ((dim,), int)
+        return (arr1, arr1)
 
     @property
     def hash(self):

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -68,6 +68,9 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
     _wires_primitive: Optional["jax.extend.core.Primitive"] = None
     _mcm_primitive: Optional["jax.extend.core.Primitive"] = None
 
+    _num_outputs: int = 1
+    """The number of arrays returned by this measurement process."""
+
     def __init_subclass__(cls, **_):
         register_pytree(cls, cls._flatten, cls._unflatten)
         name = cls._shortname or cls.__name__
@@ -116,7 +119,7 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         has_eigvals=False,
         shots: int | None = None,
         num_device_wires: int = 0,
-    ) -> tuple[tuple, type]:
+    ) -> tuple[tuple[tuple, type], ...]:
         """Calculate the shape and dtype that will be returned when a measurement is performed.
 
         This information is similar to ``numeric_type`` and ``shape``, but is provided through
@@ -130,18 +133,18 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         measurements. ``n_wires = 0`` indicates a measurement that is broadcasted across all device wires.
 
         >>> ProbabilityMP._abstract_eval(n_wires=2)
-        ((4,), float)
+        (((4,), float),)
         >>> ProbabilityMP._abstract_eval(n_wires=0, num_device_wires=2)
-        ((4,), float)
+        (((4,), float),)
         >>> SampleMP._abstract_eval(n_wires=0, shots=50, num_device_wires=2)
-        ((50, 2), int)
+        (((50, 2), int),)
         >>> SampleMP._abstract_eval(n_wires=4, has_eigvals=True, shots=50)
-        ((50,), float)
+        (((50,), float),)
         >>> SampleMP._abstract_eval(n_wires=None, shots=50)
-        ((50,), float)
+        (((50,), float),)
 
         """
-        return (), float
+        return (((), float),)
 
     def _flatten(self):
         metadata = (("wires", self.raw_wires),)

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -167,7 +167,7 @@ class MidMeasureMP(MeasurementProcess):
         shots: int | None = None,
         num_device_wires: int = 0,
     ) -> tuple:
-        return (), int
+        return (((), int),)
 
     def label(self, decimals=None, base_label=None, cache=None):  # pylint: disable=unused-argument
         r"""How the mid-circuit measurement is represented in diagrams and drawings.

--- a/pennylane/measurements/null_measurement.py
+++ b/pennylane/measurements/null_measurement.py
@@ -42,7 +42,7 @@ class NullMeasurement(SampleMeasurement, StateMeasurement):
 
     @classmethod
     def _abstract_eval(cls, *_, **__):
-        return (), float
+        return (((), float),)
 
     def shape(self, *_, **__):
         return ()

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -53,7 +53,7 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
     def _abstract_eval(cls, n_wires=None, has_eigvals=False, shots=None, num_device_wires=0):
         n_wires = num_device_wires if n_wires == 0 else n_wires
         shape = (2**n_wires,)
-        return shape, float
+        return ((shape, float),)
 
     @property
     def numeric_type(self):

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -93,9 +93,9 @@ class SampleMP(SampleMeasurement):
         dtype = float if sample_eigvals else int
 
         if sample_eigvals:
-            return (shots,), dtype
+            return (((shots,), dtype),)
         dim = num_device_wires if n_wires == 0 else n_wires
-        return (shots, dim), dtype
+        return (((shots, dim), dtype),)
 
     @property
     def numeric_type(self):

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -50,7 +50,7 @@ class StateMP(StateMeasurement):
     ):
         n_wires = n_wires or num_device_wires
         shape = (2**n_wires,)
-        return shape, complex
+        return ((shape, complex),)
 
     @property
     def numeric_type(self):
@@ -133,7 +133,7 @@ class DensityMatrixMP(StateMP):
     ):
         n_wires = n_wires or num_device_wires
         shape = (2**n_wires, 2**n_wires)
-        return shape, complex
+        return ((shape, complex),)
 
     def shape(self, shots: int | None = None, num_device_wires: int = 0) -> tuple[int, int]:
         dim = 2 ** len(self.wires)


### PR DESCRIPTION
**Context:**

Currently, program capture cannot handle counts.  This was done because `counts` in core pl returns a dictionary, rather than a numeric output.  But catalyst accomodates this by returning two arrays instead.

We need further investigation to unify the catalyst and core pl way of handling counts, and to find a way to make counts actually sparse, but for now this at least allows us to use plxpr as the frontend for catalyst.

**Description of the Change:**

`MeasurementProcess._abstract_eval` now returns a tuple of `(shape, dtype)` tuples, instead one just one.

`MeasurmentProcess._num_outputs` should now match the number of numeric outputs from the measurement process.

Some code in `_capture_qnode` now packs the multiple arrays for a single output into a tuple before our final pytree postprocessing.

**Benefits:**

Better feature coverage for our ability to use plxpr as a frontend for catalyst.

**Possible Drawbacks:**

`MeasurementProcess._abstract_eval` is now harder to read.  Only accomplishes part of what we need. 

**Related GitHub Issues:**

[sc-92900]