### PR TITLE
feat: autograph: add `disable_autograph` context manager

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -529,6 +529,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Add ability to disable autograph conversion using the newly added `qml.capture.disable_autograph` decorator or context manager.
+  [(#8102)](https://github.com/PennyLaneAI/pennylane/pull/8102)
+
 * Add capability for roundtrip testing and module verification to the Python compiler `run_filecheck` and
 `run_filecheck_qjit` fixtures.
   [(#8049)](https://github.com/PennyLaneAI/pennylane/pull/8049)

--- a/pennylane/capture/__init__.py
+++ b/pennylane/capture/__init__.py
@@ -34,6 +34,7 @@ quantum-classical programs.
     ~expand_plxpr_transforms
     ~eval_jaxpr
     ~run_autograph
+    ~disable_autograph
     ~PlxprInterpreter
     ~FlatFn
     ~make_plxpr
@@ -164,7 +165,8 @@ from collections.abc import Callable
 from .switches import disable, enable, enabled, pause
 from .capture_meta import CaptureMeta, ABCCaptureMeta
 from .flatfn import FlatFn
-from .make_plxpr import make_plxpr, run_autograph
+from .make_plxpr import make_plxpr
+from .autograph import run_autograph, disable_autograph
 from .dynamic_shapes import determine_abstracted_axes, register_custom_staging_rule
 
 # by defining this here, we avoid

--- a/pennylane/capture/autograph/__init__.py
+++ b/pennylane/capture/autograph/__init__.py
@@ -19,7 +19,7 @@ Public/internal API for the AutoGraph module.
 import functools
 
 from pennylane.exceptions import AutoGraphWarning
-from .transformer import autograph_source, run_autograph
+from .transformer import autograph_source, run_autograph, disable_autograph
 
 AUTOGRAPH_WRAPPER_ASSIGNMENTS = tuple(
     attr for attr in functools.WRAPPER_ASSIGNMENTS if attr != "__module__"
@@ -36,5 +36,6 @@ def wraps(target):
 __all__ = (
     "autograph_source",
     "run_autograph",
+    "disable_autograph",
     "wraps",
 )

--- a/pennylane/capture/autograph/transformer.py
+++ b/pennylane/capture/autograph/transformer.py
@@ -308,7 +308,8 @@ class DisableAutograph(ag_ctx.ControlStatusCtx, ContextDecorator):
 
     **Example**
 
-    We can see this works by considering a simple example. In this case, we expect to see a `cond` primitive captured in the jaxpr from the function `f`.
+    We can see this works by considering a simple example.
+    In this case, we expect to see a ``cond`` primitive captured in the jaxpr from the function ``f``.
 
     .. code-block::
 

--- a/pennylane/capture/autograph/transformer.py
+++ b/pennylane/capture/autograph/transformer.py
@@ -23,8 +23,9 @@ by PennyLane.
 import copy
 import inspect
 import warnings
+from contextlib import ContextDecorator
 
-from malt.core import converter
+from malt.core import ag_ctx, converter
 from malt.impl.api import PyToPy
 
 import pennylane as qml
@@ -289,6 +290,31 @@ def autograph_source(fn):
         "given function to be converted, please submit a bug report."
     )
 
+
+# pylint: disable=too-few-public-methods
+class DisableAutograph(ag_ctx.ControlStatusCtx, ContextDecorator):
+    """Context decorator that disables AutoGraph for the given function/context.
+
+    .. note::
+
+        A singleton instance is used for discarding parentheses usage:
+
+        @disable_autograph
+        instead of
+        @DisableAutograph()
+
+        with disable_autograph:
+        instead of
+        with DisableAutograph()
+
+    """
+
+    def __init__(self):
+        super().__init__(status=ag_ctx.Status.DISABLED)
+
+
+# Singleton instance of DisableAutograph
+disable_autograph = DisableAutograph()
 
 TOPLEVEL_OPTIONS = converter.ConversionOptions(
     recursive=True,

--- a/pennylane/capture/autograph/transformer.py
+++ b/pennylane/capture/autograph/transformer.py
@@ -192,7 +192,6 @@ def run_autograph(fn):
         ] 0 b 1 a
       in (c,) }
     """
-
     user_context = converter.ProgramContext(TOPLEVEL_OPTIONS)
 
     new_fn, module, source_map = TRANSFORMER.transform(fn, user_context)

--- a/tests/capture/autograph/test_autograph.py
+++ b/tests/capture/autograph/test_autograph.py
@@ -593,6 +593,7 @@ class TestDisableAutograph:
 
         g_ag = run_autograph(g)
         g_ag_jaxpr = make_jaxpr(g_ag)(1, 3)
+        assert "for_loop" in str(g_ag_jaxpr.jaxpr)
         # If autograph was disabled, the cond primitive will not be captured.
         assert "cond" not in str(g_ag_jaxpr.jaxpr)
         assert g_ag(1, 3) == 13  # 1 + 4 * 3
@@ -616,6 +617,7 @@ class TestDisableAutograph:
 
         g_ag = run_autograph(g)
         g_ag_jaxpr = make_jaxpr(g_ag)(1, 3)
+        assert "for_loop" in str(g_ag_jaxpr.jaxpr)
         # If autograph was disabled, the cond primitive will not be captured.
         assert "cond" not in str(g_ag_jaxpr.jaxpr)
 


### PR DESCRIPTION
## Context

We wish to move control of when `autograph` is applied from the `QNode` to an external context manager and let `qjit` take priority as the entry point for this feature. 

ℹ️  Please note that the application of `autograph` is done through `qml.capture.autograph.run_autograph` - hence there is no need for an `enable_autograph`. 

## Description of the Change

Simply adds a decorator that disables autograph for a given function / context. You can see the render for documentation [here](https://xanaduai-pennylane--8102.com.readthedocs.build/en/8102/code/api/pennylane.capture.disable_autograph.html).

## Benefits

We can see this works by considering a simple example. In this case, we expect to see a `cond` primitive captured in the jaxpr from the function `f`.
```python
import pennylane as qml
import jax

from jax import make_jaxpr
from pennylane.capture.autograph import disable_autograph, run_autograph

qml.capture.enable()

def f(x):
    if x > 1:
        return x**2
    return x

def g():
    x = 2
    return f(x)

>>> make_jaxpr(run_autograph(g))()
{ lambda ; . let
    _:bool[] a:i32[] = cond[
      args_slice=slice(2, None, None)
      consts_slices=[slice(2, 2, None), slice(2, 2, None)]
      jaxpr_branches=[{ lambda ; . let  in (True:bool[], 4:i32[]) }, { lambda ; . let  in (True:bool[], 2:i32[]) }]
    ] True:bool[] True:bool[]
  in (a,) }
```

Now if we add the decorator the function is evaluated and not captured in the jaxpr,
```python
@disable_autograph
def f(x):
    if x > 1:
        return x**2
    return x

>>> make_jaxpr(run_autograph(g))()
{ lambda ; . let  in (4:i32[],) }
```
Or we can also use the context manager,
```python
def g():
    x = 2
    with disable_autograph:
        return f(x)

>>> make_jaxpr(run_autograph(g))()
{ lambda ; . let  in (4:i32[],) }
```

## Possible Drawbacks

There is no `enable_autograph`, but one can use `run_autograph` instead.

[sc-92905]
