### PR TITLE
forbid counts of list of mcm's with classical postprocessing

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -712,6 +712,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* An error is now raised if counts are calculated from sequences of processed mid circuit measurements.
+
 * Simplifying operators raised to integer powers no longer causes recursion errors.
   [(#8044)](https://github.com/PennyLaneAI/pennylane/pull/8044)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -712,7 +712,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* An error is now raised if counts are calculated from sequences of processed mid circuit measurements.
+* An error is now raised if counts and probs are calculated from
+  sequences of processed mid circuit measurements.
   [(#8109)](https://github.com/PennyLaneAI/pennylane/pull/8109)
 
 * Simplifying operators raised to integer powers no longer causes recursion errors.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -712,8 +712,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* An error is now raised if counts and probs are calculated from
-  sequences of processed mid circuit measurements.
+* An error is now raised if sequences of classically processed mid circuit measurements
+  are used as input to :func:`pennylane.counts` or :func:`pennylane.probs`.
   [(#8109)](https://github.com/PennyLaneAI/pennylane/pull/8109)
 
 * Simplifying operators raised to integer powers no longer causes recursion errors.

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -327,7 +327,7 @@ def _measure_impl(
     # Create a UUID and a map between MP and MV to support serialization
     measurement_id = str(uuid.uuid4())
     mp = measurement_class(wires=wires, id=measurement_id, **kwargs)
-    return MeasurementValue([mp], processing_fn=lambda v: v)
+    return MeasurementValue([mp])
 
 
 class ParametricMidMeasureMP(MidMeasureMP):
@@ -751,8 +751,16 @@ def diagonalize_mcms(tape):
                 curr_idx += 1
 
                 # add conditional diagonalizing gates + computational basis MCM to the tape
-                expr_true = MeasurementValue(mps, processing_fn=true_cond.meas_val.processing_fn)
-                expr_false = MeasurementValue(mps, processing_fn=false_cond.meas_val.processing_fn)
+                p_fn = (
+                    true_cond.meas_val.processing_fn if true_cond.meas_val.has_processing else None
+                )
+                expr_true = MeasurementValue(mps, processing_fn=p_fn)
+                f_fn = (
+                    false_cond.meas_val.processing_fn
+                    if false_cond.meas_val.has_processing
+                    else None
+                )
+                expr_false = MeasurementValue(mps, processing_fn=f_fn)
 
                 with QueuingManager.stop_recording():
                     diag_gates_true = [

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -420,11 +420,11 @@ def counts(
 
     if isinstance(op, Sequence):
         if not all(
-            math.is_abstract(o) or (isinstance(o, MeasurementValue) and len(o.measurements) == 1)
+            math.is_abstract(o) or (isinstance(o, MeasurementValue) and not o.has_processing)
             for o in op
         ):
             raise QuantumFunctionError(
-                "Only sequences of single MeasurementValues can be passed with the op argument. "
+                "Only sequences of unprocessed MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."
             )

--- a/pennylane/measurements/mid_measure.py
+++ b/pennylane/measurements/mid_measure.py
@@ -39,7 +39,7 @@ def _measure_impl(
     # Create a UUID and a map between MP and MV to support serialization
     measurement_id = str(uuid.uuid4())
     mp = MidMeasureMP(wires=wires, reset=reset, postselect=postselect, id=measurement_id)
-    return MeasurementValue([mp], processing_fn=lambda v: v)
+    return MeasurementValue([mp])
 
 
 @lru_cache

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -280,10 +280,10 @@ def probs(wires=None, op=None) -> ProbabilityMP:
 
     if isinstance(op, Sequence):
         if not math.is_abstract(op[0]) and not all(
-            isinstance(o, MeasurementValue) and len(o.measurements) == 1 for o in op
+            isinstance(o, MeasurementValue) and not o.has_processing for o in op
         ):
             raise QuantumFunctionError(
-                "Only sequences of single MeasurementValues can be passed with the op argument. "
+                "Only sequences of unprocessed MeasurementValues can be passed with the op argument. "
                 "MeasurementValues manipulated using arithmetic operators cannot be used when "
                 "collecting statistics for a sequence of mid-circuit measurements."
             )

--- a/pennylane/transforms/defer_measurements.py
+++ b/pennylane/transforms/defer_measurements.py
@@ -389,7 +389,7 @@ def _get_plxpr_defer_measurements():
                 qml.PauliX(wires=wires)
 
         self.state["cur_target"] -= 1
-        return MeasurementValue([meas], lambda x: x)
+        return MeasurementValue([meas])
 
     @DeferMeasurementsInterpreter.register_primitive(cond_prim)
     def _(self, *invals, jaxpr_branches, consts_slices, args_slice):
@@ -824,7 +824,9 @@ def defer_measurements(
                 new_ms = [
                     qml.map_wires(m, {m.wires[0]: control_wires[m.id]}) for m in mp.mv.measurements
                 ]
-                new_m = MeasurementValue(new_ms, mp.mv.processing_fn)
+                new_m = MeasurementValue(
+                    new_ms, mp.mv.processing_fn if mp.mv.has_processing else None
+                )
             else:
                 new_m = []
                 for val in mp.mv:
@@ -832,7 +834,9 @@ def defer_measurements(
                         qml.map_wires(m, {m.wires[0]: control_wires[m.id]})
                         for m in val.measurements
                     ]
-                    new_m.append(MeasurementValue(new_ms, val.processing_fn))
+                    new_m.append(
+                        MeasurementValue(new_ms, val.processing_fn if val.has_processing else None)
+                    )
 
             with QueuingManager.stop_recording():
                 new_mp = (

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -217,7 +217,7 @@ def init_auxiliary_tape(circuit: qml.tape.QuantumScript):
         if "MidCircuitMeasure" in str(type(op)):  # pragma: no cover
             new_measurements.append(qml.sample(op.out_classical_tracers[0]))
         elif isinstance(op, MidMeasureMP):
-            new_measurements.append(qml.sample(MeasurementValue([op], lambda res: res)))
+            new_measurements.append(qml.sample(MeasurementValue([op])))
     return qml.tape.QuantumScript(
         circuit.operations,
         new_measurements,

--- a/tests/measurements/test_counts.py
+++ b/tests/measurements/test_counts.py
@@ -255,7 +255,7 @@ class TestProcessSamples:
 
         with pytest.raises(
             QuantumFunctionError,
-            match="Only sequences of single MeasurementValues can be passed with the op argument",
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0, qml.PauliZ(0)])
 
@@ -268,9 +268,21 @@ class TestProcessSamples:
 
         with pytest.raises(
             QuantumFunctionError,
-            match="Only sequences of single MeasurementValues can be passed with the op argument",
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
         ):
             _ = qml.counts(op=[m0 + m1, m2])
+
+    def test_processed_measurement_value_lists_not_allowed(self):
+        """Test that passing a list containing measurement values composed with arithmetic
+        raises an error."""
+        m0 = qml.measure(0)
+        m1 = qml.measure(1)
+
+        with pytest.raises(
+            QuantumFunctionError,
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
+        ):
+            _ = qml.counts(op=[2 * m0, m1])
 
     def test_counts_all_outcomes_wires(self):
         """Test that the counts output is correct when all_outcomes is passed"""

--- a/tests/measurements/test_probs.py
+++ b/tests/measurements/test_probs.py
@@ -467,7 +467,7 @@ class TestProbs:
 
         with pytest.raises(
             QuantumFunctionError,
-            match="Only sequences of single MeasurementValues can be passed with the op argument",
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0, qml.PauliZ(0)])
 
@@ -480,9 +480,21 @@ class TestProbs:
 
         with pytest.raises(
             QuantumFunctionError,
-            match="Only sequences of single MeasurementValues can be passed with the op argument",
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
         ):
             _ = qml.probs(op=[m0 + m1, m2])
+
+    def test_processed_measurement_value_lists_not_allowed(self):
+        """Test that passing a list containing measurement values composed with arithmetic
+        raises an error."""
+        m0 = qml.measure(0)
+        m1 = qml.measure(1)
+
+        with pytest.raises(
+            QuantumFunctionError,
+            match="Only sequences of unprocessed MeasurementValues can be passed with the op argument",
+        ):
+            _ = qml.probs(op=[2 * m0, m1])
 
     @pytest.mark.parametrize("shots", [None, 100])
     def test_batch_size(self, shots):


### PR DESCRIPTION
**Context:**

Measusing counts like:
```
m0 = qml.measure(0)
m1 = qml.measure(1)
counts([2*m0, m1])
```
is ill-defined, but doesn't raise an type of error or warning.  

**Description of the Change:**

Adds a `MeasurmentValue.has_processing` and uses it to forbid the above case from happening.

**Benefits:**

Less confusion about what the result in the above case should actually look like.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-97994]
