### PR TITLE
[Bug Fix Release] add upper bound to `autoray` version requirement in `pyproject.toml`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-0.42.3.md
+
 .. mdinclude:: ../releases/changelog-0.42.2.md
 
 .. mdinclude:: ../releases/changelog-0.42.1.md

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.42.2 (current release)
+# Release 0.42.2 
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.42.3.md
+++ b/doc/releases/changelog-0.42.3.md
@@ -1,0 +1,14 @@
+:orphan:
+
+# Release 0.42.3 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* Set `autoray` package upper-bound in `pyproject.toml` CI due to breaking changes in `v0.8.0`. 
+  [(#)]()
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic.

--- a/doc/releases/changelog-0.42.3.md
+++ b/doc/releases/changelog-0.42.3.md
@@ -4,8 +4,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Set `autoray` package upper-bound in `pyproject.toml` CI due to breaking changes in `v0.8.0`. 
-  [(#)]()
+* Set `autoray` package upper-bound in `pyproject.toml` due to breaking changes introduced in `v0.8.0`. 
+  [(#8111)](https://github.com/PennyLaneAI/pennylane/pull/8111)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.42.2"
+__version__ = "0.42.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rustworkx>=0.14.0",
     "autograd",
     "appdirs",
-    "autoray>=0.6.11",
+    "autoray>=0.6.11,<0.8",
     "cachetools",
     "pennylane-lightning>=0.42",
     "requests",


### PR DESCRIPTION
**Context:**

The `autoray` package released a new version and broke our PL environment.

Users installing PennyLane from PyPI currently cannot import `pennylane` due to changes in the `autoray` package.

**Description of the Change:**

Adds an upper bound to the version requirement to dodge problematic version.

**Benefits:** Users have a functional environment.

[sc-98038]
