### PR TITLE
Remove xfails from lightning tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -379,6 +379,7 @@
   down on the complexity of post-processing due to having to handle single shot and single wire cases
   separately. The return shape will now *always* be `(shots, num_wires)`.
   [(#7944)](https://github.com/PennyLaneAI/pennylane/pull/7944)
+  [(#8118)](https://github.com/PennyLaneAI/pennylane/pull/8118)
 
   For a simple qnode:
 

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -586,9 +586,6 @@ class TestDevicePreprocessing:
     def test_mcm_execution_deferred_hw_like(self, dev_name, mcm_method, seed):
         """Test that using a qnode with postselect_mode="hw-like" gives the expected results."""
 
-        if dev_name == "lightning.qubit":
-            pytest.xfail("still squeezing samples")  # [sc-96550]
-
         shots = 1000
         dev = qml.device(dev_name, wires=2, shots=shots, seed=seed)
         postselect = 1 if dev_name == "default.qubit" else None
@@ -618,9 +615,6 @@ class TestDevicePreprocessing:
 
     def test_mcms_execution_single_branch_statistics(self, dev_name, seed):
         """Test that single-branch-statistics works as expected."""
-
-        if dev_name == "lightning.qubit":
-            pytest.xfail("still squeezing samples")  # [sc-96550]
 
         shots = 1000
         dev = qml.device(dev_name, wires=2, shots=shots, seed=seed)

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -610,7 +610,7 @@ class TestDevicePreprocessing:
             )
         else:
             assert len(res) == shots
-            counts = qml.numpy.bincount(res)
+            counts = qml.numpy.bincount(qml.math.squeeze(res))
             assert qml.math.isclose(counts[0] / counts[1], 1, atol=0.3)
 
     def test_mcms_execution_single_branch_statistics(self, dev_name, seed):

--- a/tests/ftqc/test_decomposition.py
+++ b/tests/ftqc/test_decomposition.py
@@ -498,9 +498,6 @@ class TestMBQCFormalismConversion:
     # wires E2E. Following discussion at the FTQC team meeting, we are marking
     # this test as flaky and keeping it here for the time being.
     @flaky(max_runs=5, min_passes=3)
-    @pytest.mark.xfail(
-        reason="lightning qubit hasn't been switched to no squeezing yet."
-    )  # [sc-96550]
     @pytest.mark.slow
     def test_conversion_of_multi_wire_circuit(self):
         """Test that the transform converts the tape to the expected set of gates

--- a/tests/test_debugging.py
+++ b/tests/test_debugging.py
@@ -245,9 +245,6 @@ class TestSnapshotGeneral:
     def test_override_shots(self, dev):
         """Test that override shots allow snapshots to work with different numbers of measurements."""
 
-        if dev.name == "lightning.qubit":
-            pytest.xfail("Just till remove squeezing on lightning.qubit.")  # [sc-96550]
-
         @qml.qnode(dev)
         def c():
             if dev.name != "default.qutrit":
@@ -267,9 +264,6 @@ class TestSnapshotGeneral:
 
     def test_override_analytic(self, dev):
         """Test that finite shots can be written with analytic calculations."""
-
-        if dev.name == "lightning.qubit":
-            pytest.xfail("Just till remove squeezing on lightning.qubit.")  # [sc-96550]
 
         if dev.name == "default.qutrit":
             pytest.skip("hard to write generic test that works with qutrits.")


### PR DESCRIPTION
**Context:**

In PR #7944  I had to xfail a couple of tests since they required lightning to be updated to move it's squeezing too. Lightning has now been updated.

**Description of the Change:**

Remove the xfails.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-96550]