### PR TITLE
chore: merge `v0.42.3` bug fix changelog into `main`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -5,6 +5,8 @@ This page contains the release notes for PennyLane.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.42.3.md
+
 .. mdinclude:: ../releases/changelog-0.42.2.md
 
 .. mdinclude:: ../releases/changelog-0.42.1.md

--- a/doc/releases/changelog-0.42.2.md
+++ b/doc/releases/changelog-0.42.2.md
@@ -1,4 +1,4 @@
-# Release 0.42.2 (current release)
+# Release 0.42.2
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.42.3.md
+++ b/doc/releases/changelog-0.42.3.md
@@ -1,0 +1,12 @@
+# Release 0.42.3 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* Set `autoray` package upper-bound in `pyproject.toml` due to breaking changes introduced in `v0.8.0`. 
+  [(#8111)](https://github.com/PennyLaneAI/pennylane/pull/8111)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Andrija Paurevic.


### PR DESCRIPTION
**Context:**

[v0.42.3 bug fix](https://github.com/PennyLaneAI/pennylane/pull/8111) was released yesterday. This PR updates our release notes to include this fix.

[sc-98171]
