### PR TITLE
Add warning about precision in interfaces documentation

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -118,6 +118,10 @@ PennyLane also provides higher-level classes for converting QNodes into ``torch.
 
     pennylane.qnn.TorchLayer
 
+.. warning::
+
+    PennyLane's QNodes currently promote all ``float32`` (single-precision) inputs to ``float64`` (double-precision) during       execution. This may result in higher memory usage than expected.
+
 
 .. note::
 


### PR DESCRIPTION
**Context:**
A user query on our forum ([Thread #8885](https://discuss.pennylane.ai/t/pytorch-default-data-type/8885)) revealed that PennyLane silently promotes all float32 inputs to float64 during computation.

**Description of the Change:**

This change adds a warning to the [Interfaces ](https://docs.pennylane.ai/en/stable/introduction/interfaces.html)documentation regarding the behaviour (everything is promoted to 64-bit outputs).

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
