### PR TITLE
more informative draw error for deep circuits

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -789,6 +789,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* A more informative error is raised when extremely deep circuits are attempted to be drawn.
+
 * An error is now raised if sequences of classically processed mid circuit measurements
   are used as input to :func:`pennylane.counts` or :func:`pennylane.probs`.
   [(#8109)](https://github.com/PennyLaneAI/pennylane/pull/8109)

--- a/pennylane/drawer/drawable_layers.py
+++ b/pennylane/drawer/drawable_layers.py
@@ -184,7 +184,15 @@ def drawable_layers(operations, wire_map=None, bit_map=None):
             # Find occupied wires of the operator/measurement process and find which layer to
             # put it in.
             op_occupied_wires = _get_op_occupied_wires(op, wire_map, bit_map)
-            op_layer = _recursive_find_layer(max_layer, op_occupied_wires, occupied_wires_per_layer)
+            try:
+                op_layer = _recursive_find_layer(
+                    max_layer, op_occupied_wires, occupied_wires_per_layer
+                )
+            except RecursionError as e:
+                raise RecursionError(
+                    f"Drawer is currently at depth {max_layer}, which is too deep to handle. "
+                    "Try drawing a smaller subset of your circuit instead."
+                ) from e
             op_occupied_cwires = set()
 
         # see if need to add new layer

--- a/tests/drawer/test_drawable_layers.py
+++ b/tests/drawer/test_drawable_layers.py
@@ -15,6 +15,8 @@
 Unit tests for the pennylane.drawer.drawable_layers` module.
 """
 
+import sys
+
 import pytest
 
 import pennylane as qml
@@ -97,7 +99,7 @@ class TestDrawableLayers:
     def test_recursion_error(self):
         """Test that extremely deep circuits are handled with an informative message."""
 
-        ops = [qml.X(0)] * 10000 + [qml.X(1)]
+        ops = [qml.X(0)] * (sys.getrecursionlimit() + 1) + [qml.X(1)]
 
         with pytest.raises(RecursionError, match=r"which is too deep to handle"):
             drawable_layers(ops)

--- a/tests/drawer/test_drawable_layers.py
+++ b/tests/drawer/test_drawable_layers.py
@@ -94,6 +94,14 @@ class TestRecursiveFindLayer:
 class TestDrawableLayers:
     """Tests for `drawable_layers`"""
 
+    def test_recursion_error(self):
+        """Test that extremely deep circuits are handled with an informative message."""
+
+        ops = [qml.X(0)] * 10000 + [qml.X(1)]
+
+        with pytest.raises(RecursionError, match=r"which is too deep to handle"):
+            drawable_layers(ops)
+
     def test_single_wires_no_blocking(self):
         """Test simple case where nothing blocks each other"""
 


### PR DESCRIPTION
**Context:**

Unhelpful error message is raised when drawing very deep circuits.

**Description of the Change:**

Adds context to the error message.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #8137 [sc-98283]
