### PR TITLE
Mapper from operators to resource operators

### DIFF
--- a/pennylane/labs/resource_estimation/resource_mapping.py
+++ b/pennylane/labs/resource_estimation/resource_mapping.py
@@ -46,9 +46,10 @@ def map_to_resource_op(op: Operation) -> ResourceOperator:
         "Operation doesn't have a resource equivalent and doesn't define a decomposition."
     )
 
+
 @map_to_resource_op.register
-def _(op: qops.GlobalPhase):
-    return re_ops.ResourceGlobalPhase()
+def _(op: qops.Identity):
+    return re_ops.ResourceIdentity()
 
 
 @map_to_resource_op.register
@@ -57,13 +58,49 @@ def _(op: qops.Hadamard):
 
 
 @map_to_resource_op.register
-def _(op: qops.Identity):
-    return re_ops.ResourceIdentity()
+def _(op: qops.S):
+    return re_ops.ResourceS()
+
+
+@map_to_resource_op.register
+def _(op: qops.T):
+    return re_ops.ResourceT()
+
+
+@map_to_resource_op.register
+def _(op: qops.X):
+    return re_ops.ResourceX()
+
+
+@map_to_resource_op.register
+def _(op: qops.Y):
+    return re_ops.ResourceY()
+
+
+@map_to_resource_op.register
+def _(op: qops.Z):
+    return re_ops.ResourceZ()
+
+
+@map_to_resource_op.register
+def _(op: qops.SWAP):
+    return re_ops.ResourceSWAP()
+
+
+@map_to_resource_op.register
+def _(op: qops.PhaseShift):
+    return re_ops.ResourcePhaseShift()
+
+
+@map_to_resource_op.register
+def _(op: qops.Rot):
+    return re_ops.ResourceRot()
 
 
 @map_to_resource_op.register
 def _(op: qops.RX):
     return re_ops.ResourceRX()
+
 
 @map_to_resource_op.register
 def _(op: qops.RY):
@@ -76,59 +113,79 @@ def _(op: qops.RZ):
 
 
 @map_to_resource_op.register
-def _(op: qops.S):
-    return re_ops.ResourceS()
-
-@map_to_resource_op.register
-def _(op: qops.SWAP):
-    return re_ops.ResourceSWAP()
-
-@map_to_resource_op.register
-def _(op: qops.T):
-    return re_ops.ResourceT()
+def _(op: qops.MultiRZ):
+    return re_ops.ResourceMultiRZ()
 
 
 @map_to_resource_op.register
-def _(op: qops.X):
-    return re_ops.ResourceX()
+def _(op: qops.PauliRot):
+    return re_ops.ResourcePauliRot()
+
 
 @map_to_resource_op.register
-def _(op: qops.Y):
-    return re_ops.ResourceY()
+def _(op: qops.IsingXX):
+    return re_ops.ResourceIsingXX()
+
 
 @map_to_resource_op.register
-def _(op: qops.Z):
-    return re_ops.ResourceZ()
+def _(op: qops.IsingYY):
+    return re_ops.ResourceIsingYY()
 
-#### controlled_ops
+
+@map_to_resource_op.register
+def _(op: qops.IsingXY):
+    return re_ops.ResourceIsingXY()
+
+
+@map_to_resource_op.register
+def _(op: qops.IsingZZ):
+    return re_ops.ResourceIsingZZ()
+
+
+@map_to_resource_op.register
+def _(op: qops.PSWAP):
+    return re_ops.ResourcePSWAP()
+
+
+@map_to_resource_op.register
+def _(op: qops.SingleExcitation):
+    return re_ops.ResourceSingleExcitation()
+
 
 @map_to_resource_op.register
 def _(op: qops.CCZ):
     return re_ops.ResourceCCZ()
 
+
 @map_to_resource_op.register
 def _(op: qops.CH):
     return re_ops.ResourceCH()
+
 
 @map_to_resource_op.register
 def _(op: qops.CNOT):
     return re_ops.ResourceCNOT()
 
+
 @map_to_resource_op.register
 def _(op: qops.ControlledPhaseShift):
     return re_ops.ResourceControlledPhaseShift()
+
 
 @map_to_resource_op.register
 def _(op: qops.CRot):
     return re_ops.ResourceCRot()
 
+
 @map_to_resource_op.register
 def _(op: qops.CRX):
     return re_ops.ResourceCRX()
 
+
 @map_to_resource_op.register
 def _(op: qops.CRY):
     return re_ops.ResourceCRY()
+
 
 @map_to_resource_op.register
 def _(op: qops.CRZ):
@@ -139,23 +196,27 @@ def _(op: qops.CRZ):
 def _(op: qops.CSWAP):
     return re_ops.ResourceCSWAP()
 
+
 @map_to_resource_op.register
 def _(op: qops.CY):
     return re_ops.ResourceCY()
+
 
 @map_to_resource_op.register
 def _(op: qops.CZ):
     return re_ops.ResourceCZ()
 
+
 @map_to_resource_op.register
 def _(op: qops.MultiControlledX):
     return re_ops.ResourceMultiControlledX()
+
 
 @map_to_resource_op.register
 def _(op: qtemps.TemporaryAND):
     return re_ops.ResourceTempAND()
 
+
 @map_to_resource_op.register
 def _(op: qops.Toffoli):
     return re_ops.ResourceToffoli()
-

--- a/pennylane/labs/resource_estimation/resource_mapping.py
+++ b/pennylane/labs/resource_estimation/resource_mapping.py
@@ -19,6 +19,7 @@ from functools import singledispatch
 from pennylane.labs.resource_estimation import ResourceOperator
 from pennylane.operation import Operation
 import pennylane.ops as qops
+import pennylane.templates as qtemps
 import pennylane.labs.resource_estimation.ops as re_ops
 
 
@@ -82,12 +83,6 @@ def _(op: qops.S):
 def _(op: qops.SWAP):
     return re_ops.ResourceSWAP()
 
-
-@map_to_resource_op.register
-def _(op: qops.CSWAP):
-    return re_ops.ResourceCSWAP()
-
-
 @map_to_resource_op.register
 def _(op: qops.T):
     return re_ops.ResourceT()
@@ -102,13 +97,65 @@ def _(op: qops.Y):
     return re_ops.ResourceY()
 
 @map_to_resource_op.register
+def _(op: qops.Z):
+    return re_ops.ResourceZ()
+
+#### controlled_ops
+
+@map_to_resource_op.register
+def _(op: qops.CCZ):
+    return re_ops.ResourceCCZ()
+
+@map_to_resource_op.register
+def _(op: qops.CH):
+    return re_ops.ResourceCH()
+
+@map_to_resource_op.register
+def _(op: qops.CNOT):
+    return re_ops.ResourceCNOT()
+
+@map_to_resource_op.register
+def _(op: qops.ControlledPhaseShift):
+    return re_ops.ResourceControlledPhaseShift()
+
+@map_to_resource_op.register
+def _(op: qops.CRot):
+    return re_ops.ResourceCRot()
+
+@map_to_resource_op.register
+def _(op: qops.CRX):
+    return re_ops.ResourceCRX()
+
+@map_to_resource_op.register
+def _(op: qops.CRY):
+    return re_ops.ResourceCRY()
+
+@map_to_resource_op.register
+def _(op: qops.CRZ):
+    return re_ops.ResourceCRZ()
+
+
+@map_to_resource_op.register
+def _(op: qops.CSWAP):
+    return re_ops.ResourceCSWAP()
+
+@map_to_resource_op.register
 def _(op: qops.CY):
     return re_ops.ResourceCY()
 
 @map_to_resource_op.register
-def _(op: qops.Z):
-    return re_ops.ResourceZ()
-
-@map_to_resource_op.register
 def _(op: qops.CZ):
     return re_ops.ResourceCZ()
+
+@map_to_resource_op.register
+def _(op: qops.MultiControlledX):
+    return re_ops.ResourceMultiControlledX()
+
+@map_to_resource_op.register
+def _(op: qtemps.TemporaryAND):
+    return re_ops.ResourceTempAND()
+
+@map_to_resource_op.register
+def _(op: qops.Toffoli):
+    return re_ops.ResourceToffoli()
+

--- a/pennylane/labs/resource_estimation/resource_mapping.py
+++ b/pennylane/labs/resource_estimation/resource_mapping.py
@@ -18,6 +18,8 @@ from functools import singledispatch
 
 from pennylane.labs.resource_estimation import ResourceOperator
 from pennylane.operation import Operation
+import pennylane.ops as qops
+import pennylane.labs.resource_estimation.ops as re_ops
 
 
 @singledispatch
@@ -42,3 +44,71 @@ def map_to_resource_op(op: Operation) -> ResourceOperator:
     raise NotImplementedError(
         "Operation doesn't have a resource equivalent and doesn't define a decomposition."
     )
+
+@map_to_resource_op.register
+def _(op: qops.GlobalPhase):
+    return re_ops.ResourceGlobalPhase()
+
+
+@map_to_resource_op.register
+def _(op: qops.Hadamard):
+    return re_ops.ResourceHadamard()
+
+
+@map_to_resource_op.register
+def _(op: qops.Identity):
+    return re_ops.ResourceIdentity()
+
+
+@map_to_resource_op.register
+def _(op: qops.RX):
+    return re_ops.ResourceRX()
+
+@map_to_resource_op.register
+def _(op: qops.RY):
+    return re_ops.ResourceRY()
+
+
+@map_to_resource_op.register
+def _(op: qops.RZ):
+    return re_ops.ResourceRZ()
+
+
+@map_to_resource_op.register
+def _(op: qops.S):
+    return re_ops.ResourceS()
+
+@map_to_resource_op.register
+def _(op: qops.SWAP):
+    return re_ops.ResourceSWAP()
+
+
+@map_to_resource_op.register
+def _(op: qops.CSWAP):
+    return re_ops.ResourceCSWAP()
+
+
+@map_to_resource_op.register
+def _(op: qops.T):
+    return re_ops.ResourceT()
+
+
+@map_to_resource_op.register
+def _(op: qops.X):
+    return re_ops.ResourceX()
+
+@map_to_resource_op.register
+def _(op: qops.Y):
+    return re_ops.ResourceY()
+
+@map_to_resource_op.register
+def _(op: qops.CY):
+    return re_ops.ResourceCY()
+
+@map_to_resource_op.register
+def _(op: qops.Z):
+    return re_ops.ResourceZ()
+
+@map_to_resource_op.register
+def _(op: qops.CZ):
+    return re_ops.ResourceCZ()

--- a/pennylane/labs/resource_estimation/resource_mapping.py
+++ b/pennylane/labs/resource_estimation/resource_mapping.py
@@ -114,12 +114,12 @@ def _(op: qops.RZ):
 
 @map_to_resource_op.register
 def _(op: qops.MultiRZ):
-    return re_ops.ResourceMultiRZ()
+    return re_ops.ResourceMultiRZ(num_wires=len(op.wires))
 
 
 @map_to_resource_op.register
 def _(op: qops.PauliRot):
-    return re_ops.ResourcePauliRot()
+    return re_ops.ResourcePauliRot(pauli_string=op.hyperparameters["pauli_word"])
 
 
 @map_to_resource_op.register
@@ -209,7 +209,7 @@ def _(op: qops.CZ):
 
 @map_to_resource_op.register
 def _(op: qops.MultiControlledX):
-    return re_ops.ResourceMultiControlledX()
+    return re_ops.ResourceMultiControlledX(num_ctrl_wires=len(op.wires) - 1, num_ctrl_values=sum(op.control_values))
 
 
 @map_to_resource_op.register

--- a/pennylane/labs/resource_estimation/resource_tracking.py
+++ b/pennylane/labs/resource_estimation/resource_tracking.py
@@ -256,9 +256,6 @@ def resources_from_resource_ops(
     tight_budget=None,
 ) -> Resources:
     """Extract resources from a resource operator."""
-    if isinstance(obj, Operation):
-        obj = map_to_resource_op(obj)
-
     return resources_from_resource(
         1 * obj,
         gate_set,

--- a/pennylane/labs/tests/resource_estimation/test_resource_mapping.py
+++ b/pennylane/labs/tests/resource_estimation/test_resource_mapping.py
@@ -84,9 +84,9 @@ class Test_map_to_resource_op:
             (qml.Toffoli(wires=(0, 1, 2)), re_ops.ResourceToffoli()),
             
             # Multi-Qubit Gates
-            (qml.MultiRZ(0.1, wires=[0, 1, 2]), re_ops.ResourceMultiRZ()),
-            (qml.PauliRot(0.1, "XYZ", wires=[0, 1, 2]), re_ops.ResourcePauliRot()),
-            (qml.MultiControlledX(wires=[0, 1, 2]), re_ops.ResourceMultiControlledX()),
+            (qml.MultiRZ(0.1, wires=[0, 1, 2]), re_ops.ResourceMultiRZ(num_wires=3)),
+            (qml.PauliRot(0.1, "XYZ", wires=[0, 1, 2]), re_ops.ResourcePauliRot("XYZ")),
+            (qml.MultiControlledX(wires=[0, 1, 2]), re_ops.ResourceMultiControlledX(num_ctrl_wires=2, num_ctrl_values=2)),
 
             # Custom/Template Gates
             (qtemps.TemporaryAND(wires=[0, 1, 2]), re_ops.ResourceTempAND()),
@@ -95,4 +95,4 @@ class Test_map_to_resource_op:
     def test_map_to_resource_op(self, operator, expected_res_op):
         """Test that map_to_resource_op maps to the appropriate resource operator"""
 
-        assert map_to_resource_op(operator) == expected_res_op 
+        assert isinstance(map_to_resource_op(operator), type(expected_res_op))

--- a/pennylane/labs/tests/resource_estimation/test_resource_mapping.py
+++ b/pennylane/labs/tests/resource_estimation/test_resource_mapping.py
@@ -20,6 +20,9 @@ import pennylane as qml
 from pennylane.labs.resource_estimation import map_to_resource_op
 from pennylane.operation import Operation
 
+import pennylane.labs.resource_estimation.ops as re_ops
+import pennylane.templates as qtemps
+
 # pylint: disable= no-self-use
 
 
@@ -38,3 +41,58 @@ class Test_map_to_resource_op:
             NotImplementedError, match="Operation doesn't have a resource equivalent"
         ):
             map_to_resource_op(operation)
+
+
+    @pytest.mark.parametrize(
+        "operator, expected_res_op",
+        [
+            (qml.Identity(0), re_ops.ResourceIdentity()),
+            # Single-Qubit Gates
+            (qml.Hadamard(0), re_ops.ResourceHadamard()),
+            (qml.S(0), re_ops.ResourceS()),
+            (qml.T(0), re_ops.ResourceT()),
+            (qml.PauliX(0), re_ops.ResourceX()),
+            (qml.PauliY(0), re_ops.ResourceY()),
+            (qml.PauliZ(0), re_ops.ResourceZ()),
+            (qml.PhaseShift(0.1, wires=0), re_ops.ResourcePhaseShift()),
+            (qml.Rot(0.1, 0.2, 0.3, wires=0), re_ops.ResourceRot()),
+            (qml.RX(0.1, wires=0), re_ops.ResourceRX()),
+            (qml.RY(0.1, wires=0), re_ops.ResourceRY()),
+            (qml.RZ(0.1, wires=0), re_ops.ResourceRZ()),
+
+            # Two-Qubit Gates
+            (qml.SWAP(wires=(0, 1)), re_ops.ResourceSWAP()),
+            (qml.IsingXX(0.1, wires=(0, 1)), re_ops.ResourceIsingXX()),
+            (qml.IsingYY(0.1, wires=(0, 1)), re_ops.ResourceIsingYY()),
+            (qml.IsingXY(0.1, wires=(0, 1)), re_ops.ResourceIsingXY()),
+            (qml.IsingZZ(0.1, wires=(0, 1)), re_ops.ResourceIsingZZ()),
+            (qml.PSWAP(0.1, wires=(0, 1)), re_ops.ResourcePSWAP()),
+            (qml.SingleExcitation(0.1, wires=(0, 1)), re_ops.ResourceSingleExcitation()),
+            (qml.CH(wires=(0, 1)), re_ops.ResourceCH()),
+            (qml.CNOT(wires=(0, 1)), re_ops.ResourceCNOT()),
+            (qml.ControlledPhaseShift(0.1, wires=(0, 1)), re_ops.ResourceControlledPhaseShift()),
+            (qml.CRot(0.1, 0.2, 0.3, wires=(0, 1)), re_ops.ResourceCRot()),
+            (qml.CRX(0.1, wires=(0, 1)), re_ops.ResourceCRX()),
+            (qml.CRY(0.1, wires=(0, 1)), re_ops.ResourceCRY()),
+            (qml.CRZ(0.1, wires=(0, 1)), re_ops.ResourceCRZ()),
+            (qml.CY(wires=(0, 1)), re_ops.ResourceCY()),
+            (qml.CZ(wires=(0, 1)), re_ops.ResourceCZ()),
+            
+            # Three-Qubit Gates
+            (qml.CCZ(wires=(0, 1, 2)), re_ops.ResourceCCZ()),
+            (qml.CSWAP(wires=(0, 1, 2)), re_ops.ResourceCSWAP()),
+            (qml.Toffoli(wires=(0, 1, 2)), re_ops.ResourceToffoli()),
+            
+            # Multi-Qubit Gates
+            (qml.MultiRZ(0.1, wires=[0, 1, 2]), re_ops.ResourceMultiRZ()),
+            (qml.PauliRot(0.1, "XYZ", wires=[0, 1, 2]), re_ops.ResourcePauliRot()),
+            (qml.MultiControlledX(wires=[0, 1, 2]), re_ops.ResourceMultiControlledX()),
+
+            # Custom/Template Gates
+            (qtemps.TemporaryAND(wires=[0, 1, 2]), re_ops.ResourceTempAND()),
+        ],
+    )
+    def test_map_to_resource_op(self, operator, expected_res_op):
+        """Test that map_to_resource_op maps to the appropriate resource operator"""
+
+        assert map_to_resource_op(operator) == expected_res_op 


### PR DESCRIPTION
**Context:**
We need a mapper from pennylane ops to resource ops. This provides that simple 1:1 mapping.

**Description of the Change:**
Adds single dispatch function map_to_resource_op that takes in a pennylane op and returns equivalent resource op for ll operations defined in `/resource_estimation/ops/qubit` + `Identity` and  `/resource_estimation/ops/op_math/controlled_ops.py`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-96872]