### PR TITLE
[WIP] Fall back to op.decompose if op is unsolved in decomposition graph

### DIFF
--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -25,6 +25,7 @@ implementation of the basis translator, the Boost Graph library, and RustworkX.
 
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
@@ -488,8 +489,11 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         if visitor.unsolved_op_indices:
             unsolved_ops = [self._graph[op_idx] for op_idx in visitor.unsolved_op_indices]
             op_names = {op_node.op.name for op_node in unsolved_ops}
-            raise DecompositionError(
-                f"Decomposition not found for {op_names} to the gate set {set(self._gate_set_weights)}"
+            warnings.warn(
+                f"The graph-based decomposition system is unable to find a decomposition for "
+                f"{op_names} to the target gate set {set(self._gate_set_weights)}. The default "
+                "decomposition will be used.",
+                UserWarning,
             )
         return DecompGraphSolution(visitor, self._all_op_indices, self._op_to_op_nodes)
 

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -256,7 +256,7 @@ class TestDecompositionGraph:
 
         op = qml.Hadamard(wires=[0])
         graph = DecompositionGraph(operations=[op], gate_set={"RX", "RY", "GlobalPhase"})
-        with pytest.raises(DecompositionError, match="Decomposition not found for {'Hadamard'}"):
+        with pytest.warns(UserWarning, match="unable to find a decomposition for {'Hadamard'}"):
             graph.solve()
 
     def test_lazy_solve(self, _):


### PR DESCRIPTION
**Context:**
The DecompositionGraph currently errors out completely if any of the operators is unsolved for, and as a result, with graph enabled, if a circuit contains a single operator/template that is not yet integrated with the new decomposition system, the entire thing fails, and the user is forced to turn off graph mode and use the old decomposition system. We want to change this behaviour, make it so that the DecompositionGraph raise a warning instead of an error if certain operators are unsolved for, and fall back to using op.decomposition for those operators.

**Description of the Change:**
- Downgrade error to a warning when certain operators are unsolved in the graph.
- Add sensible warning for when the graph failed to find a solution due to GlobalPhase

**Benefits:**
- The user can use the new system for the rest of the circuit even if it contains templates that are not yet integrated with the new graph-based system.

**Possible Drawbacks:**

**Related GitHub Issues:**
