### PR TITLE
chore: update lower bound of autoray due to breaking change

### DIFF
--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -18,7 +18,7 @@ be installed alongside PennyLane:
 * `autograd <https://github.com/HIPS/autograd>`_
 * `tomlkit <https://github.com/python-poetry/tomlkit>`_
 * `appdirs <https://github.com/ActiveState/appdirs>`_
-* `autoray <https://github.com/jcmgray/autoray>`__ >= 0.6.11
+* `autoray <https://github.com/jcmgray/autoray>`__ >= 0.8.0 
 * `cachetools <https://github.com/tkem/cachetools>`_
 * `pennylane-lightning <https://github.com/PennyLaneAI/pennylane-lightning>`_ >= 0.42
 * `requests <https://github.com/psf/requests>`_

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -755,6 +755,7 @@
 
 * Unpin `autoray` package in `pyproject.toml` by fixing source code that was broken by release.
   [(#8147)](https://github.com/PennyLaneAI/pennylane/pull/8147)
+  [(#8160)](https://github.com/PennyLaneAI/pennylane/pull/8160)
 
 * The `autograph` keyword argument has been removed from the `QNode` constructor. 
   To enable autograph conversion, use the `qjit` decorator together with the `qml.capture.disable_autograph` context manager.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rustworkx>=0.14.0",
     "autograd",
     "appdirs",
-    "autoray>=0.6.11",
+    "autoray>=0.8.0",
     "cachetools",
     "pennylane-lightning>=0.42",
     "requests",

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,7 +8,7 @@ autograd
 tomlkit
 appdirs
 packaging
-autoray>=0.6.11
+autoray>=0.8.0
 matplotlib
 requests
 rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ autograd~=1.4
 tomlkit~=0.13
 appdirs~=1.4
 packaging
-autoray>=0.6.11
+autoray>=0.8.0
 matplotlib~=3.5
 opt_einsum~=3.3
 requests~=2.31.0


### PR DESCRIPTION
**Context:**

The lower bound is not correct. We need to make it `0.8.0` because we are accessing something that is only available in `0.8.0` or higher (ar.autoray.AutoNamespace).

[sc-98081]
