### PR TITLE
chore: add `strict=True` to `zip` in a few core modules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -756,6 +756,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Start using `strict=True` to `zip` usage in source code.
+  [(#8164)](https://github.com/PennyLaneAI/pennylane/pull/8164)
+
 * Unpin `autoray` package in `pyproject.toml` by fixing source code that was broken by release.
   [(#8147)](https://github.com/PennyLaneAI/pennylane/pull/8147)
   [(#8159)](https://github.com/PennyLaneAI/pennylane/pull/8159)

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -492,7 +492,7 @@ def _commute_phases_u(left_givens, right_givens, phases, interface):
             -math.conj(grot_mat[1, 0]) / abs_s * phases[j, j],
             grot_mat[1, 1] / abs_c * phases[j, j],
         ]
-        for diag_idx, diag_val in zip([(i, i), (j, j)], nphase_diag):
+        for diag_idx, diag_val in zip([(i, i), (j, j)], nphase_diag, strict=True):
             phases = _set_unitary_matrix(phases, diag_idx, diag_val, like=interface)
 
         nleft_givens.append((math.conj(givens_mat), (i, j)))

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -192,7 +192,7 @@ def _get_random_args(args, interface, num, seed, bounds):
             )
             _args = tuple(
                 tf.Variable(_arg) if isinstance(arg, tf.Variable) else _arg
-                for _arg, arg in zip(_args, args)
+                for _arg, arg in zip(_args, args, strict=True)
             )
             rnd_args.append(_args)
     elif interface == "torch":
@@ -243,7 +243,7 @@ def _is_indep_numerical(func, interface, args, kwargs, num_pos, seed, atol, rtol
         if is_tuple_valued:
             if not all(
                 np.allclose(new, orig, atol=atol, rtol=rtol)
-                for new, orig in zip(new_output, original_output)
+                for new, orig in zip(new_output, original_output, strict=True)
             ):
                 return False
         else:

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -375,7 +375,7 @@ def _batched_partial_trace_nonrep_indices(matrix, is_batched, indices, batch_dim
         # new state indices replace row and column indices with new ones
         new_state_indices = functools.reduce(
             lambda old_string, idx_pair: old_string.replace(idx_pair[0], idx_pair[1]),
-            zip(col_indices + row_indices, new_col_indices + new_row_indices),
+            zip(col_indices + row_indices, new_col_indices + new_row_indices, strict=True),
             state_indices,
         )
         # index mapping for einsum, e.g., 'iga,abcdef,idh->gbchef'

--- a/pennylane/math/single_dispatch.py
+++ b/pennylane/math/single_dispatch.py
@@ -274,7 +274,7 @@ def _scatter_element_add_autograd(tensor, index, value, **_):
     if pnp.isscalar(value) or len(pnp.shape(value)) == 0:
         value = [value]
     t = [0] * size
-    for _id, val in zip(flat_index, value):
+    for _id, val in zip(flat_index, value, strict=True):
         t[_id] = val
     return tensor + pnp.array(t).reshape(tensor.shape)
 
@@ -550,7 +550,7 @@ def _scatter_element_add_tf(
     import tensorflow as tf
 
     if not isinstance(index[0], int):
-        index = tuple(zip(*index))
+        index = tuple(zip(*index, strict=True))
     indices = tf.expand_dims(index, 0)
     value = tf.cast(tf.expand_dims(value, 0), tensor.dtype)
     return tf.tensor_scatter_nd_add(tensor, indices, value)
@@ -805,7 +805,7 @@ def _block_diag_torch(tensors):
     # converted the diagonal indices to row and column indices
     ridx, cidx = np.stack([p - sizes, p]).T
 
-    for t, r, c in zip(tensors, ridx, cidx):
+    for t, r, c in zip(tensors, ridx, cidx, strict=True):
         row = np.arange(*r).reshape(-1, 1)
         col = np.arange(*c).reshape(1, -1)
         res[row, col] = t

--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -133,7 +133,7 @@ def _allclose_mixed(a, b, rtol=1e-05, atol=1e-08, b_is_sparse=True):
     dense_coords = dense.nonzero()
     sparse_coords = sparse.nonzero()
 
-    coord_diff = set(zip(*dense_coords)) ^ set(zip(*sparse_coords))
+    coord_diff = set(zip(*dense_coords, strict=True)) ^ set(zip(*sparse_coords, strict=True))
     if coord_diff:
         return False
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1186,7 +1186,7 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         if ndims != self.ndim_params:
             ndims_matches = [
                 (ndim == exp_ndim, ndim == exp_ndim + 1)
-                for ndim, exp_ndim in zip(ndims, self.ndim_params)
+                for ndim, exp_ndim in zip(ndims, self.ndim_params, strict=True)
             ]
             if not all(correct or batched for correct, batched in ndims_matches):
                 raise ValueError(
@@ -1195,7 +1195,9 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
                 )
 
             first_dims = [
-                qml.math.shape(p)[0] for (_, batched), p in zip(ndims_matches, params) if batched
+                qml.math.shape(p)[0]
+                for (_, batched), p in zip(ndims_matches, params, strict=True)
+                if batched
             ]
             if not qml.math.allclose(first_dims, first_dims[0]):
                 raise ValueError(

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -108,7 +108,7 @@ def _get_batch_shape(non_const_args, non_const_batch_dims):
 
     input_shapes = [
         (arg.shape[batch_dim],)
-        for arg, batch_dim in zip(non_const_args, non_const_batch_dims)
+        for arg, batch_dim in zip(non_const_args, non_const_batch_dims, strict=True)
         if batch_dim is not None
     ]
 
@@ -287,7 +287,7 @@ def _qnode_batching_rule(
     This rule exploits the parameter broadcasting feature of the QNode to vectorize the circuit execution.
     """
 
-    for idx, (arg, batch_dim) in enumerate(zip(batched_args, batch_dims)):
+    for idx, (arg, batch_dim) in enumerate(zip(batched_args, batch_dims, strict=True)):
 
         if _is_scalar_tensor(arg):
             continue

--- a/pennylane/workflow/interfaces/jax.py
+++ b/pennylane/workflow/interfaces/jax.py
@@ -172,7 +172,9 @@ def _set_copy_and_unwrap_tape(t, a, unwrap=True):
 
 def set_parameters_on_copy_and_unwrap(tapes, params, unwrap=True):
     """Copy a set of tapes with operations and set parameters"""
-    return tuple(_set_copy_and_unwrap_tape(t, a, unwrap=unwrap) for t, a in zip(tapes, params))
+    return tuple(
+        _set_copy_and_unwrap_tape(t, a, unwrap=unwrap) for t, a in zip(tapes, params, strict=True)
+    )
 
 
 def _to_jax(result: qml.typing.ResultBatch) -> qml.typing.ResultBatch:

--- a/pennylane/workflow/interfaces/jax_jit.py
+++ b/pennylane/workflow/interfaces/jax_jit.py
@@ -67,12 +67,16 @@ def _to_jax(result: qml.typing.ResultBatch) -> qml.typing.ResultBatch:
 
 def _set_all_parameters_on_copy(tapes, params):
     """Copy a set of tapes with operations and set all parameters"""
-    return tuple(t.bind_new_parameters(a, list(range(len(a)))) for t, a in zip(tapes, params))
+    return tuple(
+        t.bind_new_parameters(a, list(range(len(a)))) for t, a in zip(tapes, params, strict=True)
+    )
 
 
 def _set_trainable_parameters_on_copy(tapes, params):
     """Copy a set of tapes with operations and set all trainable parameters"""
-    return tuple(t.bind_new_parameters(a, t.trainable_params) for t, a in zip(tapes, params))
+    return tuple(
+        t.bind_new_parameters(a, t.trainable_params) for t, a in zip(tapes, params, strict=True)
+    )
 
 
 def _jax_dtype(m_type):
@@ -194,7 +198,7 @@ def _execute_and_compute_jvp(tapes, execute_fn, jpc, device, primals, tangents):
     calculation.
     """
     # Select the trainable params. Non-trainable params contribute a 0 gradient.
-    for tangent, tape in zip(tangents[0], tapes.vals):
+    for tangent, tape in zip(tangents[0], tapes.vals, strict=True):
         tape.trainable_params = tuple(
             idx for idx, t in enumerate(tangent) if not isinstance(t, Zero)
         )

--- a/pennylane/workflow/interfaces/tensorflow.py
+++ b/pennylane/workflow/interfaces/tensorflow.py
@@ -115,7 +115,9 @@ logger.addHandler(logging.NullHandler())
 
 def set_parameters_on_copy(tapes, params):
     """Copy a set of tapes with operations and set parameters"""
-    return tuple(t.bind_new_parameters(a, list(range(len(a)))) for t, a in zip(tapes, params))
+    return tuple(
+        t.bind_new_parameters(a, list(range(len(a)))) for t, a in zip(tapes, params, strict=True)
+    )
 
 
 def _get_parameters_dtype(parameters):

--- a/pennylane/workflow/interfaces/tensorflow_autograph.py
+++ b/pennylane/workflow/interfaces/tensorflow_autograph.py
@@ -32,12 +32,12 @@ def _compute_vjp(dy, jacs, multi_measurements, has_partitioned_shots):
     # for a list of dy's and Jacobian matrices.
     vjps = []
 
-    for dy_, jac_, multi in zip(dy, jacs, multi_measurements):
+    for dy_, jac_, multi in zip(dy, jacs, multi_measurements, strict=True):
         dy_ = dy_ if has_partitioned_shots else (dy_,)
         jac_ = jac_ if has_partitioned_shots else (jac_,)
 
         shot_vjps = []
-        for d, j in zip(dy_, jac_):
+        for d, j in zip(dy_, jac_, strict=True):
             # see xfail test: test_tensorflow_qnode_default_qubit_2.py:test_autograph_adjoint_multi_out
             # And Issue #5078
             # pragma: no cover

--- a/pennylane/workflow/jacobian_products.py
+++ b/pennylane/workflow/jacobian_products.py
@@ -41,10 +41,10 @@ def _compute_vjps(jacs, dys, tapes):
     f = {True: qml.gradients.compute_vjp_multi, False: qml.gradients.compute_vjp_single}
 
     vjps = []
-    for jac, dy, t in zip(jacs, dys, tapes):
+    for jac, dy, t in zip(jacs, dys, tapes, strict=True):
         multi = len(t.measurements) > 1
         if t.shots.has_partitioned_shots:
-            shot_vjps = [f[multi](d, j) for d, j in zip(dy, jac)]
+            shot_vjps = [f[multi](d, j) for d, j in zip(dy, jac, strict=True)]
             vjps.append(qml.math.sum(qml.math.stack(shot_vjps), axis=0))
         else:
             vjps.append(f[multi](dy, jac))
@@ -67,7 +67,7 @@ def _compute_jvps(jacs, tangents, tapes):
     f = {True: qml.gradients.compute_jvp_multi, False: qml.gradients.compute_jvp_single}
 
     jvps = []
-    for jac, dx, t in zip(jacs, tangents, tapes):
+    for jac, dx, t in zip(jacs, tangents, tapes, strict=True):
         multi = len(t.measurements) > 1
         if len(t.trainable_params) == 0:
             jvps.append(_zero_jvp(t))
@@ -691,7 +691,7 @@ class DeviceJacobianProducts(JacobianProductCalculator):
         dy = qml.math.unwrap(dy)
         vjps = self._device.compute_vjp(numpy_tapes, dy, self._execution_config)
         res = []
-        for t, r in zip(tapes, vjps):
+        for t, r in zip(tapes, vjps, strict=True):
             if len(t.trainable_params) == 1 and qml.math.shape(r) == ():
                 res.append((r,))
             else:

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -158,7 +158,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
 
     terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
 
-    if terminal_measurements and any(
+    if any(
         ret is not m for ret, m in zip(measurement_processes, terminal_measurements, strict=True)
     ):
         raise QuantumFunctionError(

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -158,7 +158,9 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
 
     terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
 
-    if any(ret is not m for ret, m in zip(measurement_processes, terminal_measurements)):
+    if any(
+        ret is not m for ret, m in zip(measurement_processes, terminal_measurements, strict=True)
+    ):
         raise QuantumFunctionError(
             "All measurements must be returned in the order they are measured."
         )

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -841,7 +841,8 @@ class QNode:
         params = tape.get_parameters(trainable_only=False)
         tape.trainable_params = math.get_trainable_indices(params)
 
-        _validate_qfunc_output(self._qfunc_output, tape.measurements)
+        if q.queue:
+            _validate_qfunc_output(self._qfunc_output, tape.measurements)
         self._tape = tape
         return tape
 

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -158,7 +158,7 @@ def _validate_qfunc_output(qfunc_output, measurements) -> None:
 
     terminal_measurements = [m for m in measurements if not isinstance(m, MidMeasureMP)]
 
-    if any(
+    if terminal_measurements and any(
         ret is not m for ret, m in zip(measurement_processes, terminal_measurements, strict=True)
     ):
         raise QuantumFunctionError(
@@ -841,8 +841,7 @@ class QNode:
         params = tape.get_parameters(trainable_only=False)
         tape.trainable_params = math.get_trainable_indices(params)
 
-        if q.queue:
-            _validate_qfunc_output(self._qfunc_output, tape.measurements)
+        _validate_qfunc_output(self._qfunc_output, tape.measurements)
         self._tape = tape
         return tape
 

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -102,23 +102,6 @@ class TestStopRecording:
         assert len(tape.operations) == 1
         assert tape.operations[0].name == "Hadamard"
 
-    def test_stop_recording_qnode_qfunc(self):
-        """A QNode with a stop_recording qfunc will result in no quantum measurements."""
-        dev = qml.device("default.qubit", wires=1)
-
-        @qml.qnode(dev)
-        @QueuingManager.stop_recording()
-        def my_circuit():
-            qml.PauliX(wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        result = my_circuit()
-        assert len(result) == 0
-
-        tape = qml.workflow.construct_tape(my_circuit)()
-        assert len(tape.operations) == 0
-        assert len(tape.measurements) == 0
-
     def test_stop_recording_qnode(self):
         """A stop_recording QNode is unaffected"""
         dev = qml.device("default.qubit", wires=1)


### PR DESCRIPTION
**Context:**

By default, if the iterables passed to zip are of different lengths, the resulting iterator will be silently truncated to the length of the shortest iterable. This can lead to subtle bugs.

**Description of the Change:**

Use `ruff` to add `kwarg` (see [rule](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905)).

**Benefits:** Better code.

[sc-98487]
