### PR TITLE
Fix decomposition of `Select` with parametrized `ops` in new decomposition system. 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -959,6 +959,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug in the decomposition rules of :class:`~.Select` with the new decomposition system
+  that broke the decompositions if the target ``ops`` of the ``Select`` operator were parametrized.
+  This enables the new decomposition system with ``Select`` of parametrized target ``ops``.
+  [(#8186)](https://github.com/PennyLaneAI/pennylane/pull/8186)
+  
 * `Exp` and `Evolution` now have improved decompositions, allowing them to handle more situations
   more robustly. In particular, the generator is simplified prior to decomposition. Now more
   time evolution ops can be supported on devices that do not natively support them.

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -568,7 +568,7 @@ def _select_resources_multi_control(op_reps, num_control_wires, partial):
 
 # pylint: disable=unused-argument
 @register_resources(_select_resources_multi_control)
-def _select_decomp_multi_control(ops, control, work_wires, partial, **_):
+def _select_decomp_multi_control(*_, ops, control, work_wires, partial, **__):
 
     if partial:
         if len(ops) == 1:
@@ -758,7 +758,7 @@ def _select_resources_partial_unary(op_reps, num_control_wires, partial):
 
 
 @register_resources(_select_resources_partial_unary)
-def _select_decomp_partial_unary(ops, control, work_wires, partial, **_):
+def _select_decomp_partial_unary(*_, ops, control, work_wires, partial, **__):
     r"""This function reproduces the unary iterator behaviour in https://arxiv.org/abs/1805.03662.
     For :math:`K` operators this decomposition requires at least :math:`c=\lceil\log_2 K\rceil`
     control wires (as usual for Select), and :math:`c-1` additional work wires.


### PR DESCRIPTION
**Context**

There is a problem with the signature of new decomp rules of `Select` if there are parameters in the target `ops`.
See #8185

**Change**
Fix #8185 by updating the signature of the `Select` decomposition rules.

**Drawbacks**
N/A

**Related issues**

Fixes #8185
[sc-98595]