### PR TITLE
Fix queening issue in labs ResourceOperator tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -516,7 +516,7 @@
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
   * Fixed a queueing issue in `ResourceOperator` tests.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#8204)](https://github.com/PennyLaneAI/pennylane/pull/8204)
   
 * The module `qml.labs.zxopt` has been removed as its functionalities are now available in the
   submodule :mod:`~.transforms.zx`. The same functions are available, but their signature

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -515,6 +515,9 @@
   [(#8156)](https://github.com/PennyLaneAI/pennylane/pull/8156)
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
+  * Fixed a queueing issue in `ResourceOperator` tests.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  
 * The module `qml.labs.zxopt` has been removed as its functionalities are now available in the
   submodule :mod:`~.transforms.zx`. The same functions are available, but their signature
   may have changed.
@@ -1093,6 +1096,7 @@ Lillian Frederiksen,
 Pietropaolo Frisoni,
 Simone Gasperini,
 David Ittah,
+Soran Jahangiri,
 Korbinian Kottmann,
 Mehrdad Malekmohammadi
 Pablo Antonio Moreno Casares

--- a/pennylane/labs/tests/resource_estimation/test_resource_operator.py
+++ b/pennylane/labs/tests/resource_estimation/test_resource_operator.py
@@ -341,7 +341,7 @@ class TestResourceOperator:
         for op_to_remove, expected_queue in zip(ops_to_remove, expected_queues):
             with AnnotatedQueue() as q:
                 for op in self.ops_to_queue:
-                    qml.apply(op)
+                    op.queue()
 
                 ResourceOperator.dequeue(op_to_remove)
 


### PR DESCRIPTION
**Context:**
Fixes a test failure due to queening issues in labs ResourceOperator tests. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
