### PR TITLE
Improvements to decompositions using `ChangeOpBasis`

### DIFF
--- a/pennylane/decomposition/__init__.py
+++ b/pennylane/decomposition/__init__.py
@@ -264,6 +264,7 @@ from .resources import (
     adjoint_resource_rep,
     pow_resource_rep,
     CompressedResourceOp,
+    change_op_basis_resource_rep,
 )
 from .decomposition_rule import (
     register_resources,

--- a/pennylane/templates/subroutines/adder.py
+++ b/pennylane/templates/subroutines/adder.py
@@ -16,13 +16,11 @@ Contains the Adder template.
 """
 from pennylane.decomposition import (
     add_decomps,
-    adjoint_resource_rep,
-    controlled_resource_rep,
+    change_op_basis_resource_rep,
     register_resources,
-    resource_rep,
 )
 from pennylane.operation import Operation
-from pennylane.ops.op_math import adjoint, ctrl
+from pennylane.ops.op_math import change_op_basis
 from pennylane.wires import Wires, WiresLike
 
 from .phase_adder import PhaseAdder
@@ -206,20 +204,19 @@ class Adder(Operation):
         **Example**
 
         >>> qml.Adder.compute_decomposition(k=2, x_wires=[0,1,2], mod=8, work_wires=[3])
-        [QFT(wires=[0, 1, 2]),
-        PhaseAdder(wires=[0, 1, 2]),
-        Adjoint(QFT(wires=[0, 1, 2]))]
+        [(Adjoint(QFT(wires=[3, 0, 1, 2]))) @ PhaseAdder(wires=[3, 0, 1, 2]) @ QFT(wires=[3, 0, 1, 2])]
         """
-        op_list = []
         if mod == 2 ** len(x_wires):
             qft_wires = x_wires
             work_wire = ()
         else:
             qft_wires = work_wires[:1] + x_wires
             work_wire = work_wires[1:]
-        op_list.append(QFT(qft_wires))
-        op_list.append(PhaseAdder(k, qft_wires, mod, work_wire))
-        op_list.append(adjoint(QFT(qft_wires)))
+
+        op_list = [change_op_basis(QFT(qft_wires), PhaseAdder(k, qft_wires, mod, work_wire))]
+        # op_list.append(QFT(qft_wires))
+        # op_list.append(PhaseAdder(k, qft_wires, mod, work_wire))
+        # op_list.append(adjoint(QFT(qft_wires)))
 
         return op_list
 
@@ -231,11 +228,19 @@ def _adder_decomposition_resources(num_x_wires, mod) -> dict:
     else:
         qft_wires = 1 + num_x_wires
 
-    return {
-        resource_rep(QFT, num_wires=qft_wires): 1,
-        resource_rep(PhaseAdder, num_x_wires=qft_wires, mod=mod): 1,
-        adjoint_resource_rep(QFT, {"num_wires": qft_wires}): 1,
+    params = {
+        "compute_op_params": {"num_wires": qft_wires},
+        "target_op_params": {"num_x_wires": qft_wires, "mod": mod},
+        "uncompute_op_params": {"num_wires": qft_wires},
     }
+    return {
+        change_op_basis_resource_rep(QFT, PhaseAdder, params=params): 1,
+    }
+    # return {
+    #     resource_rep(QFT, num_wires=qft_wires): 1,
+    #     resource_rep(PhaseAdder, num_x_wires=qft_wires, mod=mod): 1,
+    #     adjoint_resource_rep(QFT, {"num_wires": qft_wires}): 1,
+    # }
 
 
 # pylint: disable=no-value-for-parameter
@@ -248,63 +253,73 @@ def _adder_decomposition(k, x_wires: WiresLike, mod, work_wires: WiresLike, **__
         qft_wires = work_wires[:1] + x_wires
         work_wire = work_wires[1:]
 
-    QFT(qft_wires)
-    PhaseAdder(k, qft_wires, mod, work_wire)
-    adjoint(QFT(qft_wires))
+    change_op_basis(QFT(qft_wires), PhaseAdder(k, qft_wires, mod, work_wire))
+    # QFT(qft_wires)
+    # PhaseAdder(k, qft_wires, mod, work_wire)
+    # adjoint(QFT(qft_wires))
 
 
 add_decomps(Adder, _adder_decomposition)
 
 
-def _controlled_adder_resources(
-    *_,
-    num_control_wires,
-    num_work_wires,
-    work_wire_type,
-    base_class,
-    base_params,
-    **__,
-):  # pylint: disable=unused-argument
-    if base_params["mod"] == 2 ** base_params["num_x_wires"]:
-        qft_wires = base_params["num_x_wires"]
-    else:
-        qft_wires = 1 + base_params["num_x_wires"]
+# def _controlled_adder_resources(
+#     *_,
+#     num_control_wires,
+#     num_work_wires,
+#     work_wire_type,
+#     base_class,
+#     base_params,
+#     **__,
+# ):  # pylint: disable=unused-argument
+#     if base_params["mod"] == 2 ** base_params["num_x_wires"]:
+#         qft_wires = base_params["num_x_wires"]
+#     else:
+#         qft_wires = 1 + base_params["num_x_wires"]
 
-    return {
-        resource_rep(QFT, num_wires=qft_wires): 1,
-        controlled_resource_rep(
-            PhaseAdder,
-            {"num_x_wires": qft_wires, "mod": base_params["mod"]},
-            num_control_wires=num_control_wires,
-            num_zero_control_values=0,
-            num_work_wires=num_work_wires,
-            work_wire_type=work_wire_type,
-        ): 1,
-        adjoint_resource_rep(QFT, {"num_wires": qft_wires}): 1,
-    }
-
-
-@register_resources(_controlled_adder_resources)
-def _controlled_adder_decomposition(
-    wires, control_wires, work_wires, work_wire_type, base, **__
-):  # pylint: disable=unused-argument
-    if base.hyperparameters["mod"] == 2 ** len(base.hyperparameters["x_wires"]):
-        qft_wires = base.hyperparameters["x_wires"]
-        base_work_wire = ()
-    else:
-        qft_wires = base.hyperparameters["work_wires"][:1] + base.hyperparameters["x_wires"]
-        base_work_wire = base.hyperparameters["work_wires"][1:]
-
-    QFT(qft_wires)
-    ctrl(
-        PhaseAdder(
-            base.hyperparameters["k"], qft_wires, base.hyperparameters["mod"], base_work_wire
-        ),
-        control=control_wires,
-        work_wires=work_wires,
-        work_wire_type=work_wire_type,
-    )
-    adjoint(QFT(qft_wires))
+#     return {
+#         resource_rep(QFT, num_wires=qft_wires): 1,
+#         controlled_resource_rep(
+#             PhaseAdder,
+#             {"num_x_wires": qft_wires, "mod": base_params["mod"]},
+#             num_control_wires=num_control_wires,
+#             num_zero_control_values=0,
+#             num_work_wires=num_work_wires,
+#             work_wire_type=work_wire_type,
+#         ): 1,
+#         adjoint_resource_rep(QFT, {"num_wires": qft_wires}): 1,
+#     }
 
 
-add_decomps("C(Adder)", _controlled_adder_decomposition)
+# @register_resources(_controlled_adder_resources)
+# def _controlled_adder_decomposition(
+#     wires, control_wires, work_wires, work_wire_type, base, **__
+# ):  # pylint: disable=unused-argument
+#     if base.hyperparameters["mod"] == 2 ** len(base.hyperparameters["x_wires"]):
+#         qft_wires = base.hyperparameters["x_wires"]
+#         base_work_wire = ()
+#     else:
+#         qft_wires = base.hyperparameters["work_wires"][:1] + base.hyperparameters["x_wires"]
+#         base_work_wire = base.hyperparameters["work_wires"][1:]
+
+
+#     k, mod = base.hyperparameters["k"], base.hyperparameters["mod"]
+#     ctrl(
+#         change_op_basis(QFT(qft_wires), PhaseAdder(k, qft_wires, mod, base_work_wire)),
+#         control=control_wires,
+#         work_wires=work_wires,
+#         work_wire_type=work_wire_type,
+#     )
+
+#     # QFT(qft_wires)
+#     # ctrl(
+#     #     PhaseAdder(
+#     #         base.hyperparameters["k"], qft_wires, base.hyperparameters["mod"], base_work_wire
+#     #     ),
+#     #     control=control_wires,
+#     #     work_wires=work_wires,
+#     #     work_wire_type=work_wire_type,
+#     # )
+#     # adjoint(QFT(qft_wires))
+
+
+# add_decomps("C(Adder)", _controlled_adder_decomposition)

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -20,12 +20,19 @@ import copy
 from pennylane import math
 from pennylane.decomposition import (
     add_decomps,
-    adjoint_resource_rep,
+    change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.operation import Operation
-from pennylane.ops import GlobalPhase, LinearCombination, Prod, StatePrep, adjoint, prod
+from pennylane.ops import (
+    GlobalPhase,
+    LinearCombination,
+    Prod,
+    StatePrep,
+    change_op_basis,
+    prod,
+)
 from pennylane.templates.embeddings import AmplitudeEmbedding
 from pennylane.wires import Wires
 
@@ -150,15 +157,20 @@ class PrepSelPrep(Operation):
     def compute_decomposition(lcu, control):
         coeffs, ops = _get_new_terms(lcu)
 
-        decomp_ops = [
-            AmplitudeEmbedding(math.sqrt(coeffs), normalize=True, pad_with=0, wires=control),
-            Select(ops, control, partial=True),
-            adjoint(
-                AmplitudeEmbedding(math.sqrt(coeffs), normalize=True, pad_with=0, wires=control)
+        # decomp_ops = [
+        #     AmplitudeEmbedding(math.sqrt(coeffs), normalize=True, pad_with=0, wires=control),
+        #     Select(ops, control, partial=True),
+        #     adjoint(
+        #         AmplitudeEmbedding(math.sqrt(coeffs), normalize=True, pad_with=0, wires=control)
+        #     ),
+        # ]
+
+        return [
+            change_op_basis(
+                AmplitudeEmbedding(math.sqrt(coeffs), normalize=True, pad_with=0, wires=control),
+                Select(ops, control, partial=True),
             ),
         ]
-
-        return decomp_ops
 
     def __copy__(self):
         """Copy this op"""
@@ -220,11 +232,22 @@ def _prepselprep_resources(op_reps, num_control):
     prod_reps = tuple(
         resource_rep(Prod, resources={resource_rep(GlobalPhase): 1, rep: 1}) for rep in op_reps
     )
-    return {
-        resource_rep(StatePrep, num_wires=num_control): 1,
-        resource_rep(Select, op_reps=prod_reps, num_control_wires=num_control, partial=True): 1,
-        adjoint_resource_rep(StatePrep, base_params={"num_wires": num_control}): 1,
+    params = {
+        "compute_op_params": {"num_wires": num_control},
+        "target_op_params": {
+            "op_reps": prod_reps,
+            "num_control_wires": num_control,
+            "partial": True,
+        },
     }
+    return {
+        change_op_basis_resource_rep(StatePrep, Select, params=params): 1,
+    }
+    # return {
+    #     resource_rep(StatePrep, num_wires=num_control): 1,
+    #     resource_rep(Select, op_reps=prod_reps, num_control_wires=num_control, partial=True): 1,
+    #     adjoint_resource_rep(StatePrep, base_params={"num_wires": num_control}): 1,
+    # }
 
 
 # pylint: disable=unused-argument, too-many-arguments
@@ -232,9 +255,10 @@ def _prepselprep_resources(op_reps, num_control):
 def _prepselprep_decomp(*_, wires, lcu, coeffs, ops, control, target_wires):
     coeffs, ops = _get_new_terms(lcu)
     sqrt_coeffs = math.sqrt(coeffs)
-    StatePrep(sqrt_coeffs, normalize=True, pad_with=0, wires=control)
-    Select(ops, control, partial=True)
-    adjoint(StatePrep(sqrt_coeffs, normalize=True, pad_with=0, wires=control))
+    change_op_basis(
+        StatePrep(sqrt_coeffs, normalize=True, pad_with=0, wires=control),
+        Select(ops, control, partial=True),
+    )
 
 
 add_decomps(PrepSelPrep, _prepselprep_decomp)

--- a/tests/templates/test_subroutines/test_adder.py
+++ b/tests/templates/test_subroutines/test_adder.py
@@ -196,9 +196,12 @@ class TestAdder:
         mod = 7
         x_wires = [0, 1, 2]
         work_wires = [3, 4]
-        adder_decomposition = qml.Adder(k, x_wires, mod, work_wires).compute_decomposition(
-            k, x_wires, mod, work_wires
+        adder_decomposition = (
+            qml.Adder(k, x_wires, mod, work_wires)
+            .compute_decomposition(k, x_wires, mod, work_wires)[0]
+            .decomposition()
         )
+
         op_list = []
         op_list.append(qml.QFT(work_wires[:1] + x_wires))
         op_list.append(qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]))
@@ -206,6 +209,37 @@ class TestAdder:
 
         for op1, op2 in zip(adder_decomposition, op_list):
             qml.assert_equal(op1, op2)
+
+    @pytest.mark.parametrize("mod", [2, 4])
+    def test_controlled_decomposition(self, mod):
+        """Tests the decomposition work for the controlled adder."""
+
+        k = 4
+        x_wires = [2, 3]
+        control_wires = [1]
+        work_wires = [4, 5]
+        wire_order = control_wires + x_wires + work_wires
+
+        ctrl_op1 = qml.ops.Controlled(
+            qml.change_op_basis(
+                qml.QFT(work_wires[:1] + x_wires),
+                qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]),
+            ),
+            control_wires,
+            [1],
+        )
+
+        ctrl_op2 = qml.prod(
+            qml.adjoint(qml.QFT(work_wires[:1] + x_wires)),
+            qml.ctrl(
+                qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]),
+                control=control_wires,
+            ),
+            qml.QFT(work_wires[:1] + x_wires),
+        )
+
+        mat1, mat2 = qml.matrix(ctrl_op1, wire_order), qml.matrix(ctrl_op2, wire_order)
+        assert qml.math.allclose(mat1, mat2)
 
     @pytest.mark.parametrize("mod", [7, 8])
     def test_decomposition_new(self, mod):
@@ -216,22 +250,6 @@ class TestAdder:
         work_wires = [0, 1]
         op = qml.Adder(k, x_wires, mod, work_wires)
         for rule in qml.list_decomps(qml.Adder):
-            _test_decomposition_rule(op, rule)
-
-    @pytest.mark.parametrize("mod", [2, 4])
-    def test_controlled_decomposition_new(self, mod):
-        """Tests the decomposition rule implemented with the new system."""
-
-        k = 4
-        x_wires = [2, 3]
-        control_wires = [1]
-        work_wires = [4, 5]
-        op = qml.ops.Controlled(
-            qml.Adder(k, x_wires, mod, work_wires),
-            control_wires,
-            [1],
-        )
-        for rule in qml.list_decomps("C(Adder)"):
             _test_decomposition_rule(op, rule)
 
     def test_work_wires_added_correctly(self):

--- a/tests/templates/test_subroutines/test_out_adder.py
+++ b/tests/templates/test_subroutines/test_out_adder.py
@@ -180,9 +180,17 @@ class TestOutAdder:
             7,
             [9, 10],
         )
-        adder_decomposition = qml.OutAdder(
-            x_wires, y_wires, output_wires, mod, work_wires
-        ).compute_decomposition(x_wires, y_wires, output_wires, mod, work_wires)
+        _adder_decomposition = (
+            qml.OutAdder(x_wires, y_wires, output_wires, mod, work_wires)
+            .compute_decomposition(x_wires, y_wires, output_wires, mod, work_wires)[0]
+            .decomposition()
+        )
+        adder_decomposition = [
+            _adder_decomposition[0],
+            *_adder_decomposition[1].decomposition(),
+            _adder_decomposition[2],
+        ]
+
         op_list = []
         if mod != 2 ** len(output_wires) and mod is not None:
             qft_new_output_wires = work_wires[:1] + output_wires

--- a/tests/templates/test_subroutines/test_prepselprep.py
+++ b/tests/templates/test_subroutines/test_prepselprep.py
@@ -207,15 +207,21 @@ class TestPrepSelPrep:
                 lcu1,
                 [0],
                 [
-                    qml.AmplitudeEmbedding(
-                        qml.math.sqrt(coeffs1), normalize=True, pad_with=0, wires=[0]
-                    ),
-                    qml.Select(ops1, control=[0]),
-                    qml.ops.Adjoint(
+                    qml.ops.ChangeOpBasis(
                         qml.AmplitudeEmbedding(
                             qml.math.sqrt(coeffs1), normalize=True, pad_with=0, wires=[0]
-                        )
-                    ),
+                        ),
+                        qml.Select(ops1, control=[0]),
+                    )
+                    # qml.AmplitudeEmbedding(
+                    #     qml.math.sqrt(coeffs1), normalize=True, pad_with=0, wires=[0]
+                    # ),
+                    # qml.Select(ops1, control=[0]),
+                    # qml.ops.Adjoint(
+                    #     qml.AmplitudeEmbedding(
+                    #         qml.math.sqrt(coeffs1), normalize=True, pad_with=0, wires=[0]
+                    #     )
+                    # ),
                 ],
             )
         ],
@@ -338,7 +344,7 @@ class TestPrepSelPrep:
         decomp = qml.list_decomps(qml.PrepSelPrep)[0]
 
         resource_obj = decomp.compute_resources(**op.resource_params)
-        assert resource_obj.num_gates == 3
+        assert resource_obj.num_gates == 1
 
         expected_counts = {
             qml.resource_rep(qml.Select, op_reps=op_reps, num_control_wires=2, partial=True): 1,
@@ -347,6 +353,19 @@ class TestPrepSelPrep:
                 qml.ops.Adjoint, base_class=qml.StatePrep, base_params={"num_wires": 2}
             ): 1,
         }
+        expected_counts = {
+            qml.resource_rep(
+                qml.ops.ChangeOpBasis,
+                compute_op=qml.resource_rep(qml.StatePrep, num_wires=2),
+                target_op=qml.resource_rep(
+                    qml.Select, op_reps=op_reps, num_control_wires=2, partial=True
+                ),
+                uncompute_op=qml.resource_rep(
+                    qml.ops.Adjoint, base_class=qml.StatePrep, base_params={"num_wires": 2}
+                ),
+            ): 1,
+        }
+
         assert resource_obj.gate_counts == expected_counts
 
         decomp = qml.list_decomps(qml.PrepSelPrep)[0]
@@ -354,7 +373,7 @@ class TestPrepSelPrep:
         with qml.queuing.AnnotatedQueue() as q:
             decomp(*op.data, wires=op.wires, **op.hyperparameters)
 
-        q = q.queue
+        q = q.queue[0].decomposition()
 
         phase_ops = [qml.prod(op, qml.GlobalPhase(0, wires=op.wires)) for op in ops]
 


### PR DESCRIPTION
**Context:** Updates the decomposition for the following templates:
1. `Adder`
2. `OutAdder`
3. `Multiplier`
4. `PrepSelPrep`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
