### PR TITLE
Dont set environment variables in tests

### DIFF
--- a/tests/devices/test_default_clifford.py
+++ b/tests/devices/test_default_clifford.py
@@ -14,7 +14,6 @@
 """
 This module contains the tests for the clifford simulator based on stim
 """
-import os
 
 import numpy as np
 import pytest
@@ -479,11 +478,10 @@ def test_snapshot_supported(measurement, tag):
         assert qml.math.allclose(snaps_qubit[key1], snaps_clifford[key2])
 
 
-def test_max_worker_clifford():
+def test_max_worker_clifford(monkeypatch):
     """Test that the execution of multiple tapes is possible with multiprocessing on this device."""
 
-    os.environ["OMP_NUM_THREADS"] = "4"
-
+    monkeypatch.setenv("OMP_NUM_THREADS", "4")
     dev_c = qml.device("default.clifford", max_workers=2)
     dev_q = qml.device("default.qubit", max_workers=2)
 


### PR DESCRIPTION
**Context:**

A default clifford test was setting an environment variable.  
**Description of the Change:**

Just use monkeypatch instead.

**Benefits:**

Individual tests don't modify the global configuration.

**Possible Drawbacks:**

Monkeypatch can sometimes be confusing. But this is the actual reason monkeypatching exists.

**Related GitHub Issues:**
