### PR TITLE
Make templates compatible with capture

### DIFF
--- a/pennylane/ops/functions/__init__.py
+++ b/pennylane/ops/functions/__init__.py
@@ -38,12 +38,12 @@ This module contains functions that act on operators and tapes.
     ~comm
 
 """
-from .assert_valid import assert_valid
 from .bind_new_parameters import bind_new_parameters
+from .equal import equal, assert_equal
+from .assert_valid import assert_valid
 from .commutator import comm, commutator
 from .dot import dot
 from .eigvals import eigvals
-from .equal import equal, assert_equal
 from .evolve import evolve
 from .generator import generator
 from .is_commuting import is_commuting

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -29,6 +29,8 @@ import pennylane as qml
 from pennylane.decomposition import DecompositionRule
 from pennylane.exceptions import EigvalsUndefinedError
 
+from .equal import assert_equal
+
 
 def _assert_error_raised(func, error, failure_comment):
     def inner_func(*args, **kwargs):
@@ -370,7 +372,7 @@ def _check_capture(op):
 
         jaxpr = jax.make_jaxpr(test_fn)(*data)
         new_op = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *data)[0]
-        assert op == new_op
+        assert_equal(op, new_op)
     except Exception as e:
         raise ValueError(
             "The capture of the operation into jaxpr failed somehow."

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -454,6 +454,7 @@ def assert_valid(
     skip_new_decomp=False,
     skip_pickle=False,
     skip_wire_mapping=False,
+    skip_capture=False,
     heuristic_resources=False,
 ) -> None:
     """Runs basic validation checks on an :class:`~.operation.Operator` to make
@@ -530,4 +531,5 @@ def assert_valid(
     _check_generator(op)
     if not skip_differentiation:
         _check_differentiation(op)
-    _check_capture(op)
+    if not skip_capture:
+        _check_capture(op)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -33,7 +33,7 @@ from pennylane.ops import Adjoint, CompositeOp, Conditional, Controlled, Exp, Po
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
 from pennylane.tape import QuantumScript
-from pennylane.templates.subroutines import ControlledSequence, PrepSelPrep, Select
+from pennylane.templates.subroutines import QSVT, ControlledSequence, PrepSelPrep, Select
 
 OPERANDS_MISMATCH_ERROR_MESSAGE = "op1 and op2 have different operands because "
 
@@ -796,6 +796,21 @@ def _equal_prep_sel_prep(op1: PrepSelPrep, op2: PrepSelPrep, **kwargs):
         return f"op1 and op2 have different wires. Got {op1.wires} and {op2.wires}."
     if not qml.equal(op1.lcu, op2.lcu):
         return f"op1 and op2 have different lcu. Got {op1.lcu} and {op2.lcu}"
+    return True
+
+
+@_equal_dispatch.register
+def _equal_qsvt(op1: QSVT, op2: QSVT, **kwargs):
+    """Determine whether two QSVT are equal"""
+    if not equal(UA1 := op1.hyperparameters["UA"], UA2 := op2.hyperparameters["UA"]):
+        return f"op1 and op2 have different block encodings UA. Got {UA1} and {UA2}."
+    projectors1 = op1.hyperparameters["projectors"]
+    projectors2 = op2.hyperparameters["projectors"]
+    if len(projectors1) != len(projectors2):
+        return f"op1 and op2 have a different number of projectors. Got {projectors1} and {projectors2}."
+    for i, (p1, p2) in enumerate(zip(projectors1, projectors2)):
+        if not equal(p1, p2):
+            return f"op1 and op2 have different projectors at position {i}. Got {p1} and {p2}."
     return True
 
 

--- a/pennylane/templates/state_preparations/state_prep_mps.py
+++ b/pennylane/templates/state_preparations/state_prep_mps.py
@@ -405,7 +405,7 @@ class MPSPrep(Operation):
         )
 
     @classmethod
-    def _primitive_bind_call(cls, mps, wires, work_wires=None, id=None):
+    def _primitive_bind_call(cls, mps, wires, work_wires=None, **kwargs):
         # pylint: disable=arguments-differ
         if cls._primitive is None:
             # guard against this being called when primitive is not defined.

--- a/pennylane/templates/state_preparations/state_prep_mps.py
+++ b/pennylane/templates/state_preparations/state_prep_mps.py
@@ -404,15 +404,22 @@ class MPSPrep(Operation):
             self.mps, new_wires, new_work_wires, self.hyperparameters["right_canonicalize"]
         )
 
+    # pylint: disable=arguments-differ, too-many-arguments
     @classmethod
-    def _primitive_bind_call(cls, mps, wires, work_wires=None, **kwargs):
-        # pylint: disable=arguments-differ
+    def _primitive_bind_call(cls, mps, wires, work_wires=None, id=None, right_canonicalize=False):
         if cls._primitive is None:
             # guard against this being called when primitive is not defined.
             return type.__call__(
-                cls, mps=mps, wires=wires, id=id, work_wires=work_wires
+                cls,
+                mps=mps,
+                wires=wires,
+                work_wires=work_wires,
+                id=id,
+                right_canonicalize=right_canonicalize,
             )  # pragma: no cover
-        return cls._primitive.bind(*mps, wires=wires, id=id, work_wires=work_wires)
+        return cls._primitive.bind(
+            *mps, wires=wires, work_wires=work_wires, id=id, right_canonicalize=right_canonicalize
+        )
 
     def decomposition(self):
         filtered_hyperparameters = {

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -105,19 +105,17 @@ class GQSP(Operation):
         }
 
     def _flatten(self):
-        data = self.parameters
-        return data, (
-            self.hyperparameters["unitary"],
-            self.hyperparameters["control"],
-        )
+        data = (self.parameters[0], self.hyperparameters["unitary"])
+        return data, (self.hyperparameters["control"],)
 
     @classmethod
     def _unflatten(cls, data, metadata):
-        return cls(unitary=metadata[0], angles=data[0], control=metadata[1])
+        return cls(unitary=data[1], angles=data[0], control=metadata[0])
 
+    # pylint: disable=arguments-differ
     @classmethod
-    def _primitive_bind_call(cls, *args, **kwargs):
-        return cls._primitive.bind(*args, **kwargs)
+    def _primitive_bind_call(cls, unitary, angles, control, **kwargs):
+        return super()._primitive_bind_call(unitary, angles, wires=control, **kwargs)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access
@@ -219,7 +217,7 @@ def _GQSP_decomposition(*parameters, **hyperparameters):
 
     for theta, phi, lamb in zip(thetas[1:], phis[1:], lambds[1:]):
 
-        ops.Controlled(unitary, control_wires=[control], control_values=[0])
+        ops.Controlled(unitary, control_wires=control, control_values=[0])
 
         ops.X(control)
         ops.U3(2 * theta, phi, lamb, wires=control)
@@ -228,3 +226,11 @@ def _GQSP_decomposition(*parameters, **hyperparameters):
 
 
 add_decomps(GQSP, _GQSP_decomposition)
+
+# pylint: disable=protected-access
+if GQSP._primitive is not None:
+
+    @GQSP._primitive.def_impl
+    def _(*args, n_wires, **kwargs):
+        args, control = args[:-n_wires], args[-n_wires:]
+        return type.__call__(GQSP, *args, control, **kwargs)

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -105,17 +105,19 @@ class GQSP(Operation):
         }
 
     def _flatten(self):
-        data = (self.parameters[0], self.hyperparameters["unitary"])
-        return data, (self.hyperparameters["control"],)
+        return self.parameters, (
+            self.hyperparameters["unitary"],
+            self.hyperparameters["control"],
+        )
 
     @classmethod
     def _unflatten(cls, data, metadata):
-        return cls(unitary=data[1], angles=data[0], control=metadata[0])
+        return cls(unitary=metadata[0], angles=data[0], control=metadata[1])
 
     # pylint: disable=arguments-differ
     @classmethod
-    def _primitive_bind_call(cls, unitary, angles, control, **kwargs):
-        return super()._primitive_bind_call(unitary, angles, wires=control, **kwargs)
+    def _primitive_bind_call(cls, unitary, angles, control, id=None):
+        return super()._primitive_bind_call(angles, unitary=unitary, wires=control, id=id)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access
@@ -232,5 +234,5 @@ if GQSP._primitive is not None:
 
     @GQSP._primitive.def_impl
     def _(*args, n_wires, **kwargs):
-        args, control = args[:-n_wires], args[-n_wires:]
-        return type.__call__(GQSP, *args, control, **kwargs)
+        (angles,), control = args[:-n_wires], args[-n_wires:]
+        return type.__call__(GQSP, angles=angles, control=control, **kwargs)

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -113,6 +113,10 @@ class PrepSelPrep(Operation):
         return (self.lcu,), (self.control,)
 
     @classmethod
+    def _primitive_bind_call(cls, lcu, control, **kwargs):
+        return super()._primitive_bind_call(lcu, wires=control, **kwargs)
+
+    @classmethod
     def _unflatten(cls, data, metadata) -> "PrepSelPrep":
         return cls(data[0], metadata[0])
 
@@ -238,3 +242,11 @@ def _prepselprep_decomp(*_, wires, lcu, coeffs, ops, control, target_wires):
 
 
 add_decomps(PrepSelPrep, _prepselprep_decomp)
+
+# pylint: disable=protected-access
+if PrepSelPrep._primitive is not None:
+
+    @PrepSelPrep._primitive.def_impl
+    def _(*args, n_wires, **kwargs):
+        (lcu,), control = args[:-n_wires], args[-n_wires:]
+        return type.__call__(PrepSelPrep, lcu, control, **kwargs)

--- a/pennylane/templates/subroutines/select_pauli_rot.py
+++ b/pennylane/templates/subroutines/select_pauli_rot.py
@@ -141,10 +141,11 @@ class SelectPauliRot(Operation):
             rot_axis=self.hyperparameters["rot_axis"],
         )
 
+    # pylint: disable=arguments-differ
     @classmethod
-    def _primitive_bind_call(cls, *args, **kwargs):
-        """Bind arguments to the primitive operation."""
-        return cls._primitive.bind(*args, **kwargs)
+    def _primitive_bind_call(cls, angles, control_wires, target_wire, **kwargs):
+        wires = [*control_wires, target_wire]
+        return super()._primitive_bind_call(angles, wires=wires, **kwargs)
 
     def decomposition(self):  # pylint: disable=arguments-differ
         """Return the operator's decomposition using its parameters and hyperparameters."""
@@ -211,3 +212,11 @@ def decompose_select_pauli_rot(angles, wires, rot_axis, **__):
 
 
 add_decomps(SelectPauliRot, decompose_select_pauli_rot)
+
+# pylint: disable=protected-access
+if SelectPauliRot._primitive is not None:
+
+    @SelectPauliRot._primitive.def_impl
+    def _(*args, n_wires, **kwargs):
+        (angles,), (*control_wires, target_wire) = args[:-n_wires], args[-n_wires:]
+        return type.__call__(SelectPauliRot, angles, control_wires, target_wire, **kwargs)

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -1253,8 +1253,8 @@ class TestModifiedTemplates:
 
         eqn = jaxpr.eqns[0]
         assert eqn.primitive == qml.Select._primitive
-        assert eqn.invars == jaxpr.jaxpr.invars
-        assert eqn.params == kwargs
+        assert [invar.val for invar in eqn.invars] == [0, 1]
+        assert eqn.params == {"ops": ops, "n_wires": 2}
         assert len(eqn.outvars) == 1
         assert isinstance(eqn.outvars[0], jax.core.DropVar)
 

--- a/tests/templates/test_embeddings/test_amplitude.py
+++ b/tests/templates/test_embeddings/test_amplitude.py
@@ -45,6 +45,7 @@ TOO_MANY_FEATURES = [
 TOO_MANY_BROADCASTED_FEATURES = [np.eye(6)[:3, :5], np.ones((3, 8)) / np.sqrt(8)]
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_embeddings/test_angle.py
+++ b/tests/templates/test_embeddings/test_angle.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     op = qml.AngleEmbedding(features=[1.0, 2.0, 3.0], wires=range(3), rotation="Z")

--- a/tests/templates/test_embeddings/test_basis.py
+++ b/tests/templates/test_embeddings/test_basis.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     wires = qml.wires.Wires((0, 1, 2))

--- a/tests/templates/test_embeddings/test_displacement_emb.py
+++ b/tests/templates/test_embeddings/test_displacement_emb.py
@@ -23,11 +23,13 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     feature_vector = [1.0, 2.0, 3.0]
     op = qml.DisplacementEmbedding(features=feature_vector, wires=range(3), method="phase", c=0.5)
-    qml.ops.functions.assert_valid(op, skip_differentiation=True)  # Skip because it's CV op.
+    # Skip differentiation and capture because it's a CV op.
+    qml.ops.functions.assert_valid(op, skip_differentiation=True, skip_capture=True)
 
 
 def test_flatten_unflatten_methods():

--- a/tests/templates/test_embeddings/test_iqp_emb.py
+++ b/tests/templates/test_embeddings/test_iqp_emb.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     features = (0.0, 1.0, 2.0)

--- a/tests/templates/test_embeddings/test_qaoa_emb.py
+++ b/tests/templates/test_embeddings/test_qaoa_emb.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     features = [1.0, 2.0]

--- a/tests/templates/test_embeddings/test_squeezing_emb.py
+++ b/tests/templates/test_embeddings/test_squeezing_emb.py
@@ -23,11 +23,13 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     feature_vector = [1.0, 2.0, 3.0]
     op = qml.SqueezingEmbedding(features=feature_vector, wires=range(3), method="phase", c=0.5)
-    qml.ops.functions.assert_valid(op, skip_differentiation=True)  # Skip because it's CV op.
+    # Skip differentiation and capture because it's a CV op.
+    qml.ops.functions.assert_valid(op, skip_differentiation=True, skip_capture=True)
 
 
 def test_flatten_unflatten_methods():

--- a/tests/templates/test_layers/test_basic_entangler.py
+++ b/tests/templates/test_layers/test_basic_entangler.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_layers/test_gate_fabric.py
+++ b/tests/templates/test_layers/test_gate_fabric.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("include_pi", (True, False))
 def test_standard_validity(include_pi):
     """Check the operation using the assert_valid function."""

--- a/tests/templates/test_layers/test_particle_conserving_u1.py
+++ b/tests/templates/test_layers/test_particle_conserving_u1.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("init_state", [np.array([1, 1, 0]), None])
 def test_standard_validity(init_state):
     """Check the operation using the assert_valid function."""

--- a/tests/templates/test_layers/test_particle_conserving_u2.py
+++ b/tests/templates/test_layers/test_particle_conserving_u2.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("init_state", [np.array([1, 1, 0, 0]), None])
 def test_standard_validity(init_state):
     """Run standard checks with the assert_valid function."""

--- a/tests/templates/test_layers/test_random.py
+++ b/tests/templates/test_layers/test_random.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard checks with the assert_valid function."""
 

--- a/tests/templates/test_layers/test_simplified_twodesign.py
+++ b/tests/templates/test_layers/test_simplified_twodesign.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard checks with the assert_valid function."""
 

--- a/tests/templates/test_layers/test_strongly_entangling.py
+++ b/tests/templates/test_layers/test_strongly_entangling.py
@@ -26,6 +26,7 @@ from pennylane.capture.autograph import run_autograph
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 @pytest.mark.external
 def test_standard_validity():
     """Check the operation using the assert_valid function."""

--- a/tests/templates/test_state_preparations/test_arbitrary_state_prep.py
+++ b/tests/templates/test_state_preparations/test_arbitrary_state_prep.py
@@ -81,6 +81,7 @@ def test_decomposition_new(weights, wires):
         _test_decomposition_rule(op, rule)
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_state_preparations/test_cosine_window.py
+++ b/tests/templates/test_state_preparations/test_cosine_window.py
@@ -26,6 +26,7 @@ from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.wires import Wires
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_state_preparations/test_mottonen_state_prep.py
+++ b/tests/templates/test_state_preparations/test_mottonen_state_prep.py
@@ -29,6 +29,7 @@ from pennylane.templates.state_preparations.mottonen import (
 )
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_state_preparations/test_qrom_state_prep.py
+++ b/tests/templates/test_state_preparations/test_qrom_state_prep.py
@@ -41,6 +41,7 @@ def test_float_to_binary(val, num_bits, expected):
 
 class TestQROMStatePreparation:
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_state_preparations/test_qutrit_basis_state_prep.py
+++ b/tests/templates/test_state_preparations/test_qutrit_basis_state_prep.py
@@ -22,6 +22,7 @@ import pytest
 import pennylane as qml
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_state_preparations/test_state_prep_mps.py
+++ b/tests/templates/test_state_preparations/test_state_prep_mps.py
@@ -28,6 +28,7 @@ from pennylane.templates.state_preparations.state_prep_mps import (
 
 class TestMPSPrep:
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Check the template using the `assert_valid` function."""
         mps = [

--- a/tests/templates/test_state_preparations/test_superposition.py
+++ b/tests/templates/test_state_preparations/test_superposition.py
@@ -112,6 +112,7 @@ def test_order_states(basis_states, exp_map):
     assert order_states(basis_states) == exp_map
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_subroutines/test_adder.py
+++ b/tests/templates/test_subroutines/test_adder.py
@@ -22,6 +22,7 @@ from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity_Adder():
     """Check the operation using the assert_valid function."""
     k = 6

--- a/tests/templates/test_subroutines/test_all_singles_doubles.py
+++ b/tests/templates/test_subroutines/test_all_singles_doubles.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard tests of operation validity."""
     op = qml.AllSinglesDoubles(

--- a/tests/templates/test_subroutines/test_amplitude_amplification.py
+++ b/tests/templates/test_subroutines/test_amplitude_amplification.py
@@ -65,6 +65,7 @@ class TestInitialization:
         with pytest.raises(ValueError, match="work_wire must be different from the wires of O."):
             qml.AmplitudeAmplification(U, O, iters=3, fixed_point=fixed_point, work_wire=work_wire)
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Test standard validity using assert_valid."""
         U = generator(wires=range(3))

--- a/tests/templates/test_subroutines/test_approx_time_evolution.py
+++ b/tests/templates/test_subroutines/test_approx_time_evolution.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane import numpy as pnp
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard tests of operation validity."""
     H = 2.0 * qml.PauliX(0) + 3.0 * qml.PauliY(0)

--- a/tests/templates/test_subroutines/test_aqft.py
+++ b/tests/templates/test_subroutines/test_aqft.py
@@ -21,6 +21,7 @@ import pennylane as qml
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     op = qml.AQFT(order=2, wires=(0, 1, 2))

--- a/tests/templates/test_subroutines/test_arbitrary_unitary.py
+++ b/tests/templates/test_subroutines/test_arbitrary_unitary.py
@@ -28,6 +28,7 @@ from pennylane.templates.subroutines.arbitrary_unitary import (
 )
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard tests of operation validity."""
     shape = (3,)

--- a/tests/templates/test_subroutines/test_basis_rotation.py
+++ b/tests/templates/test_subroutines/test_basis_rotation.py
@@ -22,6 +22,7 @@ import pennylane as qml
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize(
     "rotation",
     [

--- a/tests/templates/test_subroutines/test_commuting_evolution.py
+++ b/tests/templates/test_subroutines/test_commuting_evolution.py
@@ -22,6 +22,7 @@ import pennylane as qml
 from pennylane import numpy as np
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard tests of operation validity."""
     H = 2.0 * qml.PauliX(0) @ qml.PauliY(1) + 3.0 * qml.PauliY(0) @ qml.PauliZ(1)

--- a/tests/templates/test_subroutines/test_controlled_sequence.py
+++ b/tests/templates/test_subroutines/test_controlled_sequence.py
@@ -25,6 +25,7 @@ from pennylane.wires import Wires
 # pylint: disable=unidiomatic-typecheck, cell-var-from-loop
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     op = qml.ControlledSequence(qml.RX(0.25, wires=3), control=[0, 1, 2])

--- a/tests/templates/test_subroutines/test_double_excitation.py
+++ b/tests/templates/test_subroutines/test_double_excitation.py
@@ -22,6 +22,7 @@ from pennylane import numpy as pnp
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Run standard tests of operation validity."""
     weight = 0.5

--- a/tests/templates/test_subroutines/test_fable.py
+++ b/tests/templates/test_subroutines/test_fable.py
@@ -37,6 +37,7 @@ class TestFable:
             ]
         )
 
+    @pytest.mark.jax
     def test_standard_validity(self, input_matrix):
         """Check the operation using the assert_valid function."""
         op = qml.FABLE(input_matrix, wires=range(5), tol=0.01)

--- a/tests/templates/test_subroutines/test_flip_sign.py
+++ b/tests/templates/test_subroutines/test_flip_sign.py
@@ -24,6 +24,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.wires import Wires
 
 
+@pytest.mark.jax
 def test_standard_checks():
     """Run standard checks with the assert_valid function."""
     op = qml.FlipSign([0, 1], wires=("a", "b"))

--- a/tests/templates/test_subroutines/test_gqsp.py
+++ b/tests/templates/test_subroutines/test_gqsp.py
@@ -27,6 +27,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 class TestGQSP:
     """Test the qml.GQSP template."""
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Test standard validity criteria with assert_valid."""
 
@@ -37,8 +38,8 @@ class TestGQSP:
             qml.RX(0.3, wires)
             qml.RZ(0.6, wires)
 
-        op = qml.GQSP(unitary(1), angles, control=0)
-        qml.ops.functions.assert_valid(op)
+        op = qml.GQSP(unitary(1), angles, control=(0,))
+        qml.ops.functions.assert_valid(op, skip_differentiation=True)
 
     @pytest.mark.parametrize(
         ("unitary", "poly"),

--- a/tests/templates/test_subroutines/test_grover.py
+++ b/tests/templates/test_subroutines/test_grover.py
@@ -39,6 +39,7 @@ def test_work_wire_property():
     assert op.work_wires == expected
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Test the standard criteria for a valid operation."""
     work_wires = qml.wires.Wires((3, 4))

--- a/tests/templates/test_subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/test_subroutines/test_hilbert_schmidt.py
@@ -25,6 +25,7 @@ import pennylane as qml
 
 
 # pylint: disable=protected-access
+@pytest.mark.jax
 @pytest.mark.parametrize("op_type", (qml.HilbertSchmidt, qml.LocalHilbertSchmidt))
 def test_flatten_unflatten_standard_checks(op_type):
     """Test the flatten and unflatten methods."""

--- a/tests/templates/test_subroutines/test_kupccgsd.py
+++ b/tests/templates/test_subroutines/test_kupccgsd.py
@@ -30,6 +30,7 @@ k_delta_sz_init_state_wires = [
 ]
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("k, delta_sz, init_state, wires", k_delta_sz_init_state_wires)
 def test_standard_validity(k, delta_sz, init_state, wires):
     """Test standard validity criteria for kUpCCGSD."""

--- a/tests/templates/test_subroutines/test_mod_exp.py
+++ b/tests/templates/test_subroutines/test_mod_exp.py
@@ -22,6 +22,7 @@ from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity_ModExp():
     """Check the operation using the assert_valid function."""
     base = 6

--- a/tests/templates/test_subroutines/test_multiplier.py
+++ b/tests/templates/test_subroutines/test_multiplier.py
@@ -23,6 +23,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.multiplier import _mul_out_k_mod
 
 
+@pytest.mark.jax
 def test_standard_validity_Multiplier():
     """Check the operation using the assert_valid function."""
     k = 6

--- a/tests/templates/test_subroutines/test_out_adder.py
+++ b/tests/templates/test_subroutines/test_out_adder.py
@@ -22,6 +22,7 @@ from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity_OutAdder():
     """Check the operation using the assert_valid function."""
     x_wires = [0, 1]

--- a/tests/templates/test_subroutines/test_out_multiplier.py
+++ b/tests/templates/test_subroutines/test_out_multiplier.py
@@ -23,6 +23,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.out_multiplier import OutMultiplier
 
 
+@pytest.mark.jax
 def test_standard_validity_OutMultiplier():
     """Check the operation using the assert_valid function."""
     mod = 12

--- a/tests/templates/test_subroutines/test_out_poly.py
+++ b/tests/templates/test_subroutines/test_out_poly.py
@@ -59,6 +59,7 @@ def f_test(x, y, z):
     return x**2 + y * x * z**5 - z**3 + 3
 
 
+@pytest.mark.jax
 def test_standard_validity_OutPoly():
     """Check the operation using the assert_valid function."""
     wires = qml.registers({"x": 3, "y": 3, "z": 3, "output": 3, "aux": 2})

--- a/tests/templates/test_subroutines/test_permute.py
+++ b/tests/templates/test_subroutines/test_permute.py
@@ -23,6 +23,7 @@ import pennylane as qml
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     op = qml.Permute([0, 1, 2, 3], wires=(3, 2, 1, 0))

--- a/tests/templates/test_subroutines/test_phase_adder.py
+++ b/tests/templates/test_subroutines/test_phase_adder.py
@@ -23,6 +23,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.phase_adder import _add_k_fourier
 
 
+@pytest.mark.jax
 def test_standard_validity_Phase_Adder():
     """Check the operation using the assert_valid function."""
     k = 6

--- a/tests/templates/test_subroutines/test_prepselprep.py
+++ b/tests/templates/test_subroutines/test_prepselprep.py
@@ -23,6 +23,7 @@ import pytest
 import pennylane as qml
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize(
     ("lcu", "control", "skip_diff"),
     [

--- a/tests/templates/test_subroutines/test_qdrift.py
+++ b/tests/templates/test_subroutines/test_qdrift.py
@@ -57,6 +57,7 @@ class TestInitialization:
         assert len(q.queue) == 1
         assert q.queue[0] is op
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("n", (1, 2, 3))
     @pytest.mark.parametrize("time", (0.5, 1, 2))
     @pytest.mark.parametrize("coeffs, ops", test_hamiltonians)

--- a/tests/templates/test_subroutines/test_qft.py
+++ b/tests/templates/test_subroutines/test_qft.py
@@ -22,6 +22,7 @@ import pennylane as qml
 from pennylane.capture.autograph import run_autograph
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
     op = qml.QFT(wires=(0, 1, 2))

--- a/tests/templates/test_subroutines/test_qmc.py
+++ b/tests/templates/test_subroutines/test_qmc.py
@@ -258,6 +258,7 @@ class TestQuantumMonteCarlo:
     def func(i):
         return np.sin(i) ** 2
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Test standard validity criteria with assert_valid."""
         p = np.ones(4) / 4

--- a/tests/templates/test_subroutines/test_qpe.py
+++ b/tests/templates/test_subroutines/test_qpe.py
@@ -22,6 +22,7 @@ import pennylane as qml
 from pennylane.exceptions import QuantumFunctionError
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Test standard validity criteria using assert_valid."""
     op = qml.QuantumPhaseEstimation(np.eye(4), target_wires=(0, 1), estimation_wires=[2, 5])

--- a/tests/templates/test_subroutines/test_qrom.py
+++ b/tests/templates/test_subroutines/test_qrom.py
@@ -22,6 +22,7 @@ from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_assert_valid_qrom():
     """Run standard validity tests."""
     bitstrings = ["000", "001", "111", "011", "000", "101", "110", "111"]
@@ -30,6 +31,7 @@ def test_assert_valid_qrom():
     qml.ops.functions.assert_valid(op)
 
 
+@pytest.mark.jax
 def test_falsy_zero_as_work_wire():
     """Test that work wire is not treated as a falsy zero."""
     op = qml.QROM(["1", "0", "0", "1"], control_wires=[1, 2], target_wires=[3], work_wires=0)

--- a/tests/templates/test_subroutines/test_qsvt.py
+++ b/tests/templates/test_subroutines/test_qsvt.py
@@ -79,6 +79,7 @@ def generate_polynomial_coeffs(degree, parity=None):
 class TestQSVT:
     """Test the qml.QSVT template."""
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Test standard validity criteria with assert_valid."""
         projectors = [qml.PCPhase(0.2, dim=1, wires=0), qml.PCPhase(0.3, dim=1, wires=0)]

--- a/tests/templates/test_subroutines/test_qubitization.py
+++ b/tests/templates/test_subroutines/test_qubitization.py
@@ -66,6 +66,7 @@ def test_operator_definition_qpe(hamiltonian):
     assert np.allclose(np.sort(estimated_eigenvalues), qml.eigvals(hamiltonian), atol=0.1)
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize(
     ("lcu", "control"),
     [

--- a/tests/templates/test_subroutines/test_reflection.py
+++ b/tests/templates/test_subroutines/test_reflection.py
@@ -28,6 +28,7 @@ def hadamards(wires):
         qml.Hadamard(wires=wire)
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Test standard validity criteria using assert_valid."""
     op = qml.Reflection(qml.Hadamard(wires=0), 0.5, reflection_wires=[0])

--- a/tests/templates/test_subroutines/test_select.py
+++ b/tests/templates/test_subroutines/test_select.py
@@ -30,6 +30,7 @@ from pennylane.templates.subroutines.select import (
 )
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("num_ops", [3, 10, 15, 16])
 @pytest.mark.parametrize("partial", [True, False])
 @pytest.mark.parametrize("work_wires", [None, [5, 6, 7]])

--- a/tests/templates/test_subroutines/test_select_pauli_rot.py
+++ b/tests/templates/test_subroutines/test_select_pauli_rot.py
@@ -42,6 +42,7 @@ def get_tape(angles, wires):
 
 class TestSelectPauliRot:
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_subroutines/test_semi_adder.py
+++ b/tests/templates/test_subroutines/test_semi_adder.py
@@ -22,6 +22,7 @@ from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity_SemiAdder():
     """Check the operation using the assert_valid function."""
     x_wires = [0, 1, 2]

--- a/tests/templates/test_subroutines/test_single_excitation.py
+++ b/tests/templates/test_subroutines/test_single_excitation.py
@@ -22,6 +22,7 @@ from pennylane import numpy as pnp
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
+@pytest.mark.jax
 def test_standard_validity():
     """Test standard validity criteria using assert_valid."""
     weight = np.pi / 3

--- a/tests/templates/test_subroutines/test_temporary_and.py
+++ b/tests/templates/test_subroutines/test_temporary_and.py
@@ -38,6 +38,7 @@ class TestTemporaryAND:
         op2 = qml.Elbow(wires=[0, "a", 2], control_values=(0, 0))
         qml.assert_equal(op1, op2)
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Check the operation using the assert_valid function."""
 

--- a/tests/templates/test_subroutines/test_trotter.py
+++ b/tests/templates/test_subroutines/test_trotter.py
@@ -453,9 +453,18 @@ class TestInitialization:
         assert op.hyperparameters == new_op.hyperparameters
         assert op is not new_op
 
-    @pytest.mark.xfail(reason="https://github.com/PennyLaneAI/pennylane/issues/6333", strict=False)
+    @pytest.mark.jax
     @pytest.mark.parametrize("hamiltonian", test_hamiltonians)
     def test_standard_validity(self, hamiltonian):
+        """Test standard validity criteria using assert_valid."""
+        time, n, order = (4.2, 10, 4)
+        op = qml.TrotterProduct(hamiltonian, time, n=n, order=order)
+        qml.ops.functions.assert_valid(op, skip_differentiation=True)
+
+    @pytest.mark.jax
+    @pytest.mark.xfail(reason="https://github.com/PennyLaneAI/pennylane/issues/6333", strict=False)
+    @pytest.mark.parametrize("hamiltonian", test_hamiltonians)
+    def test_standard_validity_with_differentiation(self, hamiltonian):
         """Test standard validity criteria using assert_valid."""
         time, n, order = (4.2, 10, 4)
         op = qml.TrotterProduct(hamiltonian, time, n=n, order=order)

--- a/tests/templates/test_subroutines/test_uccsd.py
+++ b/tests/templates/test_subroutines/test_uccsd.py
@@ -162,6 +162,7 @@ test_data_decomposition_new = [
 ]
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("s_wires, d_wires, weights, n_repeats, _", test_data_decomposition)
 def test_standard_validity(s_wires, d_wires, weights, n_repeats, _):
     """Test standard validity criteria using assert_valid."""

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -73,6 +73,7 @@ class TestDynamicWire:
 
 class TestAllocateOp:
 
+    @pytest.mark.jax
     def test_valid_operation(self):
         """Test that Allocate is a valid Operator."""
         op = Allocate.from_num_wires(3)


### PR DESCRIPTION
Context:
Some templates are not up to standard with their primitive binding methods, making them incompatible with capture.

Description of the Change:
Adapt the internal methods to make the templates compatible with capture.
Where necessary, adapt the convention of what is considered data/hyperparameters of a template operator.
Where necessary, adapt the tests to a consistent convention of what is considered data/hyperparameters.
Apply `mark.jax` to `assert_valid` tests in `tests/templates/`.

Benefits:
Code quality/feature parity of capture.

Possible Drawbacks:
N/A

Related GitHub Issues:
replaces #7696 
fixes #7695
[sc-93484]