### PR TITLE
Upgrade support for `pubchempy==1.0.5` in unit tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -972,7 +972,7 @@
   [(#8193)](https://github.com/PennyLaneAI/pennylane/pull/8193)
 
 * Updated support for `pubchempy` used in the unit tests for `qml.qchem.mol_data` to `1.0.5`.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#8224)](https://github.com/PennyLaneAI/pennylane/pull/8224)
 
 <h3>Documentation 📝</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev51"
+__version__ = "0.43.0-dev52"


### PR DESCRIPTION
**Context:** Adds supports for `pubchempy==1.0.5` in `qchem.mol_data` unit tests.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
