### PR TITLE
Move ResourceOperator and CompressedResourceOp classes to PL for resource estimation

### DIFF
--- a/pennylane/estimator/__init__.py
+++ b/pennylane/estimator/__init__.py
@@ -39,3 +39,5 @@ Resource Estimation Base Classes:
 from .wires_manager import Allocate, Deallocate, WireResourceManager
 
 from .resources_base import Resources
+
+from .resource_operator import ResourceOperator, CompressedResourceOp, GateCount

--- a/pennylane/estimator/resource_operator.py
+++ b/pennylane/estimator/resource_operator.py
@@ -1,0 +1,742 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Abstract base class for resource operators."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from collections.abc import Callable, Hashable, Iterable
+from inspect import signature
+from typing import Union
+
+import numpy as np
+
+from .wires_manager import WireResourceManager
+from .resources_base import Resources
+from pennylane.operation import classproperty
+from pennylane.queuing import QueuingManager
+from pennylane.wires import Wires
+
+# pylint: disable=unused-argument, no-member
+
+
+class CompressedResourceOp:  # pylint: disable=too-few-public-methods
+    r"""Instantiate a light weight class corresponding to the operator type and parameters.
+
+    This class provides a minimal representation of an operation, containing
+    only the operator type and the necessary parameters to estimate its resources.
+    It's designed for efficient hashing and comparison, allowing it to be used
+    effectively in collections where uniqueness and quick lookups are important.
+
+    Args:
+        op_type (Type): the class object of an operation which inherits from :class:'~.pennylane.labs.resource_estimation.ResourceOperator'
+        num_wires (int): The number of wires that the operation acts upon,
+            excluding any auxiliary wires that are allocated on decomposition.
+        params (dict): a dictionary containing the minimal pairs of parameter names and values
+            required to compute the resources for the given operator
+        name (str, optional): A custom name for the compressed operator. If not
+            provided, a name will be generated using `op_type.tracking_name`
+            with the given parameters.
+
+    .. details::
+
+        This representation is the minimal amount of information required to estimate resources for the operator.
+
+    **Example**
+
+    >>> from pennylane.labs import resource_estimation as plre
+    >>> cmpr_op = plre.CompressedResourceOp(plre.Hadamard, num_wires=1)
+    >>> print(cmpr_op)
+    CompressedResourceOp(ResourceHadamard, num_wires=1)
+    """
+
+    def __init__(
+        self,
+        op_type: type[ResourceOperator],
+        num_wires: int,
+        params: dict | None = None,
+        name: str = None,
+    ):
+
+        if not issubclass(op_type, ResourceOperator):
+            raise TypeError(f"op_type must be a subclass of ResourceOperator. Got {op_type}.")
+        self.op_type = op_type
+        self.num_wires = num_wires
+        self.params = params or {}
+        self._hashable_params = _make_hashable(params) if params else ()
+        self._name = name or op_type.tracking_name(**self.params)
+
+    def __hash__(self) -> int:
+        return hash((self.op_type, self.num_wires, self._hashable_params))
+
+    def __eq__(self, other: CompressedResourceOp) -> bool:
+        return (
+            isinstance(other, CompressedResourceOp)
+            and self.op_type == other.op_type
+            and self.num_wires == other.num_wires
+            and self.params == other.params
+        )
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__qualname__
+        op_type_name = self.op_type.__name__
+
+        num_wires_str = f"num_wires={self.num_wires}"
+
+        params_arg_str = ""
+        if self.params:
+            params = sorted(self.params.items())
+            params_str = ", ".join(f"{k!r}:{v!r}" for k, v in params)
+            params_arg_str = f", params={{{params_str}}}"
+
+        return f"{class_name}({op_type_name}, {num_wires_str}{params_arg_str})"
+
+    @property
+    def name(self) -> str:
+        r"""Returns the name of operator."""
+        return self._name
+
+
+def _make_hashable(d) -> tuple:
+    r"""Converts a potentially non-hashable object into a hashable tuple.
+
+    Args:
+        d : The object to potentially convert to a hashable tuple.
+           This can be a dictionary, list, set, or an array.
+
+    Returns:
+        A hashable tuple representation of the input.
+
+    """
+
+    if isinstance(d, Hashable):
+        return d
+
+    if isinstance(d, dict):
+        return tuple(sorted((_make_hashable(k), _make_hashable(v)) for k, v in d.items()))
+    if isinstance(d, (list, tuple)):
+        return tuple(_make_hashable(elem) for elem in d)
+    if isinstance(d, set):
+        return tuple(sorted(_make_hashable(elem) for elem in d))
+    if isinstance(d, np.ndarray):
+        return _make_hashable(d.tolist())
+
+    raise TypeError(f"Object of type {type(d)} is not hashable and cannot be converted.")
+
+
+class ResourceOperator(ABC):
+    r"""Base class to represent quantum operators according to the set of information
+    required for resource estimation.
+
+    A :class:`~.pennylane.estimator.ResourceOperator` is uniquely defined by its
+    name (the class type) and its resource parameters (:code:`op.resource_params`).
+
+    **Example**
+
+    This example shows how to create a custom :class:`~.pennylane.labs.resource_estimation.ResourceOperator`
+    class for resource estimation. We use :class:`~.pennylane.QFT` as a well known gate for
+    simplicity.
+
+    .. code-block:: python
+
+        from pennylane import estimator as plre
+
+        class QFT(plre.ResourceOperator):
+
+            resource_keys = {"num_wires"}  # the only parameter that its resources depend upon.
+
+            def __init__(self, num_wires, wires=None):  # wire labels are optional
+                self.num_wires = num_wires
+                super().__init__(wires=wires)
+
+            @property
+            def resource_params(self) -> dict:        # The keys must match the `resource_keys`
+                return {"num_wires": self.num_wires}  # and values obtained from the operator.
+
+            @classmethod
+            def resource_rep(cls, num_wires):             # Takes the `resource_keys` as input
+                params = {"num_wires": num_wires}         #   and produces a compressed
+                return plre.CompressedResourceOp(cls, num_wires, params)  # representation of the operator
+
+            @classmethod
+            def default_resource_decomp(cls, num_wires, **kwargs):  # `resource_keys` are input
+
+                # Get compressed reps for each gate in the decomposition:
+
+                swap = plre.resource_rep(plre.SWAP)
+                hadamard = plre.resource_rep(plre.Hadamard)
+                ctrl_phase_shift = plre.resource_rep(plre.ControlledPhaseShift)
+
+                # Figure out the associated counts for each type of gate:
+
+                swap_counts = num_wires // 2
+                hadamard_counts = num_wires
+                ctrl_phase_shift_counts = num_wires*(num_wires - 1) // 2
+
+                return [                                  # Return the decomposition
+                    plre.GateCount(swap, swap_counts),
+                    plre.GateCount(hadamard, hadamard_counts),
+                    plre.GateCount(ctrl_phase_shift, ctrl_phase_shift_counts),
+                ]
+
+    Which can be instantiated as a normal operation, but now contains the resources:
+
+    .. code-block:: pycon
+
+        >>> op = QFT(num_wires=3)
+        >>> print(plre.estimate(op, gate_set={'Hadamard', 'SWAP', 'ControlledPhaseShift'}))
+        --- Resources: ---
+         Total wires: 3
+            algorithmic wires: 3
+            allocated wires: 0
+            	 clean wires: 0
+            	 dirty wires: 0
+         Total gates : 7
+          'SWAP': 1,
+          'ControlledPhaseShift': 3,
+          'Hadamard': 3
+
+    """
+
+    num_wires = 1
+
+    def __init__(self, *args, wires=None, **kwargs) -> None:
+        self.wires = None
+        if wires is not None:
+            wires = Wires(wires)
+            if len(wires) != self.num_wires:
+                raise ValueError(f"Expected {self.num_wires} wires, got {wires}.")
+            self.wires = wires
+
+        self.queue()
+        super().__init__()
+
+    def queue(self, context: QueuingManager = QueuingManager):
+        """Append the operator to the Operator queue."""
+        context.append(self)
+        return self
+
+    @staticmethod
+    def dequeue(
+        op_to_remove: Union["ResourceOperator", Iterable],
+        context: QueuingManager = QueuingManager,
+    ):
+        """Remove the given resource operator(s) from the Operator queue."""
+        if not isinstance(op_to_remove, Iterable):
+            op_to_remove = [op_to_remove]
+
+        for op in op_to_remove:
+            context.remove(op)
+
+    @classproperty
+    @classmethod
+    def resource_keys(cls) -> set:  # pylint: disable=no-self-use
+        """The set of parameters that affects the resource requirement of the operator.
+
+        All resource decomposition functions for this operator class are expected to accept the
+        keyword arguments that match these keys exactly. The :func:`~pennylane.resource_rep`
+        function will also expect keyword arguments that match these keys when called with this
+        operator type.
+
+        The default implementation is an empty set, which is suitable for most operators.
+        """
+        return set()
+
+    @property
+    @abstractmethod
+    def resource_params(self) -> dict:
+        """A dictionary containing the minimal information needed to compute a resource estimate
+        of the operator's decomposition. The keys of this dictionary should match the
+        ``resource_keys`` attribute of the operator class.
+        """
+
+    @classmethod
+    @abstractmethod
+    def resource_rep(cls, *args, **kwargs) -> CompressedResourceOp:
+        r"""Returns a compressed representation containing only the parameters of
+        the Operator that are needed to estimate the resources."""
+
+    def resource_rep_from_op(self) -> CompressedResourceOp:
+        r"""Returns a compressed representation directly from the operator"""
+        return self.__class__.resource_rep(**self.resource_params)
+
+    @classmethod
+    @abstractmethod
+    def default_resource_decomp(cls, *args, **kwargs) -> list:
+        r"""Returns a list of actions that define the resources of the operator."""
+
+    @classmethod
+    def resource_decomp(cls, *args, **kwargs) -> list:
+        r"""Returns a list of actions that define the resources of the operator."""
+        return cls.default_resource_decomp(*args, **kwargs)
+
+    @classmethod
+    def default_adjoint_resource_decomp(cls, *args, **kwargs) -> list:
+        r"""Returns a list representing the resources for the adjoint of the operator."""
+        raise ResourcesNotDefined
+
+    @classmethod
+    def adjoint_resource_decomp(cls, *args, **kwargs) -> list:
+        r"""Returns a list of actions that define the resources of the operator."""
+        return cls.default_adjoint_resource_decomp(*args, **kwargs)
+
+    @classmethod
+    def default_controlled_resource_decomp(
+        cls, ctrl_num_ctrl_wires: int, ctrl_num_ctrl_values: int, *args, **kwargs
+    ) -> list:
+        r"""Returns a list representing the resources for a controlled version of the operator.
+
+        Args:
+            ctrl_num_ctrl_wires (int): the number of qubits the
+                operation is controlled on
+            ctrl_num_ctrl_values (int): the number of control qubits, that are
+                controlled when in the :math:`|0\rangle` state
+        """
+        raise ResourcesNotDefined
+
+    @classmethod
+    def controlled_resource_decomp(
+        cls, ctrl_num_ctrl_wires: int, ctrl_num_ctrl_values: int, *args, **kwargs
+    ) -> list:
+        r"""Returns a list representing the resources for a controlled version of the operator.
+
+        Args:
+            ctrl_num_ctrl_wires (int): the number of qubits the
+                operation is controlled on
+            ctrl_num_ctrl_values (int): the number of control qubits, that are
+                controlled when in the :math:`|0\rangle` state
+        """
+        return cls.default_controlled_resource_decomp(
+            ctrl_num_ctrl_wires, ctrl_num_ctrl_values, *args, **kwargs
+        )
+
+    @classmethod
+    def default_pow_resource_decomp(cls, pow_z: int, *args, **kwargs) -> list:
+        r"""Returns a list representing the resources for an operator
+        raised to a power.
+
+        Args:
+            pow_z (int): exponent that the operator is being raised to
+        """
+        raise ResourcesNotDefined
+
+    @classmethod
+    def pow_resource_decomp(cls, pow_z, *args, **kwargs) -> list:
+        r"""Returns a list representing the resources for an operator
+        raised to a power.
+
+        Args:
+            pow_z (int): exponent that the operator is being raised to
+        """
+        return cls.default_pow_resource_decomp(pow_z, *args, **kwargs)
+
+    @classmethod
+    def set_resources(cls, new_func: Callable, override_type: str = "base"):
+        """Set a custom function to override the default resource decomposition.
+
+        This method allows users to replace any of the `resource_decomp`, `adjoint_resource_decomp`,
+        `ctrl_resource_decomp`, or `pow_resource_decomp` methods globally for every instance of
+        the class.
+
+        """
+        if override_type == "base":
+            keys = cls.resource_keys.union({"kwargs"})
+            _validate_signature(new_func, keys)
+            cls.resource_decomp = new_func
+        if override_type == "pow":
+            keys = cls.resource_keys.union({"pow_z", "kwargs"})
+            _validate_signature(new_func, keys)
+            cls.pow_resource_decomp = new_func
+        if override_type == "adj":
+            keys = cls.resource_keys.union({"kwargs"})
+            _validate_signature(new_func, keys)
+            cls.adjoint_resource_decomp = new_func
+        if override_type == "ctrl":
+            keys = cls.resource_keys.union(
+                {"ctrl_num_ctrl_wires", "ctrl_num_ctrl_values", "kwargs"}
+            )
+            _validate_signature(new_func, keys)
+            cls.controlled_resource_decomp = new_func
+
+    def __repr__(self) -> str:
+        str_rep = self.__class__.__name__ + "(" + str(self.resource_params) + ")"
+        return str_rep
+
+    def __mul__(self, scalar: int):
+        assert isinstance(scalar, int)
+        gate_types = defaultdict(int, {self.resource_rep_from_op(): scalar})
+        qubit_manager = QubitManager(0, algo_wires=self.num_wires)
+
+        return Resources(qubit_manager, gate_types)
+
+    def __matmul__(self, scalar: int):
+        assert isinstance(scalar, int)
+        gate_types = defaultdict(int, {self.resource_rep_from_op(): scalar})
+        qubit_manager = QubitManager(0, algo_wires=scalar * self.num_wires)
+
+        return Resources(qubit_manager, gate_types)
+
+    def __add__(self, other):
+        if isinstance(other, ResourceOperator):
+            return (1 * self) + (1 * other)
+        if isinstance(other, Resources):
+            return (1 * self) + other
+
+        raise TypeError(f"Cannot add resource operator {self} with type {type(other)}.")
+
+    def __and__(self, other):
+        if isinstance(other, ResourceOperator):
+            return (1 * self) & (1 * other)
+        if isinstance(other, Resources):
+            return (1 * self) & other
+
+        raise TypeError(f"Cannot add resource operator {self} with type {type(other)}.")
+
+    __radd__ = __add__
+    __rand__ = __and__
+    __rmul__ = __mul__
+    __rmatmul__ = __matmul__
+
+    @classmethod
+    def tracking_name(cls, *args, **kwargs) -> str:
+        r"""Returns a name used to track the operator during resource estimation."""
+        return cls.__name__.replace("Resource", "")
+
+    def tracking_name_from_op(self) -> str:
+        r"""Returns the tracking name built with the operator's parameters."""
+        return self.__class__.tracking_name(**self.resource_params)
+
+
+def _validate_signature(func: Callable, expected_args: set):
+    """Raise an error if the provided function doesn't match expected signature
+
+    Args:
+        func (Callable): function to match signature with
+        expected_args (set): expected signature
+    """
+
+    sig = signature(func)
+    actual_args = set(sig.parameters)
+
+    if extra_args := actual_args - expected_args:
+        raise ValueError(
+            f"The function provided specifies additional arguments ({extra_args}) from"
+            + f" the expected arguments ({expected_args}). Please update the function signature or"
+            + " modify the base class' `resource_keys` argument."
+        )
+
+    if missing_args := expected_args - actual_args:
+        raise ValueError(
+            f"The function is missing arguments ({missing_args}) which are expected. Please"
+            + " update the function signature or modify the base class' `resource_keys` argument."
+        )
+
+
+class ResourcesNotDefined(Exception):
+    r"""Exception to be raised when a ``ResourceOperator`` does not implement _resource_decomp"""
+
+
+def set_decomp(cls: type[ResourceOperator], decomp_func: Callable) -> None:
+    """Set a custom function to override the default resource decomposition. This
+    function will be set globally for every instance of the class.
+
+    Args:
+        cls (Type[ResourceOperator]): the operator class whose decomposition is being overriden.
+        decomp_func (Callable): the new resource decomposition function to be set as default.
+
+    .. note::
+
+        The new decomposition function should have the same signature as the one it replaces.
+        Specifically, the signature should match the :code:`resource_keys` of the base resource
+        operator class being overriden.
+
+    **Example**
+
+    .. code-block:: python
+
+        from pennylane.labs import resource_estimation as plre
+
+        def custom_res_decomp(**kwargs):
+            h = plre.resource_rep(plre.ResourceHadamard)
+            s = plre.resource_rep(plre.ResourceS)
+            return [plre.GateCount(h, 2), plre.GateCount(s, 2)]
+
+    .. code-block:: pycon
+
+        >>> print(plre.estimate_resources(plre.ResourceX(), gate_set={"Hadamard", "Z", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 3
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'Z': 1, 'Hadamard': 2}
+        >>> plre.set_decomp(plre.ResourceX, custom_res_decomp)
+        >>> print(plre.estimate_resources(plre.ResourceX(), gate_set={"Hadamard", "Z", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 4
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'S': 2, 'Hadamard': 2}
+
+    """
+    cls.set_resources(decomp_func, override_type="base")
+
+
+def set_ctrl_decomp(cls: type[ResourceOperator], decomp_func: Callable) -> None:
+    """Set a custom function to override the default controlled-resource decomposition. This
+    function will be set globally for every instance of the class.
+
+    Args:
+        cls (Type[ResourceOperator]): the operator class whose decomposition is being overriden.
+        decomp_func (Callable): the new resource decomposition function to be set as default.
+
+    .. note::
+
+        The new decomposition function should have the same signature as the one it replaces.
+        Specifically, the signature should match the `resource_keys` of the base resource operator
+        class being overriden. Addtionally, the controlled decomposition requires two additional
+        arguments: :code:`ctrl_num_ctrl_wires` and :code:`ctrl_num_ctrl_values`.
+
+    **Example**
+
+    .. code-block:: python
+
+        from pennylane.labs import resource_estimation as plre
+
+        def custom_ctrl_decomp(ctrl_num_ctrl_wires, ctrl_num_ctrl_values, **kwargs):
+            h = plre.resource_rep(plre.ResourceHadamard)
+            cz = plre.resource_rep(plre.ResourceCZ)
+            return [plre.GateCount(h, 2), plre.GateCount(cz, 1)]
+
+    .. code-block:: pycon
+
+        >>> cx = plre.ResourceControlled(plre.ResourceX(), 1, 0)
+        >>> print(plre.estimate_resources(cx, gate_set={"CNOT", "Hadamard", "CZ"}))
+        --- Resources: ---
+        Total qubits: 2
+        Total gates : 1
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 2
+        Gate breakdown:
+         {'CNOT': 1}
+        >>> plre.set_ctrl_decomp(plre.ResourceX, custom_ctrl_decomp)
+        >>> print(plre.estimate_resources(cx, gate_set={"CNOT", "Hadamard", "CZ"}))
+        --- Resources: ---
+        Total qubits: 2
+        Total gates : 3
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 2
+        Gate breakdown:
+         {'Hadamard': 2, 'CZ': 1}
+
+    """
+    cls.set_resources(decomp_func, override_type="ctrl")
+
+
+def set_adj_decomp(cls: type[ResourceOperator], decomp_func: Callable) -> None:
+    """Set a custom function to override the default adjoint-resource decomposition. This
+    function will be set globally for every instance of the class.
+
+    Args:
+        cls (Type[ResourceOperator]): the operator class whose decomposition is being overriden.
+        decomp_func (Callable): the new resource decomposition function to be set as default.
+
+    .. note::
+
+        The new decomposition function should have the same signature as the one it replaces.
+        Specifically, the signature should match the `resource_keys` of the base resource operator
+        class being overriden.
+
+    **Example**
+
+    .. code-block:: python
+
+        from pennylane.labs import resource_estimation as plre
+
+        def custom_adj_decomp(**kwargs):
+            h = plre.resource_rep(plre.ResourceHadamard)
+            s = plre.resource_rep(plre.ResourceS)
+            return [plre.GateCount(h, 2), plre.GateCount(s, 2)]
+
+    .. code-block:: pycon
+
+        >>> adj_x = plre.ResourceAdjoint(plre.ResourceX())
+        >>> print(plre.estimate_resources(adj_x, gate_set={"X", "Hadamard", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 1
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'X': 1}
+        >>> plre.set_adj_decomp(plre.ResourceX, custom_adj_decomp)
+        >>> print(plre.estimate_resources(adj_x, gate_set={"X", "Hadamard", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 4
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'Hadamard': 2, 'S': 2}
+
+    """
+    cls.set_resources(decomp_func, override_type="adj")
+
+
+def set_pow_decomp(cls: type[ResourceOperator], decomp_func: Callable) -> None:
+    """Set a custom function to override the default pow-resource decomposition. This
+    function will be set globally for every instance of the class.
+
+    Args:
+        cls (Type[ResourceOperator]): the operator class whose decomposition is being overriden.
+        decomp_func (Callable): the new resource decomposition function to be set as default.
+
+    .. note::
+
+        The new decomposition function should have the same signature as the one it replaces.
+        Specifically, the signature should match the `resource_keys` of the base resource operator
+        class being overriden. Addtionally, the pow-decomposition requires an additional argument:
+        :code:`pow_z`.
+
+    **Example**
+
+    .. code-block:: python
+
+        from pennylane.labs import resource_estimation as plre
+
+        def custom_pow_decomp(pow_z, **kwargs):
+            h = plre.resource_rep(plre.ResourceHadamard)
+            s = plre.resource_rep(plre.ResourceS)
+            id = plre.resource_rep(plre.ResourceIdentity)
+
+            if pow_z % 2 == 0:
+                return [plre.GateCount(id, 1)]
+
+            return [plre.GateCount(h, 2), plre.GateCount(s, 2)]
+
+    .. code-block:: pycon
+
+        >>> pow_x = plre.ResourcePow(plre.ResourceX(), 3)
+        >>> print(plre.estimate_resources(pow_x, gate_set={"X", "Hadamard", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 1
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'X': 1}
+        >>> plre.set_pow_decomp(plre.ResourceX, custom_pow_decomp)
+        >>> print(plre.estimate_resources(pow_x, gate_set={"X", "Hadamard", "S"}))
+        --- Resources: ---
+        Total qubits: 1
+        Total gates : 4
+        Qubit breakdown:
+         clean qubits: 0, dirty qubits: 0, algorithmic qubits: 1
+        Gate breakdown:
+         {'Hadamard': 2, 'S': 2}
+
+    """
+    cls.set_resources(decomp_func, override_type="pow")
+
+
+class GateCount:
+    r"""A class to represent a gate and its number of occurrences in a circuit or decomposition.
+
+    Args:
+        gate (CompressedResourceOp): a compressed resource representation of the gate being counted
+        counts (int, optional): The number of occurances of the quantum gate in the circuit or
+            decomposition. Defaults to 1.
+
+    Returns:
+        GateCount: the container object holding both pieces of information
+
+    **Example**
+
+    In this example we create an object to count 5 instances of :code:`plre.ResourceQFT` acting
+    on three wires:
+
+    >>> qft = plre.resource_rep(plre.ResourceQFT, {"num_wires": 3})
+    >>> counts = plre.GateCount(qft, 5)
+    >>> counts
+    (5 x QFT(3))
+
+    """
+
+    def __init__(self, gate: CompressedResourceOp, count: int = 1) -> None:
+        self.gate = gate
+        self.count = count
+
+    def __mul__(self, other):
+        if isinstance(other, int):
+            return self.__class__(self.gate, self.count * other)
+        raise NotImplementedError
+
+    def __add__(self, other):
+        if isinstance(other, self.__class__) and (self.gate == other.gate):
+            return self.__class__(self.gate, self.count + other.count)
+        raise NotImplementedError
+
+    __rmul__ = __mul__
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, GateCount):
+            return False
+        return self.gate == other.gate and self.count == other.count
+
+    def __repr__(self) -> str:
+        return f"({self.count} x {self.gate._name})"
+
+
+def resource_rep(
+    resource_op: type[ResourceOperator],
+    resource_params: dict | None = None,
+) -> CompressedResourceOp:
+    r"""Produce a compressed representation of the resource operator to be used when
+    tracking resources.
+
+    Note, the :code:`resource_params` dictionary should specify the required resource
+    parameters of the operator. The required resource parameters are listed in the
+    :code:`resource_keys` class property of every :class:`~.pennylane.labs.resource_estimation.ResourceOperator`.
+
+    Args:
+        resource_op (Type[ResourceOperator]]): The type of operator we wish to compactify
+        resource_params (Dict): The required set of parameters to specify the operator
+
+    Returns:
+        CompressedResourceOp: A compressed representation of a resource operator
+
+    **Example**
+
+    In this example we obtain the compressed resource representation for :code:`ResourceQFT`.
+    We begin by checking what parameters are required for resource estimation, and then providing
+    them accordingly:
+
+    >>> plre.ResourceQFT.resource_keys
+    {'num_wires'}
+    >>> cmpr_qft = plre.resource_rep(
+    ...     plre.ResourceQFT,
+    ...     {"num_wires": 3},
+    ... )
+    >>> cmpr_qft
+    QFT(3)
+
+    """
+
+    if resource_params:
+        return resource_op.resource_rep(**resource_params)
+
+    return resource_op.resource_rep()

--- a/tests/estimator/test_resource_operator.py
+++ b/tests/estimator/test_resource_operator.py
@@ -1,0 +1,619 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the base and abstract Resource class
+"""
+from collections import defaultdict
+from collections.abc import Hashable
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+import pennylane as qml
+from pennylane.estimator import (
+    CompressedResourceOp,
+    WireResourceManager,
+    ResourceOperator,
+    Resources,
+)
+from pennylane.estimator.resource_operator import (
+    GateCount,
+    _make_hashable,
+    resource_rep,
+)
+from pennylane.queuing import AnnotatedQueue
+
+# pylint: disable=protected-access, too-few-public-methods, no-self-use, unused-argument, arguments-differ, no-member, comparison-with-itself, too-many-arguments
+
+
+class DummyX(ResourceOperator):
+    """Dummy testing class representing X gate"""
+
+
+class DummyQFT(ResourceOperator):
+    """Dummy testing class representing QFT gate"""
+
+
+class DummyQSVT(ResourceOperator):
+    """Dummy testing class representing QSVT gate"""
+
+
+class DummyTrotterProduct(ResourceOperator):
+    """Dummy testing class representing TrotterProduct gate"""
+
+
+class DummyAdjoint(ResourceOperator):
+    """Dummy testing class representing the Adjoint symbolic operator"""
+
+
+class TestCompressedResourceOp:
+    """Testing the methods and attributes of the CompressedResourceOp class"""
+
+    test_hamiltonian = qml.dot([1, -1, 0.5], [qml.X(0), qml.Y(1), qml.Z(0) @ qml.Z(1)])
+    compressed_ops_and_params_lst = (
+        ("DummyX", DummyX, 1, {"num_wires": 1}, None),
+        ("DummyQFT", DummyQFT, 5, {"num_wires": 5}, None),
+        ("DummyQSVT", DummyQSVT, 3, {"num_wires": 3, "num_angles": 5}, None),
+        (
+            "DummyTrotterProduct",
+            DummyTrotterProduct,
+            2,
+            {"Hamiltonian": test_hamiltonian, "num_steps": 5, "order": 2},
+            None,
+        ),
+        ("X", DummyX, 1, {"num_wires": 1}, "X"),
+    )
+
+    compressed_op_names = (
+        "DummyX",
+        "DummyQFT",
+        "DummyQSVT",
+        "DummyTrotterProduct",
+        "X",
+    )
+
+    @pytest.mark.parametrize(
+        "name, op_type, num_wires, parameters, name_param", compressed_ops_and_params_lst
+    )
+    def test_init(self, name, op_type, parameters, num_wires, name_param):
+        """Test that we can correctly instantiate CompressedResourceOp"""
+        cr_op = CompressedResourceOp(op_type, num_wires, parameters, name=name_param)
+
+        assert cr_op._name == name
+        assert cr_op.op_type is op_type
+        assert cr_op.num_wires == num_wires
+        assert cr_op.params == parameters
+        assert sorted(cr_op._hashable_params) == sorted(tuple(parameters.items()))
+
+    def test_hash(self):
+        """Test that the hash method behaves as expected"""
+        CmprssedQSVT1 = CompressedResourceOp(
+            DummyQSVT, 3, {"num_wires": 3, "num_angles": 5}
+        )
+        CmprssedQSVT2 = CompressedResourceOp(
+            DummyQSVT, 3, {"num_wires": 3, "num_angles": 5}
+        )
+        Other = CompressedResourceOp(DummyQFT, 3, {"num_wires": 3})
+
+        assert hash(CmprssedQSVT1) == hash(CmprssedQSVT1)  # compare same object
+        assert hash(CmprssedQSVT1) == hash(CmprssedQSVT2)  # compare identical instance
+        assert hash(CmprssedQSVT1) != hash(Other)
+
+        # test dictionary as parameter
+        CmprssedAdjoint1 = CompressedResourceOp(
+            DummyAdjoint,
+            1,
+            {"base_class": DummyQFT, "base_params": {"num_wires": 1}},
+        )
+        CmprssedAdjoint2 = CompressedResourceOp(
+            DummyAdjoint,
+            1,
+            {"base_class": DummyQFT, "base_params": {"num_wires": 1}},
+        )
+        Other = CompressedResourceOp(
+            DummyAdjoint,
+            2,
+            {"base_class": DummyQFT, "base_params": {"num_wires": 2}},
+        )
+
+        assert hash(CmprssedAdjoint1) == hash(CmprssedAdjoint1)
+        assert hash(CmprssedAdjoint1) == hash(CmprssedAdjoint2)
+        assert hash(CmprssedAdjoint1) != hash(Other)
+
+    def test_equality(self):
+        """Test that the equality methods behaves as expected"""
+        CmprssedQSVT1 = CompressedResourceOp(
+            DummyQSVT, 3, {"num_wires": 3, "num_angles": 5}
+        )
+        CmprssedQSVT2 = CompressedResourceOp(
+            DummyQSVT, 3, {"num_wires": 3, "num_angles": 5}
+        )
+        CmprssedQSVT3 = CompressedResourceOp(
+            DummyQSVT, 3, {"num_angles": 5, "num_wires": 3}
+        )
+        Other = CompressedResourceOp(DummyQFT, 3, {"num_wires": 3})
+
+        assert CmprssedQSVT1 == CmprssedQSVT2  # compare identical instance
+        assert CmprssedQSVT1 == CmprssedQSVT3  # compare swapped parameters
+        assert CmprssedQSVT1 != Other
+
+    @pytest.mark.parametrize("args, name", zip(compressed_ops_and_params_lst, compressed_op_names))
+    def test_name(self, args, name):
+        """Test that the name method behaves as expected."""
+        _, op_type, num_wires, parameters, name_param = args
+        cr_op = CompressedResourceOp(op_type, num_wires, parameters, name=name_param)
+
+        assert cr_op.name == name
+
+    @pytest.mark.parametrize("args", compressed_ops_and_params_lst)
+    def test_repr(self, args):
+        """Test that the name method behaves as expected."""
+        _, op_type, num_wires, parameters, name_param = args
+
+        cr_op = CompressedResourceOp(op_type, num_wires, parameters, name=name_param)
+
+        op_name = op_type.__name__
+        expected_params_str_parts = [f"{k!r}:{v!r}" for k, v in sorted(parameters.items())]
+        expected_params_str = ", ".join(expected_params_str_parts)
+
+        expected_repr_string = f"CompressedResourceOp({op_name}, num_wires={num_wires}, params={{{expected_params_str}}})"
+        assert str(cr_op) == expected_repr_string
+
+    def test_type_error(self):
+        """Test that an error is raised if wrong type is provided for op_type."""
+        with pytest.raises(TypeError, match="op_type must be a subclass of ResourceOperator."):
+            CompressedResourceOp(int, num_wires=2)
+
+
+@dataclass(frozen=True)
+class DummyCmprsRep:
+    """A dummy class to populate the gate types dictionary for testing."""
+
+    name: str
+    param: int = 0
+
+
+class DummyOp(ResourceOperator):
+    """A dummy class to test ResourceOperator instantiation."""
+
+    resource_keys = {"x"}
+
+    def __init__(self, x=None, wires=None):
+        self.x = x
+        super().__init__(wires=wires)
+
+    def __eq__(self, other: object) -> bool:
+        return (self.__class__.__name__ == other.__class__.__name__) and (self.x == other.x)
+
+    @property
+    def resource_params(self):
+        """dummy resource params method"""
+        return {"x": self.x}
+
+    @classmethod
+    def resource_rep(cls, x):
+        """dummy resource rep method"""
+        return DummyCmprsRep(cls.__name__, param=x)
+
+    @classmethod
+    def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
+        return [x]
+
+
+class DummyOp_no_resource_rep(ResourceOperator):
+    """A dummy class to test ResourceOperator instantiation."""
+
+    def __init__(self, x, wires=None):
+        self.x = x
+        super().__init__(wires=wires)
+
+    @property
+    def resource_params(self):
+        """dummy resource params method"""
+        return DummyCmprsRep({"x": self.x})
+
+    @classmethod
+    def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
+        return [x]
+
+
+class DummyOp_no_resource_params(ResourceOperator):
+    """A dummy class to test ResourceOperator instantiation."""
+
+    def __init__(self, x, wires=None):
+        self.x = x
+        super().__init__(wires=wires)
+
+    @classmethod
+    def resource_rep(cls, x):
+        """dummy resource rep method"""
+        return DummyCmprsRep(cls.__name__, param=x)
+
+    @classmethod
+    def default_resource_decomp(cls, x) -> list:
+        """dummy resources"""
+        return [x]
+
+
+class DummyOp_no_resource_decomp(ResourceOperator):
+    """A dummy class to test ResourceOperator instatiation."""
+
+    def __init__(self, x, wires=None):
+        self.x = x
+        super().__init__(wires=wires)
+
+    @classmethod
+    def resource_rep(cls, x):
+        """dummy resource rep method"""
+        return DummyCmprsRep(cls.__name__, param=x)
+
+    @property
+    def resource_params(self):
+        """dummy resource params method"""
+        return DummyCmprsRep({"x": self.x})
+
+
+class RX(DummyOp):
+    """Dummy op representing RX"""
+
+    num_wires = 1
+
+
+class Hadamard(DummyOp):
+    """Dummy op representing Hadamard"""
+
+    num_wires = 1
+
+
+class CNOT(DummyOp):
+    """Dummy op representing CNOT"""
+
+    num_wires = 2
+
+
+class TestResourceOperator:
+    """Tests for the ResourceOperator class"""
+
+    res_op_error_lst = [
+        DummyOp_no_resource_rep,
+        DummyOp_no_resource_params,
+        DummyOp_no_resource_decomp,
+    ]
+
+    @pytest.mark.parametrize("res_op", res_op_error_lst)
+    def test_init_error_abstract_methods(self, res_op):
+        """Test that errors are raised when the resource operator
+        is implemented without specifying the abstract methods."""
+
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            res_op(x=1)
+
+    ops_to_queue = [
+        Hadamard(wires=[0]),
+        Hadamard(wires=[1]),
+        CNOT(wires=[0, 1]),
+        RX(x=1.23, wires=[0]),
+    ]
+
+    def test_init_queuing(self):
+        """Test that instantiating a resource operator correctly sets its arguments
+        and queues it."""
+        with AnnotatedQueue() as q:
+            Hadamard(wires=[0])
+            Hadamard(wires=[1])
+            CNOT(wires=[0, 1])
+            RX(x=1.23, wires=[0])
+
+        assert q.queue == self.ops_to_queue
+
+    def test_dequeue(self):
+        """Test that we can remove a resource operator correctly."""
+        ops_to_remove = (
+            self.ops_to_queue[0],
+            [self.ops_to_queue[2]],
+            self.ops_to_queue[0:3],
+        )
+
+        expected_queues = (
+            self.ops_to_queue[1:],
+            self.ops_to_queue[:2] + self.ops_to_queue[3:],
+            self.ops_to_queue[3:],
+        )
+
+        for op_to_remove, expected_queue in zip(ops_to_remove, expected_queues):
+            with AnnotatedQueue() as q:
+                for op in self.ops_to_queue:
+                    op.queue()
+
+                ResourceOperator.dequeue(op_to_remove)
+
+            assert q.queue == expected_queue
+
+    def test_wire_error(self):
+        """Test that providing a different number of wire labels than the operator's
+        num_wires aregument leads to an error."""
+        dummy_op1 = DummyOp()
+        assert dummy_op1.wires is None
+        assert dummy_op1.num_wires == 1
+
+        with pytest.raises(ValueError, match="Expected 1 wires, got"):
+            dummy_op2 = DummyOp(wires=[0, 1, 2])
+
+    @pytest.mark.parametrize("s", [1, 2, 3])
+    def test_mul(self, s):
+        """Test multiply dunder method"""
+        op = RX(1.23)
+        resources = s * op
+
+        gt = defaultdict(int, {DummyCmprsRep("RX", 1.23): s})
+        wm = WireResourceManager(clean=0, dirty=0, algo_wires=1)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    @pytest.mark.parametrize("s", [1, 2, 3])
+    def test_mat_mul(self, s):
+        """Test matrix-multiply dunder method"""
+        op = CNOT()
+        resources = s @ op
+
+        gt = defaultdict(int, {DummyCmprsRep("CNOT", None): s})
+        wm = WireResourceManager(clean=0, dirty=0, algo_wires=s * 2)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    def test_add(self):
+        """Test addition dunder method between two ResourceOperator classes"""
+        op1 = RX(1.23)
+        op2 = CNOT()
+        resources = op1 + op2
+
+        gt = defaultdict(
+            int,
+            {
+                DummyCmprsRep("RX", 1.23): 1,
+                DummyCmprsRep("CNOT", None): 1,
+            },
+        )
+        wm = WireResourceManager(work_wires=0, algo_wires=2)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    def test_add_resources(self):
+        """Test addition dunder method between a ResourceOperator and a Resources object"""
+        op1 = RX(1.23)
+        gt2 = defaultdict(int, {DummyCmprsRep("CNOT", None): 1})
+        wm2 = WireResourceManager(clean=0, dirty=0, algo_wires=2)
+        res2 = Resources(wire_manager=wm2, gate_types=gt2)
+        resources = op1 + res2
+
+        gt = defaultdict(
+            int,
+            {
+                DummyCmprsRep("RX", 1.23): 1,
+                DummyCmprsRep("CNOT", None): 1,
+            },
+        )
+        wm = WireResourceManager(clean=0, dirty=0, algo_wires=2)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    def test_add_error(self):
+        """Test addition dunder method raises error when adding with unsupported type"""
+        with pytest.raises(TypeError, match="Cannot add resource operator"):
+            op1 = RX(1.23)
+            _ = op1 + True
+
+    def test_and(self):
+        """Test and dunder method between two ResourceOperator classes"""
+        op1 = RX(1.23)
+        op2 = CNOT()
+        resources = op1 & op2
+
+        gt = defaultdict(
+            int,
+            {
+                DummyCmprsRep("RX", 1.23): 1,
+                DummyCmprsRep("CNOT", None): 1,
+            },
+        )
+        wm = WireResourceManager(clean=0, dirty=0, algo_wires=3)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    def test_and_resources(self):
+        """Test and dunder method between a ResourceOperator and a Resources object"""
+        op1 = RX(1.23)
+        gt2 = defaultdict(int, {DummyCmprsRep("CNOT", None): 1})
+        wm2 = WireResourceManager(clean=0, dirty=0, algo_wires=2)
+        res2 = Resources(wire_manager=wm2, gate_types=gt2)
+        resources = op1 & res2
+
+        gt = defaultdict(
+            int,
+            {
+                DummyCmprsRep("RX", 1.23): 1,
+                DummyCmprsRep("CNOT", None): 1,
+            },
+        )
+        wm = WireResourceManager(work_wires=0, algo_wires=3)
+        expected_resources = Resources(wire_manager=wm, gate_types=gt)
+        assert resources == expected_resources
+
+    def test_and_error(self):
+        """Test and dunder method raises error when adding with unsupported type"""
+        with pytest.raises(TypeError, match="Cannot add resource operator"):
+            op1 = RX(1.23)
+            _ = op1 & True
+
+
+@pytest.mark.parametrize(
+    "input_obj, expected_hashable",
+    [
+        (123, 123),
+        ("hello", "hello"),
+        (3.14, 3.14),
+        (None, None),
+        ((1, 2, 3), (1, 2, 3)),
+        ([], ()),
+        ([1, 2, 3], (1, 2, 3)),
+        ([[1, 2], [3, 4]], ((1, 2), (3, 4))),
+        (set(), ()),
+        ({3, 1, 2}, (1, 2, 3)),
+        ({}, ()),
+        ({"b": 2, "a": 1}, (("a", 1), ("b", 2))),
+        ({"key": [1, 2]}, (("key", (1, 2)),)),
+        ({"nested": {"x": 1, "y": [2, 3]}}, (("nested", (("x", 1), ("y", (2, 3)))),)),
+        (np.array([1, 2, 3]), (1, 2, 3)),
+        (np.array([["a", "b"], ["c", "d"]]), (("a", "b"), ("c", "d"))),
+        ([{"a": 1}, {2, 3}], ((("a", 1),), (2, 3))),
+        (
+            {"list_key": [1, {"nested_dict": "val"}]},
+            (("list_key", (1, (("nested_dict", "val"),))),),
+        ),
+    ],
+)
+def test_make_hashable(input_obj, expected_hashable):
+    """Test that _make_hashable function works as expected"""
+    result = _make_hashable(input_obj)
+    assert result == expected_hashable
+    assert isinstance(result, Hashable)
+    assert hash(result) is not None
+
+class TestGateCount:
+    """Tests for the GateCount class."""
+
+    @pytest.mark.parametrize("n", (1, 2, 3, 5))
+    def test_init(self, n):
+        """Test that we can correctly instantiate a GateCount object"""
+        op = DummyOp(x=5)
+        gate_counts = GateCount(op) if n == 1 else GateCount(op, n)
+
+        assert gate_counts.gate == op
+        assert gate_counts.count == n
+
+    def test_equality(self):
+        """Test that the equality method works as expected"""
+        op = DummyOp(x=5)
+        op1 = DummyOp(x=6)
+
+        gc1 = GateCount(op, count=5)
+        gc2 = GateCount(op, count=5)
+        gc3 = GateCount(op, count=3)
+        gc4 = GateCount(op1, count=5)
+
+        assert gc1 == gc1
+        assert gc1 == gc2
+        assert gc1 != gc3
+        assert gc1 != gc4
+
+    def test_add_method(self):
+        """Test that the arithmetic methods work as expected"""
+        op = DummyOp(x=5)
+        op1 = DummyOp(x=6)
+
+        gc = GateCount(op, count=3)
+        gc1 = GateCount(op, count=2)
+        assert gc + gc1 == GateCount(op, count=5)
+
+        with pytest.raises(NotImplementedError):
+            gc2 = GateCount(op1, count=2)
+            _ = gc + gc2
+
+    def test_mul_method(self):
+        """Test that the arithmetic methods work as expected"""
+        op = DummyOp(x=5)
+        gc = GateCount(op, count=3)
+
+        assert gc * 5 == GateCount(op, count=15)
+
+        with pytest.raises(NotImplementedError):
+            _ = gc * 0.5
+
+
+def test_resource_rep():
+    """Test that the resource_rep method works as expected"""
+
+    class ResourceOpA(ResourceOperator):
+        """Test resource op class"""
+
+        resource_keys = {"num_wires", "continuous_param", "bool_param"}
+
+        @property
+        def resource_params(self):
+            """resource params method"""
+            return {
+                "num_wires": self.num_wires,
+                "continuous_param": self.continuous_param,
+                "bool_param": self.bool_param,
+            }
+
+        @classmethod
+        def resource_rep(cls, num_wires, continuous_param, bool_param):
+            """resource rep method"""
+            params = {
+                "num_wires": num_wires,
+                "continuous_param": continuous_param,
+                "bool_param": bool_param,
+            }
+            return CompressedResourceOp(cls, params)
+
+        @classmethod
+        def default_resource_decomp(cls, num_wires, continuous_param, bool_param):
+            """dummy default resource decomp method"""
+            raise NotImplementedError
+
+    class ResourceOpB(ResourceOperator):
+        """Test resource op class"""
+
+        resource_keys = {}
+
+        @property
+        def resource_params(self):
+            """resource params method"""
+            return {}
+
+        @classmethod
+        def resource_rep(cls):
+            """resource rep method"""
+            return CompressedResourceOp(cls, {})
+
+        @classmethod
+        def default_resource_decomp(cls, **kwargs):
+            """dummy default resource decomp method"""
+            raise NotImplementedError
+
+    expected_resource_rep_A = CompressedResourceOp(
+        ResourceOpA,
+        {
+            "num_wires": 1,
+            "continuous_param": 2.34,
+            "bool_param": False,
+        },
+    )
+    actual_resource_rep_A = resource_rep(
+        ResourceOpA,
+        {
+            "num_wires": 1,
+            "continuous_param": 2.34,
+            "bool_param": False,
+        },
+    )
+    assert expected_resource_rep_A == actual_resource_rep_A
+
+    expected_resource_rep_B = CompressedResourceOp(ResourceOpB, {})
+    actual_resource_rep_B = resource_rep(ResourceOpB)
+    assert expected_resource_rep_B == actual_resource_rep_B


### PR DESCRIPTION
**Context:**
Move ResourceOperator, CompressedResourceOp classes to PennyLane as part of migration for resource estimation

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-96876]