### PR TITLE
fix: update sphinx directive in documentation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,6 +497,7 @@
 
 * With :func:`~.decomposition.enable_graph()`, dynamically allocated wires are now supported in decomposition rules. This provides a smoother overall experience when decomposing operators in a way that requires auxiliary/work wires.
   [(#7861)](https://github.com/PennyLaneAI/pennylane/pull/7861)
+  [(#8228)](https://github.com/PennyLaneAI/pennylane/pull/8228)
 
   * The :func:`~.transforms.decompose` transform now accepts a `num_available_work_wires` argument that allows the user to specify the number of work wires available for dynamic allocation.
   [(#7963)](https://github.com/PennyLaneAI/pennylane/pull/7963)

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -282,7 +282,7 @@ def register_resources(
 
             :func:`~pennylane.resource_rep`
 
-    .. details:
+    .. details::
        :title: Dynamically Allocated Wires as a Resource
 
        Some decomposition rules make use of work wires, which can be dynamically requested within

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -304,7 +304,7 @@ def register_resources(
 
        Here's a decomposition for a multi-controlled ``Rot`` that uses a zeroed work wire:
 
-       .. code-block: python
+       .. code-block:: python
 
           from functools import partial
           import pennylane as qml

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -293,7 +293,7 @@ def register_resources(
        There are four types of work wires:
 
        - "zeroed" wires are guaranteed to be in the :math:`|0\rangle` state initially, and they
-         must be restored to the :math:`|0\rangle>` state before deallocation.
+         must be restored to the :math:`|0\rangle` state before deallocation.
 
        - "borrowed" wires are allocated in an arbitrary state, but they must be restored to the same initial state before deallocation.
 
@@ -302,7 +302,7 @@ def register_resources(
 
        - "garbage" wires can be allocated in any state, and can be deallocated in any state.
 
-       Here's a decomposition for a multi-controlled `Rot` that uses a zeroed work wire:
+       Here's a decomposition for a multi-controlled ``Rot`` that uses a zeroed work wire:
 
        .. code-block: python
 


### PR DESCRIPTION
A `.. details::` section was not even rendering 🤦🏼 .

Render is here: https://xanaduai-pennylane--8228.com.readthedocs.build/en/8228/code/api/pennylane.decomposition.register_resources.html.

<img width="437" height="658" alt="image" src="https://github.com/user-attachments/assets/2ab9b856-0631-4a1e-9f40-5df7c1cc17ba" />

