### PR TITLE
Include jax version in about

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -128,7 +128,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The jax version is now included in `qml.about()`.
+* The JAX version is now included in :func:`pennylane.about`.
   [(#8277)](https://github.com/PennyLaneAI/pennylane/pull/8277)
 
 * `qml.to_openqasm` now supports mid circuit measurements and conditionals of unprocessed measurement values.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -128,6 +128,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* The jax version is now included in `qml.about()`.
+
 * `qml.to_openqasm` now supports mid circuit measurements and conditionals of unprocessed measurement values.
   [(#8210)](https://github.com/PennyLaneAI/pennylane/pull/8210)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -129,6 +129,7 @@
 <h3>Improvements 🛠</h3>
 
 * The jax version is now included in `qml.about()`.
+  [(#8277)](https://github.com/PennyLaneAI/pennylane/pull/8277)
 
 * `qml.to_openqasm` now supports mid circuit measurements and conditionals of unprocessed measurement values.
   [(#8210)](https://github.com/PennyLaneAI/pennylane/pull/8210)

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -24,9 +24,13 @@ from sys import version_info
 import numpy
 import scipy
 
-try:
-    from jax import __version__ as jax_version
-except ImportError:
+from importlib.metadata import version
+from importlib.util import find_spec
+from packaging.version import Version
+
+if find_spec("jax"):
+    jax_version = version("jax")
+else:
     jax_version = None
 
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -51,7 +51,7 @@ def about():
     )
     print(f"Numpy version:           {numpy.__version__}")
     print(f"Scipy version:           {scipy.__version__}")
-    print(f"Jax version:             {jax_version}")
+    print(f"JAX version:             {jax_version}")
 
     print("Installed devices:")
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -24,6 +24,11 @@ from sys import version_info
 import numpy
 import scipy
 
+try:
+    from jax import __version__ as jax_version
+except ImportError:
+    jax_version = None
+
 
 def about():
     """
@@ -44,6 +49,7 @@ def about():
     )
     print(f"Numpy version:           {numpy.__version__}")
     print(f"Scipy version:           {scipy.__version__}")
+    print(f"Jax version:             {jax_version}")
 
     print("Installed devices:")
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -18,15 +18,13 @@ e.g., OS, version, `Numpy` and `Scipy` versions, installation method.
 import platform
 import sys
 from importlib import metadata
+from importlib.metadata import version
+from importlib.util import find_spec
 from subprocess import check_output
 from sys import version_info
 
 import numpy
 import scipy
-
-from importlib.metadata import version
-from importlib.util import find_spec
-from packaging.version import Version
 
 if find_spec("jax"):
     jax_version = version("jax")


### PR DESCRIPTION
**Context:**

We are really picky about jax versions, so the jax version should be included in the `qml.about()` to help us debug issues.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
