### PR TITLE
removing push trigger from nightly RC builds

### DIFF
--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -1,11 +1,10 @@
 name: Build nightly PennyLane RC releases for TestPyPI
 
 on:
-  push:
-    schedule:
-      # Run every weekday at 5:50 EDT (cron is in UTC)
-      - cron: "50 9 * * 1-5"
-    workflow_dispatch:
+  schedule:
+    # Run every weekday at 5:50 EDT (cron is in UTC)
+    - cron: "50 9 * * 1-5"
+  workflow_dispatch:
 
 jobs:
   setup:


### PR DESCRIPTION
**Context:**
RC branch nightly builds were added recently but mistakenly include a trigger to run on push.

**Description of the Change:**
Removing `push` trigger from RC nightly build.

**Benefits:**
prevent accidental uploads.

**Possible Drawbacks:**

**Related GitHub Issues:**
