### PR TITLE
chore: add tests for nested `adjoint` and `ctrl` transforms with `autograph`

### DIFF
--- a/tests/capture/autograph/test_autograph.py
+++ b/tests/capture/autograph/test_autograph.py
@@ -352,10 +352,10 @@ class TestIntegration:
     @pytest.mark.parametrize(
         "func1, func2",
         [
-            (qml.adjoint, qml.ctrl),
-            (qml.ctrl, qml.adjoint),
+            (qml.adjoint, partial(qml.ctrl, control=0)),
+            (partial(qml.ctrl, control=0), qml.adjoint),
             (qml.adjoint, qml.adjoint),
-            (qml.ctrl, qml.ctrl),
+            (partial(qml.ctrl, control=0), partial(qml.ctrl, control=0)),
         ],
     )
     def test_nested_adjoint_ctrl(self, func1, func2):

--- a/tests/capture/autograph/test_autograph.py
+++ b/tests/capture/autograph/test_autograph.py
@@ -362,8 +362,8 @@ class TestIntegration:
         """Test that nested adjoint and ctrl successfully pass through autograph"""
 
         # Build the nested operator
-        op = func2(qml.X) if func2 is qml.adjoint else func2(qml.X, control=0)
-        final_op = func1(op) if func1 is qml.adjoint else func1(op, control=1)
+        op = func2(qml.X)
+        final_op = func1(op)
 
         @qml.qnode(qml.device("default.qubit", wires=3))
         def circ():

--- a/tests/capture/autograph/test_autograph.py
+++ b/tests/capture/autograph/test_autograph.py
@@ -17,6 +17,8 @@ source-to-source transformation feature."""
 
 # pylint: disable = wrong-import-position, wrong-import-order, ungrouped-imports
 
+from functools import partial
+
 import numpy as np
 import pytest
 from malt.core import converter

--- a/tests/capture/autograph/test_autograph.py
+++ b/tests/capture/autograph/test_autograph.py
@@ -359,7 +359,7 @@ class TestIntegration:
             (qml.adjoint, qml.adjoint, "adjoint_transform", "adjoint_transform"),
             (
                 partial(qml.ctrl, control=0),
-                partial(qml.ctrl, control=0),
+                partial(qml.ctrl, control=1),
                 "ctrl_transform",
                 "ctrl_transform",
             ),


### PR DESCRIPTION
**Context:**

Missing some important tests in the autograph module.

**Description of the Change:**

Add a test to make sure these functions get captured in the plxpr. We don't care about plxpr execution through PL anymore.

**Benefits:** Robust code.

[sc-99324]
