### PR TITLE
`has_decomps` and `list_decomps` work with operator instances

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -416,7 +416,7 @@
 * :func:`~.tape.plxpr_to_tape` now supports converting circuits containing dynamic wire allocation.
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
 
-* :func:`~.decomposition.has_decomp` and :func:`~.decomposition.list_decomps` now take operator instances as arguments
+* :func:`~.decomposition.has_decomp` and :func:`~.decomposition.list_decomps` now take operator instances as arguments.
   [(#8286)](https://github.com/PennyLaneAI/pennylane/pull/8286)
 
 <h4>OpenQASM-PennyLane interoperability</h4>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -412,7 +412,7 @@
 * :func:`~.tape.plxpr_to_tape` now supports converting circuits containing dynamic wire allocation.
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
 
-* :func:`~.has_decomp` and :func:`~.list_decomps` now take operator instances as arguments
+* :func:`~.decomposition.has_decomp` and :func:`~.decomposition.list_decomps` now take operator instances as arguments
   [(#8286)](https://github.com/PennyLaneAI/pennylane/pull/8286)
 
 <h4>OpenQASM-PennyLane interoperability</h4>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -412,6 +412,9 @@
 * :func:`~.tape.plxpr_to_tape` now supports converting circuits containing dynamic wire allocation.
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
 
+* :func:`~.has_decomps` and :func:`~.list_decomps` now take operator instances as arguments
+  [(#8286)](https://github.com/PennyLaneAI/pennylane/pull/8286)
+
 <h4>OpenQASM-PennyLane interoperability</h4>
 
 * The :func:`qml.from_qasm3` function can now convert OpenQASM 3.0 circuits that contain

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -412,7 +412,7 @@
 * :func:`~.tape.plxpr_to_tape` now supports converting circuits containing dynamic wire allocation.
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
 
-* :func:`~.has_decomps` and :func:`~.list_decomps` now take operator instances as arguments
+* :func:`~.has_decomp` and :func:`~.list_decomps` now take operator instances as arguments
   [(#8286)](https://github.com/PennyLaneAI/pennylane/pull/8286)
 
 <h4>OpenQASM-PennyLane interoperability</h4>

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -532,7 +532,7 @@ def add_decomps(op_type: type[Operator] | str, *decomps: DecompositionRule) -> N
     _decompositions[translate_op_alias(op_type)].extend(decomps)
 
 
-def list_decomps(op_type: type[Operator] | str) -> list[DecompositionRule]:
+def list_decomps(op: type[Operator] | Operator | str) -> list[DecompositionRule]:
     """Lists all stored decomposition rules for an operator class.
 
     .. note::
@@ -543,8 +543,9 @@ def list_decomps(op_type: type[Operator] | str) -> list[DecompositionRule]:
         decomposition rules for an operator.
 
     Args:
-        op_type (type or str): the operator class to retrieve decomposition rules for. For symbolic
-            operators, use strings such as ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
+        op (type or Operator or str): the operator or operator type to retrieve decomposition
+            rules for. For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``,
+            ``"C(RX)"``, etc.
 
     Returns:
         list[DecompositionRule]: a list of decomposition rules registered for the given operator.
@@ -571,12 +572,14 @@ def list_decomps(op_type: type[Operator] | str) -> list[DecompositionRule]:
     1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
 
     """
-    if isinstance(op_type, type):
-        op_type = op_type.__name__
-    return _decompositions[translate_op_alias(op_type)][:]
+    if isinstance(op, Operator):
+        return _decompositions[op.name][:]
+    if isinstance(op, type):
+        op = op.__name__
+    return _decompositions[translate_op_alias(op)][:]
 
 
-def has_decomp(op_type: type[Operator] | str) -> bool:
+def has_decomp(op: type[Operator] | Operator | str) -> bool:
     """Checks whether an operator has decomposition rules defined.
 
     .. note::
@@ -587,17 +590,20 @@ def has_decomp(op_type: type[Operator] | str) -> bool:
         decomposition rules for an operator.
 
     Args:
-        op_type (type or str): the operator class to check for decomposition rules. For symbolic
-            operators, use strings such as ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
+        op (type or Operator or str): the operator or operator type to check for
+            decomposition rules. For symbolic operators, use strings like ``"Adjoint(RY)"``,
+            ``"Pow(H)"``, ``"C(RX)"``, etc.
 
     Returns:
         bool: whether decomposition rules are defined for the given operator.
 
     """
-    if isinstance(op_type, type):
-        op_type = op_type.__name__
-    op_type = translate_op_alias(op_type)
-    return op_type in _decompositions and len(_decompositions[op_type]) > 0
+    if isinstance(op, Operator):
+        return op.name in _decompositions and len(_decompositions[op.name]) > 0
+    if isinstance(op, type):
+        op = op.__name__
+    op = translate_op_alias(op)
+    return op in _decompositions and len(_decompositions[op]) > 0
 
 
 @register_resources({})

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -220,7 +220,9 @@ class TestDecompositionRule:
         qml.add_decomps(CustomOp, custom_decomp2, custom_decomp3)
 
         assert qml.decomposition.has_decomp(CustomOp)
+        assert qml.decomposition.has_decomp(CustomOp(wires=[0, 1]))
         assert qml.list_decomps(CustomOp) == [custom_decomp, custom_decomp2, custom_decomp3]
+        assert qml.list_decomps(CustomOp(wires=[0, 1])) == [custom_decomp, custom_decomp2, custom_decomp3]
 
         def custom_decomp4(theta, wires, **__):
             qml.RZ(theta, wires=wires[0])

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -242,7 +242,7 @@ class TestDecompositionRule:
     def test_custom_symbolic_decomposition(self):
         """Tests that custom decomposition rules for symbolic operators can be registered."""
 
-        class CustomOp(Operator):
+        class CustomOp(Operator):  # pylint: disable=too-few-public-methods
             pass
 
         @register_resources({qml.RX: 1, qml.RZ: 1})


### PR DESCRIPTION
**Context:**
These two helpers used to work with classes. As a result, one might see usage (e.g. this [commit](https://github.com/PennyLaneAI/pennylane/pull/8260/files#diff-9da436a44007b8abb8170447c6b939836bbb5920b1a05f26454fe3c3537aab30R523)) like
```python
has_decomp(type(op))
```

**Description of the Change:**

**Benefits:**
Now we can simply
```python
has_decomp(op)
```

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-99425]
