### PR TITLE
Fix qubit deallocation failure in convert_to_mbqc_formalism pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1094,6 +1094,7 @@
 
 * The `mbqc.graph_state_prep` operation is integrated into the `convert_to_mbqc_formalism` pass.
   [(#8153)](https://github.com/PennyLaneAI/pennylane/pull/8153)
+  [(#8301)](https://github.com/PennyLaneAI/pennylane/pull/8301)
 
 * :func:`.transforms.decompose` and :func:`.preprocess.decompose` now have a unified internal implementation.
   [(#8193)](https://github.com/PennyLaneAI/pennylane/pull/8193)

--- a/pennylane/compiler/python_compiler/transforms/convert_to_mbqc_formalism.py
+++ b/pennylane/compiler/python_compiler/transforms/convert_to_mbqc_formalism.py
@@ -523,20 +523,20 @@ class ConvertToMBQCFormalismPattern(
     def _deallocate_aux_qubits(
         self,
         graph_qubits_dict: dict,
-        res_target_qb: list[int],
+        res_aux_qb: list[int],
         insert_before: CustomOp,
         rewriter: pattern_rewriter.PatternRewriter,
     ):
-        """Deallocate the auxiliary qubits in the graph qubit dict.
+        """Deallocate non-result auxiliary qubits in the graph qubit dict.
         Args:
             graph_qubits_dict (dict) : A dict stores all qubits in a graph state.
-            res_target_qb (list[int]) : A list of keys of result auxiliary and target (in the global register) qubits.
+            res_aux_qb (list[int]) : A list of keys of result auxiliary qubits.
             insert_before (CustomOp) : A gate operation object.
             rewriter (pattern_rewriter.PatternRewriter): A pattern rewriter.
         """
         # Deallocate non result aux_qubits
         for node in graph_qubits_dict:
-            if node not in res_target_qb:
+            if node not in res_aux_qb:
                 dealloc_qubit_op = DeallocQubitOp(graph_qubits_dict[node])
                 rewriter.insert_op(dealloc_qubit_op, InsertPoint.before(insert_before))
 
@@ -642,7 +642,7 @@ class ConvertToMBQCFormalismPattern(
                     )
 
                     # Deallocate non-result aux_qubits and the target/control qubits in the qreg
-                    self._deallocate_aux_qubits(graph_qubits_dict, [9, 15], op, rewriter)
+                    self._deallocate_aux_qubits(graph_qubits_dict, [7, 15], op, rewriter)
 
                     # Replace all uses of output qubit of op with the result auxiliary qubit
                     rewriter.replace_all_uses_with(op.results[0], graph_qubits_dict[7])

--- a/pennylane/compiler/python_compiler/transforms/convert_to_mbqc_formalism.py
+++ b/pennylane/compiler/python_compiler/transforms/convert_to_mbqc_formalism.py
@@ -527,7 +527,7 @@ class ConvertToMBQCFormalismPattern(
         insert_before: CustomOp,
         rewriter: pattern_rewriter.PatternRewriter,
     ):
-        """Deallocate non-result auxiliary qubits in the graph qubit dict.
+        """Deallocate non-result qubits in the graph qubit dict.
         Args:
             graph_qubits_dict (dict) : A dict stores all qubits in a graph state.
             res_aux_qb (list[int]) : A list of keys of result auxiliary qubits.


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-99558]

The result control qubit is falsely deallocated in the MBQC transform pass, which leads to the failure reported in the  [sc-99558]. This PR fix it and update a few docstr on the related methods.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
