### PR TITLE
Fix constant op to use property instead of attribute

### DIFF
--- a/pennylane/compiler/python_compiler/dialects/stablehlo/__init__.py
+++ b/pennylane/compiler/python_compiler/dialects/stablehlo/__init__.py
@@ -55,6 +55,7 @@ from .elementwise_binary import (
 from .elementwise_other import (
     ClampOp,
     CompareOp,
+    ConstantOp,
     MapOp,
     ReducePrecisionOp,
     SelectOp,
@@ -120,6 +121,7 @@ __all__ = [
     # Elementwise other operations
     "ClampOp",
     "CompareOp",
+    "ConstantOp",
     "MapOp",
     "ReducePrecisionOp",
     "SelectOp",

--- a/pennylane/compiler/python_compiler/dialects/stablehlo/dialect.py
+++ b/pennylane/compiler/python_compiler/dialects/stablehlo/dialect.py
@@ -50,6 +50,7 @@ from .elementwise_binary import (
 from .elementwise_other import (
     ClampOp,
     CompareOp,
+    ConstantOp,
     MapOp,
     ReducePrecisionOp,
     SelectOp,
@@ -85,6 +86,7 @@ OPERATIONS = [
     ClampOp,
     CompareOp,
     ComplexOp,
+    ConstantOp,
     ConvertOp,
     CosineOp,
     DivideOp,
@@ -137,7 +139,9 @@ ATTRIBUTES = [
 ]
 
 # Operations/attributes from upstream that should be deleted/replaced in the local version
-UPSTREAM_OPERATIONS_TO_DELETE = []
+UPSTREAM_OPERATIONS_TO_DELETE = [
+    xstablehlo.ConstantOp,
+]
 UPSTREAM_ATTRIBUTES_TO_DELETE = []
 
 

--- a/tests/python_compiler/dialects/test_stablehlo_dialect.py
+++ b/tests/python_compiler/dialects/test_stablehlo_dialect.py
@@ -173,6 +173,9 @@ def test_all_other_operations(run_filecheck):
     
     // CHECK: %select = "stablehlo.select"(%[[ti1]], %[[tf32]], %[[tf32]]) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
     %select = "stablehlo.select"(%ti1, %tf32, %tf32) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
+
+    // CHECK: %constant1 = "stablehlo.constant"() <{value = dense<[[0.000000e+00, 1.000000e+00], [2.000000e+00, 3.000000e+00]]> : tensor<2x2xf32>}> : () -> tensor<2x2xf32>
+    %constant1 = "stablehlo.constant"() <{value = dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>}> : () -> tensor<2x2xf32>
     """
 
     run_filecheck(program, roundtrip=True, verify=True)


### PR DESCRIPTION
**Context:**
Currently the `constantOp` in the upstream stableHLO dialect in xdsl defines its `value` as an attribute. This means that the xdsl parser will always parse an attribute when parsing generic format IR, can cause issues in some workloads where `value` is defined as a property.

**Description of the Change:**
changed `attr` to `prop`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
