### PR TITLE
add validation for mcm_method on default.qubit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1336,6 +1336,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `default.qubit` now properly validates the `mcm_method`.
+
 * :class:`~.SpecialUnitary` now correctly obeys the interfaces of input parameters when large numbers of wires are used.
   [(#8209)](https://github.com/PennyLaneAI/pennylane/pull/8209)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -752,6 +752,13 @@ class DefaultQubit(Device):
             final_mcm_method = "one-shot" if getattr(tape, "shots", None) else "deferred"
         elif mcm_config.mcm_method == "device":
             final_mcm_method = "tree-traversal"
+
+        supported_methods = {"one-shot", "deferred", "tree-traversal"}
+        if final_mcm_method not in supported_methods:
+            raise DeviceError(
+                f"mcm_method {final_mcm_method} not supported on default.qubit. "
+                f"Supported methods are {supported_methods}"
+            )
         return replace(mcm_config, mcm_method=final_mcm_method)
 
     def _capture_setup_mcm_config(self, mcm_config):

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -218,6 +218,16 @@ class TestConfigSetup:
         processed = dev.setup_execution_config(config)
         assert processed.mcm_config.mcm_method == "deferred"
 
+    def test_error_on_unsupported_mcm_method(self):
+        """Test that an error is raised on unsupported mcm_method's."""
+
+        config = ExecutionConfig(mcm_config=MCMConfig(mcm_method="bad method"))
+
+        dev = qml.device("default.qubit")
+
+        with pytest.raises(DeviceError, match="not supported on default.qubit"):
+            dev.setup_execution_config(config)
+
 
 # pylint: disable=too-few-public-methods
 class TestPreprocessing:

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1877,7 +1877,7 @@ class TestMCMConfiguration:
     def test_single_branch_statistics_error_without_qjit(self):
         """Test that an error is raised if attempting to use mcm_method="single-branch-statistics
         without qml.qjit"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qml.device("reference.qubit", wires=1)
 
         @qml.qnode(dev, mcm_method="single-branch-statistics")
         def circuit(x):


### PR DESCRIPTION
**Context:** We weren't erroring out at unsupported mcm methods.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
