### PR TITLE
[CI] fix CI on altered expected mcm config

### DIFF
--- a/tests/workflow/test_construct_execution_config.py
+++ b/tests/workflow/test_construct_execution_config.py
@@ -58,7 +58,8 @@ def test_resolved_construction_lightning_qubit(interface):
 
     config = construct_execution_config(qn, resolve=True)()
 
-    mcm_config = MCMConfig(None, None)
+    postselect_mode = "fill-shots" if "jax-jit" == interface else None
+    mcm_config = MCMConfig("deferred", postselect_mode)
     expected_config = ExecutionConfig(
         grad_on_execution=True,
         use_device_gradient=True,


### PR DESCRIPTION


**Context:**

Parts of py3.12 3.13 tests on `test_resolved_construction_lightning_qubit` failed.
https://github.com/PennyLaneAI/pennylane/actions/runs/18042712217/job/51345679701

According to [a recent Lightning change](https://github.com/PennyLaneAI/pennylane-lightning/commit/199a740cf3e2326b0b489caccdb73aef3acd899f#diff-068e2aa5237a375b6af67a124f81018aa46c2d335fecf3035346f0627e6ef7a4R483-R500)
The expectation of `mcm_config` when `shots=None` should be changed correspondingly

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**
We should also figure out why py3.11 tests did not reveal this failure?

**Related GitHub Issues:**
