### PR TITLE
Fix the logic in symbolic operators

### DIFF
--- a/pennylane/estimator/ops/op_math/symbolic.py
+++ b/pennylane/estimator/ops/op_math/symbolic.py
@@ -151,14 +151,16 @@ class Adjoint(ResourceOperator):
 
         """
         base_class, base_params = (base_cmpr_op.op_type, base_cmpr_op.params)
-        base_params = {key: value for key, value in base_params.items() if value is not None}
-        kwargs = {key: value for key, value in kwargs.items() if key not in base_params}
+
+        for key, value in kwargs.items():
+            if key in base_params and base_params[key] is None:
+                base_params[key] = value
 
         try:
             return base_class.adjoint_resource_decomp(base_params)
         except ResourcesUndefinedError:
             gate_lst = []
-            decomp = base_class.resource_decomp(**base_params, **kwargs)
+            decomp = base_class.resource_decomp(**base_params)
 
             for gate in decomp[::-1]:  # reverse the order
                 gate_lst.append(_apply_adj(gate))
@@ -355,8 +357,10 @@ class Controlled(ResourceOperator):
         """
 
         base_class, base_params = (base_cmpr_op.op_type, base_cmpr_op.params)
-        base_params = {key: value for key, value in base_params.items() if value is not None}
-        kwargs = {key: value for key, value in kwargs.items() if key not in base_params}
+        for key, value in kwargs.items():
+            if key in base_params and base_params[key] is None:
+                base_params[key] = value
+
         try:
             return base_class.controlled_resource_decomp(
                 num_ctrl_wires=num_ctrl_wires,
@@ -371,7 +375,7 @@ class Controlled(ResourceOperator):
             x = resource_rep(qre.X)
             gate_lst.append(GateCount(x, 2 * num_zero_ctrl))
 
-        decomp = base_class.resource_decomp(**base_params, **kwargs)
+        decomp = base_class.resource_decomp(**base_params)
         for action in decomp:
             if isinstance(action, GateCount):
                 gate = action.gate
@@ -560,8 +564,9 @@ class Pow(ResourceOperator):
 
         """
         base_class, base_params = (base_cmpr_op.op_type, base_cmpr_op.params)
-        base_params = {key: value for key, value in base_params.items() if value is not None}
-        kwargs = {key: value for key, value in kwargs.items() if key not in base_params}
+        for key, value in kwargs.items():
+            if key in base_params and base_params[key] is None:
+                base_params[key] = value
 
         if pow_z == 0:
             return [GateCount(resource_rep(qre.Identity))]

--- a/pennylane/estimator/resource_config.py
+++ b/pennylane/estimator/resource_config.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from pennylane.estimator.ops import CRX, CRY, CRZ, RX, RY, RZ
 from pennylane.estimator.ops.templates import (
     AliasSampling,
     MPSPrep,
@@ -48,6 +49,12 @@ class ResourceConfig:
         _DEFAULT_PRECISION = 1e-9
         _DEFAULT_BIT_PRECISION = 15
         self.resource_op_precisions = {
+            RX: {"precision": _DEFAULT_PRECISION},
+            RY: {"precision": _DEFAULT_PRECISION},
+            RZ: {"precision": _DEFAULT_PRECISION},
+            CRX: {"precision": _DEFAULT_PRECISION},
+            CRY: {"precision": _DEFAULT_PRECISION},
+            CRZ: {"precision": _DEFAULT_PRECISION},
             SelectPauliRot: {"precision": _DEFAULT_PRECISION},
             QubitUnitary: {"precision": _DEFAULT_PRECISION},
             AliasSampling: {"precision": _DEFAULT_PRECISION},


### PR DESCRIPTION
**Context:**
With the removal of **kwargs from custom symbolic decompositions. The precisions for nested symbolic operators were not accessed properly through config. This PR fixes that issue.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
