### PR TITLE
Add warning about callable behavior in `qml.from_qasm` documentation

### DIFF
--- a/pennylane/io/io.py
+++ b/pennylane/io/io.py
@@ -524,6 +524,10 @@ def from_qasm(quantum_circuit: str, measurements=None):
     0: ──H──┤↗├──RZ(0.24)─╭●─┤  Var[Y]
     1: ───────────────────╰X─┤
 
+    .. warning::
+
+        The ``qml.from_qasm`` function returns a callable that must be executed to run the imported circuit.
+
     .. details::
         :title: Removing terminal measurements
 


### PR DESCRIPTION
**Context:**
Docs did not explain that `qml.to_openqasm()` adds measurements by default or that `qml.from_qasm()` returns a callable, causing confusion in round-trip usage.

**Description of the Change:**
Added a warning clarifying the default measurement behavior and noting that the callable from `qml.from_qasm()` must be executed.

**Benefits:**
- Prevents user confusion when attempting round-trip QASM export/import.

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/issues/8268
