### PR TITLE
Add ops and transforms to top-level import

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1238,6 +1238,7 @@
 * Update PennyLane's top-level `__init__.py` file imports to improve Python language server support for finding
   PennyLane submodules.
   [(#7959)](https://github.com/PennyLaneAI/pennylane/pull/7959)
+  [(#8359)](https://github.com/PennyLaneAI/pennylane/pull/8359)
 
 * Adds `measurements` as a "core" module in the tach specification.
   [(#7945)](https://github.com/PennyLaneAI/pennylane/pull/7945)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -95,6 +95,7 @@ from pennylane.measurements import (
 from pennylane.ops import *
 from pennylane.ops import adjoint, ctrl, cond, change_op_basis, exp, sum, pow, prod, s_prod
 from pennylane.ops import LinearCombination as Hamiltonian
+from pennylane import ops
 from pennylane.templates import layer
 from pennylane.templates.embeddings import *
 from pennylane.templates.layers import *
@@ -121,6 +122,7 @@ from pennylane.transforms import (
     pattern_matching_optimization,
     clifford_t_decomposition,
 )
+from pennylane import transforms
 from pennylane.noise import (
     add_noise,
     insert,


### PR DESCRIPTION
As a follow up to https://github.com/PennyLaneAI/pennylane/pull/7959, add `ops` and `transforms` to be available at the top level, so that the contents of `qml.transforms` and `qml.ops` are visible to language servers and static type checkers such as pyright or mypy.