### PR TITLE
[Unified Compiler] Disable error raise for Paulis/GPhase op in the convert-to-mbqc-formalism

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1327,6 +1327,7 @@
   [(#8153)](https://github.com/PennyLaneAI/pennylane/pull/8153)
   [(#8301)](https://github.com/PennyLaneAI/pennylane/pull/8301)
   [(#8314)](https://github.com/PennyLaneAI/pennylane/pull/8314)
+  [(#8362)](https://github.com/PennyLaneAI/pennylane/pull/8362)
 
 * :func:`.transforms.decompose` and :func:`.preprocess.decompose` now have a unified internal implementation.
   [(#8193)](https://github.com/PennyLaneAI/pennylane/pull/8193)

--- a/pennylane/compiler/python_compiler/transforms/mbqc/convert_to_mbqc_formalism.py
+++ b/pennylane/compiler/python_compiler/transforms/mbqc/convert_to_mbqc_formalism.py
@@ -31,7 +31,7 @@ from ...dialects.mbqc import (
     MeasurementPlaneAttr,
     MeasurementPlaneEnum,
 )
-from ...dialects.quantum import CustomOp, DeallocQubitOp, ExtractOp, QubitType
+from ...dialects.quantum import CustomOp, DeallocQubitOp, ExtractOp, GlobalPhaseOp, QubitType
 from ...pass_api import compiler_transform
 from .graph_state_utils import generate_adj_matrix, get_num_aux_wires
 
@@ -649,6 +649,17 @@ class ConvertToMBQCFormalismPattern(
                     rewriter.replace_all_uses_with(op.results[1], graph_qubits_dict[15])
                     # Remove op operation
                     rewriter.erase_op(op)
+                elif isinstance(op, GlobalPhaseOp) or (
+                    isinstance(op, CustomOp)
+                    and op.gate_name.data
+                    in [
+                        "PauliX",
+                        "PauliY",
+                        "PauliZ",
+                        "Identity",
+                    ]
+                ):
+                    continue
                 elif isinstance(op, CustomOp):
                     raise NotImplementedError(
                         f"{op.gate_name.data} cannot be converted to the MBQC formalism."

--- a/pennylane/compiler/python_compiler/transforms/mbqc/convert_to_mbqc_formalism.py
+++ b/pennylane/compiler/python_compiler/transforms/mbqc/convert_to_mbqc_formalism.py
@@ -35,6 +35,24 @@ from ...dialects.quantum import CustomOp, DeallocQubitOp, ExtractOp, GlobalPhase
 from ...pass_api import compiler_transform
 from .graph_state_utils import generate_adj_matrix, get_num_aux_wires
 
+_PAULIS = {
+    "PauliX",
+    "PauliY",
+    "PauliZ",
+    "Identity",
+}
+
+_MBQC_ONE_QUBIT_GATES = {
+    "Hadamard",
+    "S",
+    "RZ",
+    "RotXZX",
+}
+
+_MBQC_TWO_QUBIT_GATES = {
+    "CNOT",
+}
+
 
 @dataclass(frozen=True)
 class ConvertToMBQCFormalismPass(passes.ModulePass):
@@ -555,12 +573,7 @@ class ConvertToMBQCFormalismPattern(
             two_wire_adj_matrix_op = None
             for op in region.ops:
                 # TODOs: Refactor the code below in this loop into separate functions
-                if isinstance(op, CustomOp) and op.gate_name.data in [
-                    "Hadamard",
-                    "S",
-                    "RZ",
-                    "RotXZX",
-                ]:
+                if isinstance(op, CustomOp) and op.gate_name.data in _MBQC_ONE_QUBIT_GATES:
                     # Allocate auxiliary qubits and entangle them
                     if one_wire_adj_matrix_op is None:
                         adj_matrix = generate_adj_matrix(op.gate_name.data)
@@ -602,7 +615,7 @@ class ConvertToMBQCFormalismPattern(
                     rewriter.replace_all_uses_with(op.results[0], graph_qubits_dict[5])
                     # Remove op operation
                     rewriter.erase_op(op)
-                elif isinstance(op, CustomOp) and op.gate_name.data == "CNOT":
+                elif isinstance(op, CustomOp) and op.gate_name.data in _MBQC_TWO_QUBIT_GATES:
                     # Allocate auxiliary qubits and entangle them
                     if two_wire_adj_matrix_op is None:
                         adj_matrix = generate_adj_matrix(op.gate_name.data)
@@ -650,14 +663,7 @@ class ConvertToMBQCFormalismPattern(
                     # Remove op operation
                     rewriter.erase_op(op)
                 elif isinstance(op, GlobalPhaseOp) or (
-                    isinstance(op, CustomOp)
-                    and op.gate_name.data
-                    in [
-                        "PauliX",
-                        "PauliY",
-                        "PauliZ",
-                        "Identity",
-                    ]
+                    isinstance(op, CustomOp) and op.gate_name.data in _PAULIS
                 ):
                     continue
                 elif isinstance(op, CustomOp):

--- a/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
+++ b/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
@@ -298,7 +298,7 @@ class TestConvertToMBQCFormalismPass:
     def test_cnot_gate(self, run_filecheck):
         """Test for lowering a CNOT gate to a MBQC formalism."""
         program = """
-            func.func @test_func(%arg0 : f64) {
+            func.func @test_func() {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
                 // CHECK-NEXT: [[q1:%.+]] = "test.op"() : () -> !quantum.bit

--- a/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
+++ b/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
@@ -55,13 +55,15 @@ class TestConvertToMBQCFormalismPass:
             func.func @test_func() {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
-                // CHECK: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
-                // CHECK: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
-                // CHECK: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
-                // CHECK: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]] = quantum.custom "PauliX"() [[q0:%.+]] : !quantum.bit
+                %1 = quantum.custom "PauliX"() %0 : !quantum.bit
+                // CHECK-NEXT: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
+                // CHECK-NEXT: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
+                // CHECK-NEXT: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
                 // CHECK: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m1:%.+]], [[q0:%.+]] = mbqc.measure_in_basis[XY, [[q0:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
                 // CHECK-NEXT: [[half_pi:%.+]] = arith.constant {{1.+}} : f64
@@ -85,12 +87,11 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK-NEXT: } else {
                 // CHECK-NEXT: scf.yield [[qb4_x_res:%.+]] : !quantum.bit
                 // CHECK-NEXT: }
-                // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.custom "PauliX"() [[qb4:%.+]] : !quantum.bit
-                %1 = quantum.custom "Hadamard"() %0 : !quantum.bit
-                %2 = quantum.custom "PauliX"() %1 : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb4:%.+]] : !quantum.bit
+                %2 = quantum.custom "Hadamard"() %1 : !quantum.bit
                 return
             }
         """
@@ -104,14 +105,16 @@ class TestConvertToMBQCFormalismPass:
             func.func @test_func() {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
-                // CHECK: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
-                // CHECK: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
-                // CHECK: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
-                // CHECK: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
-                // CHECK: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
+                // CHECK-NEXT: [[q0:%.+]] = quantum.custom "PauliY"() [[q0:%.+]] : !quantum.bit
+                %1 = quantum.custom "PauliY"() %0 : !quantum.bit
+                // CHECK-NEXT: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
+                // CHECK-NEXT: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
+                // CHECK-NEXT: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
+                // CHECK-NEXT: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m1:%.+]], [[q0:%.+]] = mbqc.measure_in_basis[XY, [[q0:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
                 // CHECK-NEXT: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m2:%.+]], [[qb1:%.+]] = mbqc.measure_in_basis[XY, [[qb1:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
@@ -136,12 +139,11 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK-NEXT: } else {
                 // CHECK-NEXT: scf.yield [[qb4_x_res:%.+]] : !quantum.bit
                 // CHECK-NEXT: }
-                // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.custom "PauliY"() [[qb4:%.+]] : !quantum.bit
-                %1 = quantum.custom "S"() %0 : !quantum.bit
-                %2 = quantum.custom "PauliY"() %1 : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb4:%.+]] : !quantum.bit
+                %2 = quantum.custom "S"() %1 : !quantum.bit
                 return
             }
         """
@@ -155,14 +157,16 @@ class TestConvertToMBQCFormalismPass:
             func.func @test_func(%param0: f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
-                // CHECK: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
-                // CHECK: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
-                // CHECK: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
-                // CHECK: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
-                // CHECK: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
+                // CHECK-NEXT: [[q0:%.+]] = quantum.custom "PauliZ"() [[q0:%.+]] : !quantum.bit
+                %1 = quantum.custom "PauliZ"() %0 : !quantum.bit
+                // CHECK-NEXT: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
+                // CHECK-NEXT: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
+                // CHECK-NEXT: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
+                // CHECK-NEXT: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m1:%.+]], [[q0:%.+]] = mbqc.measure_in_basis[XY, [[q0:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
                 // CHECK-NEXT: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m2:%.+]], [[qb1:%.+]] = mbqc.measure_in_basis[XY, [[qb1:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
@@ -190,12 +194,11 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK-NEXT: } else {
                 // CHECK-NEXT: scf.yield [[qb4_x_res:%.+]] : !quantum.bit
                 // CHECK-NEXT: }
-                // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.custom "PauliZ"() [[qb4:%.+]] : !quantum.bit
-                %1 = quantum.custom "RZ"(%param0) %0 : !quantum.bit
-                %2 = quantum.custom "PauliZ"() %1 : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb4:%.+]] : !quantum.bit
+                %2 = quantum.custom "RZ"(%param0) %1 : !quantum.bit
                 return
             }
         """
@@ -208,16 +211,19 @@ class TestConvertToMBQCFormalismPass:
         program = """
             func.func @test_func(%param0: f64, %param1: f64, %param2: f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
-                // CHECK: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
-                // CHECK: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
-                // CHECK: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
-                // CHECK: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
+                %0 = "test.op"() : () -> !quantum.bit
+                // CHECK: [[q0:%.+]] = quantum.custom "Identity"() [[q0:%.+]] : !quantum.bit
+                %1 = quantum.custom "Identity"() %0 : !quantum.bit
+                // CHECK-NEXT: [[adj_matrix:%.+]] = arith.constant dense<[true, false, true, false, false, true]> : tensor<6xi1>
+                // CHECK-NEXT: [[graph_state:%.+]] = mbqc.graph_state_prep([[adj_matrix:%.+]] : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
+                // CHECK-NEXT: [[qb1:%.+]] = quantum.extract [[graph_state:%.+]][0] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb2:%.+]] = quantum.extract [[graph_state:%.+]][1] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb3:%.+]] = quantum.extract [[graph_state:%.+]][2] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[qb4:%.+]] = quantum.extract [[graph_state:%.+]][3] : !quantum.reg -> !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]], [[qb1:%.+]] = quantum.custom "CZ"() [[q0:%.+]], [[qb1:%.+]] : !quantum.bit, !quantum.bit
                 
                 
-                // CHECK: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
+                // CHECK-NEXT: [[cst_zero:%.+]] = arith.constant {{0.+}} : f64
                 // CHECK-NEXT: [[m1:%.+]], [[q0:%.+]] = mbqc.measure_in_basis[XY, [[q0:%.+]]] [[cst_zero:%.+]] : i1, !quantum.bit
                 
                 // CHECK-NEXT: [[m2:%.+]], [[qb1:%.+]] = scf.if [[m1:%.+]] -> (i1, !quantum.bit) {
@@ -263,13 +269,11 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK-NEXT: } else {
                 // CHECK-NEXT: scf.yield [[qb4_x_res:%.+]] : !quantum.bit
                 // CHECK-NEXT: }
-                // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
-                // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
-                // CHECK: [[qb4:%.+]] = quantum.custom "Identity"() [[qb4:%.+]] : !quantum.bit
-                %0 = "test.op"() : () -> !quantum.bit
-                %1 = quantum.custom "RotXZX"(%param0, %param1, %param2) %0 : !quantum.bit
-                %2 = quantum.custom "Identity"() %1 : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK-NEXT: quantum.dealloc_qb [[qb4:%.+]] : !quantum.bit
+                %2 = quantum.custom "RotXZX"(%param0, %param1, %param2) %1 : !quantum.bit
                 return
             }
         """
@@ -280,16 +284,15 @@ class TestConvertToMBQCFormalismPass:
     def test_cnot_gate(self, run_filecheck):
         """Test for lowering a CNOT gate to a MBQC formalism."""
         program = """
-            func.func @test_func() {
-                // CHECK: [[q1:%.+]] = "test.op"() : () -> !quantum.bit
-                // CHECK: [[q9:%.+]] = "test.op"() : () -> !quantum.bit
+            func.func @test_func(%arg0 : f64) {
+                // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
+                // CHECK-NEXT: [[q1:%.+]] = "test.op"() : () -> !quantum.bit
                 %1 = "test.op"() : () -> !quantum.bit
+                // CHECK-NEXT: quantum.gphase
+                quantum.gphase %arg0
                 // CHECK-NOT: quantum.custom "CNOT"()
-                // CHECK: quantum.gphase
                 %2, %3 = quantum.custom "CNOT"() %0, %1 : !quantum.bit, !quantum.bit
-                %4 = arith.constant 2 : f64
-                quantum.gphase %4
                 return
             }
         """

--- a/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
+++ b/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
@@ -61,7 +61,7 @@ class TestConvertToMBQCFormalismPass:
                 %2 = quantum.custom "PauliY"() %1 : !quantum.bit
                 // CHECK-NEXT: [[q0:%.+]] = quantum.custom "PauliZ"() [[q0:%.+]] : !quantum.bit
                 %3 = quantum.custom "PauliZ"() %2 : !quantum.bit
-                // CHECK: [[q0:%.+]] = quantum.custom "Identity"() [[q0:%.+]] : !quantum.bit
+                // CHECK-NEXT: [[q0:%.+]] = quantum.custom "Identity"() [[q0:%.+]] : !quantum.bit
                 %4 = quantum.custom "Identity"() %3 : !quantum.bit
                 // CHECK-NEXT: quantum.gphase
                 quantum.gphase %arg0

--- a/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
+++ b/tests/python_compiler/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
@@ -88,7 +88,9 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK: [[qb4:%.+]] = quantum.custom "PauliX"() [[qb4:%.+]] : !quantum.bit
                 %1 = quantum.custom "Hadamard"() %0 : !quantum.bit
+                %2 = quantum.custom "PauliX"() %1 : !quantum.bit
                 return
             }
         """
@@ -137,7 +139,9 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK: [[qb4:%.+]] = quantum.custom "PauliY"() [[qb4:%.+]] : !quantum.bit
                 %1 = quantum.custom "S"() %0 : !quantum.bit
+                %2 = quantum.custom "PauliY"() %1 : !quantum.bit
                 return
             }
         """
@@ -189,7 +193,9 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK: [[qb4:%.+]] = quantum.custom "PauliZ"() [[qb4:%.+]] : !quantum.bit
                 %1 = quantum.custom "RZ"(%param0) %0 : !quantum.bit
+                %2 = quantum.custom "PauliZ"() %1 : !quantum.bit
                 return
             }
         """
@@ -260,8 +266,10 @@ class TestConvertToMBQCFormalismPass:
                 // CHECK: quantum.dealloc_qb [[qb1:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb2:%.+]] : !quantum.bit
                 // CHECK: quantum.dealloc_qb [[qb3:%.+]] : !quantum.bit
+                // CHECK: [[qb4:%.+]] = quantum.custom "Identity"() [[qb4:%.+]] : !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
                 %1 = quantum.custom "RotXZX"(%param0, %param1, %param2) %0 : !quantum.bit
+                %2 = quantum.custom "Identity"() %1 : !quantum.bit
                 return
             }
         """
@@ -278,7 +286,10 @@ class TestConvertToMBQCFormalismPass:
                 %0 = "test.op"() : () -> !quantum.bit
                 %1 = "test.op"() : () -> !quantum.bit
                 // CHECK-NOT: quantum.custom "CNOT"()
+                // CHECK: quantum.gphase
                 %2, %3 = quantum.custom "CNOT"() %0, %1 : !quantum.bit, !quantum.bit
+                %4 = arith.constant 2 : f64
+                quantum.gphase %4
                 return
             }
         """


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-100523]

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
