### PR TITLE
Change ubuntu-latest to ubuntu-2404

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -92,7 +92,7 @@ jobs:
     name: Determine runner type to use
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-24.04
       force_large_runner: ${{ inputs.use_large_runner }}
 
   warnings-as-errors-setup:

--- a/.github/workflows/module-validation.yml
+++ b/.github/workflows/module-validation.yml
@@ -38,4 +38,3 @@ jobs:
           tach report pennylane/labs
           tach report pennylane/ftqc
           tach check
-

--- a/.github/workflows/tests-labs.yml
+++ b/.github/workflows/tests-labs.yml
@@ -15,7 +15,7 @@ jobs:
   # exit early with a successful status (no tests will get run).
   determine_if_workflow_should_run:
     name: Determine if QML Labs Unit-Tests need to run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout PR
@@ -37,7 +37,7 @@ jobs:
       - determine_if_workflow_should_run
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-24.04
       force_large_runner: ${{ github.event_name == 'merge_group' }}
   
   default-dependency-versions:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,7 +31,7 @@ on:
         description: The name of the runner to use for the job
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       checkout_fetch_depth:
         description: How many commits to checkout from HEAD of branch passed
         required: false

--- a/.github/workflows/upload-nightly-release.yml
+++ b/.github/workflows/upload-nightly-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   setup:
     name: Setup the release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout PennyLane repo
       uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
   upload:
     name: Upload wheels to TestPyPI
     needs: [setup]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -8,7 +8,7 @@ jobs:
     name: Change to Large Runner
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-24.04
       force_large_runner: true
 
   tests:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1144,6 +1144,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* GitHub actions and workflows (`interface-unit-tests.yml`, `tests-labs.yml`, `unit-test.yml`, `upload-nightly-release.yml` and `upload.yml`) have been updated to 
+  use `ubuntu-24.04` runners. [(8371)](https://github.com/PennyLaneAI/pennylane/pull/8371)
+
 * Add CI workflow to test documentation using `sybil`. 
   [(#8324)](https://github.com/PennyLaneAI/pennylane/pull/8324)
 


### PR DESCRIPTION
**Context:**
Github will be updating their `ubuntu-latest` version from ubuntu-24 to ubuntu-26 in the near future.  This may cause issues later so it's best to fix the ubuntu version and manually update it.

**Description of the Change:**
Changing `ubuntu-latest` to `ubuntu-24.04` on workflows that may be version specific.

**Benefits:**
No unexpected issues when `ubuntu-latest` is updated in the future. 

**Possible Drawbacks:**
None. `ubuntu-latest` is currently ubuntu-24

**Related GitHub Issues:**
