### PR TITLE
Set `allow_unregistered=False` for context used in lit tests

### DIFF
--- a/tests/python_compiler/conftest.py
+++ b/tests/python_compiler/conftest.py
@@ -42,7 +42,7 @@ def _run_filecheck_impl(program_str, pipeline=(), verify=False, roundtrip=False)
     if not deps_available:
         return
 
-    ctx = Context(allow_unregistered=False)
+    ctx = Context()
     xdsl_module = QuantumParser(ctx, program_str, extra_dialects=(test.Test,)).parse_module()
 
     if roundtrip:


### PR DESCRIPTION
Setting `allow_unregistered=True` will make the context too permissive, which can cause testing to get weaker.

[sc-100655]