### PR TITLE
Better error message for dynamic allocation size when capture is enabled

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,6 +71,7 @@
   [(#8163)](https://github.com/PennyLaneAI/pennylane/pull/8163)
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
   [(#8198)](https://github.com/PennyLaneAI/pennylane/pull/8198)
+  [(#????)](https://github.com/PennyLaneAI/pennylane/pull/????)
 
   The :func:`~.allocate` function can accept three arguments that dictate how dynamically allocated
   wires are handled:
@@ -1572,5 +1573,6 @@ Justin Pickering,
 Alex Preciado,
 Shuli Shu,
 Jay Soni,
+Paul Haochen Wang,
 David Wierichs,
 Jake Zaia

--- a/pennylane/allocation.py
+++ b/pennylane/allocation.py
@@ -19,6 +19,7 @@ from enum import StrEnum
 from typing import Literal
 
 from pennylane.capture import enabled as capture_enabled
+from pennylane.capture.dynamic_shapes import pe
 from pennylane.operation import Operator
 from pennylane.wires import DynamicWire, Wires
 
@@ -227,6 +228,9 @@ def allocate(
         The ``allocate`` function can be used as a context manager with automatic deallocation
         (recommended for most cases) or with manual deallocation via :func:`~.deallocate`.
 
+    .. note::
+        The ``num_wires`` argument must be static when capture is enabled.
+
     .. seealso::
         :func:`~.deallocate`
 
@@ -357,6 +361,8 @@ def allocate(
     """
     state = AllocateState(state)
     if capture_enabled():
+        if isinstance(num_wires, pe.DynamicJaxprTracer):
+            raise NotImplementedError("Number of allocated wires must be static when capture is enabled.")
         wires = allocate_prim.bind(num_wires=num_wires, state=state, restored=restored)
     else:
         wires = [DynamicWire() for _ in range(num_wires)]

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -304,6 +304,16 @@ class TestCaptureIntegration:
         with pytest.raises(NotImplementedError):
             deallocate(2)
 
+    def test_no_dynamic_allocation_size(self):
+        """Test that allocation size must be static with capture."""
+        with pytest.raises(
+            NotImplementedError,
+            match="Number of allocated wires must be static when capture is enabled.",
+        ):
+
+            def c(n: int):
+                allocate(n)
+
 
 @pytest.mark.integration
 class TestDeviceIntegration:


### PR DESCRIPTION
**Context:**
With capture enabled, it was decided that the allocation size can only be static.

However, the current error message just falls through to whatever first error is encountered down the line. For the user this is not very actionable.

```python
qml.capture.enable()

@qml.qnode(qml.device("default.qubit", wires=10))
def circuit(n: int):
    qml.X(0)                        # |10>

    with qml.allocate(n) as q:      # |10> and |0>, 1 dynamically allocated qubit
        qml.X(q[0])                 # |10> and |1>
        qml.CNOT(wires=[q[0], 1])   # |11> and |1>

    return qml.probs(wires=[0, 1])

print(circuit(1))
```
```
  File "/home/paul.wang/catalyst_new/catalyst/cat_env/lib/python3.11/site-packages/pennylane/workflow/_capture_qnode.py", line 481, in _extract_qfunc_jaxpr
    raise CaptureError(
pennylane.exceptions.CaptureError: Autograph must be used when Python control flow is dependent on a dynamic variable (a function input). Please ensure that autograph is being correctly enabled with `qml.capture.run_autograph` or disabled with `qml.capture.disable_autograph` or consider using PennyLane native control flow functions like `qml.for_loop`, `qml.while_loop`, or `qml.cond`.
```

**Description of the Change:**
Raise a better error message.

**Benefits:**
Clearer suggestion for user action.

