### PR TITLE
chore: add missed / incorrect changelog entries for v0.43 release

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1173,7 +1173,7 @@
 
 * GitHub actions and workflows (`interface-unit-tests.yml`, `tests-labs.yml`, `unit-test.yml`, `upload-nightly-release.yml` and `upload.yml`) have been updated to 
   use `ubuntu-24.04` runners. 
-  [(8371)](https://github.com/PennyLaneAI/pennylane/pull/8371)
+  [(#8371)](https://github.com/PennyLaneAI/pennylane/pull/8371)
 
 * Issues with imports and circular dependencies in files were addressed in the ``ops/``and ``templates/`` directories.
   [(#7865)](https://github.com/PennyLaneAI/pennylane/pull/7865)


### PR DESCRIPTION
As the name suggests.

[sc-100825]