### PR TITLE
Decompose `Controlled(Identity)` to `Identity`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -316,6 +316,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* ``Controlled(Identity)`` is now directly decomposed to a single Identity operator instead of going
+  through a numeric decomposition algorithm.
+  [(#8388)](https://github.com/PennyLaneAI/pennylane/pull/8388)
+
 <h4>Resource-efficient decompositions</h4>
 
 * Several templates now have decompositions that can be accessed within the graph-based

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -995,6 +995,9 @@ def _decompose_custom_ops(op: Controlled) -> list[Operator] | None:
         # (Id_{2^N} - |1><1|^N)⊗ Id_2 + |1><1|^N ⊗ e^{i\phi}
         # = (Id_{2^{N-1}} - |1><1|^{N-1}) ⊗ Id_4 + |1><1|^{N-1} ⊗ [|0><0|+|1><1|e^{i\phi}]⊗ Id_2
         return [ctrl(phase_shift, control=op.control_wires[:-1])]
+    elif isinstance(op.base, qml.Identity):
+        # A controlled identity is just the identity.
+        return [qml.Identity(wires=[*op.control_wires, *op.base.wires])]
 
     # TODO: will be removed in the second part of the controlled rework [sc-37951]
     if len(op.control_wires) == 1 and hasattr(op.base, "_controlled"):

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -968,6 +968,7 @@ def _decompose_pauli_x_based_no_control_values(op: Controlled):
     )
 
 
+# pylint: disable=too-many-return-statements
 def _decompose_custom_ops(op: Controlled) -> list[Operator] | None:
     """Custom handling for decomposing a controlled operation"""
 
@@ -995,7 +996,8 @@ def _decompose_custom_ops(op: Controlled) -> list[Operator] | None:
         # (Id_{2^N} - |1><1|^N)⊗ Id_2 + |1><1|^N ⊗ e^{i\phi}
         # = (Id_{2^{N-1}} - |1><1|^{N-1}) ⊗ Id_4 + |1><1|^{N-1} ⊗ [|0><0|+|1><1|e^{i\phi}]⊗ Id_2
         return [ctrl(phase_shift, control=op.control_wires[:-1])]
-    elif isinstance(op.base, qml.Identity):
+
+    if isinstance(op.base, qml.Identity):
         # A controlled identity is just the identity.
         return [qml.Identity(wires=[*op.control_wires, *op.base.wires])]
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -815,6 +815,14 @@ class TestMatrix:
 
 
 special_non_par_op_decomps = [
+    (
+        qml.Identity,
+        [],
+        [3],
+        [0, 1, 2],
+        (lambda wires: qml.ctrl(qml.Identity(wires[-1]), control=wires[:-1])),
+        [qml.Identity([0, 1, 2, 3])],
+    ),
     (qml.PauliY, [], [0], [1], qml.CY, [qml.CRY(np.pi, wires=[1, 0]), qml.S(1)]),
     (qml.PauliZ, [], [1], [0], qml.CZ, [qml.ControlledPhaseShift(np.pi, wires=[0, 1])]),
     (
@@ -1117,7 +1125,7 @@ class TestDecomposition:
         assert custom_ctrl_op.decomposition() == expected
         # There is not custom ctrl class for GlobalPhase (yet), so no `compute_decomposition`
         # to test, just the controlled decompositions logic.
-        if base_cls != qml.GlobalPhase:
+        if base_cls not in (qml.GlobalPhase, qml.Identity):
             assert custom_ctrl_cls.compute_decomposition(*params, active_wires) == expected
 
         mat = qml.matrix(ctrl_op.decomposition, wire_order=active_wires)()


### PR DESCRIPTION
A small patch to simplify the decomposition of the `Controlled` operator, specifically when the base class is the `Identity`. This patch is proposed since we already have similar simplifications in place for other operators, and it avoids computing the more complex `ctrl_decomp_bisect`.