### PR TITLE
Add error to `default.qubit` with postselection and defer measurements if `postselect_mode="fill-shots"`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1443,6 +1443,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* An error is now raised if using postselection with finite shots and :class:`~pennylane.devices.DefaultQubit` when
+  `mcm_method="deferred"` and `postselect_mode="fill-shots"`, as this previously led to invalid results.
+
 * `default.qubit` now properly validates the `mcm_method`.
   [(#8343)](https://github.com/PennyLaneAI/pennylane/pull/8343)
 

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -116,6 +116,11 @@ def _postselection_postprocess(state, is_state_batched, shots, **execution_kwarg
     norm = qml.math.norm(state)
 
     if not qml.math.is_abstract(state) and qml.math.allclose(norm, 0.0):
+        if postselect_mode == "fill-shots" and shots:
+            raise RuntimeError(
+                "The probability of the postselected state is 0. This will lead to invalid "
+                "results when using postselect_mode='fill-shots'."
+            )
         norm = 0.0
 
     if shots:


### PR DESCRIPTION
**Context:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/8332 for `defer_measurements`.

**Description of the Change:**
* Update `default.qubit`'s execution with defer measurements so that we raise an error if the following constraints are met:
  * We're postselecting a zero probability outcome.
  * `postselect_mode="fill-shots"`
  * Finite shots

**Benefits:**
No more unexpected behaviour with postselection with `defer_measurements`.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-100658]