### PR TITLE
[v0.43.0 release] preparation for release candidate branches

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.43.0.md
 
 .. mdinclude:: ../releases/changelog-0.42.3.md
 

--- a/doc/releases/changelog-0.42.3.md
+++ b/doc/releases/changelog-0.42.3.md
@@ -1,4 +1,4 @@
-# Release 0.42.3 (current release)
+# Release 0.42.3
 
 <h3>Bug fixes 🐛</h3>
 

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -1,5 +1,5 @@
 
-# Release 0.43.0-dev (development release)
+# Release 0.43.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-dev71"
+__version__ = "0.43.0rc0"


### PR DESCRIPTION
Context:

Following instructions laid out in the release guide - the changes were automatically generated via shell script.

Changes are the same as last release: https://github.com/PennyLaneAI/pennylane/pull/7796

[sc-100867]