### PR TITLE
Disable fill-shots on default.qubit for one-shot and tree-traversal

### DIFF
--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-rc0"
+__version__ = "0.43.0rc0"

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0rc0"
+__version__ = "0.43.0-rc0"

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -22,7 +22,7 @@ import warnings
 from collections.abc import Sequence
 from dataclasses import replace
 from functools import partial
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -47,12 +47,10 @@ from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumScriptOrBat
 from pennylane.transforms import (
     broadcast_expand,
     convert_to_numpy_parameters,
-)
-from pennylane.transforms import decompose as transforms_decompose
-from pennylane.transforms import (
     defer_measurements,
     dynamic_one_shot,
 )
+from pennylane.transforms import decompose as transforms_decompose
 from pennylane.transforms.core import TransformProgram, transform
 from pennylane.typing import PostprocessingFn, Result, ResultBatch, TensorLike
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -47,10 +47,12 @@ from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumScriptOrBat
 from pennylane.transforms import (
     broadcast_expand,
     convert_to_numpy_parameters,
+)
+from pennylane.transforms import decompose as transforms_decompose
+from pennylane.transforms import (
     defer_measurements,
     dynamic_one_shot,
 )
-from pennylane.transforms import decompose as transforms_decompose
 from pennylane.transforms.core import TransformProgram, transform
 from pennylane.typing import PostprocessingFn, Result, ResultBatch, TensorLike
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -14,6 +14,7 @@
 """
 The default.qubit device is PennyLane's standard qubit-based device.
 """
+
 from __future__ import annotations
 
 import logging
@@ -21,7 +22,7 @@ import warnings
 from collections.abc import Sequence
 from dataclasses import replace
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 import numpy as np
 
@@ -43,9 +44,15 @@ from pennylane.measurements import (
 from pennylane.operation import DecompositionUndefinedError
 from pennylane.ops.op_math import Conditional
 from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumScriptOrBatch
-from pennylane.transforms import broadcast_expand, convert_to_numpy_parameters
+from pennylane.transforms import (
+    broadcast_expand,
+    convert_to_numpy_parameters,
+)
 from pennylane.transforms import decompose as transforms_decompose
-from pennylane.transforms import defer_measurements, dynamic_one_shot
+from pennylane.transforms import (
+    defer_measurements,
+    dynamic_one_shot,
+)
 from pennylane.transforms.core import TransformProgram, transform
 from pennylane.typing import PostprocessingFn, Result, ResultBatch, TensorLike
 
@@ -743,7 +750,6 @@ class DefaultQubit(Device):
         return replace(config, **updated_values)
 
     def _setup_mcm_config(self, mcm_config: MCMConfig, tape: QuantumScript) -> MCMConfig:
-
         if capture.enabled():
             return self._capture_setup_mcm_config(mcm_config)
 
@@ -759,6 +765,12 @@ class DefaultQubit(Device):
                 f"mcm_method {final_mcm_method} not supported on default.qubit. "
                 f"Supported methods are {supported_methods}"
             )
+
+        if mcm_config.postselect_mode == "fill-shots" and final_mcm_method != "deferred":
+            raise DeviceError(
+                "Using postselect_mode='fill-shots' is only supported with mcm_method='deferred'."
+            )
+
         return replace(mcm_config, mcm_method=final_mcm_method)
 
     def _capture_setup_mcm_config(self, mcm_config):
@@ -808,7 +820,6 @@ class DefaultQubit(Device):
             )
 
         if max_workers is None:
-
             return tuple(
                 _simulate_wrapper(
                     c,

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -21,8 +21,9 @@ import numpy as np
 import scipy as sp
 
 import pennylane as qml
-from pennylane import math
+from pennylane import math, ops
 from pennylane.measurements import MidMeasureMP
+from pennylane.operation import Operator
 from pennylane.ops import Conditional
 
 SQRT2INV = 1 / math.sqrt(2)
@@ -60,7 +61,7 @@ def _get_slice(index, axis, num_axes):
     return tuple(idx)
 
 
-def apply_operation_einsum(op: qml.operation.Operator, state, is_state_batched: bool = False):
+def apply_operation_einsum(op: Operator, state, is_state_batched: bool = False):
     """Apply ``Operator`` to ``state`` using ``einsum``. This is more efficent at lower qubit
     numbers.
 
@@ -76,9 +77,9 @@ def apply_operation_einsum(op: qml.operation.Operator, state, is_state_batched: 
     # when backpropagating if casting explicitly. Some type of casting is needed
     # to prevent ComplexWarnings with backpropagation with other interfaces
     if (
-        qml.math.get_interface(state) == "tensorflow"
+        math.get_interface(state) == "tensorflow"
     ):  # pragma: no cover (TensorFlow tests were disabled during deprecation)
-        mat = qml.math.cast_like(op.matrix(), state)
+        mat = math.cast_like(op.matrix(), state)
     else:
         mat = op.matrix() + 0j
 
@@ -111,7 +112,7 @@ def apply_operation_einsum(op: qml.operation.Operator, state, is_state_batched: 
     return math.einsum(einsum_indices, reshaped_mat, state)
 
 
-def apply_operation_tensordot(op: qml.operation.Operator, state, is_state_batched: bool = False):
+def apply_operation_tensordot(op: Operator, state, is_state_batched: bool = False):
     """Apply ``Operator`` to ``state`` using ``math.tensordot``. This is more efficent at higher qubit
     numbers.
 
@@ -127,9 +128,9 @@ def apply_operation_tensordot(op: qml.operation.Operator, state, is_state_batche
     # when backpropagating if casting explicitly. Some type of casting is needed
     # to prevent ComplexWarnings with backpropagation with other interfaces
     if (
-        qml.math.get_interface(state) == "tensorflow"
+        math.get_interface(state) == "tensorflow"
     ):  # pragma: no cover (TensorFlow tests were disabled during deprecation)
-        mat = qml.math.cast_like(op.matrix(), state)
+        mat = math.cast_like(op.matrix(), state)
     else:
         mat = op.matrix() + 0j
 
@@ -169,7 +170,7 @@ def apply_operation_tensordot(op: qml.operation.Operator, state, is_state_batche
 
 @singledispatch
 def apply_operation(
-    op: qml.operation.Operator,
+    op: Operator,
     state,
     is_state_batched: bool = False,
     debugger=None,
@@ -291,7 +292,7 @@ def apply_conditional(
     mid_measurements = execution_kwargs.get("mid_measurements", None)
     rng = execution_kwargs.get("rng", None)
     prng_key = execution_kwargs.get("prng_key", None)
-    interface = qml.math.get_deep_interface(state)
+    interface = math.get_deep_interface(state)
     if interface == "jax":
         # pylint: disable=import-outside-toplevel
         from jax.lax import cond
@@ -349,82 +350,81 @@ def apply_mid_measure(
     mid_measurements = execution_kwargs.get("mid_measurements", None)
     rng = execution_kwargs.get("rng", None)
     prng_key = execution_kwargs.get("prng_key", None)
-    postselect_mode = execution_kwargs.get("postselect_mode", None)
 
     if is_state_batched:
         raise ValueError("MidMeasureMP cannot be applied to batched states.")
     wire = op.wires
-    interface = qml.math.get_deep_interface(state)
+    interface = math.get_deep_interface(state)
 
-    if postselect_mode == "fill-shots" and op.postselect is not None:
-        sample = op.postselect
+    axis = wire.toarray()[0]
+    slices = [slice(None)] * math.ndim(state)
+    slices[axis] = 0
+    prob0 = math.real(math.norm(state[tuple(slices)])) ** 2
+
+    if prng_key is not None:
+        # pylint: disable=import-outside-toplevel
+        from jax.random import binomial
+
+        def binomial_fn(n, p):
+            return binomial(prng_key, n, p).astype(int)
+
     else:
-        axis = wire.toarray()[0]
-        slices = [slice(None)] * qml.math.ndim(state)
-        slices[axis] = 0
-        prob0 = qml.math.real(qml.math.norm(state[tuple(slices)])) ** 2
+        binomial_fn = np.random.binomial if rng is None else rng.binomial
 
-        if prng_key is not None:
-            # pylint: disable=import-outside-toplevel
-            from jax.random import binomial
+    sample = binomial_fn(1, 1 - prob0)
 
-            def binomial_fn(n, p):
-                return binomial(prng_key, n, p).astype(int)
-
-        else:
-            binomial_fn = np.random.binomial if rng is None else rng.binomial
-        sample = binomial_fn(1, 1 - prob0)
+    assert mid_measurements is not None
     mid_measurements[op] = sample
 
     # Using apply_operation(qml.QubitUnitary,...) instead of apply_operation(qml.Projector([sample], wire),...)
     # to select the sample branch enables jax.jit and prevents it from using Python callbacks
-    matrix = qml.math.array([[(sample + 1) % 2, 0.0], [0.0, (sample) % 2]], like=interface)
+    matrix = math.array([[(sample + 1) % 2, 0.0], [0.0, (sample) % 2]], like=interface)
     state = apply_operation(
-        qml.QubitUnitary(matrix, wire),
+        ops.QubitUnitary(matrix, wire),
         state,
         is_state_batched=is_state_batched,
         debugger=debugger,
     )
-    state = state / qml.math.norm(state)
+    state = state / math.norm(state)
 
     # Using apply_operation(qml.QubitUnitary,...) instead of apply_operation(qml.X(wire), ...)
     # to reset enables jax.jit and prevents it from using Python callbacks
     element = op.reset and sample == 1
-    matrix = qml.math.array(
+    matrix = math.array(
         [[(element + 1) % 2, (element) % 2], [(element) % 2, (element + 1) % 2]],
         like=interface,
         dtype=float,
     )
     state = apply_operation(
-        qml.QubitUnitary(matrix, wire), state, is_state_batched=is_state_batched, debugger=debugger
+        ops.QubitUnitary(matrix, wire), state, is_state_batched=is_state_batched, debugger=debugger
     )
 
     return state
 
 
 @apply_operation.register
-def apply_identity(op: qml.Identity, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_identity(op: ops.Identity, state, is_state_batched: bool = False, debugger=None, **_):
     """Applies a :class:`~.Identity` operation by just returning the input state."""
     return state
 
 
 @apply_operation.register
 def apply_global_phase(
-    op: qml.GlobalPhase, state, is_state_batched: bool = False, debugger=None, **_
+    op: ops.GlobalPhase, state, is_state_batched: bool = False, debugger=None, **_
 ):
     """Applies a :class:`~.GlobalPhase` operation by multiplying the state by ``exp(1j * op.data[0])``"""
-    return qml.math.exp(-1j * qml.math.cast(op.data[0], complex)) * state
+    return math.exp(-1j * math.cast(op.data[0], complex)) * state
 
 
 @apply_operation.register
-def apply_paulix(op: qml.X, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_paulix(op: ops.X, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply :class:`pennylane.PauliX` operator to the quantum state"""
     axis = op.wires[0] + is_state_batched
     return math.roll(state, 1, axis)
 
 
 @apply_operation.register
-def apply_pauliz(op: qml.Z, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_pauliz(op: ops.Z, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply pauliz to state."""
 
     axis = op.wires[0] + is_state_batched
@@ -444,7 +444,7 @@ def apply_pauliz(op: qml.Z, state, is_state_batched: bool = False, debugger=None
 
 
 @apply_operation.register
-def apply_phaseshift(op: qml.PhaseShift, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_phaseshift(op: ops.PhaseShift, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply PhaseShift to state."""
 
     n_dim = math.ndim(state)
@@ -479,7 +479,7 @@ def apply_phaseshift(op: qml.PhaseShift, state, is_state_batched: bool = False, 
 
 
 @apply_operation.register
-def apply_T(op: qml.T, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_T(op: ops.T, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply T to state."""
 
     axis = op.wires[0] + is_state_batched
@@ -498,7 +498,7 @@ def apply_T(op: qml.T, state, is_state_batched: bool = False, debugger=None, **_
 
 
 @apply_operation.register
-def apply_S(op: qml.S, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_S(op: ops.S, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply S to state."""
 
     axis = op.wires[0] + is_state_batched
@@ -517,7 +517,7 @@ def apply_S(op: qml.S, state, is_state_batched: bool = False, debugger=None, **_
 
 
 @apply_operation.register
-def apply_cnot(op: qml.CNOT, state, is_state_batched: bool = False, debugger=None, **_):
+def apply_cnot(op: ops.CNOT, state, is_state_batched: bool = False, debugger=None, **_):
     """Apply cnot gate to state."""
     target_axes = (op.wires[1] - 1 if op.wires[1] > op.wires[0] else op.wires[1]) + is_state_batched
     control_axes = op.wires[0] + is_state_batched
@@ -537,7 +537,7 @@ def apply_cnot(op: qml.CNOT, state, is_state_batched: bool = False, debugger=Non
 
 @apply_operation.register
 def apply_multicontrolledx(
-    op: qml.MultiControlledX,
+    op: ops.MultiControlledX,
     state,
     is_state_batched: bool = False,
     debugger=None,
@@ -620,7 +620,7 @@ def _apply_grover_without_matrix(state, op_wires, is_state_batched):
     sum_axes = [w + is_state_batched for w in op_wires]
     collapsed = math.sum(state, axis=tuple(sum_axes))
 
-    if num_wires == (len(qml.math.shape(state)) - is_state_batched):
+    if num_wires == (len(math.shape(state)) - is_state_batched):
         # If the operation acts on all wires, we can skip the tensor product with all-ones state
         new_shape = (-1,) + (1,) * num_wires if is_state_batched else (1,) * num_wires
         return prefactor * math.reshape(collapsed, new_shape) - state
@@ -639,7 +639,7 @@ def _apply_grover_without_matrix(state, op_wires, is_state_batched):
 
 @apply_operation.register
 def apply_snapshot(
-    op: qml.Snapshot, state, is_state_batched: bool = False, debugger=None, **execution_kwargs
+    op: ops.Snapshot, state, is_state_batched: bool = False, debugger=None, **execution_kwargs
 ):
     """Take a snapshot of the state."""
     if debugger is None or not debugger.active:
@@ -687,8 +687,8 @@ def apply_parametrized_evolution(
     if we are operating on more than half of the subsystem"""
 
     # shape(state) is static (not a tracer), we can use an if statement
-    num_wires = len(qml.math.shape(state)) - is_state_batched
-    state = qml.math.cast(state, complex)
+    num_wires = len(math.shape(state)) - is_state_batched
+    state = math.cast(state, complex)
     if (
         2 * len(op.wires) <= num_wires
         or op.hyperparameters["complementary"]
@@ -741,7 +741,7 @@ def _evolve_state_vector_under_parametrized_evolution(
 
     if is_state_batched:
         batch_dim = state.shape[0]
-        state = qml.math.moveaxis(state.reshape((batch_dim, 2**num_wires)), 1, 0)
+        state = math.moveaxis(state.reshape((batch_dim, 2**num_wires)), 1, 0)
         out_shape = [2] * num_wires + [batch_dim]  # this shape is before moving the batch_dim back
     else:
         state = state.flatten()
@@ -760,8 +760,8 @@ def _evolve_state_vector_under_parametrized_evolution(
 
     result = odeint(fun, state, operation.t, **operation.odeint_kwargs)
     if operation.hyperparameters["return_intermediate"]:
-        return qml.math.reshape(result, [-1] + out_shape)
-    result = qml.math.reshape(result[-1], out_shape)
+        return math.reshape(result, [-1] + out_shape)
+    result = math.reshape(result[-1], out_shape)
     if is_state_batched:
-        return qml.math.moveaxis(result, -1, 0)
+        return math.moveaxis(result, -1, 0)
     return result

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -402,7 +402,6 @@ def simulate_tree_mcm(
     """
     PROBS_TOL = 0.0
     interface = execution_kwargs.get("interface", None)
-    postselect_mode = execution_kwargs.get("postselect_mode", None)
 
     ##########################
     # shot vector processing #

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Simulate a quantum script."""
+
 import logging
 
 # pylint: disable=protected-access
@@ -22,6 +23,7 @@ import numpy as np
 from numpy.random import default_rng
 
 import pennylane as qml
+from pennylane import math
 from pennylane.logging import debug_logger
 from pennylane.math.interface_utils import Interface
 from pennylane.measurements import (
@@ -30,9 +32,13 @@ from pennylane.measurements import (
     MidMeasureMP,
     ProbabilityMP,
     SampleMP,
+    ShotCopies,
+    Shots,
     VarianceMP,
     find_post_processed_mcms,
 )
+from pennylane.operation import StatePrepBase
+from pennylane.tape import QuantumScript
 from pennylane.transforms.dynamic_one_shot import gather_mcm
 from pennylane.typing import Result
 
@@ -79,14 +85,14 @@ class TreeTraversalStack:
         self.states[depth] = None
 
 
-class _FlexShots(qml.measurements.Shots):
+class _FlexShots(Shots):
     """Shots class that allows zero shots."""
 
     # pylint: disable=super-init-not-called
     def __init__(self, shots=None):
         if isinstance(shots, int):
             self.total_shots = shots
-            self.shot_vector = (qml.measurements.ShotCopies(shots, 1),)
+            self.shot_vector = (ShotCopies(shots, 1),)
         elif isinstance(shots, self.__class__):
             return  # self already _is_ shots as defined by __new__
         else:
@@ -113,9 +119,9 @@ def _postselection_postprocess(state, is_state_batched, shots, **execution_kwarg
     # equal to zero so that the state can become invalid. This way, execution can continue, and
     # bad postselection gives results that are invalid rather than results that look valid but
     # are incorrect.
-    norm = qml.math.norm(state)
+    norm = math.norm(state)
 
-    if not qml.math.is_abstract(state) and qml.math.allclose(norm, 0.0):
+    if not math.is_abstract(state) and math.allclose(norm, 0.0):
         norm = 0.0
 
     if shots:
@@ -131,7 +137,7 @@ def _postselection_postprocess(state, is_state_batched, shots, **execution_kwarg
 
         postselected_shots = (
             shots
-            if postselect_mode == "fill-shots" or qml.math.is_abstract(norm)
+            if postselect_mode == "fill-shots" or math.is_abstract(norm)
             else [int(binomial_fn(s, float(norm**2))) for s in shots]
         )
 
@@ -173,7 +179,7 @@ def get_final_state(circuit, debugger=None, **execution_kwargs):
     interface = execution_kwargs.get("interface", None)
 
     prep = None
-    if len(circuit) > 0 and isinstance(circuit[0], qml.operation.StatePrepBase):
+    if len(circuit) > 0 and isinstance(circuit[0], StatePrepBase):
         prep = circuit[0]
 
     state = create_initial_state(
@@ -210,7 +216,7 @@ def get_final_state(circuit, debugger=None, **execution_kwargs):
     for _ in range(circuit.num_wires - len(circuit.op_wires)):
         # if any measured wires are not operated on, we pad the state with zeros.
         # We know they belong at the end because the circuit is in standard wire-order
-        state = qml.math.stack([state, qml.math.zeros_like(state)], axis=-1)
+        state = math.stack([state, math.zeros_like(state)], axis=-1)
 
     return state, is_state_batched
 
@@ -279,7 +285,7 @@ def measure_final_state(circuit, state, is_state_batched, **execution_kwargs) ->
 
 @debug_logger
 def simulate(
-    circuit: qml.tape.QuantumScript,
+    circuit: QuantumScript,
     debugger=None,
     state_cache: dict | None = None,
     **execution_kwargs,
@@ -335,7 +341,7 @@ def simulate(
         results = []
         aux_circ = circuit.copy(shots=[1])
         keys = jax_random_split(prng_key, num=circuit.shots.total_shots)
-        if qml.math.get_deep_interface(circuit.data) == "jax" and prng_key is not None:
+        if math.get_deep_interface(circuit.data) == "jax" and prng_key is not None:
             # pylint: disable=import-outside-toplevel
             import jax
 
@@ -368,7 +374,7 @@ def simulate(
 
 # pylint: disable=too-many-branches,too-many-statements
 def simulate_tree_mcm(
-    circuit: qml.tape.QuantumScript,
+    circuit: QuantumScript,
     debugger=None,
     **execution_kwargs,
 ) -> Result:
@@ -435,7 +441,7 @@ def simulate_tree_mcm(
     # `mcm_samples` is a register of MCMs. It is necessary to correctly keep track of
     # correlated MCM values which may be requested by terminal measurements.
     mcm_samples = {
-        k + 1: qml.math.empty((circuit.shots.total_shots,), dtype=bool) if finite_shots else None
+        k + 1: math.empty((circuit.shots.total_shots,), dtype=bool) if finite_shots else None
         for k in measured_mcms_indices
     }
 
@@ -448,7 +454,7 @@ def simulate_tree_mcm(
     # For example, if `d = 2` and `mcm_current = [0, 1, 1, 0]` we are on the 11-branch,
     # i.e. the first two MCMs had outcome 1. The last entry isn't meaningful until we are
     # at depth `d=3`.
-    mcm_current = qml.math.zeros(n_mcms + 1, dtype=int)
+    mcm_current = math.zeros(n_mcms + 1, dtype=int)
     # `mid_measurements` maps the elements of `mcm_current` to their respective MCMs
     # This is used by `get_final_state::apply_operation` for `Conditional` operations
     mid_measurements = dict(zip(mcms[1:], mcm_current[1:].tolist()))
@@ -465,7 +471,6 @@ def simulate_tree_mcm(
     depth = 0
 
     while stack.any_is_empty(1):
-
         ###########################################
         # Combine measurements & step up the tree #
         ###########################################
@@ -539,7 +544,7 @@ def simulate_tree_mcm(
                 initial_state = stack.states[0]
             else:
                 initial_state = branch_state(stack.states[depth], mcm_current[depth], mcms[depth])
-            circtmp = circuits[depth].copy(shots=qml.measurements.shots.Shots(shots))
+            circtmp = circuits[depth].copy(shots=Shots(shots))
 
             circtmp = prepend_state_prep(circtmp, initial_state, interface, sorted(circuit.wires))
             state, is_state_batched = get_final_state(
@@ -559,14 +564,7 @@ def simulate_tree_mcm(
             depth += 1
             # Update the active branch samples with `update_mcm_samples`
             if finite_shots:
-                if (
-                    mcms[depth]
-                    and mcms[depth].postselect is not None
-                    and postselect_mode == "fill-shots"
-                ):
-                    samples = mcms[depth].postselect * qml.math.ones_like(measurements)
-                else:
-                    samples = qml.math.atleast_1d(measurements)
+                samples = math.atleast_1d(measurements)
                 stack.counts[depth] = samples_to_counts(samples)
                 stack.probs[depth] = counts_to_probs(stack.counts[depth])
             else:
@@ -648,9 +646,7 @@ def split_circuit_at_mcms(circuit):
             last_circuit_measurements.append(m)
 
     circuits.append(
-        qml.tape.QuantumScript(
-            last_circuit_operations, last_circuit_measurements, shots=circuit.shots
-        )
+        QuantumScript(last_circuit_operations, last_circuit_measurements, shots=circuit.shots)
     )
     return circuits
 
@@ -662,13 +658,13 @@ def prepend_state_prep(circuit, state, interface, wires):
     or measurements. This function makes sure that an initial state with the correct size is created
     on the first invocation of ``simulate_tree_mcm``. ``wires`` should be the wires attribute
     of the original circuit (which included all wires)."""
-    if len(circuit) > 0 and isinstance(circuit[0], qml.operation.StatePrepBase):
+    if len(circuit) > 0 and isinstance(circuit[0], StatePrepBase):
         return circuit
 
     interface = Interface(interface)
     state = create_initial_state(wires, None, like=interface.get_like()) if state is None else state
     new_ops = [
-        qml.StatePrep(qml.math.ravel(state), wires=wires, validate_norm=False)
+        qml.StatePrep(math.ravel(state), wires=wires, validate_norm=False)
     ] + circuit.operations
     return circuit.copy(operations=new_ops)
 
@@ -679,12 +675,12 @@ def insert_mcms(circuit, results, mid_measurements):
         return results
     results = list(results)
     new_results = []
-    mid_measurements = {k: qml.math.array([[v]]) for k, v in mid_measurements.items()}
+    mid_measurements = {k: math.array([[v]]) for k, v in mid_measurements.items()}
     for m in circuit.measurements:
         if m.mv is None:
             new_results.append(results.pop(0))
         else:
-            new_results.append(gather_mcm(m, mid_measurements, qml.math.array([[True]])))
+            new_results.append(gather_mcm(m, mid_measurements, math.array([[True]])))
 
     return new_results
 
@@ -723,15 +719,15 @@ def branch_state(state, branch, mcm):
     if isinstance(state, np.ndarray):
         # FASTER
         state = state.copy()
-        slices = [slice(None)] * qml.math.ndim(state)
+        slices = [slice(None)] * math.ndim(state)
         axis = mcm.wires.toarray()[0]
         slices[axis] = int(not branch)
         state[tuple(slices)] = 0.0
-        state /= qml.math.norm(state)
+        state /= math.norm(state)
     else:
         # SLOWER
         state = apply_operation(qml.Projector([branch], mcm.wires), state)
-        state = state / qml.math.norm(state)
+        state = state / math.norm(state)
 
     if mcm.reset and branch == 1:
         state = apply_operation(qml.PauliX(mcm.wires), state)
@@ -743,14 +739,14 @@ def samples_to_counts(samples):
 
     This function forces integer keys and values which are required by ``simulate_tree_mcm``.
     """
-    counts_1 = int(qml.math.count_nonzero(samples))
+    counts_1 = int(math.count_nonzero(samples))
     return {0: samples.size - counts_1, 1: counts_1}
 
 
 def counts_to_probs(counts):
     """Converts counts to probs."""
-    probs = qml.math.array(list(counts.values()))
-    probs = probs / qml.math.sum(probs)
+    probs = math.array(list(counts.values()))
+    probs = probs / math.sum(probs)
     return dict(zip(counts.keys(), probs))
 
 
@@ -764,11 +760,11 @@ def prune_mcm_samples(mcm_samples):
     """
     if not mcm_samples or all(v is None for v in mcm_samples.values()):
         return mcm_samples
-    mask = qml.math.ones(list(mcm_samples.values())[0].shape, dtype=bool)
+    mask = math.ones(list(mcm_samples.values())[0].shape, dtype=bool)
     for mcm, s in mcm_samples.items():
         if mcm.postselect is None:
             continue
-        mask = qml.math.logical_and(mask, s == mcm.postselect)
+        mask = math.logical_and(mask, s == mcm.postselect)
     return {k: v[mask] for k, v in mcm_samples.items()}
 
 
@@ -786,7 +782,7 @@ def update_mcm_samples(samples, mcm_samples, depth, cumcounts):
     """
     if depth not in mcm_samples or mcm_samples[depth] is None:
         return mcm_samples, cumcounts
-    count1 = qml.math.sum(samples)
+    count1 = math.sum(samples)
     count0 = samples.size - count1
     mcm_samples[depth][cumcounts[depth] : cumcounts[depth] + count0] = 0
     cumcounts[depth] += count0
@@ -827,7 +823,7 @@ def variance_transform(circuit):
     new_measurements.extend(extra_measurements)
     return (
         (
-            qml.tape.QuantumScript(
+            QuantumScript(
                 circuit.operations,
                 new_measurements,
                 shots=circuit.shots,
@@ -840,7 +836,7 @@ def variance_transform(circuit):
 def measurement_with_no_shots(measurement):
     """Returns a NaN scalar or array of the correct size when executing an all-invalid-shot circuit."""
     if isinstance(measurement, ProbabilityMP):
-        return np.nan * qml.math.ones(2 ** len(measurement.wires))
+        return np.nan * math.ones(2 ** len(measurement.wires))
     return np.nan
 
 
@@ -861,7 +857,7 @@ def combine_measurements(terminal_measurements, results, mcm_samples):
             comb_meas = measurement_with_no_shots(circ_meas)
         elif need_mcm_samples and circ_meas.mv is not None:
             mcm_samples = {k: v.reshape((-1, 1)) for k, v in mcm_samples.items()}
-            is_valid = qml.math.ones(list(mcm_samples.values())[0].shape[0], dtype=bool)
+            is_valid = math.ones(list(mcm_samples.values())[0].shape[0], dtype=bool)
             comb_meas = gather_mcm(circ_meas, mcm_samples, is_valid)
         elif not results or not results[0]:
             if len(results) > 0:
@@ -901,7 +897,7 @@ def _(original_measurement: ExpectationMP, measures):
     for v in measures.values():
         if not v[0] or v[1] is tuple():
             continue
-        cum_value += qml.math.multiply(v[0], v[1])
+        cum_value += math.multiply(v[0], v[1])
         total_counts += v[0]
     return cum_value / total_counts
 
@@ -914,7 +910,7 @@ def _(original_measurement: ProbabilityMP, measures):
     for v in measures.values():
         if not v[0] or v[1] is tuple():
             continue
-        cum_value += qml.math.multiply(v[0], v[1])
+        cum_value += math.multiply(v[0], v[1])
         total_counts += v[0]
     return cum_value / total_counts
 
@@ -923,14 +919,14 @@ def _(original_measurement: ProbabilityMP, measures):
 def _(original_measurement: SampleMP, measures):
     """The combined samples of two branches is obtained by concatenating the sample of each branch."""
     new_sample = tuple(
-        qml.math.atleast_1d(m[1]) for m in measures.values() if m[0] and not m[1] is tuple()
+        math.atleast_1d(m[1]) for m in measures.values() if m[0] and not m[1] is tuple()
     )
-    return qml.math.concatenate(new_sample)
+    return math.concatenate(new_sample)
 
 
 @debug_logger
 def simulate_one_shot_native_mcm(
-    circuit: qml.tape.QuantumScript, debugger=None, **execution_kwargs
+    circuit: QuantumScript, debugger=None, **execution_kwargs
 ) -> Result:
     """Simulate a single shot of a single quantum script with native mid-circuit measurements.
 

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -61,7 +61,6 @@ class HasDiagonalizingGatesOp(qml.operation.Operator):
 
 # pylint: disable=too-few-public-methods
 class CustomizedSparseOp(qml.operation.Operator):
-
     def __init__(self, wires):
         U = sp.sparse.eye(2 ** len(wires))
         super().__init__(U, wires)
@@ -226,6 +225,17 @@ class TestConfigSetup:
         dev = qml.device("default.qubit")
 
         with pytest.raises(DeviceError, match="not supported on default.qubit"):
+            dev.setup_execution_config(config)
+
+    @pytest.mark.parametrize("mcm_method", ["one-shot", "tree-traversal"])
+    def test_error_on_unsupported_postselect_mode(self, mcm_method):
+        """Tests that fill-shots is not supported on anything but deferred."""
+
+        config = ExecutionConfig(
+            mcm_config=MCMConfig(mcm_method=mcm_method, postselect_mode="fill-shots")
+        )
+        dev = qml.device("default.qubit")
+        with pytest.raises(DeviceError, match="Using postselect_mode='fill-shots'"):
             dev.setup_execution_config(config)
 
 
@@ -867,7 +877,6 @@ class TestPreprocessingIntegration:
         m0 = qml.measure(0)
 
         class MyOp(qml.operation.Operator):
-
             def decomposition(self):
                 return m0.measurements
 

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -14,6 +14,7 @@
 """
 Tests the apply_operation functions from devices/qubit
 """
+
 from functools import reduce
 
 import numpy as np
@@ -1521,36 +1522,6 @@ class TestConditionalsAndMidMeasure:
         assert qml.math.allclose(end_state, res_state)
 
         assert mid_meas == {m0: m_res[0], m1: m_res[1]}
-
-    @pytest.mark.parametrize("reset", (False, True))
-    @pytest.mark.parametrize("m_res", ([0, 0], [1, 0], [1, 1]))
-    def test_mid_measure_with_postselect_and_reset(self, m_res, reset):
-        """Test the application of a MidMeasureMP with postselection and reset."""
-
-        initial_state = np.array([[0.5 + 0.0j, 0.5 + 0.0j], [0.5 + 0.0j, 0.5 + 0.0j]])
-        mid_state, end_state = np.zeros((4, 4)), np.zeros((4, 4))
-
-        if reset:
-            m_res[0] = 0
-
-        mid_state[2 * m_res[0] : 2 * (m_res[0] + 1), 2 * m_res[0] : 2 * (m_res[0] + 1)] = 0.5
-        end_state[2 * m_res[0] + m_res[1], 2 * m_res[0] + m_res[1]] = 1.0
-
-        m0 = qml.measure(0, postselect=m_res[0], reset=reset).measurements[0]
-        m1 = qml.measure(1, postselect=m_res[1]).measurements[0]
-        mid_meas = {m0: m_res[0], m1: m_res[1]}
-
-        new_state = apply_operation(
-            m0, initial_state, mid_measurements=mid_meas, postselect_mode="fill-shots"
-        )
-        res_state = qml.math.reshape(new_state, 4)
-        assert qml.math.allclose(mid_state, qml.math.outer(res_state, res_state))
-
-        new_state = apply_operation(
-            m1, new_state, mid_measurements=mid_meas, postselect_mode="fill-shots"
-        )
-        res_state = qml.math.reshape(new_state, 4)
-        assert qml.math.allclose(end_state, qml.math.outer(res_state, res_state))
 
     def test_error_bactched_mid_measure(self):
         """Test that an error is raised when mid_measure is applied to a batched input state."""

--- a/tests/devices/qubit/test_simulate.py
+++ b/tests/devices/qubit/test_simulate.py
@@ -1475,9 +1475,7 @@ class TestMidMeasurements:
             )
 
     @pytest.mark.parametrize("ml_framework", ml_frameworks_list)
-    @pytest.mark.parametrize(
-        "postselect_mode", [None, "hw-like", "pad-invalid-samples", "fill-shots"]
-    )
+    @pytest.mark.parametrize("postselect_mode", [None, "hw-like", "pad-invalid-samples"])
     def test_tree_traversal_interface_mcm(self, ml_framework, postselect_mode, seed):
         """Test that tree traversal works numerically with different interfaces"""
         # pylint:disable = singleton-comparison, import-outside-toplevel
@@ -1519,8 +1517,7 @@ class TestMidMeasurements:
         p4 = [qml.math.mean(res4 == -1), qml.math.mean(res4 == 1)]
         assert qml.math.allclose(qml.math.sum(sp.special.rel_entr(p3, p4)), 0.0, atol=0.05)
 
-    @pytest.mark.parametrize("postselect_mode", ["hw-like", "fill-shots"])
-    def test_tree_traversal_postselect_mode(self, postselect_mode):
+    def test_tree_traversal_postselect_mode(self):
         """Test that invalid shots are discarded if requested"""
 
         shots = 100
@@ -1534,9 +1531,9 @@ class TestMidMeasurements:
             shots=shots,
         )
 
-        res = simulate_tree_mcm(qscript, postselect_mode=postselect_mode)
+        res = simulate_tree_mcm(qscript, postselect_mode="hw-like")
 
-        assert (len(res) < shots) if postselect_mode == "hw-like" else (len(res) == shots)
+        assert len(res) < shots
         assert np.all(res != np.iinfo(np.int32).min)
 
     def test_tree_traversal_deep_circuit(self):
@@ -1568,10 +1565,6 @@ class TestMidMeasurements:
         for circ in split_circs:
             assert not [o for o in circ.operations if isinstance(o, qml.measurements.MidMeasureMP)]
 
-        res = simulate_tree_mcm(qscript, postselect_mode="fill-shots")
-        assert len(res[0]) == 20
-        assert isinstance(res[1], dict) and sum(list(res[1].values())) == 20
-
     @pytest.mark.parametrize(
         "measurements, expected",
         [
@@ -1596,9 +1589,7 @@ class TestMidMeasurements:
     # FIXME: [sc-95724]
     @pytest.mark.local_salt(9)
     @pytest.mark.parametrize("ml_framework", ml_frameworks_list)
-    @pytest.mark.parametrize(
-        "postselect_mode", [None, "hw-like", "pad-invalid-samples", "fill-shots"]
-    )
+    @pytest.mark.parametrize("postselect_mode", [None, "hw-like", "pad-invalid-samples"])
     def test_simulate_one_shot_native_mcm(self, ml_framework, postselect_mode, seed):
         """Unit tests for simulate_one_shot_native_mcm"""
 
@@ -1623,34 +1614,25 @@ class TestMidMeasurements:
         ]
         terminal_results, mcm_results = zip(*results)
 
-        if postselect_mode == "fill-shots":
-            assert all(ms == 0 for ms in mcm_results)
-            equivalent_tape = qml.tape.QuantumScript(
-                [qml.RX(np.pi / 4, wires=0)], [qml.expval(qml.Z(0))], shots=n_shots
-            )
-            expected_sample = simulate(equivalent_tape, rng=rng)
-            fisher_exact_test(terminal_results, expected_sample, outcomes=(-1, 1))
+        equivalent_tape = qml.tape.QuantumScript(
+            [qml.RX(np.pi / 4, wires=0)], [qml.sample(wires=0)], shots=n_shots
+        )
+        expected_result = simulate(equivalent_tape, rng=rng)
+        fisher_exact_test(mcm_results, expected_result)
 
-        else:
-            equivalent_tape = qml.tape.QuantumScript(
-                [qml.RX(np.pi / 4, wires=0)], [qml.sample(wires=0)], shots=n_shots
-            )
-            expected_result = simulate(equivalent_tape, rng=rng)
-            fisher_exact_test(mcm_results, expected_result)
+        subset = [ts for ms, ts in zip(mcm_results, terminal_results) if ms == 0]
+        equivalent_tape = qml.tape.QuantumScript(
+            [qml.RX(np.pi / 4, wires=0)], [qml.expval(qml.Z(0))], shots=n_shots
+        )
+        expected_sample = simulate(equivalent_tape, rng=rng)
+        fisher_exact_test(subset, expected_sample, outcomes=(-1, 1))
 
-            subset = [ts for ms, ts in zip(mcm_results, terminal_results) if ms == 0]
-            equivalent_tape = qml.tape.QuantumScript(
-                [qml.RX(np.pi / 4, wires=0)], [qml.expval(qml.Z(0))], shots=n_shots
-            )
-            expected_sample = simulate(equivalent_tape, rng=rng)
-            fisher_exact_test(subset, expected_sample, outcomes=(-1, 1))
-
-            subset = [ts for ms, ts in zip(mcm_results, terminal_results) if ms == 1]
-            equivalent_tape = qml.tape.QuantumScript(
-                [qml.X(0), qml.RX(np.pi / 4, wires=0)], [qml.expval(qml.Z(0))], shots=n_shots
-            )
-            expected_sample = simulate(equivalent_tape, rng=rng)
-            fisher_exact_test(subset, expected_sample, outcomes=(-1, 1))
+        subset = [ts for ms, ts in zip(mcm_results, terminal_results) if ms == 1]
+        equivalent_tape = qml.tape.QuantumScript(
+            [qml.X(0), qml.RX(np.pi / 4, wires=0)], [qml.expval(qml.Z(0))], shots=n_shots
+        )
+        expected_sample = simulate(equivalent_tape, rng=rng)
+        fisher_exact_test(subset, expected_sample, outcomes=(-1, 1))
 
     def test_tree_traversal_non_standard_wire_order(self):
         """Test that tree-traversal still works with a non-standard wire order."""

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for the QNode"""
+
 import copy
 
 # pylint: disable=import-outside-toplevel, protected-access, no-member
@@ -1160,7 +1161,6 @@ class TestIntegration:
         """Test that an error is raised in the device_vjp is unsupported."""
 
         class DummyDev(qml.devices.Device):
-
             def execute(self, circuits, execution_config=qml.devices.ExecutionConfig()):
                 return 0
 
@@ -1895,6 +1895,10 @@ class TestMCMConfiguration:
     @pytest.mark.parametrize("mcm_method", [None, "one-shot", "deferred"])
     def test_execution_does_not_mutate_config(self, mcm_method, postselect_mode):
         """Test that executing a QNode does not mutate its mid-circuit measurement config options"""
+
+        if postselect_mode == "fill-shots" and mcm_method != "deferred":
+            pytest.skip("fill-shots is disabled for anything but deferred.")
+
         dev = qml.device("default.qubit", wires=2)
 
         original_config = qml.devices.MCMConfig(

--- a/tests/transforms/test_dynamic_one_shot.py
+++ b/tests/transforms/test_dynamic_one_shot.py
@@ -98,45 +98,20 @@ def test_postselection_error_with_wrong_device():
             return qml.probs(wires=[0])
 
 
-@pytest.mark.parametrize("postselect_mode", ["hw-like", "fill-shots"])
-def test_postselect_mode(postselect_mode):
+def test_postselect_mode():
     """Test that invalid shots are discarded if requested"""
     shots = 100
     dev = qml.device("default.qubit")
 
     @qml.set_shots(shots)
-    @qml.qnode(dev, postselect_mode=postselect_mode)
+    @qml.qnode(dev, postselect_mode="hw-like")
     def f(x):
         qml.RX(x, 0)
         _ = qml.measure(0, postselect=1)
         return qml.sample(wires=[0, 1])
 
     res = f(np.pi / 2)
-    if postselect_mode == "hw-like":
-        assert len(res) < shots
-    else:
-        assert len(res) == shots
-    assert np.all(res != np.iinfo(np.int32).min)
-
-
-@pytest.mark.parametrize("postselect_mode", ["hw-like", "fill-shots"])
-def test_postselect_mode_transform(postselect_mode):
-    """Test that invalid shots are discarded if requested"""
-    shots = 100
-    dev = qml.device("default.qubit")
-
-    @qml.set_shots(shots)
-    @qml.qnode(dev, mcm_method="one-shot", postselect_mode=postselect_mode)
-    def f(x):
-        qml.RX(x, 0)
-        _ = qml.measure(0, postselect=1)
-        return qml.sample(wires=[0, 1])
-
-    res = f(np.pi / 2)
-    if postselect_mode == "hw-like":
-        assert len(res) < shots
-    else:
-        assert len(res) == shots
+    assert len(res) < shots
     assert np.all(res != np.iinfo(np.int32).min)
 
 
@@ -300,7 +275,6 @@ def generate_dummy_raw_results(measure_f, n_mcms, shots, postselect, interface):
         raw_results = (single_shot_res,) * shots
 
     else:
-
         # When postselecting, we start by creating results for two shots as alternating indices
         # will have valid results.
         # Alternating tuple. Only the values at odd indices are valid


### PR DESCRIPTION
**Context:**

When using `mcm_method="one-shot"` or `"tree-traversal"`,  combined with `postselect_mode="fill-shots"`,  the postselection breaks the correlation between correlated measurements completely, producing incorrect results. The only way to fix that is by continuously running the simulation until we have enough valid shots, which fundamentally goes against the philosophy of treating shots as a budget constraint. Therefore, we have opted to disallow `"fill-shots"` for anything but `"deferred"` in `default.qubit`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-100562]
[sc-99992]
Fixes https://github.com/PennyLaneAI/pennylane/issues/8366
https://github.com/PennyLaneAI/pennylane/issues/8332