### PR TITLE
[v0.43.0 Release] Un-block CI by fixing `test_about.py`

### DIFF
--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -37,7 +37,10 @@ def test_about():
 
     assert "Version:" in out
     pl_version_match = re.search(r"Version:\s+([\S]+)\n", out).group(1)
-    assert qml.version().replace("-", ".") in pl_version_match
+    # 0.43.0-rc0 -> 0.43.0rc0
+    # 0.43.0-dev0 -> 0.43.0.dev0
+    is_rc_version = "rc" in pl_version_match
+    assert qml.version().replace("-", "" if is_rc_version else ".") in pl_version_match
     assert "Numpy version" in out
     assert "Scipy version" in out
     assert "default.qubit" in out


### PR DESCRIPTION
Our new nightly RC build workflow automatically updated v0.43.0's version to 0.43.0-rc0 (see [commit](https://github.com/PennyLaneAI/pennylane/commit/b4f1d80b40467756987993970ae57c80ba5537c5)). This is technically valid but the test failed as it thinks this is a `dev` prerelease and expects the wheels to be named `v0.43.0.rc0` and not `v0.43.0rc0`.

Quick fix to the test to work with the current version name.

[sc-100943]