### PR TITLE
Fix RC nightly build uploads

### DIFF
--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -7,9 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
+  setup-rc:
     name: Setup the release
     runs-on: ubuntu-24.04
+    outputs:
+      rc_branch: ${{ steps.check_rc.outputs.rc_branch }}
+      branch_exists: ${{ steps.check_rc.outputs.branch_exists }}
     steps:
     - name: Checkout PennyLane repo
       uses: actions/checkout@v4
@@ -29,15 +32,17 @@ jobs:
         pip install --upgrade setuptools        
 
     - name: Check for rc branch
+      id: check_rc
       run: |
         VERSION=$(python setup.py --version)
         IFS=. read MAJ MIN PAT <<< "${VERSION%-dev[0-9]*}"
         RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
-          echo "branch_exists=true" >> $GITHUB_ENV
-          echo "rc_branch=$RC_BRANCH" >> $GITHUB_ENV
+          echo "branch_exists=true" >> $GITHUB_OUTPUT
+          echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
+          echo "Found rc branch: $RC_BRANCH"
         else
-          echo "branch_exists=false" >> $GITHUB_ENV
+          echo "branch_exists=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Checkout PennyLane repo
@@ -50,7 +55,6 @@ jobs:
     - name: Bump rc version
       if: ${{ env.branch_exists == 'true' }}
       run: |
-        echo "rc_branch is ${{ env.rc_branch }}"
         python $GITHUB_WORKSPACE/.github/workflows/scripts/set_nightly_version_rc.py
         git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
         git config --global user.name "ringo-but-quantum"
@@ -70,23 +74,23 @@ jobs:
         name: rc-nightly-wheels
         path: ./dist/*.whl
 
-  upload:
+  upload-rc:
     name: Upload wheels to TestPyPI
-    needs: [setup]
+    needs: [setup-rc]
     runs-on: ubuntu-24.04
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
     - uses: actions/download-artifact@v4
-      if: ${{ env.branch_exists == 'true' }}
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
       with:
         name: rc-nightly-wheels
         path: dist
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: ${{ env.branch_exists == 'true' }}
+      if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
       with:
         repository-url: https://test.pypi.org/legacy/
         packages-dir: dist


### PR DESCRIPTION
**Context:**
RC nightly builds is not uploading to testpypi due to the current logic of the uploads.

**Description of the Change:**
Change logic of nightly build uploads to include the output from the previous job.

**Benefits:**
RC nightly builds get uploaded.

**Possible Drawbacks:**
None.
**Related GitHub Issues:**
