### PR TITLE
Support additional operators in `ParitySynth`

### DIFF
--- a/pennylane/compiler/python_compiler/compiler.py
+++ b/pennylane/compiler/python_compiler/compiler.py
@@ -55,7 +55,6 @@ class Compiler:
         xmod = parser.parse_module()
         pipeline = PassPipeline((ApplyTransformSequence(callback=callback),))
         pipeline.apply(ctx, xmod)
-        print(xmod)
         buffer = io.StringIO()
         Printer(stream=buffer, print_generic_format=True).print_op(xmod)
         with jaxContext() as jctx:

--- a/tests/python_compiler/conftest.py
+++ b/tests/python_compiler/conftest.py
@@ -56,6 +56,7 @@ def _run_filecheck_impl(program_str, pipeline=(), verify=False, roundtrip=False)
 
     pipeline = PassPipeline(pipeline)
     pipeline.apply(ctx, xdsl_module)
+    print(xdsl_module)
 
     if verify:
         xdsl_module.verify()


### PR DESCRIPTION
**Context:**
#8414 adds the `ParitySynth` compilation pass. It can only handle `CNOT` and `RZ` gates.

**Description of the Change:**
Add support for other operators that are effectively `RZ` rotations or a combination of `RZ` and `CNOT`s, as well as `GlobalPhase`:
- `PauliZ`
- `S`
- `T`
- `MultiRZ`
- `IsingZZ`
- `GlobalPhase`

**Benefits:**
Broader feature

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**

[sc-100929]