### PR TITLE
[Docs QA] Mudit's updates to documentation for the 0.43.0 release

### DIFF
--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -195,8 +195,8 @@
   {2: 1, 1: 1}
   ```
 
-* The `qml.specs` function now accepts a `compute_depth` keyword argument, which is set to `True` by default.
-  This makes the depth computation performed by `qml.specs` optional.
+* The :func:`~.specs` function now accepts a `compute_depth` keyword argument, which is set to `True` by default.
+  This makes the depth computation performed by :func:`~.specs` optional.
   [(#7998)](https://github.com/PennyLaneAI/pennylane/pull/7998)
   [(#8042)](https://github.com/PennyLaneAI/pennylane/pull/8042)
 

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -139,7 +139,7 @@
               with qml.allocate(1, state="any", restored=False) as new_qubit2:
                   m0 = qml.measure(new_qubit1[0], reset=True)
                   qml.cond(m0 == 1, qml.Z)(new_qubit2[0])
-                  qml.CNOT((0, new_qubit2))
+                  qml.CNOT((0, new_qubit2[0]))
 
       return qml.expval(qml.Z(0))
   ```

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -63,7 +63,8 @@
 
 <h4>Dynamic wire allocation 🎁</h4>
 
-* A `DynamicRegister` can no longer be used as an individual wire itself, as this led to confusing results.
+* A :class:`~pennylane.allocation.DynamicRegister` can no longer be used as an individual wire itself, as this led to confusing results.
+  [(#8151)](https://github.com/PennyLaneAI/pennylane/pull/8151)
 
 * Wires can now be dynamically allocated and deallocated in quantum functions with
   :func:`~.allocate` and :func:`~.deallocate`. These features unlock many important applications
@@ -72,7 +73,6 @@
   wire management.
 
   [(#7718)](https://github.com/PennyLaneAI/pennylane/pull/7718)
-  [(#8151)](https://github.com/PennyLaneAI/pennylane/pull/8151)
   [(#8163)](https://github.com/PennyLaneAI/pennylane/pull/8163)
   [(#8179)](https://github.com/PennyLaneAI/pennylane/pull/8179)
   [(#8198)](https://github.com/PennyLaneAI/pennylane/pull/8198)

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -462,47 +462,19 @@
 
   ```pycon
   >>> circuit.shots
-  Shots(total=1000)
+  Shots(total_shots=1000, shot_vector=(ShotCopies(1000 shots x 1),))
   >>> circuit()
   np.float64(-0.004)
   ```
 
-  Setting the `shots` value in a QNode is equivalent to decorating with :func:`qml.workflow.set_shots`. Note, however, that decorating with :func:`qml.workflow.set_shots` overrides QNode `shots`:
+  Setting the `shots` value in a QNode is equivalent to decorating with :func:`~.set_shots`. Note, however, that
+  decorating with :func:`~.set_shots` overrides QNode `shots`:
 
   ```pycon
   >>> new_circ = qml.set_shots(circuit, shots=123)
   >>> new_circ.shots
-  Shots(total=123)
+  Shots(total_shots=123, shot_vector=(ShotCopies(123 shots x 1),))
   ```
-
-* PennyLane `autograph` supports standard python for updating arrays like `array[i] += x` instead of jax `arr.at[i].add(x)`.
-  Users can now use this when designing quantum circuits with experimental program capture enabled.
-
-  ```python
-  import pennylane as qml
-  import jax.numpy as jnp
-
-  qml.capture.enable()
-
-  @qml.qnode(qml.device("default.qubit", wires=3))
-  def circuit(val):
-    angles = jnp.zeros(3)
-    angles[0:3] += val
-
-    for i, angle in enumerate(angles):
-        qml.RX(angle, i)
-
-    return qml.expval(qml.Z(0)), qml.expval(qml.Z(1)), qml.expval(qml.Z(2))
-  ```
-
-  ```pycon
-  >>> circuit(jnp.pi)
-  (Array(-1, dtype=float32),
-   Array(-1, dtype=float32),
-   Array(-1, dtype=float32))
-  ```
-
-  [(#8076)](https://github.com/PennyLaneAI/pennylane/pull/8076)
 
 <h4>Clifford+T decomposition</h4>
 
@@ -619,6 +591,35 @@
   ```
 
 <h4>Other improvements</h4>
+
+* PennyLane `autograph` supports standard python for updating arrays like `array[i] += x` instead of jax `arr.at[i].add(x)`.
+  Users can now use this when designing quantum circuits with experimental program capture enabled.
+
+  ```python
+  import pennylane as qml
+  import jax.numpy as jnp
+
+  qml.capture.enable()
+
+  @qml.qnode(qml.device("default.qubit", wires=3))
+  def circuit(val):
+    angles = jnp.zeros(3)
+    angles[0:3] += val
+
+    for i, angle in enumerate(angles):
+        qml.RX(angle, i)
+
+    return qml.expval(qml.Z(0)), qml.expval(qml.Z(1)), qml.expval(qml.Z(2))
+  ```
+
+  ```pycon
+  >>> circuit(jnp.pi)
+  (Array(-1, dtype=float32),
+   Array(-1, dtype=float32),
+   Array(-1, dtype=float32))
+  ```
+
+  [(#8076)](https://github.com/PennyLaneAI/pennylane/pull/8076)
 
 * Make the user warning of :class:`~.decomposition.decomposition_graph.DecompositionGraph` more generic.
   [(#8361)](https://github.com/PennyLaneAI/pennylane/pull/8361)

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -367,9 +367,6 @@
   no or single :class:`~.PhaseShift` gate is required in case the matrix has a determinant :math:`\pm 1`.
   [(#7765)](https://github.com/PennyLaneAI/pennylane/pull/7765)
 
-* :func:`.transforms.decompose` and :func:`.preprocess.decompose` now have a unified internal implementation.
-  [(#8193)](https://github.com/PennyLaneAI/pennylane/pull/8193)
-
 * The :func:`~.transforms.decompose` transform is now able to decompose classically controlled operations.
   [(#8145)](https://github.com/PennyLaneAI/pennylane/pull/8145)
 
@@ -1180,6 +1177,9 @@
   [(#8266)](https://github.com/PennyLaneAI/pennylane/pull/8266)
 
 <h3>Internal changes ⚙️</h3>
+
+* :func:`.transforms.decompose` and :func:`.preprocess.decompose` now have a unified internal implementation.
+  [(#8193)](https://github.com/PennyLaneAI/pennylane/pull/8193)
 
 * GitHub actions and workflows (`interface-unit-tests.yml`, `tests-labs.yml`, `unit-test.yml`, `upload-nightly-release.yml` and `upload.yml`) have been updated to 
   use `ubuntu-24.04` runners. 

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -185,12 +185,14 @@
   print(qml.specs(circuit, level="device")()["resources"])
   ```
   ```
-  Resources(num_wires=2,
-            num_gates=2,
-            gate_types=defaultdict(<class 'int'>, {'CNOT': 1, 'Hadamard': 1}),
-            gate_sizes=defaultdict(<class 'int'>, {2: 1, 1: 1}),
-            depth=2,
-            shots=Shots(total_shots=None, shot_vector=()))
+  num_wires: 2
+  num_gates: 2
+  depth: 2
+  shots: Shots(total=None)
+  gate_types:
+  {'CNOT': 1, 'Hadamard': 1}
+  gate_sizes:
+  {2: 1, 1: 1}
   ```
 
 * The `qml.specs` function now accepts a `compute_depth` keyword argument, which is set to `True` by default.


### PR DESCRIPTION
* Updates to the release notes for dynamic qubit allocation
  * Update code example that was using a dynamic register as a wire label
* Updates to the release notes for `qml.specs` with Catalyst
  * Output of code example was slightly different to what I observed locally
* Updates to the "Specifying shots" section
  * Update code examples for which the `Shots` object wasn't displaying the shot vector
  * There was an entry about autograph under this section, so I moved it to "Other improvements".
* Moved the changelog entry for parity between `transforms.decompose` and `preprocess.decompose` from the "other improvements" to the "internal changes" section.