### PR TITLE
[v0.43 release] strip `-rcX` suffix from version in preparation for release

### DIFF
--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.43.0-rc7"
+__version__ = "0.43.0"


### PR DESCRIPTION
Normally, this happens once the RC branch is created but this release we kept changing the _version.py as we are uploading nightly to TestPyPI. 

Therefore, we hit some issues during Catalyst release and we need to manually strip the rc suffix. See story for more details.

[sc-101352]