### PR TITLE
[v0.43 release] bump catalyst and lightning versions to new release

### DIFF
--- a/.github/stable/external.txt
+++ b/.github/stable/external.txt
@@ -135,9 +135,9 @@ pandocfilters==1.5.1
 parso==0.8.5
 pathspec==0.12.1
 PennyLane-qiskit @ git+https://github.com/PennyLaneAI/pennylane-qiskit.git@12dacf9a867f17b05b26b6d78ef8f9c7987713cb
-pennylane_catalyst==0.13.0.dev60
-pennylane_lightning==0.43.0.dev36
-pennylane_lightning_kokkos==0.43.0.dev36
+pennylane_catalyst==0.13.0
+pennylane_lightning==0.43.0
+pennylane_lightning_kokkos==0.43.0
 pexpect==4.9.0
 pillow==11.3.0
 platformdirs==4.4.0

--- a/pennylane/compiler/compiler.py
+++ b/pennylane/compiler/compiler.py
@@ -24,7 +24,7 @@ from packaging.version import Version
 
 from pennylane.exceptions import CompileError
 
-PL_CATALYST_MIN_VERSION = Version("0.12.0")
+PL_CATALYST_MIN_VERSION = Version("0.13.0")
 
 
 @dataclasses.dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "appdirs",
     "autoray==0.8.0",
     "cachetools",
-    "pennylane-lightning>=0.42",
+    "pennylane-lightning>=0.43",
     "requests",
     "tomlkit",
     "typing_extensions",


### PR DESCRIPTION
Same PR as last time https://github.com/PennyLaneAI/pennylane/pull/7869

Correct versions are being pulled in,
```
2025-10-15T17:09:48.0266778Z  + pennylane==0.43.0 (from file:///home/runner/work/pennylane/pennylane/dist/pennylane-0.43.0-py3-none-any.whl)
2025-10-15T17:09:48.0267138Z  + pennylane-lightning==0.43.0
```

[sc-101519]