### PR TITLE
add `python -m` to the `format.yml` execution

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Run Pylint (source files)
         if: always()
-        run: pylint --rcfile .pylintrc $(find pennylane -name "*.py")
+        run: python -m pylint --rcfile .pylintrc $(find pennylane -name "*.py")
 
       - name: Run Pylint (test files)
         if: always()
-        run: pylint --rcfile tests/.pylintrc $(find tests -name "*.py")
+        run: python -m pylint --rcfile tests/.pylintrc $(find tests -name "*.py")


### PR DESCRIPTION
This should help fix the issue where CI will randomly fail with black-pylint job.

[sc-102081]