### PR TITLE
Remove redundant asserts that are too strict for `test_finite_shot_multiple_measurements`

### DIFF
--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -895,7 +895,6 @@ class TestShotsIntegration:
         expected_g = 2 * np.cos(0.5) * np.sin(0.5)
         assert qml.math.allclose(g, expected_g, atol=1 / qml.math.sqrt(shots), rtol=0.03)
 
-    @pytest.mark.xfail(reason="Test under investigation (tracked in sc-101768)", strict=False)
     @pytest.mark.parametrize("shots", [10000, 10005])
     def test_finite_shot_multiple_measurements(self, interface, shots, seed):
         """Test jax-jit can work with shot vectors and returns correct shapes."""


### PR DESCRIPTION
**Context:**
Line 917 has already checked once `res` with reasonable tolerance, roughly 4 sigma acceptance. Somehow we wrote redundant separate component-wise check right afterwards, which is apparently too much for such a sanity check.

Specifically, the fourth assert at original line 922 caused ~4% chance to fail as false positivity.

**Description of the Change:**
Delete the third and fourth asserts, which are redundant in this context.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-101768]