### PR TITLE
Skip three dataload tests

### DIFF
--- a/tests/data/attributes/operator/test_operator.py
+++ b/tests/data/attributes/operator/test_operator.py
@@ -243,7 +243,9 @@ def test_value_init_not_supported():
         DatasetOperator(NotSupported(1))
 
 
-@pytest.mark.skip(reason="Integration test requiring network access to cloud.pennylane.ai to download datasets - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869.")
+@pytest.mark.skip(
+    reason="Integration test requiring network access to cloud.pennylane.ai to download datasets - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869."
+)
 def test_retrieve_operator_from_loaded_data():
     """Test that uploaded data can be downloaded and used to retrieve an
     operation representing the Hamiltonian"""

--- a/tests/data/data_manager/test_graphql.py
+++ b/tests/data/data_manager/test_graphql.py
@@ -19,7 +19,9 @@ class TestGetGraphql:
         }
         """
 
-    @pytest.mark.skip(reason="Integration test requiring network access to cloud.pennylane.ai - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869.")
+    @pytest.mark.skip(
+        reason="Integration test requiring network access to cloud.pennylane.ai - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869."
+    )
     def test_return_json(self):
         """Tests that a dictionary representation of a json response is returned for a
         valid query and url."""
@@ -38,7 +40,9 @@ class TestGetGraphql:
                 self.query,
             )
 
-    @pytest.mark.skip(reason="Integration test requiring network access to cloud.pennylane.ai - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869.")
+    @pytest.mark.skip(
+        reason="Integration test requiring network access to cloud.pennylane.ai - prone to timeouts in CI/offline environments. Should be taken care of by mocking sc-101869."
+    )
     def test_bad_query(self):
         """Tests that a ``HTTPError`` is returned for a invalid query and valid url."""
 


### PR DESCRIPTION
**Context:**
The following tests in data module:

 - tests/data/data_manager/test_graphql.py::TestGetGraphql::test_return_json
 - tests/data/data_manager/test_graphql.py::TestGetGraphql::test_bad_query
 - tests/data/attributes/operator/test_operator.py::test_retrieve_operator_from_loaded_data

require internet connection thus prone to 3rd party server **instability** (For instance, the AWS outage on 20th Oct 2025).

**Description of the Change:**
Skipped them

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-101870]