### PR TITLE
Small doc fixes

### DIFF
--- a/doc/introduction/compiling_circuits.rst
+++ b/doc/introduction/compiling_circuits.rst
@@ -38,7 +38,6 @@ other PennyLane objects.
     ~pennylane.transforms.cancel_inverses
     ~pennylane.transforms.commute_controlled
     ~pennylane.transforms.merge_amplitude_embedding
-    ~pennylane.transforms.cancel_inverses
     ~pennylane.transforms.merge_rotations
     ~pennylane.transforms.pattern_matching
     ~pennylane.transforms.remove_barrier


### PR DESCRIPTION
Remove a rogue period and a duplicate entry of the `cancel_inverses` transform.