### PR TITLE
Update documentation of GlobalPhase

### DIFF
--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -292,21 +292,6 @@ class GlobalPhase(Operation):
     array([0.        +0.j        , 0.        +0.j        ,
             0.99244503-0.12269009j, 0.        +0.j        ])
 
-    The operator can be applied with a control to create a relative phase between terms:
-
-    .. code-block:: python
-
-        dev = qml.device("default.qubit")
-
-        @qml.qnode(dev)
-        def circuit():
-            qml.Hadamard(0)
-            qml.ctrl(qml.GlobalPhase(0.123), 0)
-            return qml.state()
-
-    >>> circuit()
-    array([0.70710678+0.j        , 0.70176461-0.08675499j])
-
 
     """
 


### PR DESCRIPTION
**Context:**
The existence of a controlled global phase is an inevitable intermediate product of decompositions, but the concept is confusing, since the control makes the "global phase" not "global" anymore. The user shouldn't be explicitly creating a controlled global phase. We cannot disallow it because that would break decompositions, but we should at least stop advertising it.

**Description of the Change:**
Removes section in the `GlobalPhase` docstring about controlling a `GloablPhase`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-101986]
