### PR TITLE
correct measurement class checking in `test_postselection_valid_finite_shots`

### DIFF
--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -1887,7 +1887,7 @@ class TestPostselection:
         if use_jit and (interface != "jax" or isinstance(shots, tuple)):
             pytest.skip("Cannot JIT in non-JAX interfaces, or with shot vectors.")
 
-        if isinstance(mp, qml.measurements.ClassicalShadowMP):
+        if isinstance(mp, qml.measurements.ShadowExpvalMP):
             mp.seed = seed
 
         dev = qml.device("default.qubit", seed=seed)


### PR DESCRIPTION
**Context:**
This test has been failing at `mp3` which is the shadow expval mutliple times recently:
https://github.com/PennyLaneAI/pennylane/actions/runs/18726379668/job/53412214707
https://github.com/PennyLaneAI/pennylane/actions/runs/18724107467/job/53404180364?pr=8502
After debugging we found that it's because the mp seeding branch has been checking with a wrong class all the time.

Due to this incorrection, this checking branch was never visited, and the seeding was never effective as well.

**Description of the Change:**
Correction: `ClassicalShadowMP` -> `ShadowExpvalMP`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-102080]