### PR TITLE
shuffle seed in integration test

### DIFF
--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -251,7 +251,7 @@ class TestComparison:
         ]
 
         layers = 3
-        # Avoid seed 1968 until https://github.com/Qiskit/qiskit/issues/15278 is fixed.
+        # Avoid seed 1967 until https://github.com/Qiskit/qiskit/issues/15278 is fixed.
         rng = pnp.random.default_rng(1968)
         gates_per_layers = [rng.permutation(gates).numpy() for _ in range(layers)]
 


### PR DESCRIPTION
This specific seed creates an unlucky circuit that uncovers a bug in Qiskit (https://github.com/Qiskit/qiskit/issues/15278). 

This was discovered through the [CI integration tests](https://github.com/PennyLaneAI/pennylane-qiskit/actions/runs/18943694524/job/54088966569?pr=666) in a PL-Qiskit PR that updates Qiskit eco-system dependencies. A X-FAIL'd regression test was added to the PR to cover the MWE failing edge case to ensure the upstream fix is captured.

Shuffling the seed in PL ensures we don't lose said test coverage and don't need to add any patching xfail's

[sc-102708]