### PR TITLE
fix `test_simple_circuit_execution`

### DIFF
--- a/tests/capture/test_capture_mid_measure.py
+++ b/tests/capture/test_capture_mid_measure.py
@@ -355,7 +355,7 @@ class TestMidMeasureExecute:
                     std_sample_avg = qml.math.sqrt(p_plus * p_minus / shots)
                     atol = 3 * std_sample_avg
                     assert qml.math.allclose(sample_expected_avg, expected_avg, atol=atol, rtol=0)
-            else:  # qml.expval, qml.var, qml.sample, qml.probs
+            else:  # qml.expval, qml.var, qml.probs
                 assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
         else:
             assert compare_with_capture_disabled(f, phi)


### PR DESCRIPTION
**Context:**
Validate a binary samples with number checking the plus and minus using the same universal threshold is dangerous: the variance of a binomial dist is fully determined by the probs:
$$Var = N p (1-p)$$
Therefore when checking a binary sampling list we better take into consideration its dependency over circuit parameter, which is the `phi` in the test of interest here.

**Description of the Change:**
0. Direct if branch for sampling case
1. Merge those repeating branches into the `else:`
2. Refine the sampling validation by checking the average instead of checking ones or minus with the same tolerance; tolerance is revised by carefully considering their std

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95723]