### PR TITLE
Install latest lightning in external CI job

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -496,7 +496,7 @@ jobs:
         git+https://github.com/xdslproject/xdsl-jax.git@main
         ${{ needs.default-dependency-versions.outputs.catalyst-nightly }}
         ${{ inputs.additional_python_packages }}
-
+      additional_pip_packages_post: ${{ needs.default-dependency-versions.outputs.pennylane-lightning-latest }}
       requirements_file: ${{ github.event_name == 'schedule' && strategy.job-index == 0 && 'external.txt' || '' }}
 
 


### PR DESCRIPTION
**Context:** We need to be able to coordinate changes between PL and Lightning. This is hard when tests are run against stable Lightning in PL's CI. 

**Description of the Change:** Install latest Lightning in PL CI.

**Benefits:** We can now test our functionality against the latest features in Lightning.

**Possible Drawbacks:** N/A
