### PR TITLE
fix a patter match problem induced by xdsl version update

### DIFF
--- a/tests/python_compiler/dialects/test_stablehlo_dialect.py
+++ b/tests/python_compiler/dialects/test_stablehlo_dialect.py
@@ -206,7 +206,7 @@ def test_invalid_ir_type_mismatch(run_filecheck):
     %cos = "stablehlo.cosine"(%ti32) : (tensor<2x3xi32>) -> tensor<2x3xi32>
     """
 
-    with pytest.raises(Exception, match="operand at position 0 does not verify"):
+    with pytest.raises(Exception, match="'operand' at position 0 does not verify"):
         run_filecheck(program, roundtrip=True, verify=True)
 
 


### PR DESCRIPTION
**Context:**
xdsl 0.55.0 would raise a different error format that we are matching against in `tests/python_compiler/dialects/test_stablehlo_dialect.py`

**Description of the Change:**
fix the format 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
