### PR TITLE
chore: merge v0.43.1 bug fix back into `main`

### DIFF
--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -5,6 +5,8 @@ This page contains the release notes for PennyLane.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.43.1.md
+
 .. mdinclude:: ../releases/changelog-0.43.0.md
 
 .. mdinclude:: ../releases/changelog-0.42.3.md

--- a/doc/releases/changelog-0.43.0.md
+++ b/doc/releases/changelog-0.43.0.md
@@ -1,5 +1,5 @@
 
-# Release 0.43.0 (current release)
+# Release 0.43.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.43.1.md
+++ b/doc/releases/changelog-0.43.1.md
@@ -1,0 +1,16 @@
+
+# Release 0.43.1 (current release)
+
+<h3>Bug fixes 🐛</h3>
+
+* Fixed a bug in the output of :func:`~pennylane.to_openqasm`, where the `creg` declaration for mid-circuit measurements was missing 
+  a semicolon and leading to invalid QASM.
+  [(#8556)](https://github.com/PennyLaneAI/pennylane/pull/8556)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Yushao Chen,
+Marcus Edwards,
+Nate Stemen.


### PR DESCRIPTION
**Context:**
GH has trouble correctly recognizing the commits that are supposed to be new from the BF branch. Hence here we manually created a PR to merge

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
