### PR TITLE
Create alias for qre.Hadamard and qre.Identity

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,5 +1,7 @@
 # Release 0.44.0-dev (development release)
 
+* The `qre.H` and `qre.I` aliases have been added for `qre.Hadamard` and `qre.Identity` respectively. These provide convenient shorthand for frequently used resource operators.
+
 <h3>New features since last release</h3>
 
 * A new decomposition has been added for the Controlled :class:`~.SemiAdder`,
@@ -450,6 +452,7 @@ Yushao Chen,
 Marcus Edwards,
 Lillian Frederiksen,
 Sengthai Heng,
+Austin Huang,
 Soran Jahangiri,
 Christina Lee,
 Joseph Lee,

--- a/pennylane/estimator/__init__.py
+++ b/pennylane/estimator/__init__.py
@@ -29,7 +29,7 @@ from .resource_operator import (
 
 from .estimate import estimate
 
-from .ops.identity import Identity, GlobalPhase
+from .ops.identity import Identity, I, GlobalPhase
 
 from .ops.qubit import (
     X,
@@ -37,6 +37,7 @@ from .ops.qubit import (
     Z,
     SWAP,
     Hadamard,
+    H,
     S,
     T,
     PhaseShift,

--- a/pennylane/estimator/ops/__init__.py
+++ b/pennylane/estimator/ops/__init__.py
@@ -17,6 +17,7 @@ from .identity import GlobalPhase, Identity
 
 from .qubit import (
     Hadamard,
+    H,
     S,
     SWAP,
     T,

--- a/pennylane/estimator/ops/identity.py
+++ b/pennylane/estimator/ops/identity.py
@@ -158,7 +158,7 @@ Resource class for the Identity gate.
 .. seealso:: The equivalent long-form alias :class:`~.Identity`
 
 Args:
-    wires (Iterable[Any] | None): wire label(s) that the identity acts on
+    wires (WiresLike | None): wire label(s) that the identity acts on
 
 Resources:
     The Identity gate does not require any resources and thus it cannot be decomposed

--- a/pennylane/estimator/ops/identity.py
+++ b/pennylane/estimator/ops/identity.py
@@ -151,6 +151,21 @@ class Identity(ResourceOperator):
         return [GateCount(cls.resource_rep())]
 
 
+I = Identity
+r"""Identity(wires)
+Resource class for the Identity gate.
+
+.. seealso:: The equivalent long-form alias :class:`~.Identity`
+
+Args:
+    wires (Iterable[Any] | None): wire label(s) that the identity acts on
+
+Resources:
+    The Identity gate does not require any resources and thus it cannot be decomposed
+    further. Requesting the resources of this gate returns an empty list.
+"""
+
+
 class GlobalPhase(ResourceOperator):
     r"""Resource class for the GlobalPhase gate.
 

--- a/pennylane/estimator/ops/qubit/__init__.py
+++ b/pennylane/estimator/ops/qubit/__init__.py
@@ -15,6 +15,7 @@ r"""This module contains experimental resource estimation functionality."""
 
 from .non_parametric_ops import (
     Hadamard,
+    H,
     S,
     T,
     X,

--- a/pennylane/estimator/ops/qubit/non_parametric_ops.py
+++ b/pennylane/estimator/ops/qubit/non_parametric_ops.py
@@ -193,7 +193,7 @@ Resource class for the Hadamard gate.
 .. seealso:: The equivalent long-form alias :class:`~.Hadamard`
 
 Args:
-    wires (Sequence[int] | int | None): the wire the operation acts on
+    wires (WiresLike | int | None): the wire the operation acts on
 
 Resources:
     The Hadamard gate is treated as a fundamental gate and thus it cannot be decomposed

--- a/pennylane/estimator/ops/qubit/non_parametric_ops.py
+++ b/pennylane/estimator/ops/qubit/non_parametric_ops.py
@@ -186,6 +186,22 @@ class Hadamard(ResourceOperator):
         return [GateCount(cls.resource_rep())]
 
 
+H = Hadamard
+r"""Hadamard(wires)
+Resource class for the Hadamard gate.
+
+.. seealso:: The equivalent long-form alias :class:`~.Hadamard`
+
+Args:
+    wires (Sequence[int] | int | None): the wire the operation acts on
+
+Resources:
+    The Hadamard gate is treated as a fundamental gate and thus it cannot be decomposed
+    further. Requesting the resources of this gate raises a :class:`~.pennylane.exceptions.ResourcesUndefinedError` error.
+
+"""
+
+
 class S(ResourceOperator):
     r"""Resource class for the S-gate.
 

--- a/tests/estimator/ops/test_estimator_identity.py
+++ b/tests/estimator/ops/test_estimator_identity.py
@@ -93,6 +93,10 @@ class TestIdentity:
         op = Identity(0)
         assert op.pow_resource_decomp(z) == expected_res
 
+    def test_alias_I(self):
+        """Test that qre.I is an alias for Identity."""
+        assert qre.I is Identity
+
 
 class TestGlobalPhase:
     """Test ResourceGlobalPhase"""

--- a/tests/estimator/ops/test_estimator_non_parameteric.py
+++ b/tests/estimator/ops/test_estimator_non_parameteric.py
@@ -118,6 +118,10 @@ class TestHadamard:
         op = Hadamard(0)
         assert op.pow_resource_decomp(z) == expected_res
 
+    def test_alias_H(self):
+        """Test that qre.H is an alias for Hadamard."""
+        assert qre.H is Hadamard
+
 
 class TestSWAP:
     """Tests for SWAP resource operator"""


### PR DESCRIPTION
**Context:**
It would be nice to have aliases for Hadamard and Identity e.g. qre.H, qre.I

**Description of the Change:**
Adds these as aliases.

**Benefits:**
Syntactic sugar

**Possible Drawbacks:**
None

**Related GitHub Issues:**
[sc-100771]
