### PR TITLE
Fixing tag refs for Release Automation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name:
+name: Create Release
 on:
   workflow_dispatch:
     inputs:
@@ -110,7 +110,7 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git tag -a "${{ inputs.release_branch }}" -m "Release version ${{ inputs.release_branch }}"
-          git push origin "${{ inputs.release_branch }}"
+          git push origin "refs/tags/${{ inputs.release_branch }}"
 
       - name: Merge RC branch into master
         run: |


### PR DESCRIPTION
**Context:**
The last step release automation has a bug that [prevents it from uploading the tag for the rc branch](https://github.com/PennyLaneAI/pennylane/actions/runs/19480175172/job/55750110025#step:3:12) because the tag is the same name as the branch.

**Description of the Change:**
Specifying `tag` when pushing the branch tag.

**Benefits:**
Branch tag gets pushed.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/pennylane/pull/8352