### PR TITLE
Bump torch version to 2.9.0 for GPU

### DIFF
--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TORCH_VERSION: 2.5.1
+  TORCH_VERSION: 2.9.0
 
 jobs:
   gpu-tests:


### PR DESCRIPTION
**Context:**
GPU CI for 3.14 can't find the torch 2.5.1: https://github.com/PennyLaneAI/pennylane/actions/runs/20079719756/job/57603421446

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-105565]