### PR TITLE
Add a function to return the VSCF rotation matrix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -354,7 +354,7 @@
   - :class:`~.SWAP`, :class:`~.ISWAP`, :class:`~.SISWAP`
   - :class:`~.CY`, :class:`~.CZ`, :class:`~.CSWAP`, :class:`~.CNOT`, :class:`~.Toffoli`
 
-* New function `~pennylane.qchem.vscf_rot_mats` has been added for computing VSCF rotation matrices.
+* New function `~pennylane.qchem.vscf_rotations` has been added for computing VSCF rotation matrices.
   [(#8784)](https://github.com/PennyLaneAI/pennylane/pull/8784)
 
 <h3>Breaking changes 💔</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -354,6 +354,9 @@
   - :class:`~.SWAP`, :class:`~.ISWAP`, :class:`~.SISWAP`
   - :class:`~.CY`, :class:`~.CZ`, :class:`~.CSWAP`, :class:`~.CNOT`, :class:`~.Toffoli`
 
+* New function `~pennylane.qchem.vscf_rot_mats` has been added for computing VSCF rotation matrices.
+  [(#8784)](https://github.com/PennyLaneAI/pennylane/pull/8784)
+
 <h3>Breaking changes 💔</h3>
 
 * The output format of `qml.specs` has been restructured into a dataclass to streamline the outputs.

--- a/pennylane/qchem/__init__.py
+++ b/pennylane/qchem/__init__.py
@@ -97,5 +97,5 @@ from .vibrational import (
     taylor_hamiltonian,
     vibrational_pes,
     vscf_integrals,
-    vscf_rot_mats,
+    vscf_rotations,
 )

--- a/pennylane/qchem/__init__.py
+++ b/pennylane/qchem/__init__.py
@@ -97,4 +97,5 @@ from .vibrational import (
     taylor_hamiltonian,
     vibrational_pes,
     vscf_integrals,
+    vscf_rot_mats,
 )

--- a/pennylane/qchem/vibrational/__init__.py
+++ b/pennylane/qchem/vibrational/__init__.py
@@ -21,4 +21,4 @@ from .localize_modes import localize_normal_modes
 from .pes_generator import vibrational_pes
 from .taylor_ham import taylor_bosonic, taylor_coeffs, taylor_dipole_coeffs, taylor_hamiltonian
 from .vibrational_class import VibrationalPES, optimize_geometry
-from .vscf import vscf_integrals, vscf_rot_mats
+from .vscf import vscf_integrals, vscf_rotations

--- a/pennylane/qchem/vibrational/__init__.py
+++ b/pennylane/qchem/vibrational/__init__.py
@@ -21,4 +21,4 @@ from .localize_modes import localize_normal_modes
 from .pes_generator import vibrational_pes
 from .taylor_ham import taylor_bosonic, taylor_coeffs, taylor_dipole_coeffs, taylor_hamiltonian
 from .vibrational_class import VibrationalPES, optimize_geometry
-from .vscf import vscf_integrals
+from .vscf import vscf_integrals, vscf_rot_mats

--- a/pennylane/qchem/vibrational/vscf.py
+++ b/pennylane/qchem/vibrational/vscf.py
@@ -409,9 +409,7 @@ def vscf_rot_mats(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
     [ 0.07886101 -0.62241373  0.27864235 -0.72714547]]
 
     """
-    nmodes = np.shape(h_integrals[0])[0]
-
-    imax = np.shape(h_integrals[0])[1]
+    nmodes, imax = np.shape(h_integrals[0])[0:2]
     max_modals = nmodes * [imax]
     if modals is None:
         modals = max_modals
@@ -420,13 +418,13 @@ def vscf_rot_mats(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
             raise ValueError(
                 "Number of maximum modals cannot be greater than the modals for unrotated integrals."
             )
-        imax = np.max(modals)
 
     if cutoff is None:
         max_val = np.max([np.max(np.abs(H)) for H in h_integrals])
         cutoff = max_val * cutoff_ratio
 
     _, mode_rots = _vscf(h_integrals, modals=modals, cutoff=cutoff)
+
     return mode_rots
 
 
@@ -508,7 +506,18 @@ def vscf_integrals(h_integrals, d_integrals=None, modals=None, cutoff=None, cuto
                 f"Building n-mode dipole is not implemented for n equal to {len(d_integrals)}."
             )
 
-    mode_rots = vscf_rot_mats(h_integrals, modals, cutoff, cutoff_ratio)
+    nmodes, imax = np.shape(h_integrals[0])[0:2]
+    max_modals = nmodes * [imax]
+    mode_rots = vscf_rot_mats(h_integrals, max_modals, cutoff, cutoff_ratio)
+
+    if modals is None:
+        modals = max_modals
+    else:
+        if np.max(modals) > imax:
+            raise ValueError(
+                "Number of maximum modals cannot be greater than the modals for unrotated integrals."
+            )
+
     h_data = _rotate_hamiltonian(h_integrals, mode_rots, modals)
 
     if d_integrals is not None:

--- a/pennylane/qchem/vibrational/vscf.py
+++ b/pennylane/qchem/vibrational/vscf.py
@@ -484,3 +484,63 @@ def vscf_integrals(h_integrals, d_integrals=None, modals=None, cutoff=None, cuto
         return h_data, dip_data
 
     return h_data, None
+
+
+def rot_matrix(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
+    r"""Generates VSCF rotation matrix.
+
+
+    Args:
+        h_integrals (list[TensorLike[float]]): List of Hamiltonian integrals for up to 3 coupled vibrational modes.
+            Look at the Usage Details for more information.
+        modals (list[int]): list containing the maximum number of modals to consider for each vibrational mode.
+            Default value is the maximum number of modals.
+        cutoff (float): threshold value for including matrix elements into operator
+        cutoff_ratio (float): ratio for discarding elements with respect to biggest element in the integrals.
+            Default value is ``1e-6``.
+
+    Returns:
+        TensorLike[float]: VSCF rotation matrix
+
+    *Example*
+
+    >>> from pennylane.labs.trotter_error.realspace import HOState
+    >>> symbols, charge  = ['H', 'H'], 0
+    >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    >>> mol = qml.qchem.Molecule(symbols, geometry, charge=charge)
+    >>> pes = vibrational_pes(mol, n_points=3, backend='cf_threadpool', cubic=True)
+    >>> h_integrals = christiansen_integrals(pes, n_states=n_states, cubic=False, backend="cf_threadpool")
+    >>> mode_rots = rot_matrix(h_integrals)
+    >>> states_harm = [HOState(1, len_state, {(i,): 1}) for i in range(n_states)]  # harmonic oscillator states
+    >>> states_vscf = []
+    >>> for i in range(n_states):
+    >>>     state = sum((states_harm[j] * mode_rots[j, i] for j in range(n_states)), HOState.zero_state(1, len_state))
+    >>>     states_vscf.append(state)
+    >>> print(states_vscf[0])
+    HOState(modes=1, gridpoints=3, <Compressed Sparse Row sparse array of dtype 'float64'
+        with 1 stored elements and shape (9, 1)>
+      Coords	Values
+      (0, 0)	1)
+    """
+
+    # h_integrals = [h_integrals]
+    nmodes = np.shape(h_integrals[0])[0]
+
+    imax = np.shape(h_integrals[0])[1]
+    max_modals = nmodes * [imax]
+    if modals is None:
+        modals = max_modals
+    else:
+        if np.max(modals) > imax:
+            raise ValueError(
+                "Number of maximum modals cannot be greater than the modals for unrotated integrals."
+            )
+        imax = np.max(modals)
+
+    if cutoff is None:
+        max_val = np.max([np.max(np.abs(H)) for H in h_integrals])
+        cutoff = max_val * cutoff_ratio
+
+    _, mode_rots = _vscf(h_integrals, modals=max_modals, cutoff=cutoff)
+
+    return mode_rots[0]

--- a/pennylane/qchem/vibrational/vscf.py
+++ b/pennylane/qchem/vibrational/vscf.py
@@ -15,6 +15,8 @@
 
 import numpy as np
 
+from pennylane.typing import TensorLike
+
 # pylint: disable=too-many-arguments, too-many-positional-arguments
 
 
@@ -380,7 +382,12 @@ def _rotate_hamiltonian(h_integrals, mode_rots, modals):
     return h_data
 
 
-def vscf_rotations(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
+def vscf_rotations(
+    h_integrals: list[TensorLike],
+    modals: list[int] | None = None,
+    cutoff: float | None = None,
+    cutoff_ratio: float = 1e-6,
+) -> list[TensorLike]:
     r"""Generates the vibrational self-consistent field rotation matrices.
 
     This functions generates the matrices :math:`U` for each vibrational mode
@@ -431,6 +438,10 @@ def vscf_rotations(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
     if modals is None:
         modals = max_modals
     else:
+        if len(modals) != nmodes:
+            raise ValueError(
+                "Number of maximum modals must be a list of length equal to the number of modes."
+            )
         if np.max(modals) > imax:
             raise ValueError(
                 "Number of maximum modals cannot be greater than the modals for unrotated integrals."

--- a/pennylane/qchem/vibrational/vscf.py
+++ b/pennylane/qchem/vibrational/vscf.py
@@ -380,7 +380,7 @@ def _rotate_hamiltonian(h_integrals, mode_rots, modals):
     return h_data
 
 
-def vscf_rot_mats(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
+def vscf_rotations(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
     r"""Generates the VSCF rotation matrices.
 
     Args:
@@ -399,9 +399,13 @@ def vscf_rot_mats(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
     >>> symbols, charge  = ['H', 'H'], 0
     >>> geometry = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     >>> mol = qml.qchem.Molecule(symbols, geometry, charge=charge)
-    >>> pes = qml.qchem.vibrational_pes(mol, n_points=3, backend='cf_threadpool', cubic=True)
-    >>> h_integrals = qml.qchem.christiansen_integrals(pes, n_states=4, cubic=False, backend="cf_threadpool")
-    >>> mode_rots = qml.qchem.vscf_rot_mats(h_integrals)
+    >>> pes = qml.qchem.vibrational_pes(
+    ...     mol, n_points=3, backend='cf_threadpool', cubic=True
+    ... )
+    >>> h_integrals = qml.qchem.christiansen_integrals(
+    ...     pes, n_states=4, cubic=False, backend="cf_threadpool"
+    ... )
+    >>> mode_rots = qml.qchem.vscf_rotations(h_integrals)
     >>> print(mode_rots[0])
     [[ 0.98366824  0.17314139 -0.01438041 -0.04703255]
     [ 0.16168107 -0.74327452 -0.0123072   0.64903833]
@@ -508,7 +512,7 @@ def vscf_integrals(h_integrals, d_integrals=None, modals=None, cutoff=None, cuto
 
     nmodes, imax = np.shape(h_integrals[0])[0:2]
     max_modals = nmodes * [imax]
-    mode_rots = vscf_rot_mats(h_integrals, max_modals, cutoff, cutoff_ratio)
+    mode_rots = vscf_rotations(h_integrals, max_modals, cutoff, cutoff_ratio)
 
     if modals is None:
         modals = max_modals

--- a/pennylane/qchem/vibrational/vscf.py
+++ b/pennylane/qchem/vibrational/vscf.py
@@ -381,7 +381,20 @@ def _rotate_hamiltonian(h_integrals, mode_rots, modals):
 
 
 def vscf_rotations(h_integrals, modals=None, cutoff=None, cutoff_ratio=1e-6):
-    r"""Generates the VSCF rotation matrices.
+    r"""Generates the vibrational self-consistent field rotation matrices.
+
+    This functions generates the matrices :math:`U` for each vibrational mode
+    that transforms the primitive harmonic oscillator (HO) basis states
+    (:math:`|\phi_j^{\text{HO}}\rangle`) into the optimized vibrational
+    self-consistent field (VSCF) states (:math:`|\psi_i^{\text{VSCF}}\rangle`).
+
+    The relationship is defined as:
+
+    .. math::
+        |\psi_i^{\text{VSCF}}\rangle = \sum_{j} U_{ji} |\phi_j^{\text{HO}}\rangle,
+
+    where :math:`j` runs over the number of bosonic states per mode and
+    :math:`i` denotes the index of the specific VSCF state.
 
     Args:
         h_integrals (list[TensorLike[float]]): list of n-mode expansion of Hamiltonian integrals

--- a/tests/qchem/vibrational/test_vscf.py
+++ b/tests/qchem/vibrational/test_vscf.py
@@ -124,13 +124,16 @@ def test_vscf_rot_mats(h_data, h2s_result):
     assert np.allclose(rot_matrix, rot_matrix2)
 
 
-def test_vscf_rot_mats_raise():
+def test_vscf_funcs_raise():
     r"""Test that vscf rotation matrices produces error if modals is greater than the modals for unrotated integrals."""
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
         vscf.vscf_rot_mats(h_data_h2s, modals=[5, 5, 5, 5])
 
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
         vscf.vscf_rot_mats(h_data_h2s, modals=[6, 6, 6])
+
+    with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
+        vscf.vscf_integrals(h_data_h2s, modals=[7, 7])
 
 
 @pytest.mark.parametrize(

--- a/tests/qchem/vibrational/test_vscf.py
+++ b/tests/qchem/vibrational/test_vscf.py
@@ -126,7 +126,7 @@ def test_vscf_rotations(h_data, h2s_result):
 
 def test_vscf_funcs_raise():
     r"""Test that vscf rotation matrices produces error if modals is greater than the modals for unrotated integrals."""
-    with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
+    with pytest.raises(ValueError, match="Number of maximum modals must be a list"):
         vscf.vscf_rotations(h_data_h2s, modals=[5, 5, 5, 5])
 
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):

--- a/tests/qchem/vibrational/test_vscf.py
+++ b/tests/qchem/vibrational/test_vscf.py
@@ -111,6 +111,29 @@ def test_vscf_calculation(h_data, h2s_result):
 
 
 @pytest.mark.parametrize(
+    ("h_data", "h2s_result"),
+    [(h_data_h2s, h2s_exp_result)],
+)
+def test_vscf_rot_mats(h_data, h2s_result):
+    r"""Test that vscf rotation matrices are produced correctly"""
+    rot_matrix = vscf.vscf_rot_mats(h_data, modals=[3, 3, 3], cutoff=1e-8)
+    assert np.allclose(rot_matrix, h2s_result["u_mat"])
+
+    rot_matrix = vscf.vscf_rot_mats(h_data, modals=None, cutoff=None, cutoff_ratio=2.15e-07)
+    _, rot_matrix2 = vscf._vscf(h_data, modals=[4, 4, 4], cutoff=1e-8)
+    assert np.allclose(rot_matrix, rot_matrix2)
+
+
+def test_vscf_rot_mats_raise():
+    r"""Test that vscf rotation matrices produces error if modals is greater than the modals for unrotated integrals."""
+    with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
+        vscf.vscf_rot_mats(h_data_h2s, modals=[5, 5, 5, 5])
+
+    with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
+        vscf.vscf_rot_mats(h_data_h2s, modals=[6, 6, 6])
+
+
+@pytest.mark.parametrize(
     ("h_data", "dip_data", "h2s_result"),
     [
         (h_data_h2s, dip_data_h2s, h2s_exp_result),

--- a/tests/qchem/vibrational/test_vscf.py
+++ b/tests/qchem/vibrational/test_vscf.py
@@ -114,12 +114,12 @@ def test_vscf_calculation(h_data, h2s_result):
     ("h_data", "h2s_result"),
     [(h_data_h2s, h2s_exp_result)],
 )
-def test_vscf_rot_mats(h_data, h2s_result):
+def test_vscf_rotations(h_data, h2s_result):
     r"""Test that vscf rotation matrices are produced correctly"""
-    rot_matrix = vscf.vscf_rot_mats(h_data, modals=[3, 3, 3], cutoff=1e-8)
+    rot_matrix = vscf.vscf_rotations(h_data, modals=[3, 3, 3], cutoff=1e-8)
     assert np.allclose(rot_matrix, h2s_result["u_mat"])
 
-    rot_matrix = vscf.vscf_rot_mats(h_data, modals=None, cutoff=None, cutoff_ratio=2.15e-07)
+    rot_matrix = vscf.vscf_rotations(h_data, modals=None, cutoff=None, cutoff_ratio=2.15e-07)
     _, rot_matrix2 = vscf._vscf(h_data, modals=[4, 4, 4], cutoff=1e-8)
     assert np.allclose(rot_matrix, rot_matrix2)
 
@@ -127,10 +127,10 @@ def test_vscf_rot_mats(h_data, h2s_result):
 def test_vscf_funcs_raise():
     r"""Test that vscf rotation matrices produces error if modals is greater than the modals for unrotated integrals."""
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
-        vscf.vscf_rot_mats(h_data_h2s, modals=[5, 5, 5, 5])
+        vscf.vscf_rotations(h_data_h2s, modals=[5, 5, 5, 5])
 
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
-        vscf.vscf_rot_mats(h_data_h2s, modals=[6, 6, 6])
+        vscf.vscf_rotations(h_data_h2s, modals=[6, 6, 6])
 
     with pytest.raises(ValueError, match="Number of maximum modals cannot be greater"):
         vscf.vscf_integrals(h_data_h2s, modals=[7, 7])


### PR DESCRIPTION
**Context:** PennyLane has proper tools to construct vibrational states

**Description of the Change:** Creates a function to return the VSCF rotation matrix

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** [sc-106120]
