### PR TITLE
Pin numpy below 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "typing_extensions",
     "packaging",
     "diastatic-malt",
-    "numpy"
+    "numpy<2.4"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
**Context:**
Numpy released 2.4 last Saturday, which broke too many things. Temporarily, we should pin it below 2.4 such that no more downstream breaks

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
