### PR TITLE
Fixing docs for qualtran-pl UI

### DIFF
--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -1224,7 +1224,7 @@ class ToBloq(Bloq):
             call graph is built via the PennyLane decomposition. Default is ``'estimator'``.
 
     Raises:
-        TypeError: op must be an instance of :class:`~.Operation`, :class:`~.QNode`, or a quantum function.
+        TypeError: ``op`` must be an instance of :class:`~.Operation`, :class:`~.QNode`, or a quantum function.
         ValueError: If ``call_graph`` is not ``'estimator'`` or ``'decomposition'``.
 
     .. seealso:: :func:`~.to_bloq` for the recommended way to convert from PennyLane objects to


### PR DESCRIPTION
**Context:**
The link to `estimate` doesn't work. It will not work there is another estimate function that lives in labs. Therefore, we edit the docs so that it references the estimator module instead.

**Description of the Change:**
References the estimator module instead in the docstring of call_graph.

**Benefits:**
Less confusing, clickable links.

**Possible Drawbacks:**

**Related GitHub Issues:**
