### PR TITLE
Skip reminder for version rc branch

### DIFF
--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -8,6 +8,8 @@ jobs:
   remind:
     name: Changelog Reminder
     runs-on: ubuntu-latest
+    if: |
+      !(startsWith(github.event.pull_request.base.ref, 'v') && contains(github.event.pull_request.base.ref, '-rc'))
     steps:
     - uses: actions/checkout@master
     - name: Changelog Reminder


### PR DESCRIPTION
rc branch PR should not add changelog since they are supposed to be taken by Product against `-changelog` branches