### PR TITLE
Support addition of `SpecsResources`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* Implement addition of :class:`~.resources.SpecsResources`, corresponding to the resources
+  required by executing the added circuits in series.
+  [(#8866)](https://github.com/PennyLaneAI/pennylane/pull/8866)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 <h3>Breaking changes 💔</h3>
@@ -17,3 +21,5 @@
 <h3>Bug fixes 🐛</h3>
 
 <h3>Contributors ✍️</h3>
+
+David Wierichs,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,7 +4,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* Implement addition of :class:`~.resources.SpecsResources`, corresponding to the resources
+* Implement addition of :class:`~.resource.SpecsResources`, corresponding to the resources
   required by executing the added circuits in series.
   [(#8866)](https://github.com/PennyLaneAI/pennylane/pull/8866)
 

--- a/tests/resource/test_resource.py
+++ b/tests/resource/test_resource.py
@@ -811,6 +811,51 @@ class TestSpecsResources:
 
         assert s.to_dict() == expected
 
+    def test_addition(self):
+        """Test the addition of SpecsResources."""
+        s0 = self.example_specs_resource()
+        s_add = s0 + s0
+        s_add_expected = SpecsResources(
+            gate_types={"Hadamard": 4, "CNOT": 2},
+            gate_sizes={1: 4, 2: 2},
+            measurements={"expval(PauliZ)": 2},
+            num_allocs=2,
+            depth=4,
+        )
+        assert s_add == s_add_expected
+
+        s_more_alloc = SpecsResources(
+            gate_types={"Hadamard": 7, "CNOT": 2},
+            gate_sizes={1: 7, 2: 2},
+            measurements={"expval(PauliZ)": 2},
+            num_allocs=3,
+            depth=2,
+        )
+        s_add = s0 + s_more_alloc
+        s_add_expected = SpecsResources(
+            gate_types={"Hadamard": 9, "CNOT": 3},
+            gate_sizes={1: 9, 2: 3},
+            measurements={"expval(PauliZ)": 3},
+            num_allocs=3,
+            depth=4,
+        )
+        assert s_add == s_add_expected
+
+        s_no_depth = SpecsResources(
+            gate_types={"Hadamard": 7, "CNOT": 2},
+            gate_sizes={1: 7, 2: 2},
+            measurements={"expval(PauliZ)": 2},
+            num_allocs=3,
+        )
+        s_add = s0 + s_no_depth
+        s_add_expected = SpecsResources(
+            gate_types={"Hadamard": 9, "CNOT": 3},
+            gate_sizes={1: 9, 2: 3},
+            measurements={"expval(PauliZ)": 3},
+            num_allocs=3,
+        )
+        assert s_add == s_add_expected
+
 
 class TestCircuitSpecs:
 


### PR DESCRIPTION
**Context:**
`qml.resource.Resources` supports addition through the dunder method `__add__`.
`qml.resource.SpecsResources` does not.

**Description of the Change:**
Add support for addition of `qml.resource.SpecsResources` through the dunder method `__add__`.

**Benefits:**
Conveniently combine resources returned by `qml.specs`

**Possible Drawbacks:**
N/A 

**Related GitHub Issues:**
