### PR TITLE
Skip patch process if it is not jax 0.7.x

### DIFF
--- a/pennylane/capture/jax_patches.py
+++ b/pennylane/capture/jax_patches.py
@@ -61,7 +61,7 @@ JAX versions no longer exists. All patches assume DynamicJaxprTrace.
 
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-import,no-else-return,unidiomatic-typecheck,use-dict-literal
-# pylint: disable=protected-access
+# pylint: disable=protected-access,possibly-used-before-assignment
 
 has_jax = True
 try:


### PR DESCRIPTION
gist: 
Jax is not a hard dependency of Pennylane. Therefore, if not necessary, any jax importing processes should be avoided if not necessary


How to test:
1. Install `jax==0.6.2 jaxlib==0.6.2`
2. `import pennylane`

Should pass!