### PR TITLE
Remove unnecessary dependency in external tests CI

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -489,7 +489,7 @@ jobs:
       pytest_additional_args: ${{ needs.warnings-as-errors-setup.outputs.pytest_warning_args }}
       pytest_xml_file_path: '${{ inputs.job_name_prefix }}external-libraries-tests (${{ matrix.python-version }})${{ inputs.job_name_suffix }}.xml'
       additional_pip_packages: |
-        pyzx matplotlib stim quimb mitiq>=0.45.1 ply optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime
+        pyzx matplotlib stim quimb mitiq>=0.45.1 optax scipy-openblas32>=0.3.26 qualtran openqasm3 antlr4_python3_runtime
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         git+https://github.com/PennyLaneAI/pennylane-qiskit.git@master
         ${{ needs.default-dependency-versions.outputs.catalyst-nightly }}


### PR DESCRIPTION
https://github.com/PennyLaneAI/pennylane/actions/runs/20934591214/job/60153878827?pr=8909
Since on one every failed, let's just remove it.