### PR TITLE
Re-trim the `-rc0`

### DIFF
--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.44.0-rc0"
+__version__ = "0.44.0"


### PR DESCRIPTION
So the bot added back the `-rc0` suffix this morning....