### PR TITLE
[Bug fix] Allow QSVT to be called without wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,6 +151,10 @@
   is a `Sequence`, but not a `Sequence` of tapes.
   [(#8920)](https://github.com/PennyLaneAI/pennylane/pull/8920)
 
+* Fixes a bug with `qml.estimator.QSVT` which allows users to instantiate the class without
+  providing wires. This is now consistent with the standard in the estimator module.
+  [(#8949)](https://github.com/PennyLaneAI/pennylane/pull/8949)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,7 +151,7 @@
   is a `Sequence`, but not a `Sequence` of tapes.
   [(#8920)](https://github.com/PennyLaneAI/pennylane/pull/8920)
 
-* Fixes a bug with `qml.estimator.QSVT` which allows users to instantiate the class without
+* Fixes a bug with `qml.estimator.templates.QSVT` which allows users to instantiate the class without
   providing wires. This is now consistent with the standard in the estimator module.
   [(#8949)](https://github.com/PennyLaneAI/pennylane/pull/8949)
 

--- a/pennylane/estimator/templates/qsp.py
+++ b/pennylane/estimator/templates/qsp.py
@@ -607,7 +607,7 @@ class QSVT(ResourceOperator):
         if wires is None and block_encoding.wires is not None:
             wires = block_encoding.wires
 
-        if len(wires) != self.num_wires:
+        if wires is not None and len(wires) != self.num_wires:
             raise ValueError(f"Expected {self.num_wires} wires, got {len(wires)}.")
         super().__init__(wires=wires)
 

--- a/tests/estimator/templates/test_estimator_qsp.py
+++ b/tests/estimator/templates/test_estimator_qsp.py
@@ -86,6 +86,15 @@ class TestQSVT:
         with pytest.raises(ValueError, match="Expected 1 wires, got 2"):
             qre.QSVT(op, encoding_dims=2, poly_deg=2, wires=[0, 1])
 
+    def test_init_without_wires(self):
+        """Test that we can instantiate QSVT without providing wires."""
+        op = qre.RX()
+        qsvt = qre.QSVT(block_encoding=op, encoding_dims=(1, 1), poly_deg=5)
+        
+        assert qsvt.num_wires == 1
+        assert qsvt.encoding_dims == (1, 1)
+        assert qsvt.block_encoding == qre.resource_rep(qre.RX)
+
     @pytest.mark.parametrize(
         "encoding_dims, poly_deg",
         [

--- a/tests/estimator/templates/test_estimator_qsp.py
+++ b/tests/estimator/templates/test_estimator_qsp.py
@@ -90,7 +90,7 @@ class TestQSVT:
         """Test that we can instantiate QSVT without providing wires."""
         op = qre.RX()
         qsvt = qre.QSVT(block_encoding=op, encoding_dims=(1, 1), poly_deg=5)
-        
+
         assert qsvt.num_wires == 1
         assert qsvt.encoding_dims == (1, 1)
         assert qsvt.block_encoding == qre.resource_rep(qre.RX)


### PR DESCRIPTION
**Context:**
The `qre.QSVT` operator in the `estimator` module raises an error when it's initialized without `wires` and the `ResourceOperator` provided in its `block_encoding` argument also doesn't have any wires. This is not consistent with 
the rest of the `estimator` module, where providing wire labels is entirely optional.

**Description of the Change:**
- Fix the `__init__` method to only check wires length if it is not `None`.
- Update tests

**Benefits:**
- Matches rest of the estimator module