### PR TITLE
fix: move NumPy 1.x deprecation to completed deprecation cycles

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,13 +9,6 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* Maintenance support of NumPy<2.0 is deprecated and will be dropped in v0.45.
-  PennyLane v0.45 and beyond are not guaranteed to work with NumPy<2.0.
-  We recommend upgrading your version of NumPy to benefit from enhanced support and features.
-  
-  - Deprecated in v0.44
-  - Will be removed in v0.45
-
 * Setting shots on a device through the ``shots`` keyword argument is deprecated. Instead,
   please specify shots using the ``shots`` keyword argument of :class:`~.QNode`, or use the
   :func:`pennylane.set_shots` transform on the :class:`~.QNode`.
@@ -75,6 +68,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* Maintenance support of NumPy<2.0 has been removed. PennyLane v0.45 and beyond are not guaranteed to work with NumPy<2.0.
+  We recommend upgrading your version of NumPy to benefit from enhanced support and features.
+  
+  - Deprecated in v0.44
+  - Removed in v0.45
 
 * ``compute_qfunc_decomposition`` and ``has_qfunc_decomposition`` have been removed from  :class:`~.Operator`
   and all subclasses that implemented them. The graph decomposition system should be used to enable capture instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -35,6 +35,7 @@
 
 * Dropped support for NumPy 1.x following its end-of-life. NumPy 2.0 or higher is now required.
   [(#8914)](https://github.com/PennyLaneAI/pennylane/pull/8914)
+  [(#8954)](https://github.com/PennyLaneAI/pennylane/pull/8954)
   
 * ``compute_qfunc_decomposition`` and ``has_qfunc_decomposition`` have been removed from  :class:`~.Operator`
   and all subclasses that implemented them. The graph decomposition system should be used when capture is enabled.


### PR DESCRIPTION
After the removal, I realized I forgot to move the pending deprecation to the completed cycle section.

[sc-107813]