### PR TITLE
Fix: increase tolerance in test_complex_hamiltonian to 3σ

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,7 +138,11 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Bump the absolute tolerace in `TestBroadcastingPRNG::test_nonsample_measure` from `0.01` to `0.03`
+* Bump the absolute tolerance in `TestSampling::test_complex_hamiltonian` from `0.001` to `0.0035`
+  to match a 3-sigma practice and reduce stochastic test failures.
+  [(#8958)](https://github.com/PennyLaneAI/pennylane/pull/8958)
+
+* Bump the absolute tolerance in `TestBroadcastingPRNG::test_nonsample_measure` from `0.01` to `0.03`
   to match the non-PRNG version and reduce stochastic test failures.
   [(#8938)](https://github.com/PennyLaneAI/pennylane/pull/8938)
 

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -1311,7 +1311,9 @@ class TestHamiltonianSamples:
         qs_exp = qml.tape.QuantumScript(ops, [qml.expval(H)])
         expected = simulate(qs_exp)
 
-        assert np.allclose(res, expected, atol=0.001)
+        # Tolerance set to 3σ (σ ≈ 0.0008 for this Hamiltonian with 100k shots)
+        # See .benchmarks/test_complex_hamiltonian/statistical_analysis.py
+        assert np.allclose(res, expected, atol=0.003)
 
 
 class TestSampleProbs:

--- a/tests/devices/qubit/test_sampling.py
+++ b/tests/devices/qubit/test_sampling.py
@@ -1311,9 +1311,9 @@ class TestHamiltonianSamples:
         qs_exp = qml.tape.QuantumScript(ops, [qml.expval(H)])
         expected = simulate(qs_exp)
 
-        # Tolerance set to 3σ (σ ≈ 0.0008 for this Hamiltonian with 100k shots)
-        # See .benchmarks/test_complex_hamiltonian/statistical_analysis.py
-        assert np.allclose(res, expected, atol=0.003)
+        # [sc=107860]
+        # Tolerance set to 3σ (σ ≈ 0.00116 for this Hamiltonian with
+        assert np.allclose(res, expected, atol=0.0035)
 
 
 class TestSampleProbs:


### PR DESCRIPTION
## Test Location
`tests/devices/qubit/test_sampling.py::TestHamiltonianSamples::test_complex_hamiltonian`

## Issue Description
This is a stochastic test that samples a complex 15-term molecular Hamiltonian and compares 
with analytic result. The test fails when the rng_salt is bumped to `v0.45.0`.

## Failure Details
```
assert np.allclose(res, expected, atol=0.001)
assert False
 +  where False = allclose(np.float64(0.3155522726138925), array(0.31335877), atol=0.001)
```

The difference is approximately 0.0022, exceeding the 0.001 tolerance.

## 🚨 THIS IS A TEST DESIGN ISSUE

### Theoretical Analysis

For the 15-term Hamiltonian H = Σᵢ cᵢ Pᵢ with the given quantum state:

1. **Variance computation**
   
   The full variance formula is:
   ```
   Var(H) = Σᵢⱼ cᵢcⱼ Cov(Pᵢ, Pⱼ) = Σᵢⱼ cᵢcⱼ (⟨PᵢPⱼ⟩ - ⟨Pᵢ⟩⟨Pⱼ⟩)
   ```

   
   **Actual variance (from 500-trial MC):** Var(H) ≈ **0.135**

2. **Standard deviation of sample mean:**
   - σ_sample = √(0.135/100000) = **0.00116**

3. **Tolerance analysis:**
   - Current tolerance: atol = 0.001
   - Z-threshold: 0.001 / 0.00116 = **0.86σ** (extremely tight!)
   
4. **Failure probability:**
   - P(fail) = 2 × Φᶜ(0.86) = **39%**

### Numerical Validation

Monte Carlo simulation with 500 trials (exact test code):
- Empirical failure rate: **38%** ✓ (matches corrected theory)

### 3-Sigma Rule

For ≤1% failure rate, need tolerance ≥ 3σ:
- Recommended: atol = 3 × 0.00116 = **0.0035**
- Practical: round up to **0.004** (conservative)

# Related Issues/Stories
[sc-107860]