### PR TITLE
 Fix the finite-shot test `test_multi_wires` by standardizing its usage of tolerance

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,6 +138,11 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Adjust the tolerance in `TestHamiltonianSamples::test_multi_wires` of `test_default_qubit` from
+  a fixed magic number to dynamically computed based on 3-sigma of the standard error given by the theoretical
+  variance and number of shots.
+  [(#8959)](https://github.com/PennyLaneAI/pennylane/pull/8959)
+
 * Bump the absolute tolerace in `TestBroadcastingPRNG::test_nonsample_measure` from `0.01` to `0.03`
   to match the non-PRNG version and reduce stochastic test failures.
   [(#8938)](https://github.com/PennyLaneAI/pennylane/pull/8938)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,17 +138,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Adjust the tolerance in `TestHamiltonianSamples::test_multi_wires` of `test_default_qubit` from
-  a fixed magic number to dynamically computed based on 3-sigma of the standard error given by the theoretical
-  variance and number of shots.
+* Standardized the tolerances of several stochastic tests to use a 3-sigma rule based on theoretical variance and number of shots, reducing spurious failures. This includes `TestHamiltonianSamples::test_multi_wires`, `TestSampling::test_complex_hamiltonian`, and `TestBroadcastingPRNG::test_nonsample_measure`.
   [(#8959)](https://github.com/PennyLaneAI/pennylane/pull/8959)
-
-* Bump the absolute tolerance in `TestSampling::test_complex_hamiltonian` from `0.001` to `0.0035`
-  to match a 3-sigma practice and reduce stochastic test failures.
   [(#8958)](https://github.com/PennyLaneAI/pennylane/pull/8958)
-
-* Bump the absolute tolerance in `TestBroadcastingPRNG::test_nonsample_measure` from `0.01` to `0.03`
-  to match the non-PRNG version and reduce stochastic test failures.
   [(#8938)](https://github.com/PennyLaneAI/pennylane/pull/8938)
 
 * Updated test helper `get_device` to correctly seed lightning devices.

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -1585,7 +1585,7 @@ class TestHamiltonianSamples:
         # <H^2> = 2.5^2 + 6.2^2 because cross terms vanish (<X> = 0 for RX states)
         var_h_theoretical = (2.5**2 + 6.2**2) - expected**2
         std_error = np.sqrt(var_h_theoretical / shots)
-        
+
         # Use 3-sigma tolerance to prevent flaky tests
         # We use atol (absolute) because noise does not scale with the expectation value
         assert np.allclose(res, expected, atol=3 * std_error)

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -1571,8 +1571,9 @@ class TestHamiltonianSamples:
         t2 = 6.2 * qml.prod(*(qml.PauliY(i) for i in range(n_wires)))
         H = t1 + t2
 
+        shots = 30000
         dev = DefaultQubit(seed=seed, max_workers=max_workers)
-        qs = qml.tape.QuantumScript(ops, [qml.expval(H)], shots=30000)
+        qs = qml.tape.QuantumScript(ops, [qml.expval(H)], shots=shots)
         res = dev.execute(qs)
 
         phase = offset + scale * np.array(range(n_wires))
@@ -1580,10 +1581,14 @@ class TestHamiltonianSamples:
         sines = qml.math.sin(phase)
         expected = 2.5 * qml.math.prod(cosines) + 6.2 * qml.math.prod(sines)
 
-        # Tolerance set to ~3.5σ (σ ≈ 0.038 for this 10-wire Hamiltonian with 30k shots)
-        # rtol=0.12 gives atol_eff ≈ 0.135 for expected≈1.12
-        # See .benchmarks/test_multi_wires/statistical_analysis.py
-        assert np.allclose(res, expected, rtol=0.12)
+        # Theoretical Standard Error Calculation
+        # <H^2> = 2.5^2 + 6.2^2 because cross terms vanish (<X> = 0 for RX states)
+        var_h_theoretical = (2.5**2 + 6.2**2) - expected**2
+        std_error = np.sqrt(var_h_theoretical / shots)
+        
+        # Use 3-sigma tolerance to prevent flaky tests
+        # We use atol (absolute) because noise does not scale with the expectation value
+        assert np.allclose(res, expected, atol=3 * std_error)
 
     @pytest.mark.parametrize("max_workers", max_workers_list)
     def test_complex_hamiltonian(self, max_workers, seed):

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -1580,7 +1580,10 @@ class TestHamiltonianSamples:
         sines = qml.math.sin(phase)
         expected = 2.5 * qml.math.prod(cosines) + 6.2 * qml.math.prod(sines)
 
-        assert np.allclose(res, expected, rtol=0.05)
+        # Tolerance set to ~3.5σ (σ ≈ 0.038 for this 10-wire Hamiltonian with 30k shots)
+        # rtol=0.12 gives atol_eff ≈ 0.135 for expected≈1.12
+        # See .benchmarks/test_multi_wires/statistical_analysis.py
+        assert np.allclose(res, expected, rtol=0.12)
 
     @pytest.mark.parametrize("max_workers", max_workers_list)
     def test_complex_hamiltonian(self, max_workers, seed):


### PR DESCRIPTION
## Test Location
`tests/devices/default_qubit/test_default_qubit.py::TestHamiltonianSamples::test_multi_wires`

## Issue Description
This stochastic test samples a 10-wire Hamiltonian and fails when the rng_salt is bumped to `v0.45.0`.

## Failure Details
```
assert np.allclose(res, expected, rtol=0.05)
# max_workers=None: res=0.9931, expected=1.1205, rtol_diff=0.1137
# max_workers=2:    res=1.0272, expected=1.1205, rtol_diff=0.0832
```

The relative difference exceeds the 5% tolerance for certain seeds.

## 🚨 THIS IS A TEST DESIGN ISSUE

### Theoretical Analysis

For the 10-wire Hamiltonian H = 2.5·Z⊗Z⊗...⊗Z + 6.2·Y⊗Y⊗...⊗Y:

1. **Variance computation:**

   The expectation of H² is:
   ```
   ⟨H²⟩ = 2.5²⟨(Z⊗...⊗Z)²⟩ + 6.2²⟨(Y⊗...⊗Y)²⟩ + 2×2.5×6.2⟨Z⊗...⊗Z·Y⊗...⊗Y⟩
   ```
   
   Since `(Z⊗...⊗Z)² = I` and `(Y⊗...⊗Y)² = I`, we have `⟨(P)²⟩ = 1`.
   
   The cross term vanishes because for RX(θ)|0⟩ states, `⟨X⟩ = 0`, and the
   product Z⊗...⊗Z · Y⊗...⊗Y contains X operators on each qubit.
   
   Therefore:
   ```
   ⟨H²⟩ = 2.5² + 6.2² = 44.69
   Var(H) = ⟨H²⟩ - ⟨H⟩² = 44.69 - 1.12² ≈ 43.4
   ```

2. **Standard error of sample mean:**
   ```
   σ_sample = √(Var(H)/n) = √(43.4/30000) ≈ 0.038
   ```

3. **Tolerance analysis (original):**
   - ⟨H⟩ ≈ 1.12
   - Old `rtol=0.05` → effective atol = 0.05 × 1.12 = 0.056
   - Z-threshold: 0.056 / 0.038 = **1.47σ** (too tight!)

4. **Failure probability:**
   - P(fail) = 2×Φᶜ(1.47) = **14.1%**

### Why Use `atol` Instead of `rtol`?

Shot noise can be roughly modeled using standard error
`σ = √(Var(H)/n)` which does not linearly scale with the expectation value `⟨H⟩`. Using `rtol` conflates
the tolerance with the signal magnitude, which is conceptually incorrect for shot noise.
(Note that, there's no perfect one single model for all situations; it's always about which one can provide more reliability)

### Fix Applied

Replace hardcoded `rtol=0.05` with a **dynamic 3σ absolute tolerance**:

```python
# Before (14% failure rate):
assert np.allclose(res, expected, rtol=0.05)

# After (<1% failure rate):
# Theoretical Standard Error Calculation
# <H^2> = 2.5^2 + 6.2^2 because cross terms vanish (<X> = 0 for RX states)
var_h_theoretical = (2.5**2 + 6.2**2) - expected**2
std_error = np.sqrt(var_h_theoretical / shots)

# Use 3-sigma tolerance to prevent flaky tests
# We use atol (absolute) because noise does not scale with the expectation value
assert np.allclose(res, expected, atol=3 * std_error)
```

This approach:
1. **Computes variance from first principles** — no magic numbers
2. **Uses absolute tolerance** — correct for additive shot noise
3. **Applies 3σ rule** — ensures <1% failure probability
4. **Self-documenting** — the physics is explicit in the code

# Related Issues/Stories
[sc-107859]