### PR TITLE
Fix `tests/capture/test_capture_mid_measure.py`

### DIFF
--- a/tests/capture/test_capture_mid_measure.py
+++ b/tests/capture/test_capture_mid_measure.py
@@ -396,11 +396,11 @@ class TestMidMeasureExecute:
             # Using 3σ tolerance: atol = 3 * sqrt(2/shots) for <1% failure rate.
             atol = 3 * qml.math.sqrt(2.0 / shots)
             if mp_fn is qml.expval:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.1)
             elif mp_fn is qml.var:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.1)
             elif mp_fn is qml.probs:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.1)
             else:
                 # mp_fn is qml.sample
                 assert not (jnp.all(res == 1) or jnp.all(res == -1))
@@ -442,11 +442,11 @@ class TestMidMeasureExecute:
             # See .benchmarks/test_circuit_with_boolean_arithmetic_execution/
             atol = 3 * qml.math.sqrt(2.0 / shots)
             if mp_fn is qml.expval:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.2)
             elif mp_fn is qml.var:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.2)
             elif mp_fn is qml.probs:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=atol, rtol=0.2)
             else:
                 # mp_fn is qml.sample
                 assert not (jnp.all(res == 1) or jnp.all(res == -1))

--- a/tests/capture/test_capture_mid_measure.py
+++ b/tests/capture/test_capture_mid_measure.py
@@ -394,15 +394,13 @@ class TestMidMeasureExecute:
             # Var(res - expected) = Var(res) + Var(expected) = 2/shots (for unit-variance obs)
             # σ_diff = sqrt(2/shots)
             # Using 3σ tolerance: atol = 3 * sqrt(2/shots) for <1% failure rate.
+            atol = 3 * qml.math.sqrt(2.0 / shots)
             if mp_fn is qml.expval:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
             elif mp_fn is qml.var:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
             elif mp_fn is qml.probs:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.1)
             else:
                 # mp_fn is qml.sample
                 assert not (jnp.all(res == 1) or jnp.all(res == -1))
@@ -442,15 +440,13 @@ class TestMidMeasureExecute:
             # σ_diff = sqrt(2/shots)
             # Using 3σ tolerance: atol = 3 * sqrt(2/shots) for <1% failure rate.
             # See .benchmarks/test_circuit_with_boolean_arithmetic_execution/
+            atol = 3 * qml.math.sqrt(2.0 / shots)
             if mp_fn is qml.expval:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
             elif mp_fn is qml.var:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
             elif mp_fn is qml.probs:
-                atol = 3 * qml.math.sqrt(2.0 / shots)
-                assert qml.math.allclose(res, expected, atol=atol, rtol=0.3)
+                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
             else:
                 # mp_fn is qml.sample
                 assert not (jnp.all(res == 1) or jnp.all(res == -1))

--- a/tests/capture/test_capture_mid_measure.py
+++ b/tests/capture/test_capture_mid_measure.py
@@ -430,12 +430,16 @@ class TestMidMeasureExecute:
             qml.capture.disable()
             expected = f(phi, phi + 1.5)
             qml.capture.enable()
+            # Note: Comparing TWO independent estimates doubles variance.
+            # With 100 shots, Std(difference) = sqrt(2)/sqrt(100) ≈ 0.14
+            # Using atol=0.4 gives ~3σ tolerance for <1% failure rate.
+            # See .benchmarks/test_circuit_with_boolean_arithmetic_execution/
             if mp_fn is qml.expval:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=0.4, rtol=0.3)
             elif mp_fn is qml.var:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=0.4, rtol=0.3)
             elif mp_fn is qml.probs:
-                assert qml.math.allclose(res, expected, atol=1 / qml.math.sqrt(shots), rtol=0.2)
+                assert qml.math.allclose(res, expected, atol=0.4, rtol=0.3)
             else:
                 # mp_fn is qml.sample
                 assert not (jnp.all(res == 1) or jnp.all(res == -1))


### PR DESCRIPTION
Multiple issues to be resolved in the same test file...

Within `test_capture_mid_measure.py` we adjust:

1. `test_circuit_with_terminal_measurement_execution` to use a refined atol
2. `test_circuit_with_boolean_arithmetic_execution` to use a refined atol
3. `test_simple_circuit_execution` has theoretical std slightly off from what's described in dev not. Adjusted `std_sample_avg` to match and tuned dev notes for better clarity
4. two tests that were not correctly named (hence skipped by pytest) now shall be corrected named with prefix `test_` and collected by pytest, `mid_measure_processed_with_jax_numpy_capture` and `mid_measure_processed_with_jax_numpy_execution`

[sc-107858]