### PR TITLE
Thread-safe context for toggling graph decomp

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -167,6 +167,11 @@
   they are compatible with the new graph-based decomposition system.
   [(#8939)](https://github.com/PennyLaneAI/pennylane/pull/8939)
 
+* Added a `qml.decomposition.toggle_graph_ctx` context manager to temporarily enable or disable graph-based
+  decompositions in a thread-safe way. The fixtures `"enable_graph_decomposition"`, `"disable_graph_decomposition"`,
+  and `"enable_and_disable_graph_decomp"` have been updated to use this method so that they are thread-safe.
+  [(#8966)](https://github.com/PennyLaneAI/pennylane/pull/8966)
+
 <h3>Documentation 📝</h3>
 
 <h3>Bug fixes 🐛</h3>

--- a/pennylane/decomposition/__init__.py
+++ b/pennylane/decomposition/__init__.py
@@ -34,6 +34,7 @@ By default, this system is disabled.
     ~enable_graph
     ~disable_graph
     ~enabled_graph
+    ~toggle_graph_ctx
 
 >>> qml.decomposition.enabled_graph()
 False
@@ -238,6 +239,7 @@ from .utils import (
     enable_graph,
     disable_graph,
     enabled_graph,
+    toggle_graph_ctx,
 )
 from .decomposition_graph import DecompositionGraph, DecompGraphSolution
 from .resources import (

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -97,7 +97,7 @@ def toggle_graph_decomposition():
 
     @contextmanager
     def toggle_ctx(new_state: bool):
-        """A context manager in which graph is enabled."""
+        """A context manager in which graph is enabled or disabled temporarily."""
 
         token = _GRAPH_DECOMPOSITION.set(new_state)
         try:

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -16,8 +16,9 @@ r"""
 This module implements utility functions for the decomposition module.
 
 """
-
 import re
+from contextlib import contextmanager
+from contextvars import ContextVar
 
 OP_NAME_ALIASES = {
     "X": "PauliX",
@@ -60,7 +61,7 @@ def translate_op_alias(op_alias):
 def toggle_graph_decomposition():
     """A closure that toggles the experimental graph-based decomposition on and off."""
 
-    _GRAPH_DECOMPOSITION = False
+    _GRAPH_DECOMPOSITION = ContextVar("_GRAPH_DECOMPOSITION", default=True)
 
     def enable():
         """
@@ -70,9 +71,7 @@ def toggle_graph_decomposition():
 
         When this is enabled, :func:`~pennylane.transforms.decompose` will use the new decompositions system.
         """
-
-        nonlocal _GRAPH_DECOMPOSITION
-        _GRAPH_DECOMPOSITION = True
+        _GRAPH_DECOMPOSITION.set(True)
 
     def disable() -> None:
         """
@@ -81,10 +80,9 @@ def toggle_graph_decomposition():
         decomposition system is disabled by default in PennyLane.
 
         .. seealso:: :func:`~pennylane.decomposition.enable_graph`
-        """
 
-        nonlocal _GRAPH_DECOMPOSITION
-        _GRAPH_DECOMPOSITION = False
+        """
+        _GRAPH_DECOMPOSITION.set(False)
 
     def status() -> bool:
         """
@@ -93,12 +91,21 @@ def toggle_graph_decomposition():
         graph-based decomposition system is disabled by default in PennyLane.
 
         .. seealso:: :func:`~pennylane.decomposition.enable_graph`
+
         """
+        return _GRAPH_DECOMPOSITION.get()
 
-        nonlocal _GRAPH_DECOMPOSITION
-        return _GRAPH_DECOMPOSITION
+    @contextmanager
+    def toggle_ctx(new_state: bool):
+        """A context manager in which graph is enabled."""
 
-    return enable, disable, status
+        token = _GRAPH_DECOMPOSITION.set(new_state)
+        try:
+            yield
+        finally:
+            _GRAPH_DECOMPOSITION.reset(token)
+
+    return enable, disable, status, toggle_ctx
 
 
-enable_graph, disable_graph, enabled_graph = toggle_graph_decomposition()
+enable_graph, disable_graph, enabled_graph, toggle_graph_ctx = toggle_graph_decomposition()

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -61,7 +61,7 @@ def translate_op_alias(op_alias):
 def toggle_graph_decomposition():
     """A closure that toggles the experimental graph-based decomposition on and off."""
 
-    _GRAPH_DECOMPOSITION = ContextVar("_GRAPH_DECOMPOSITION", default=True)
+    _GRAPH_DECOMPOSITION = ContextVar("_GRAPH_DECOMPOSITION", default=False)
 
     def enable():
         """

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -74,25 +74,9 @@ def enable_and_disable_graph_decomp(request):
     It automatically handles the setup (enabling/disabling) before the
     test runs and the teardown (always disabling) after the test completes.
     """
-    try:
-        use_graph_decomp = request.param
-
-        # --- Setup Phase ---
-        # This code runs before the test function is executed.
-        if use_graph_decomp:
-            qml.decomposition.enable_graph()
-        else:
-            # Explicitly disable to ensure a clean state
-            qml.decomposition.disable_graph()
-
-        # Yield control to the test function
-        yield use_graph_decomp
-
-    finally:
-        # --- Teardown Phase ---
-        # This code runs after the test function has finished,
-        # regardless of whether it passed or failed.
-        qml.decomposition.disable_graph()
+    use_graph_decomp = request.param
+    with qml.decomposition.toggle_graph_ctx(use_graph_decomp):
+        yield
 
 
 def get_legacy_capabilities(dev):

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -29,7 +29,10 @@ import pennylane as qml
 from pennylane import math
 from pennylane.exceptions import DeviceError
 
-pytestmark = pytest.mark.skip_unsupported
+pytestmark = [
+    pytest.mark.skip_unsupported,
+    pytest.mark.usefixtures("enable_and_disable_graph_decomp"),
+]
 
 
 def check_op_supported(op, dev):
@@ -46,7 +49,6 @@ def check_op_supported(op, dev):
             pytest.skip("operation not supported on the device")
 
 
-@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestTemplates:  # pylint:disable=too-many-public-methods
     """Test various templates."""
 
@@ -876,7 +878,6 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         assert all(np.isclose(val, probs[i], atol=tol) for i, val in zip(order, res))
 
 
-@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestMoleculeTemplates:
     """Test templates using the H2 molecule."""
 

--- a/tests/capture/transforms/test_capture_decompose.py
+++ b/tests/capture/transforms/test_capture_decompose.py
@@ -33,7 +33,11 @@ from pennylane.capture.primitives import (
 from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 from pennylane.transforms.decompose import DecomposeInterpreter, decompose_plxpr_to_plxpr
 
-pytestmark = [pytest.mark.jax, pytest.mark.capture]
+pytestmark = [
+    pytest.mark.jax,
+    pytest.mark.capture,
+    pytest.mark.usefixtures("disable_graph_decomposition"),
+]
 
 
 class TestDecomposeInterpreter:

--- a/tests/capture/transforms/test_capture_decompose.py
+++ b/tests/capture/transforms/test_capture_decompose.py
@@ -69,7 +69,6 @@ class TestDecomposeInterpreter:
         with pytest.raises(TypeError, match="The keyword arguments fixed_decomps and alt_decomps"):
             DecomposeInterpreter(alt_decomps={qml.CNOT: [my_cnot]})
 
-    @pytest.mark.fixtures("disable_graph_decomposition")
     @pytest.mark.parametrize("op", [qml.RX(1.5, 0), qml.RZ(1.5, 0)])
     def test_stopping_condition(self, op):
         """Test that stopping_condition works correctly."""

--- a/tests/capture/transforms/test_capture_graph_decompose.py
+++ b/tests/capture/transforms/test_capture_graph_decompose.py
@@ -33,7 +33,11 @@ from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.transforms.resolve_dynamic_wires import resolve_dynamic_wires
 
-pytestmark = [pytest.mark.jax, pytest.mark.capture]
+pytestmark = [
+    pytest.mark.jax,
+    pytest.mark.capture,
+    pytest.mark.usefixtures("enable_graph_decomposition"),
+]
 
 
 class CustomOpDynamicWireDecomp(Operation):  # pylint: disable=too-few-public-methods
@@ -94,7 +98,6 @@ def _decomp2_without_work_wire(wires, **__):
     qml.Toffoli(wires=[wires[2], wires[1], wires[0]])
 
 
-@pytest.mark.usefixtures("enable_graph_decomposition")
 class TestDecomposeInterpreterGraphEnabled:
     """Tests the DecomposeInterpreter with the new graph-based decomposition system enabled."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,25 +195,30 @@ def enable_disable_dynamic_shapes():
 @pytest.fixture(scope="function")
 def enable_graph_decomposition():
     """enable and disable graph-decomposition around each test."""
-    enabled = qml.decomposition.enabled_graph()
-    qml.decomposition.enable_graph()
-    try:
+    with qml.decomposition.toggle_graph_ctx(True):
         yield
-    finally:
-        if not enabled:
-            qml.decomposition.disable_graph()
 
 
 @pytest.fixture(scope="function")
 def disable_graph_decomposition():
     """disable graph-decomposition."""
-    enabled = qml.decomposition.enabled_graph()
-    qml.decomposition.disable_graph()
-    try:
+    with qml.decomposition.toggle_graph_ctx(False):
         yield
-    finally:
-        if enabled:
-            qml.decomposition.enable_graph()
+
+
+@pytest.fixture(params=[False, True], ids=["graph_disabled", "graph_enabled"])
+def enable_and_disable_graph_decomp(request):
+    """
+    A fixture that parametrizes a test to run twice: once with graph
+    decomposition disabled and once with it enabled.
+
+    It automatically handles the setup (enabling/disabling) before the
+    test runs and the teardown (always disabling) after the test completes.
+
+    """
+    use_graph_decomp = request.param
+    with qml.decomposition.toggle_graph_ctx(use_graph_decomp):
+        yield
 
 
 #######################################################################
@@ -334,37 +339,3 @@ def pytest_runtest_setup(item):
                 pytest.skip(
                     f"\nTest {item.nodeid} only runs with {allowed_interfaces} interfaces(s) but {b} interface provided",
                 )
-
-
-@pytest.fixture(params=[False, True], ids=["graph_disabled", "graph_enabled"])
-def enable_and_disable_graph_decomp(request):
-    """
-    A fixture that parametrizes a test to run twice: once with graph
-    decomposition disabled and once with it enabled.
-
-    It automatically handles the setup (enabling/disabling) before the
-    test runs and the teardown (always disabling) after the test completes.
-    """
-    enabled = qml.decomposition.enabled_graph()
-    try:
-        use_graph_decomp = request.param
-
-        # --- Setup Phase ---
-        # This code runs before the test function is executed.
-        if use_graph_decomp:
-            qml.decomposition.enable_graph()
-        else:
-            # Explicitly disable to ensure a clean state
-            qml.decomposition.disable_graph()
-
-        # Yield control to the test function
-        yield use_graph_decomp
-
-    finally:
-        # --- Teardown Phase ---
-        # This code runs after the test function has finished,
-        # regardless of whether it passed or failed.
-        if not enabled:
-            qml.decomposition.disable_graph()
-        else:
-            qml.decomposition.disable_graph()

--- a/tests/decomposition/test_decomp_utils.py
+++ b/tests/decomposition/test_decomp_utils.py
@@ -47,6 +47,16 @@ def test_toggle_graph_decomposition():
     assert not qml.decomposition.enabled_graph()
 
 
+def test_graph_ctx():
+    """Tests the context manager for toggling graph."""
+
+    with qml.decomposition.toggle_graph_ctx(True):
+        assert qml.decomposition.enabled_graph()
+
+    with qml.decomposition.toggle_graph_ctx(False):
+        assert not qml.decomposition.enabled_graph()
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "base_op_alias, expected_op_name",

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -172,7 +172,6 @@ class TestConfigSetup:
         with pytest.raises(DeviceError, match="device option bla"):
             qml.device("default.qubit").preprocess(config)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_choose_best_gradient_method(self):
         """Test that preprocessing chooses backprop as the best gradient method."""
         config = qml.devices.ExecutionConfig(gradient_method="best")
@@ -181,18 +180,17 @@ class TestConfigSetup:
         assert config.use_device_gradient
         assert not config.grad_on_execution
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_config_choices_for_adjoint(self):
         """Test that preprocessing request grad on execution and says to use the device gradient if adjoint is requested."""
         config = qml.devices.ExecutionConfig(
-            gradient_method="adjoint", use_device_gradient=None, grad_on_execution=None
+            gradient_method="adjoint",
+            use_device_gradient=None,
+            grad_on_execution=None,
         )
         new_config = qml.device("default.qubit").setup_execution_config(config)
-
         assert new_config.use_device_gradient
         assert new_config.grad_on_execution
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_chose_adjoint_as_best_if_max_workers_on_device(self):
         """Test that adjoint is best if max_workers as present."""
 
@@ -204,13 +202,13 @@ class TestConfigSetup:
         assert config.grad_on_execution
         assert config.use_device_jacobian_product
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_chose_adjoint_as_best_if_max_workers_on_config(self):
         """Test that adjoint is best if max_workers as present."""
 
         dev = qml.device("default.qubit")
         config = qml.devices.ExecutionConfig(
-            gradient_method="best", device_options={"max_workers": 2}
+            gradient_method="best",
+            device_options={"max_workers": 2},
         )
         config = dev.setup_execution_config(config)
         assert config.gradient_method == "adjoint"
@@ -313,30 +311,28 @@ class TestConfigSetup:
 class TestPreprocessing:
     """Unit tests for the preprocessing method."""
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_chooses_best_gradient_method(self):
         """Test that preprocessing chooses backprop as the best gradient method."""
         dev = DefaultQubit()
-
         config = ExecutionConfig(
-            gradient_method="best", use_device_gradient=None, grad_on_execution=None
+            gradient_method="best",
+            use_device_gradient=None,
+            grad_on_execution=None,
         )
-
         new_config = dev.setup_execution_config(config)
 
         assert new_config.gradient_method == "backprop"
         assert new_config.use_device_gradient
         assert not new_config.grad_on_execution
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_config_choices_for_adjoint(self):
         """Test that preprocessing request grad on execution and says to use the device gradient if adjoint is requested."""
         dev = DefaultQubit()
-
         config = ExecutionConfig(
-            gradient_method="adjoint", use_device_gradient=None, grad_on_execution=None
+            gradient_method="adjoint",
+            use_device_gradient=None,
+            grad_on_execution=None,
         )
-
         new_config = dev.setup_execution_config(config)
 
         assert new_config.use_device_gradient
@@ -433,7 +429,6 @@ class TestPreprocessing:
             (CustomizedSparseOp([0, 1, 2]), True),
         ],
     )
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_accepted_operator(self, op, expected):
         """Test that _accepted_operator works correctly"""
         res = stopping_condition(op)
@@ -443,9 +438,8 @@ class TestPreprocessing:
     def test_adjoint_only_one_wire(self):
         """Tests adjoint accepts operators with no parameters or a single parameter and a generator."""
 
-        program = qml.device("default.qubit").preprocess_transforms(
-            ExecutionConfig(gradient_method="adjoint")
-        )
+        config = ExecutionConfig(gradient_method="adjoint")
+        program = qml.device("default.qubit").preprocess_transforms(config)
 
         tape1 = qml.tape.QuantumScript([MatOp(wires=0)])
         batch, _ = program((tape1,))
@@ -534,10 +528,10 @@ class TestPreprocessing:
             program([tape])
 
 
+@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestPreprocessingIntegration:
     """Test preprocess produces output that can be executed by the device."""
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_batch_transform_no_batching(self):
         """Test that batch_transform does nothing when no batching is required."""
         ops = [qml.Hadamard(0), qml.CNOT([0, 1]), qml.RX(0.123, wires=1)]
@@ -553,7 +547,6 @@ class TestPreprocessingIntegration:
         for op, expected in zip(tapes[0].circuit, ops + measurements):
             qml.assert_equal(op, expected)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_batch_transform_broadcast_not_adjoint(self):
         """Test that batch_transform does nothing when batching is required but
         internal PennyLane broadcasting can be used (diff method != adjoint)"""
@@ -568,7 +561,6 @@ class TestPreprocessingIntegration:
         assert len(tapes) == 1
         assert tapes[0].circuit == ops + measurements
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_batch_transform_broadcast_adjoint(self):
         """Test that batch_transform splits broadcasted tapes correctly when
         the diff method is adjoint"""
@@ -592,7 +584,6 @@ class TestPreprocessingIntegration:
             for op, expected in zip(t.circuit, expected_ops[i] + measurements):
                 qml.assert_equal(op, expected)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_batch_transform_not_adjoint(self):
         """Test that preprocess returns the correct tapes when a batch transform
         is needed."""
@@ -620,7 +611,6 @@ class TestPreprocessingIntegration:
         val = ([[1, 2], [3, 4]], [[5, 6], [7, 8]])
         assert np.array_equal(batch_fn(val), np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]))
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_batch_transform_adjoint(self):
         """Test that preprocess returns the correct tapes when a batch transform
         is needed."""
@@ -660,7 +650,6 @@ class TestPreprocessingIntegration:
         expected = (np.array([1, 2, 3]), np.array([4, 5, 6]))
         assert np.array_equal(batch_fn(val), expected)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_expand(self):
         """Test that preprocess returns the correct tapes when expansion is needed."""
         ops = [qml.Hadamard(0), NoMatOp(1), qml.RZ(0.123, wires=1)]
@@ -683,7 +672,6 @@ class TestPreprocessingIntegration:
         val = (("a", "b"), "c", "d")
         assert batch_fn(val) == (("a", "b"), "c")
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_split_and_expand_not_adjoint(self):
         """Test that preprocess returns the correct tapes when splitting and expanding
         is needed."""
@@ -717,7 +705,6 @@ class TestPreprocessingIntegration:
         val = ([[1, 2], [3, 4]], [[5, 6], [7, 8]])
         assert np.array_equal(batch_fn(val), np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]]))
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_split_and_expand_adjoint(self):
         """Test that preprocess returns the correct tapes when splitting and expanding
         is needed."""
@@ -756,6 +743,7 @@ class TestPreprocessingIntegration:
         expected = (np.array([1, 2, 3]), np.array([4, 5, 6]))
         assert np.array_equal(batch_fn(val), expected)
 
+    @pytest.mark.usefixtures("disable_graph_decomposition")
     def test_preprocess_check_validity_fail(self):
         """Test that preprocess throws an error if the split and expanded tapes have
         unsupported operators."""
@@ -781,7 +769,6 @@ class TestPreprocessingIntegration:
         ],
     )
     @pytest.mark.filterwarnings("ignore:Differentiating with respect to")
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_invalid_tape_adjoint(self, ops, measurement, message):
         """Test that preprocessing fails if adjoint differentiation is requested and an
         invalid tape is used"""
@@ -792,7 +779,6 @@ class TestPreprocessingIntegration:
         with pytest.raises(DeviceError, match=message):
             program([qs])
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_tape_for_adjoint(self):
         """Test that a tape is expanded correctly if adjoint differentiation is requested"""
         qs = qml.tape.QuantumScript(
@@ -825,7 +811,6 @@ class TestPreprocessingIntegration:
         assert expanded_qs.trainable_params == expected_qs.trainable_params
 
     @pytest.mark.parametrize("max_workers", [None, 1, 2])
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_single_circuit(self, max_workers):
         """Test integration between preprocessing and execution with numpy parameters."""
 
@@ -862,7 +847,6 @@ class TestPreprocessingIntegration:
         assert qml.math.allclose(processed_result[2], np.sin(y))
 
     @pytest.mark.parametrize("max_workers", [None, 1, 2])
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_preprocess_batch_circuit(self, max_workers):
         """Test preprocess integrates with default qubit when we start with a batch of circuits."""
 
@@ -945,6 +929,7 @@ class TestPreprocessingIntegration:
             prog((tape,))
 
 
+@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestAdjointDiffTapeValidation:
     """Unit tests for validate_and_expand_adjoint"""
 
@@ -1000,7 +985,6 @@ class TestAdjointDiffTapeValidation:
         qml.assert_equal(res[3], qml.PhaseShift(qml.numpy.array(0.2), wires=0))
         qml.assert_equal(res[4], qml.PhaseShift(qml.numpy.array(0.1), wires=0))
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_trainable_params_decomposed(self):
         """Test that the trainable parameters of a tape are updated when it is expanded"""
 
@@ -1045,7 +1029,6 @@ class TestAdjointDiffTapeValidation:
         qml.assert_equal(res[7], qml.RZ(qml.numpy.array(0.3), 0))
         assert res.trainable_params == [0, 1, 2, 3, 4, 5, 6]
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_u3_non_trainable_params(self):
         """Test that a warning is raised and all parameters are trainable in the expanded
         tape when not all parameters in U3 are trainable"""
@@ -1086,7 +1069,6 @@ class TestAdjointDiffTapeValidation:
             _ = program((qs,))
 
     @pytest.mark.parametrize("G", [qml.RX, qml.RY, qml.RZ])
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_valid_tape_no_expand(self, G):
         """Test that a tape that is valid doesn't raise errors and is not expanded"""
         prep_op = qml.StatePrep(
@@ -1110,7 +1092,6 @@ class TestAdjointDiffTapeValidation:
             qml.assert_equal(o1, o2)
         assert qs_valid.trainable_params == [1]  # same as input tape since no decomposition
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_valid_tape_with_expansion(self):
         """Test that a tape that is valid with operations that need to be expanded doesn't raise errors
         and is expanded"""
@@ -1149,7 +1130,6 @@ class TestAdjointDiffTapeValidation:
         assert qs_valid.trainable_params == [0, 1, 2, 3]
         assert qs.shots == qs_valid.shots
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_untrainable_operations(self):
         """Tests that a parametrized QubitUnitary that is not trainable is not expanded"""
 
@@ -1163,19 +1143,13 @@ class TestAdjointDiffTapeValidation:
         assert qml.jacobian(circuit)(x) == 0
 
 
+@pytest.mark.usefixtures("enable_graph_decomposition")
 class TestDefaultQubitGraphModeExclusive:
     """Tests for DefaultQubit features that require graph mode enabled.
     The legacy decomposition mode should not be able to run these tests.
 
     NOTE: All tests in this suite will auto-enable graph mode via fixture.
     """
-
-    @pytest.fixture(autouse=True)
-    def enable_graph_mode_only(self):
-        """Auto-enable graph mode for all tests in this class."""
-        qml.decomposition.enable_graph()
-        yield
-        qml.decomposition.disable_graph()
 
     def test_insufficient_work_wires_causes_fallback(self):
         """Test that if a decomposition requires more work wires than available on default.qubit,

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -183,11 +183,10 @@ class TestConfigSetup:
     def test_config_choices_for_adjoint(self):
         """Test that preprocessing request grad on execution and says to use the device gradient if adjoint is requested."""
         config = qml.devices.ExecutionConfig(
-            gradient_method="adjoint",
-            use_device_gradient=None,
-            grad_on_execution=None,
+            gradient_method="adjoint", use_device_gradient=None, grad_on_execution=None
         )
         new_config = qml.device("default.qubit").setup_execution_config(config)
+
         assert new_config.use_device_gradient
         assert new_config.grad_on_execution
 
@@ -207,8 +206,7 @@ class TestConfigSetup:
 
         dev = qml.device("default.qubit")
         config = qml.devices.ExecutionConfig(
-            gradient_method="best",
-            device_options={"max_workers": 2},
+            gradient_method="best", device_options={"max_workers": 2}
         )
         config = dev.setup_execution_config(config)
         assert config.gradient_method == "adjoint"
@@ -314,11 +312,11 @@ class TestPreprocessing:
     def test_chooses_best_gradient_method(self):
         """Test that preprocessing chooses backprop as the best gradient method."""
         dev = DefaultQubit()
+
         config = ExecutionConfig(
-            gradient_method="best",
-            use_device_gradient=None,
-            grad_on_execution=None,
+            gradient_method="best", use_device_gradient=None, grad_on_execution=None
         )
+
         new_config = dev.setup_execution_config(config)
 
         assert new_config.gradient_method == "backprop"
@@ -328,11 +326,11 @@ class TestPreprocessing:
     def test_config_choices_for_adjoint(self):
         """Test that preprocessing request grad on execution and says to use the device gradient if adjoint is requested."""
         dev = DefaultQubit()
+
         config = ExecutionConfig(
-            gradient_method="adjoint",
-            use_device_gradient=None,
-            grad_on_execution=None,
+            gradient_method="adjoint", use_device_gradient=None, grad_on_execution=None
         )
+
         new_config = dev.setup_execution_config(config)
 
         assert new_config.use_device_gradient
@@ -438,8 +436,9 @@ class TestPreprocessing:
     def test_adjoint_only_one_wire(self):
         """Tests adjoint accepts operators with no parameters or a single parameter and a generator."""
 
-        config = ExecutionConfig(gradient_method="adjoint")
-        program = qml.device("default.qubit").preprocess_transforms(config)
+        program = qml.device("default.qubit").preprocess_transforms(
+            ExecutionConfig(gradient_method="adjoint")
+        )
 
         tape1 = qml.tape.QuantumScript([MatOp(wires=0)])
         batch, _ = program((tape1,))

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -579,18 +579,9 @@ class TestDecomposeTransformations:
             ), f"Expected num_work_wires={expected_work_wires} not found in calls"
 
 
+@pytest.mark.usefixtures("enable_graph_decomposition")
 class TestGraphModeExclusiveFeatures:
-    """Tests that only work when graph mode is enabled.
-
-    NOTE: All tests in this suite will auto-enable graph mode via fixture.
-    """
-
-    @pytest.fixture(autouse=True)
-    def enable_graph_mode_only(self):
-        """Auto-enable graph mode for all tests in this class."""
-        qml.decomposition.enable_graph()
-        yield
-        qml.decomposition.disable_graph()
+    """Tests that only work when graph mode is enabled."""
 
     def test_work_wire_unavailability_causes_fallback(self):
         """Test that decompositions requiring more work wires than available are discarded.

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -388,10 +388,10 @@ class TestValidateMeasurements:
             validate_measurements(tape, lambda obj: True)
 
 
+@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestDecomposeTransformations:
     """Tests for the behavior of the `decompose` helper."""
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize("shots", [None, 100])
     def test_decompose_expand_unsupported_op(self, shots):
         """Test that decompose expands the tape when unsupported operators are present"""
@@ -408,7 +408,6 @@ class TestDecomposeTransformations:
 
         assert tape.shots == expanded_tape.shots
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_decompose_no_expansion(self):
         """Test that expand_fn does nothing to a fully supported quantum script."""
         ops = [qml.Hadamard(0), qml.CNOT([0, 1]), qml.RZ(0.123, wires=1)]
@@ -420,7 +419,6 @@ class TestDecomposeTransformations:
         for op, exp in zip(expanded_tape.circuit, ops + measurements):
             qml.assert_equal(op, exp)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize("validation_transform", (validate_measurements, validate_observables))
     def test_valdiate_measurements_non_commuting_measurements(self, validation_transform):
         """Test that validate_measurements and validate_observables works when non commuting measurements exist in the circuit."""
@@ -431,7 +429,6 @@ class TestDecomposeTransformations:
         new_qs = new_qs[0]
         assert new_qs.measurements == qs.measurements
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
         "prep_op",
         (
@@ -471,7 +468,6 @@ class TestDecomposeTransformations:
 
         assert expanded_tape.circuit == expected + measurements
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
         "prep_op",
         (
@@ -489,7 +485,6 @@ class TestDecomposeTransformations:
 
         assert new_tape[0] != prep_op
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_decompose_with_device_wires_and_target_gates(self):
         """Test that decompose works correctly with device_wires and target_gates parameters."""
         # Mock a simple target gate set
@@ -520,7 +515,6 @@ class TestDecomposeTransformations:
         assert len(legacy_tape.operations) > len(tape.operations)
         assert all(op.name in target_gates for op in legacy_tape.operations)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
         "device_wires_list,tape_wires_list,expected_work_wires",
         [

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1726,7 +1726,8 @@ class TestDecomposition:
 
         assert q.queue == _ops[::-1]
 
-    def test_integration(self, enable_graph_decomposition):
+    @pytest.mark.usefixtures("enable_graph_decomposition")
+    def test_integration(self):
         """Test that prod's can be integrated into the decomposition."""
 
         op = qml.S(0) @ qml.S(1) @ qml.T(0) @ qml.Y(1)

--- a/tests/templates/layers/test_gate_fabric.py
+++ b/tests/templates/layers/test_gate_fabric.py
@@ -38,84 +38,11 @@ def test_standard_validity(include_pi):
     qml.ops.functions.assert_valid(op)
 
 
-class TestDecomposition:
-    """Tests that the template defines the correct decomposition."""
+@pytest.mark.system
+@pytest.mark.usefixtures("enable_and_disable_graph_decomp")
+class TestCorrectness:
+    """Tests the correctness of the template in a qnode."""
 
-    @pytest.mark.parametrize(
-        "layers, qubits, init_state, include_pi",
-        [
-            (1, 4, qml.math.array([1, 1, 0, 0]), False),
-            (2, 4, qml.math.array([1, 1, 0, 0]), True),
-            (1, 6, qml.math.array([1, 1, 0, 0, 0, 0]), False),
-            (2, 6, qml.math.array([1, 1, 0, 0, 0, 0]), True),
-            (1, 8, qml.math.array([1, 1, 0, 0, 0, 0, 0, 0]), False),
-            (2, 8, qml.math.array([1, 1, 1, 1, 0, 0, 0, 0]), True),
-        ],
-    )
-    def test_operations(self, layers, qubits, init_state, include_pi):
-        """Test the correctness of the GateFabric template including the gate count
-        and order, the wires each operation acts on and the correct use of parameters
-        in the circuit."""
-
-        weights = np.random.normal(0, 2 * np.pi, (layers, qubits // 2 - 1, 2))
-
-        if not include_pi:
-            n_gates = 1 + (qubits - 2) * layers
-            exp_gates = (
-                ([qml.DoubleExcitation] + [qml.OrbitalRotation]) * (qubits // 2 - 1)
-            ) * layers
-        else:
-            n_gates = 1 + 3 * (qubits // 2 - 1) * layers
-            exp_gates = (
-                ([qml.OrbitalRotation] + [qml.DoubleExcitation] + [qml.OrbitalRotation])
-                * (qubits // 2 - 1)
-            ) * layers
-
-        op = qml.GateFabric(
-            weights, wires=range(qubits), init_state=init_state, include_pi=include_pi
-        )
-        queue = op.decomposition()
-
-        # number of gates
-        assert len(queue) == n_gates
-
-        # initialization
-        assert isinstance(queue[0], qml.BasisEmbedding)
-
-        # order of gates
-        for op1, op2 in zip(queue[1:], exp_gates):
-            assert isinstance(op1, op2)
-
-        # gate parameter
-        params = qml.math.array(
-            [queue[i].parameters for i in range(1, n_gates) if queue[i].parameters != []]
-        )
-
-        if include_pi:
-            weights = qml.math.insert(weights, 0, [[np.pi] * (qubits // 2 - 1)] * layers, axis=2)
-
-        assert qml.math.allclose(params.flatten(), weights.flatten())
-
-        # gate wires
-        wires = range(qubits)
-        qwires = [wires[i : i + 4] for i in range(0, len(wires), 4) if len(wires[i : i + 4]) == 4]
-        if len(wires) // 2 > 2:
-            qwires += [
-                wires[i : i + 4] for i in range(2, len(wires), 4) if len(wires[i : i + 4]) == 4
-            ]
-
-        exp_wires = []
-        for _ in range(layers):
-            for wire in qwires:
-                if include_pi:
-                    exp_wires.append(list(wire))
-                exp_wires.append(list(wire))
-                exp_wires.append(list(wire))
-
-        res_wires = [queue[i].wires.tolist() for i in range(1, n_gates)]
-        assert res_wires == exp_wires
-
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
         ("init_state", "exp_state"),
         [
@@ -506,7 +433,6 @@ class TestDecomposition:
 
         assert qml.math.allclose(circuit(weight), exp_state, atol=tol)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
         ("num_qubits", "layers", "exp_state"),
         [
@@ -627,7 +553,6 @@ class TestDecomposition:
 
         assert qml.math.allclose(circuit(weight), exp_state, atol=tol)
 
-    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_custom_wire_labels(self, tol):
         """Test that template can deal with non-numeric, nonconsecutive wire labels."""
         weights = np.random.random(size=(1, 1, 2))
@@ -651,6 +576,84 @@ class TestDecomposition:
 
         assert np.allclose(res1, res2, atol=tol, rtol=0)
         assert np.allclose(state1, state2, atol=tol, rtol=0)
+
+
+class TestDecomposition:  # pylint: disable=too-few-public-methods
+    """Tests that the template defines the correct decomposition."""
+
+    @pytest.mark.parametrize(
+        "layers, qubits, init_state, include_pi",
+        [
+            (1, 4, qml.math.array([1, 1, 0, 0]), False),
+            (2, 4, qml.math.array([1, 1, 0, 0]), True),
+            (1, 6, qml.math.array([1, 1, 0, 0, 0, 0]), False),
+            (2, 6, qml.math.array([1, 1, 0, 0, 0, 0]), True),
+            (1, 8, qml.math.array([1, 1, 0, 0, 0, 0, 0, 0]), False),
+            (2, 8, qml.math.array([1, 1, 1, 1, 0, 0, 0, 0]), True),
+        ],
+    )
+    def test_operations(self, layers, qubits, init_state, include_pi):
+        """Test the correctness of the GateFabric template including the gate count
+        and order, the wires each operation acts on and the correct use of parameters
+        in the circuit."""
+
+        weights = np.random.normal(0, 2 * np.pi, (layers, qubits // 2 - 1, 2))
+
+        if not include_pi:
+            n_gates = 1 + (qubits - 2) * layers
+            exp_gates = (
+                ([qml.DoubleExcitation] + [qml.OrbitalRotation]) * (qubits // 2 - 1)
+            ) * layers
+        else:
+            n_gates = 1 + 3 * (qubits // 2 - 1) * layers
+            exp_gates = (
+                ([qml.OrbitalRotation] + [qml.DoubleExcitation] + [qml.OrbitalRotation])
+                * (qubits // 2 - 1)
+            ) * layers
+
+        op = qml.GateFabric(
+            weights, wires=range(qubits), init_state=init_state, include_pi=include_pi
+        )
+        queue = op.decomposition()
+
+        # number of gates
+        assert len(queue) == n_gates
+
+        # initialization
+        assert isinstance(queue[0], qml.BasisEmbedding)
+
+        # order of gates
+        for op1, op2 in zip(queue[1:], exp_gates):
+            assert isinstance(op1, op2)
+
+        # gate parameter
+        params = qml.math.array(
+            [queue[i].parameters for i in range(1, n_gates) if queue[i].parameters != []]
+        )
+
+        if include_pi:
+            weights = qml.math.insert(weights, 0, [[np.pi] * (qubits // 2 - 1)] * layers, axis=2)
+
+        assert qml.math.allclose(params.flatten(), weights.flatten())
+
+        # gate wires
+        wires = range(qubits)
+        qwires = [wires[i : i + 4] for i in range(0, len(wires), 4) if len(wires[i : i + 4]) == 4]
+        if len(wires) // 2 > 2:
+            qwires += [
+                wires[i : i + 4] for i in range(2, len(wires), 4) if len(wires[i : i + 4]) == 4
+            ]
+
+        exp_wires = []
+        for _ in range(layers):
+            for wire in qwires:
+                if include_pi:
+                    exp_wires.append(list(wire))
+                exp_wires.append(list(wire))
+                exp_wires.append(list(wire))
+
+        res_wires = [queue[i].wires.tolist() for i in range(1, n_gates)]
+        assert res_wires == exp_wires
 
     DECOMP_PARAMS = [
         (qml.math.array([[[-0.080, 2.629]]]), [0, 1, 2, 3], qml.math.array([1, 1, 0, 0]), False),

--- a/tests/transforms/test_decompose_transform.py
+++ b/tests/transforms/test_decompose_transform.py
@@ -28,7 +28,7 @@ from pennylane.transforms.decompose import _operator_decomposition_gen, decompos
 # pylint: disable=unnecessary-lambda-assignment
 # pylint: disable=too-few-public-methods
 
-pytest.mark.usefixtures("disable_graph_decomposition")
+pytestmark = pytest.mark.usefixtures("disable_graph_decomposition")
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +67,24 @@ class InfiniteOp(Operation):
 
     def decomposition(self):
         return [InfiniteOp(*self.parameters, self.wires)]
+
+
+@pytest.mark.unit
+def test_fixed_alt_decomps_not_available():
+    """Test that a TypeError is raised when graph is disabled and
+    fixed_decomps or alt_decomps is used."""
+
+    @qml.register_resources({qml.H: 2, qml.CZ: 1})
+    def my_cnot(*_, **__):
+        raise NotImplementedError
+
+    tape = qml.tape.QuantumScript([])
+
+    with pytest.raises(TypeError, match="The keyword arguments fixed_decomps and alt_decomps"):
+        qml.transforms.decompose(tape, fixed_decomps={qml.CNOT: my_cnot})
+
+    with pytest.raises(TypeError, match="The keyword arguments fixed_decomps and alt_decomps"):
+        qml.transforms.decompose(tape, alt_decomps={qml.CNOT: [my_cnot]})
 
 
 class TestDecompose:

--- a/tests/transforms/test_decompose_transform.py
+++ b/tests/transforms/test_decompose_transform.py
@@ -28,6 +28,8 @@ from pennylane.transforms.decompose import _operator_decomposition_gen, decompos
 # pylint: disable=unnecessary-lambda-assignment
 # pylint: disable=too-few-public-methods
 
+pytest.mark.usefixtures("disable_graph_decomposition")
+
 
 @pytest.fixture(autouse=True)
 def warnings_as_errors():

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -28,6 +28,8 @@ from pennylane.ops.mid_measure.pauli_measure import PauliMeasure
 from pennylane.ops.op_math.condition import Conditional
 from pennylane.transforms.decompose import _resolve_gate_set
 
+pytest.mark.usefixtures("enable_graph_decomposition")
+
 
 @pytest.mark.unit
 def test_weighted_graph_handles_negative_weight():
@@ -41,7 +43,6 @@ def test_weighted_graph_handles_negative_weight():
 
 
 @pytest.mark.unit
-@pytest.mark.usefixtures("enable_graph_decomposition")
 def test_weights_affect_graph_decomposition():
     tape = qml.tape.QuantumScript([qml.CRX(0.1, wires=[0, 1]), qml.Toffoli(wires=[0, 1, 2])])
 
@@ -68,6 +69,7 @@ def test_weights_affect_graph_decomposition():
 
 
 @pytest.mark.unit
+@pytest.mark.usefixtures("disable_graph_decomposition")
 def test_fixed_alt_decomps_not_available():
     """Test that a TypeError is raised when graph is disabled and
     fixed_decomps or alt_decomps is used."""
@@ -143,7 +145,6 @@ def _decomp2_without_work_wire(wires, **__):
     qml.Toffoli(wires=[wires[2], wires[1], wires[0]])
 
 
-@pytest.mark.usefixtures("enable_graph_decomposition")
 class TestDecomposeGraphEnabled:
     """Tests the decompose transform with graph enabled."""
 
@@ -627,7 +628,6 @@ class TestDecomposeGraphEnabled:
 
 @pytest.mark.capture
 @pytest.mark.system
-@pytest.mark.usefixtures("enable_graph_decomposition")
 def test_decompose_qnode():
     """Tests that the decompose transform works with a QNode."""
 
@@ -642,7 +642,6 @@ def test_decompose_qnode():
 
 
 @pytest.mark.unit
-@pytest.mark.usefixtures("enable_graph_decomposition")
 def test_stopping_condition_graph_enabled():
     """Tests that the stopping condition is resolved correctly when the graph is disabled."""
 
@@ -658,7 +657,6 @@ def test_stopping_condition_graph_enabled():
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("enable_graph_decomposition")
 def test_stopping_condition():
     """Tests that the stopping condition is respected."""
 

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -28,7 +28,7 @@ from pennylane.ops.mid_measure.pauli_measure import PauliMeasure
 from pennylane.ops.op_math.condition import Conditional
 from pennylane.transforms.decompose import _resolve_gate_set
 
-pytest.mark.usefixtures("enable_graph_decomposition")
+pytestmark = pytest.mark.usefixtures("enable_graph_decomposition")
 
 
 @pytest.mark.unit
@@ -66,25 +66,6 @@ def test_weights_affect_graph_decomposition():
         qml.H(wires=[1]),
         qml.Toffoli(wires=[0, 1, 2]),
     ]
-
-
-@pytest.mark.unit
-@pytest.mark.usefixtures("disable_graph_decomposition")
-def test_fixed_alt_decomps_not_available():
-    """Test that a TypeError is raised when graph is disabled and
-    fixed_decomps or alt_decomps is used."""
-
-    @qml.register_resources({qml.H: 2, qml.CZ: 1})
-    def my_cnot(*_, **__):
-        raise NotImplementedError
-
-    tape = qml.tape.QuantumScript([])
-
-    with pytest.raises(TypeError, match="The keyword arguments fixed_decomps and alt_decomps"):
-        qml.transforms.decompose(tape, fixed_decomps={qml.CNOT: my_cnot})
-
-    with pytest.raises(TypeError, match="The keyword arguments fixed_decomps and alt_decomps"):
-        qml.transforms.decompose(tape, alt_decomps={qml.CNOT: [my_cnot]})
 
 
 class CustomOpDynamicWireDecomp(Operation):  # pylint: disable=too-few-public-methods

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -18,9 +18,12 @@ Unit tests for tape expansion stopping criteria and expansion functions.
 # pylint: disable=arguments-differ, arguments-renamed,
 
 import numpy as np
+import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+
+pytest.mark.usefixtures("disable_graph_decomposition")
 
 
 def crit_0(op: qml.operation.Operator):

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -23,7 +23,7 @@ from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
 
-pytest.mark.usefixtures("disable_graph_decomposition")
+pytestmark = pytest.mark.usefixtures("disable_graph_decomposition")
 
 
 def crit_0(op: qml.operation.Operator):


### PR DESCRIPTION
**Context:**
Implement a thread-safe context manager for toggling graph decomposition, used primarily for enabling and disabling graph decomposition for certain test cases without affecting other concurrent test runners.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-109205]
