### PR TITLE
Fix `to_ppr` doctest

### DIFF
--- a/pennylane/transforms/decompositions/pauli_based_computation.py
+++ b/pennylane/transforms/decompositions/pauli_based_computation.py
@@ -98,6 +98,7 @@ def to_ppr_setup_inputs():
         Circuit depth: Not computed
     <BLANKLINE>
     Gate types:
+        GlobalPhase: 3
         PPR-pi/4: 6
         PPM: 1
         PPR-pi/8: 1
@@ -529,6 +530,7 @@ def ppm_compilation_setup_inputs(
     Circuit depth: Not computed
     <BLANKLINE>
     Gate types:
+        GlobalPhase: 3
         qec.fabricate: 1
         PPM: 14
         PPR-pi/2: 7

--- a/pennylane/transforms/decompositions/pauli_based_computation.py
+++ b/pennylane/transforms/decompositions/pauli_based_computation.py
@@ -94,7 +94,7 @@ def to_ppr_setup_inputs():
     <BLANKLINE>
     Resource specifications:
         Total wire allocations: 2
-        Total gates: 8
+        Total gates: 11
         Circuit depth: Not computed
     <BLANKLINE>
     Gate types:
@@ -526,7 +526,7 @@ def ppm_compilation_setup_inputs(
     <BLANKLINE>
     Resource specifications:
     Total wire allocations: 8
-    Total gates: 22
+    Total gates: 25
     Circuit depth: Not computed
     <BLANKLINE>
     Gate types:

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -75,7 +75,7 @@ class TestFromBloq:
 
         from qualtran.bloqs.basic_gates import XGate
 
-        assert repr(qml.FromBloq(XGate(), 1)) == "FromBloq(XGate, wires=Wires([1]))"
+        assert repr(qml.FromBloq(XGate(), 1)) == "FromBloq(X, wires=Wires([1]))"
         with pytest.raises(TypeError, match="bloq must be an instance of"):
             qml.FromBloq("123", 1)
 


### PR DESCRIPTION
**Context:**
A [catalyst PR](https://github.com/PennyLaneAI/catalyst/pull/2419) changed the operators generated by the pass `to_ppr`.
This broke the doctest in the PL docstring of `to_ppr`.

**Description of the Change:**
Adjust doctest output to the change in Catalyst

**Benefits:**
unblock CI

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
