### PR TITLE
fix: update sub-optimal ordering of boolean operations

### DIFF
--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -940,7 +940,7 @@ def _(original_measurement: ProbabilityMP, measures):
 def _(original_measurement: SampleMP, measures):
     """The combined samples of two branches is obtained by concatenating the sample of each branch."""
     new_sample = tuple(
-        math.atleast_1d(m[1]) for m in measures.values() if m[0] and not m[1] is tuple()
+        math.atleast_1d(m[1]) for m in measures.values() if m[0] and m[1] is not tuple()
     )
     return math.concatenate(new_sample)
 

--- a/pennylane/estimator/templates/qsp.py
+++ b/pennylane/estimator/templates/qsp.py
@@ -808,7 +808,7 @@ class QSP(ResourceOperator):
         if block_encoding.num_wires > 1:
             raise ValueError("The block encoding operator should act on a single qubit!")
 
-        if not (convention in {"Z", "X"}):
+        if convention not in {"Z", "X"}:
             raise ValueError(f"The valid conventions are 'Z' or 'X'. Got {convention}")
 
         self.block_encoding = block_encoding.resource_rep_from_op()
@@ -867,7 +867,7 @@ class QSP(ResourceOperator):
         if block_encoding.num_wires > 1:
             raise ValueError("The block encoding operator should act on a single qubit!")
 
-        if not (convention in {"Z", "X"}):
+        if convention not in {"Z", "X"}:
             raise ValueError(f"The valid conventions are 'Z' or 'X'. Got {convention}")
 
         params = {

--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -117,7 +117,7 @@ def _(op: qtemps.subroutines.TrotterizedQfunc):
         with AnnotatedQueue() as q:
             qfunc_args = op.parameters
             qfunc_kwargs = {
-                k: v for k, v in op.hyperparameters.items() if not k in base_hyper_params
+                k: v for k, v in op.hyperparameters.items() if k not in base_hyper_params
             }
 
             qfunc = op.hyperparameters["qfunc"]
@@ -1018,12 +1018,12 @@ class FromBloq(Operation):
                     in_quregs = {}
                     for succ in succ_cxns:
                         soq = succ.left
-                        if soq.reg.side == qt.Side.RIGHT and not soq.reg.name in in_quregs:
+                        if soq.reg.side == qt.Side.RIGHT and soq.reg.name not in in_quregs:
                             soq_to_wires_len -= np.prod(soq.reg.shape) * soq.reg.bitsize
 
                     for succ in succ_cxns:
                         soq = succ.left
-                        if soq.reg.side == qt.Side.RIGHT and not soq.reg.name in in_quregs:
+                        if soq.reg.side == qt.Side.RIGHT and soq.reg.name not in in_quregs:
                             total_elements = np.prod(soq.reg.shape) * soq.reg.bitsize
                             ascending_vals = np.arange(
                                 soq_to_wires_len,

--- a/pennylane/labs/dla/recursive_cartan_decomp.py
+++ b/pennylane/labs/dla/recursive_cartan_decomp.py
@@ -253,7 +253,7 @@ def recursive_cartan_decomp(g, chain, validate=True, verbose=True):
         if verbose:
             print(f"Iteration {i}: {len(g):>4} -{name:-^8}> {len(k):>4},{len(m):>4}")
         decompositions[i] = (k, m)
-        if not bc is IDENTITY:
+        if bc is not IDENTITY:
             k = _apply_basis_change(bc, k)
             m = _apply_basis_change(bc, m)
         g = k

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -683,7 +683,7 @@ def givens_decomposition(unitary):
     """
     interface = math.get_deep_interface(unitary)
     unitary_mat = math.copy(unitary) if interface == "jax" else math.toarray(unitary).copy()
-    is_real = not "complex" in math.get_dtype_name(unitary)
+    is_real = "complex" not in math.get_dtype_name(unitary)
 
     shape = math.shape(unitary_mat)
 

--- a/pennylane/math/is_independent.py
+++ b/pennylane/math/is_independent.py
@@ -363,7 +363,7 @@ def is_independent(
 
     # pylint:disable=too-many-arguments
 
-    if not interface in {"autograd", "jax", "tf", "torch", "tensorflow"}:
+    if interface not in {"autograd", "jax", "tf", "torch", "tensorflow"}:
         raise ValueError(f"Unknown interface: {interface}")
 
     kwargs = kwargs or {}

--- a/pennylane/qchem/vibrational/christiansen_ham.py
+++ b/pennylane/qchem/vibrational/christiansen_ham.py
@@ -123,7 +123,7 @@ def christiansen_bosonic(one, two=None, three=None, ordered=True):
                 obs[w] = one[l, k_l, h_l]
 
     # two-body terms
-    if not two is None:
+    if two is not None:
         for l in range(modes):
             if ordered is False:
                 m_range = [p for p in range(modes) if p != l]
@@ -151,7 +151,7 @@ def christiansen_bosonic(one, two=None, three=None, ordered=True):
                                 obs[w] = two[l, m, k_l, k_m, h_l, h_m]
 
     # three-body terms
-    if not three is None:
+    if three is not None:
         for l in range(modes):
             if not ordered:
                 m_range = [p for p in range(modes) if p != l]

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -880,7 +880,7 @@ def substitute(initial_resources: Resources, gate_info: tuple[str, int], replace
 
     gate_name, num_wires = gate_info
 
-    if not num_wires in initial_resources.gate_sizes:
+    if num_wires not in initial_resources.gate_sizes:
         raise ValueError(f"initial_resources does not contain a gate acting on {num_wires} wires.")
 
     gate_count = initial_resources.gate_types.get(gate_name, 0)

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -190,7 +190,7 @@ def _specs_qjit_intermediate_passes(
     # Note that this only gets transforms manually applied by the user
     trans_prog = original_qnode.compile_pipeline
 
-    single_level = isinstance(level, (int, str)) and not level in ("all", "all-mlir")
+    single_level = isinstance(level, (int, str)) and level not in ("all", "all-mlir")
 
     # Maps to convert back and forth between marker name and int level
     marker_to_level = {

--- a/pennylane/templates/subroutines/arithmetic/out_poly.py
+++ b/pennylane/templates/subroutines/arithmetic/out_poly.py
@@ -446,7 +446,7 @@ class OutPoly(Operation):
 
         for item, coeff in coeffs_dic.items():
 
-            if not 1 in item:
+            if 1 not in item:
                 # Add the constant term
                 list_ops.append(PhaseAdder(int(coeff), output_adder_mod))
             else:
@@ -531,7 +531,7 @@ def _out_poly_decomposition(
 
     for item, coeff in coeffs_dic.items():
 
-        if not 1 in item:
+        if 1 not in item:
             # Add the constant term
             PhaseAdder(int(coeff), output_adder_mod)
         else:

--- a/pennylane/templates/subroutines/time_evolution/trotter.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter.py
@@ -692,7 +692,7 @@ class TrotterizedQfunc(Operation):
         qfunc_args = self.parameters[1:]
 
         base_hyper_params = ("n", "order", "qfunc", "reverse")
-        qfunc_kwargs = {k: v for k, v in self.hyperparameters.items() if not k in base_hyper_params}
+        qfunc_kwargs = {k: v for k, v in self.hyperparameters.items() if k not in base_hyper_params}
 
         decomp = (
             _recursive_qfunc(

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -388,7 +388,7 @@ def merge_rotations(
                 continue
 
         # Check if the rotation is composable; if it is not, move on.
-        if not current_gate in composable_rotations:
+        if current_gate not in composable_rotations:
             new_operations.append(current_gate)
             list_copy.pop(0)
             continue


### PR DESCRIPTION
`ruff` detection is great. 🎉 

E.g.,

```python
>>> fruit = "banana"
>>> not "apple" in fruit # not great
True
>>> "apple" not in fruit # preferred
True
```