### PR TITLE
Scope deprecation warnings

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,12 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* ``tape.expand()`` and related functions, methods have been deprecated and will be removed in v0.46.
+  Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
+
+  - Deprecated in v0.45
+  - Will be removed in v0.46
+
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.
 

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,12 +9,6 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* ``tape.expand()`` and related functions, methods have been deprecated and will be removed in v0.46.
-  Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -142,6 +142,9 @@
 
 <h3>Deprecations 👋</h3>
 
+* ``tape.expand()`` and related functions, methods have been deprecated and will be removed in v0.46.
+  Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
+  [(#8943)](https://github.com/PennyLaneAI/pennylane/pull/8943)
 
 * The ``qml.transforms.create_expand_fn`` has been deprecated and will be removed in v0.46.
   Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -146,6 +146,7 @@
 * The ``qml.transforms.create_expand_fn`` has been deprecated and will be removed in v0.46.
   Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
   [(#8941)](https://github.com/PennyLaneAI/pennylane/pull/8941)
+  [(#8977)](https://github.com/PennyLaneAI/pennylane/pull/8977)
 
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -142,9 +142,6 @@
 
 <h3>Deprecations 👋</h3>
 
-* ``tape.expand()`` and related functions, methods have been deprecated and will be removed in v0.46.
-  Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
-  [(#8943)](https://github.com/PennyLaneAI/pennylane/pull/8943)
 
 * The ``qml.transforms.create_expand_fn`` has been deprecated and will be removed in v0.46.
   Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -166,8 +166,8 @@ def _multipar_stopping_fn(obj):
             or len(obj.data) == 0
             or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
         )
-    except TermsUndefinedError:
-        return True
+    except TermsUndefinedError:  # pragma: no cover
+        return True  # pragma: no cover
 
 
 # pylint: disable=too-many-statements

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -162,8 +162,7 @@ def _process_ids(
 def _multipar_stopping_fn(obj):
     try:
         return (
-            isinstance(obj, MeasurementProcess)
-            or len(obj.data) == 0
+            len(obj.data) == 0
             or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
         )
     except TermsUndefinedError:  # pragma: no cover

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -28,7 +28,6 @@ from pennylane import gradients, math, measurements, workflow
 from pennylane.capture.autograph import wraps
 from pennylane.decomposition import gate_sets
 from pennylane.exceptions import TermsUndefinedError
-from pennylane.measurements import MeasurementProcess
 from pennylane.transforms import decompose
 
 from .utils import get_spectrum, join_spectra
@@ -161,10 +160,7 @@ def _process_ids(
 
 def _multipar_stopping_fn(obj):
     try:
-        return (
-            len(obj.data) == 0
-            or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
-        )
+        return len(obj.data) == 0 or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
     except TermsUndefinedError:  # pragma: no cover
         return True  # pragma: no cover
 

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -77,8 +77,7 @@ def _contract_metric_tensor_with_cjac(mt, cjac, tape):  # pylint: disable=unused
 def _multipar_stopping_fn(obj):
     try:
         return (
-            isinstance(obj, MeasurementProcess)
-            or len(obj.data) == 0
+            len(obj.data) == 0
             or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
         )
     except TermsUndefinedError:
@@ -87,8 +86,7 @@ def _multipar_stopping_fn(obj):
 
 def _expand_nonunitary_gen_stop_at(obj):
     return (
-        isinstance(obj, MeasurementProcess)
-        or len(obj.data) == 0
+        len(obj.data) == 0
         or (obj.has_generator and obj in has_unitary_generator)
     )
 

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -106,16 +106,19 @@ def _expand_metric_tensor(
     # pylint: disable=unused-argument,too-many-arguments
 
     if not allow_nonunitary and approx is None:
-        [tape], postprocessing = decompose(
+        [new_tape], postprocessing = decompose(
             tape,
             gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
             stopping_condition=_expand_nonunitary_gen_stop_at,
         )
-        return [tape], postprocessing
-    [tape], postprocessing = decompose(
-        tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_multipar_stopping_fn
-    )
-    return [tape], postprocessing
+    else:
+        [new_tape], postprocessing = decompose(
+            tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_multipar_stopping_fn
+        )
+    if new_tape is not tape:
+        params = new_tape.get_parameters(trainable_only=False)
+        new_tape.trainable_params = math.get_trainable_indices(params)
+    return [new_tape], postprocessing
 
 
 @partial(

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -31,7 +31,7 @@ from pennylane.ops.functions import generator, matrix
 from pennylane.ops.qubit.attributes import has_unitary_generator
 from pennylane.queuing import WrappedObj
 from pennylane.tape import QuantumScript, QuantumScriptBatch
-from pennylane.transforms import decompose, expand_multipar, expand_nonunitary_gen
+from pennylane.transforms import decompose
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 from pennylane.wires import Wires

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -26,7 +26,7 @@ from pennylane import math
 from pennylane.circuit_graph import LayerData
 from pennylane.decomposition import gate_sets
 from pennylane.exceptions import TermsUndefinedError, WireError
-from pennylane.measurements import MeasurementProcess, expval, probs
+from pennylane.measurements import expval, probs
 from pennylane.ops.functions import generator, matrix
 from pennylane.ops.qubit.attributes import has_unitary_generator
 from pennylane.queuing import WrappedObj
@@ -76,19 +76,13 @@ def _contract_metric_tensor_with_cjac(mt, cjac, tape):  # pylint: disable=unused
 
 def _multipar_stopping_fn(obj):
     try:
-        return (
-            len(obj.data) == 0
-            or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
-        )
+        return len(obj.data) == 0 or (obj.has_generator and len(obj.generator().terms()[0]) == 1)
     except TermsUndefinedError:
         return True
 
 
 def _expand_nonunitary_gen_stop_at(obj):
-    return (
-        len(obj.data) == 0
-        or (obj.has_generator and obj in has_unitary_generator)
-    )
+    return len(obj.data) == 0 or (obj.has_generator and obj in has_unitary_generator)
 
 
 # pylint: disable=too-many-positional-arguments

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -25,13 +25,13 @@ import pennylane.ops as qops
 from pennylane import math
 from pennylane.circuit_graph import LayerData
 from pennylane.decomposition import gate_sets
-from pennylane.exceptions import WireError, TermsUndefinedError
-from pennylane.measurements import expval, probs, MeasurementProcess
+from pennylane.exceptions import TermsUndefinedError, WireError
+from pennylane.measurements import MeasurementProcess, expval, probs
 from pennylane.ops.functions import generator, matrix
 from pennylane.ops.qubit.attributes import has_unitary_generator
 from pennylane.queuing import WrappedObj
 from pennylane.tape import QuantumScript, QuantumScriptBatch
-from pennylane.transforms import expand_multipar, expand_nonunitary_gen, decompose
+from pennylane.transforms import decompose, expand_multipar, expand_nonunitary_gen
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 from pennylane.wires import Wires
@@ -106,9 +106,15 @@ def _expand_metric_tensor(
     # pylint: disable=unused-argument,too-many-arguments
 
     if not allow_nonunitary and approx is None:
-        [tape], postprocessing = decompose(tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_expand_nonunitary_gen_stop_at)
+        [tape], postprocessing = decompose(
+            tape,
+            gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
+            stopping_condition=_expand_nonunitary_gen_stop_at,
+        )
         return [tape], postprocessing
-    [tape], postprocessing = decompose(tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_multipar_stopping_fn)
+    [tape], postprocessing = decompose(
+        tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_multipar_stopping_fn
+    )
     return [tape], postprocessing
 
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -507,8 +507,7 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
 
 def _stop_at_expand_invalid_trainable(obj):
     return (
-        isinstance(obj, MeasurementProcess)
-        or not any(math.requires_grad(d) for d in obj.data)
+        not any(math.requires_grad(d) for d in obj.data)
         or obj.grad_method is not None
     )
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -506,10 +506,7 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
 
 
 def _stop_at_expand_invalid_trainable(obj):
-    return (
-        not any(math.requires_grad(d) for d in obj.data)
-        or obj.grad_method is not None
-    )
+    return not any(math.requires_grad(d) for d in obj.data) or obj.grad_method is not None
 
 
 # pylint: disable=too-many-positional-arguments

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -22,6 +22,7 @@ from functools import partial
 import numpy as np
 
 from pennylane import math
+from pennylane.decomposition import gate_sets
 from pennylane.measurements import (
     ExpectationMP,
     MeasurementProcess,
@@ -32,13 +33,10 @@ from pennylane.measurements import (
 )
 from pennylane.ops.cv import PolyXP
 from pennylane.tape import QuantumScript, QuantumScriptBatch
+from pennylane.transforms import decompose
 from pennylane.transforms.core import transform
-from pennylane.transforms.tape_expand import expand_invalid_trainable
 from pennylane.typing import PostprocessingFn
 
-from ..decomposition import gate_sets
-from ..devices.default_qutrit_mixed import stopping_condition
-from ..transforms import decompose
 from .finite_difference import finite_diff
 from .general_shift_rules import generate_shifted_tapes, process_shifts
 from .gradient_transform import (

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -65,8 +65,7 @@ def _rademacher_sampler(indices, num_params, *args, rng):
 
 def _stop_at_expand_invalid_trainable(obj):
     return (
-        isinstance(obj, MeasurementProcess)
-        or not any(math.requires_grad(d) for d in obj.data)
+        not any(math.requires_grad(d) for d in obj.data)
         or obj.grad_method is not None
     )
 

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -22,9 +22,11 @@ import numpy as np
 from pennylane import math
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import transform
-from pennylane.transforms.tape_expand import expand_invalid_trainable
 from pennylane.typing import PostprocessingFn
 
+from ..decomposition import gate_sets
+from ..measurements import MeasurementProcess
+from ..transforms import decompose
 from .finite_difference import _processing_fn, finite_diff_coeffs
 from .general_shift_rules import generate_multishifted_tapes
 from .gradient_transform import (
@@ -35,11 +37,6 @@ from .gradient_transform import (
     contract_qjac_with_cjac,
     find_and_validate_gradient_methods,
 )
-from ..decomposition import gate_sets
-from ..devices.default_qutrit_mixed import stopping_condition
-from ..measurements import MeasurementProcess
-from ..transforms import decompose
-
 
 # pylint: disable=too-many-arguments,unused-argument
 
@@ -89,7 +86,11 @@ def _expand_transform_spsa(
     sampler_rng=None,
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
     """Expand function to be applied before spsa gradient."""
-    [expanded_tape], _ = decompose(tape, gate_set=gate_sets.ROTATIONS_PLUS_CNOT, stopping_condition=_stop_at_expand_invalid_trainable)
+    [expanded_tape], _ = decompose(
+        tape,
+        gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
+        stopping_condition=_stop_at_expand_invalid_trainable,
+    )
 
     def null_postprocessing(results):
         """A postprocessing function returned by a transform that only converts the batch of results

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -20,13 +20,13 @@ from functools import partial
 import numpy as np
 
 from pennylane import math
+from pennylane.decomposition import gate_sets
+from pennylane.measurements import MeasurementProcess
 from pennylane.tape import QuantumScript, QuantumScriptBatch
+from pennylane.transforms import decompose
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 
-from pennylane.decomposition import gate_sets
-from pennylane.measurements import MeasurementProcess
-from pennylane.transforms import decompose
 from .finite_difference import _processing_fn, finite_diff_coeffs
 from .general_shift_rules import generate_multishifted_tapes
 from .gradient_transform import (

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from pennylane import math
 from pennylane.decomposition import gate_sets
-from pennylane.measurements import MeasurementProcess
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import decompose
 from pennylane.transforms.core import transform
@@ -64,10 +63,7 @@ def _rademacher_sampler(indices, num_params, *args, rng):
 
 
 def _stop_at_expand_invalid_trainable(obj):
-    return (
-        not any(math.requires_grad(d) for d in obj.data)
-        or obj.grad_method is not None
-    )
+    return not any(math.requires_grad(d) for d in obj.data) or obj.grad_method is not None
 
 
 # pylint: disable=too-many-positional-arguments

--- a/pennylane/gradients/spsa_gradient.py
+++ b/pennylane/gradients/spsa_gradient.py
@@ -24,9 +24,9 @@ from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 
-from ..decomposition import gate_sets
-from ..measurements import MeasurementProcess
-from ..transforms import decompose
+from pennylane.decomposition import gate_sets
+from pennylane.measurements import MeasurementProcess
+from pennylane.transforms import decompose
 from .finite_difference import _processing_fn, finite_diff_coeffs
 from .general_shift_rules import generate_multishifted_tapes
 from .gradient_transform import (

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -159,6 +159,7 @@ def expand_multipar(*args, **kwargs):
         docstring=_expand_multipar_doc,
     )(*args, **kwargs)
 
+
 _expand_trainable_multipar_doc = """Expand out a tape so that all its trainable
 operations have a single parameter.
 
@@ -240,6 +241,7 @@ def expand_nonunitary_gen(*args, **kwargs):
         stop_at=_expand_nonunitary_gen_stop_at,
         docstring=_expand_nonunitary_gen_doc,
     )(*args, **kwargs)
+
 
 _expand_invalid_trainable_doc = """Expand out a tape so that it supports differentiation
 of requested operations.

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -152,6 +152,7 @@ def _multipar_stopping_fn(obj):
         return True
 
 
+# pylint: disable=missing-function-docstring
 def expand_multipar(*args, **kwargs):
     return create_expand_fn(
         depth=None,
@@ -182,6 +183,7 @@ def _trainable_multipar_stopping_fn(obj):
     return _multipar_stopping_fn(obj) or not any(math.requires_grad(d) for d in obj.data)
 
 
+# pylint: disable=missing-function-docstring
 def expand_trainable_multipar(*args, **kwargs):
     return create_expand_fn(
         depth=None,
@@ -236,6 +238,7 @@ def _expand_nonunitary_gen_stop_at(obj):
 
 
 def expand_nonunitary_gen(*args, **kwargs):
+    """Expands until all ops have unitary generators."""
     return create_expand_fn(
         depth=None,
         stop_at=_expand_nonunitary_gen_stop_at,
@@ -270,6 +273,7 @@ def _stop_at_expand_invalid_trainable(obj):
 
 
 def expand_invalid_trainable(*args, **kwargs):
+    """Expands until all ops are trainable."""
     return create_expand_fn(
         depth=None,
         stop_at=_stop_at_expand_invalid_trainable,

--- a/pennylane/transforms/tape_expand.py
+++ b/pennylane/transforms/tape_expand.py
@@ -152,11 +152,12 @@ def _multipar_stopping_fn(obj):
         return True
 
 
-expand_multipar = create_expand_fn(
-    depth=None,
-    stop_at=_multipar_stopping_fn,
-    docstring=_expand_multipar_doc,
-)
+def expand_multipar(*args, **kwargs):
+    return create_expand_fn(
+        depth=None,
+        stop_at=_multipar_stopping_fn,
+        docstring=_expand_multipar_doc,
+    )(*args, **kwargs)
 
 _expand_trainable_multipar_doc = """Expand out a tape so that all its trainable
 operations have a single parameter.
@@ -180,11 +181,12 @@ def _trainable_multipar_stopping_fn(obj):
     return _multipar_stopping_fn(obj) or not any(math.requires_grad(d) for d in obj.data)
 
 
-expand_trainable_multipar = create_expand_fn(
-    depth=None,
-    stop_at=_trainable_multipar_stopping_fn,
-    docstring=_expand_trainable_multipar_doc,
-)
+def expand_trainable_multipar(*args, **kwargs):
+    return create_expand_fn(
+        depth=None,
+        stop_at=_trainable_multipar_stopping_fn,
+        docstring=_expand_trainable_multipar_doc,
+    )(*args, **kwargs)
 
 
 def create_expand_trainable_multipar(tape, use_tape_argnum=False):
@@ -232,11 +234,12 @@ def _expand_nonunitary_gen_stop_at(obj):
     )
 
 
-expand_nonunitary_gen = create_expand_fn(
-    depth=None,
-    stop_at=_expand_nonunitary_gen_stop_at,
-    docstring=_expand_nonunitary_gen_doc,
-)
+def expand_nonunitary_gen(*args, **kwargs):
+    return create_expand_fn(
+        depth=None,
+        stop_at=_expand_nonunitary_gen_stop_at,
+        docstring=_expand_nonunitary_gen_doc,
+    )(*args, **kwargs)
 
 _expand_invalid_trainable_doc = """Expand out a tape so that it supports differentiation
 of requested operations.
@@ -264,8 +267,9 @@ def _stop_at_expand_invalid_trainable(obj):
     )
 
 
-expand_invalid_trainable = create_expand_fn(
-    depth=None,
-    stop_at=_stop_at_expand_invalid_trainable,
-    docstring=_expand_invalid_trainable_doc,
-)
+def expand_invalid_trainable(*args, **kwargs):
+    return create_expand_fn(
+        depth=None,
+        stop_at=_stop_at_expand_invalid_trainable,
+        docstring=_expand_invalid_trainable_doc,
+    )(*args, **kwargs)

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1545,18 +1545,18 @@ def test_expand_metric_tensor():
     allow_nonunitary = [True, False]
     res = []
 
-    for i, allow in enumerate(allow_nonunitary):
-        dev = qml.device("default.qubit", wires=qml.wires.Wires(["wire1", "wire2", "wire3"]))
+    dev = qml.device("default.qubit", wires=qml.wires.Wires(["wire1", "wire2", "wire3"]))
 
-        x = np.array(0.5, requires_grad=True)
-        z = np.array(0.1, requires_grad=True)
+    x = np.array(0.5, requires_grad=True)
+    z = np.array(0.1, requires_grad=True)
 
-        @qml.qnode(dev)
-        def circuit(x, z):
-            qml.RX(x, wires="wire1")
-            qml.RZ(z, wires="wire1")
-            return qml.expval(qml.PauliZ("wire2"))
+    @qml.qnode(dev)
+    def circuit(x, z):
+        qml.RX(x, wires="wire1")
+        qml.RZ(z, wires="wire1")
+        return qml.expval(qml.PauliZ("wire2"))
 
+    for allow in enumerate(allow_nonunitary):
         res.append(qml.metric_tensor(circuit, approx=None, allow_nonunitary=allow)(x, z))
 
     assert qml.numpy.allclose(res[0], res[1])

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1552,11 +1552,12 @@ def test_expand_metric_tensor():
 
     @qml.qnode(dev)
     def circuit(x, z):
+        qml.H("wire2")
         qml.RX(x, wires="wire1")
         qml.RZ(z, wires="wire1")
-        return qml.expval(qml.PauliZ("wire2"))
+        return qml.expval(qml.PauliZ("wire1"))
 
-    for allow in enumerate(allow_nonunitary):
+    for allow in allow_nonunitary:
         res.append(qml.metric_tensor(circuit, approx=None, allow_nonunitary=allow)(x, z))
 
     assert qml.numpy.allclose(res[0], res[1])

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -1540,6 +1540,28 @@ def test_error_generator_not_registered(allow_nonunitary):
             qml.metric_tensor(circuit1, approx=None, allow_nonunitary=allow_nonunitary)(x, z)
 
 
+def test_expand_metric_tensor():
+    """Tests _expand_metric_tensor works with and without allowed non-unitaries."""
+    allow_nonunitary = [True, False]
+    res = []
+
+    for i, allow in enumerate(allow_nonunitary):
+        dev = qml.device("default.qubit", wires=qml.wires.Wires(["wire1", "wire2", "wire3"]))
+
+        x = np.array(0.5, requires_grad=True)
+        z = np.array(0.1, requires_grad=True)
+
+        @qml.qnode(dev)
+        def circuit(x, z):
+            qml.RX(x, wires="wire1")
+            qml.RZ(z, wires="wire1")
+            return qml.expval(qml.PauliZ("wire2"))
+
+        res.append(qml.metric_tensor(circuit, approx=None, allow_nonunitary=allow)(x, z))
+
+    assert qml.numpy.allclose(res[0], res[1])
+
+
 def test_no_error_missing_aux_wire_not_used():
     """Tests that a no error is raised if the requested (or default, if not given)
     auxiliary wire for the Hadamard test is missing but it is not used, either

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -154,7 +154,8 @@ class TestExpandTrainableMultipar:
             _CRX(1.5, wires=[0, 2])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_trainable_multipar(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_trainable_multipar(tape)
         new_ops = new_tape.operations
 
         assert [op.name for op in new_ops] == ["RX", "Rot", "RZ", "RY", "RZ", "_CRX"]

--- a/tests/transforms/test_tape_expand.py
+++ b/tests/transforms/test_tape_expand.py
@@ -151,7 +151,9 @@ class TestExpandMultipar:
             _CRX(1.5, wires=[0, 2])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_multipar(tape)
+
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_multipar(tape)
         new_ops = new_tape.operations
 
         assert [op.name for op in new_ops] == ["RX", "RZ", "RY", "RZ", "_CRX"]
@@ -177,7 +179,8 @@ class TestExpandMultipar:
             _CRX(1.5, wires=[0, 2])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_multipar(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_multipar(tape)
         new_ops = new_tape.operations
         expected = ["RX", "RZ", "RY", "RZ", "RZ", "RY", "CNOT", "RY", "CNOT", "RZ"]
         assert [op.name for op in new_ops] == expected
@@ -196,7 +199,8 @@ class TestExpandNonunitaryGen:
             qml.SingleExcitationPlus(-1.2, wires=[1, 0])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_nonunitary_gen(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_nonunitary_gen(tape)
 
         assert tape.operations == new_tape.operations
 
@@ -210,7 +214,8 @@ class TestExpandNonunitaryGen:
             qml.SingleExcitationPlus(-1.2, wires=[1, 0])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_nonunitary_gen(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_nonunitary_gen(tape)
         expanded = [
             qml.RZ(0.9, wires=0),
             qml.RY(1.2, wires=0),
@@ -238,7 +243,8 @@ class TestExpandNonunitaryGen:
             qml.SingleExcitationPlus(-1.2, wires=[1, 0])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_nonunitary_gen(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_nonunitary_gen(tape)
         assert tape.operations[:2] == new_tape.operations[:2]
         exp_op, gph_op = new_tape.operations[2:4]
         assert exp_op.name == "RZ" and exp_op.data == (2.1,) and exp_op.wires == qml.wires.Wires(1)
@@ -256,7 +262,8 @@ class TestExpandNonunitaryGen:
             qml.SingleExcitationPlus(-1.2, wires=[1, 0])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_nonunitary_gen(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_nonunitary_gen(tape)
 
         assert tape.operations[:2] == new_tape.operations[:2]
         exp_op, gph_op = new_tape.operations[2:4]
@@ -295,7 +302,8 @@ class TestExpandNonunitaryGen:
             qml.FermionicSWAP(0.3, wires=[2, 3])
 
         tape = qml.tape.QuantumScript.from_queue(q)
-        new_tape = qml.transforms.expand_nonunitary_gen(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_nonunitary_gen(tape)
 
         for op in new_tape.operations:
             assert op.name in unitarily_generated or op.num_params == 0
@@ -318,7 +326,8 @@ class TestExpandInvalidTrainable:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         spy = mocker.spy(tape, "expand")
-        new_tape = qml.transforms.expand_invalid_trainable(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_invalid_trainable(tape)
 
         assert new_tape is tape
         spy.assert_not_called()
@@ -340,7 +349,8 @@ class TestExpandInvalidTrainable:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         spy = mocker.spy(qml.transforms, "decompose")
-        new_tape = qml.transforms.expand_invalid_trainable(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_invalid_trainable(tape)
 
         assert new_tape is not tape
         spy.assert_called()
@@ -372,7 +382,8 @@ class TestExpandInvalidTrainable:
         assert tape.trainable_params == [1]
 
         spy = mocker.spy(tape, "expand")
-        new_tape = qml.transforms.expand_invalid_trainable(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_invalid_trainable(tape)
 
         assert new_tape is tape
         spy.assert_not_called()
@@ -394,7 +405,8 @@ class TestExpandInvalidTrainable:
 
         tape = qml.tape.QuantumScript.from_queue(q)
         spy = mocker.spy(tape, "expand")
-        new_tape = qml.transforms.expand_invalid_trainable(tape)
+        with pytest.warns(PennyLaneDeprecationWarning, match="expand"):
+            new_tape = qml.transforms.expand_invalid_trainable(tape)
 
         assert new_tape is tape
         spy.assert_not_called()


### PR DESCRIPTION
**Context:** A deprecation warning is now raised when PL is imported, due to a recent change. We need to scope this warning appropriately and deal with it in the appropriate places.

**Description of the Change:** Scopes calls to `create_expand_fn`. Unfortunately, this means that warnings which would have been raised only on import before are now raised whenever a number of functions are called, revealing new places where we need to handle dep warnings or update functionality in the codebase.

**Benefits:** This is a pervasive warning that could be really distracting to users. We are getting rid of that confusing behaviour.

**Possible Drawbacks:** N/A

**Related Shortcut Stories:** [sc-107783]
