### PR TITLE
Improve for_loop error messages

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,6 +192,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Improves the error messages when the inputs and outputs to a `qml.for_loop` function do not match.
+
 * Fixes a bug that `qml.QubitDensityMatrix` was applied in `default.mixed` device using `qml.math.partial_trace` incorrectly.
   This would cause wrong results as described in [this issue](https://github.com/PennyLaneAI/pennylane/pull/8932).
   [(#8933)](https://github.com/PennyLaneAI/pennylane/pull/8933)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -193,6 +193,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Improves the error messages when the inputs and outputs to a `qml.for_loop` function do not match.
+  [(#8984)](https://github.com/PennyLaneAI/pennylane/pull/8984)
 
 * Fixes a bug that `qml.QubitDensityMatrix` was applied in `default.mixed` device using `qml.math.partial_trace` incorrectly.
   This would cause wrong results as described in [this issue](https://github.com/PennyLaneAI/pennylane/pull/8932).

--- a/pennylane/control_flow/for_loop.py
+++ b/pennylane/control_flow/for_loop.py
@@ -425,7 +425,7 @@ class ForLoopCallable:  # pylint:disable=too-few-public-methods, too-many-argume
             return self._call_capture_disabled(*init_state)
 
         # don't fallback with this error, as will get similar error
-        if (ni := len(jaxpr_body_fn.out_avals)) != ((no := len(jaxpr_body_fn.in_avals)) - 1):
+        if (ni := len(jaxpr_body_fn.in_avals)) != ((no := len(jaxpr_body_fn.out_avals)) + 1):
             raise ValueError(
                 "The number of inputs must be one greater than the number of"
                 " outputs for the for_loop function. The additional input "

--- a/pennylane/control_flow/for_loop.py
+++ b/pennylane/control_flow/for_loop.py
@@ -354,6 +354,11 @@ class ForLoopCallable:  # pylint:disable=too-few-public-methods, too-many-argume
         for i in range(self.start, self.stop, self.step):
             fn_res = self.body_fn(i, *args)
             args = fn_res if len(args) > 1 else (fn_res,) if len(args) == 1 else ()
+            if len(args) == 0 and fn_res:
+                raise ValueError(
+                    "The for_loop function should not return anything if it only accepts the loop index."
+                    f" Got output {fn_res} even though the function accepted no additional inputs."
+                )
 
         return fn_res
 
@@ -418,6 +423,15 @@ class ForLoopCallable:  # pylint:disable=too-few-public-methods, too-many-argume
                 CaptureWarning,
             )
             return self._call_capture_disabled(*init_state)
+
+        # don't fallback with this error, as will get similar error
+        if (ni := len(jaxpr_body_fn.out_avals)) != ((no := len(jaxpr_body_fn.in_avals)) - 1):
+            raise ValueError(
+                "The number of inputs must be one greater than the number of"
+                " outputs for the for_loop function. The additional input "
+                f"is the loop index. Got num_inputs {ni} and num_outputs {no}."
+            )
+
         for_loop_prim = _get_for_loop_qfunc_prim()
 
         consts_slice = slice(0, len(jaxpr_body_fn.consts))

--- a/tests/capture/test_capture_for_loop.py
+++ b/tests/capture/test_capture_for_loop.py
@@ -35,6 +35,18 @@ from pennylane.capture.primitives import for_loop_prim  # pylint: disable=wrong-
 class TestCaptureForLoop:
     """Tests for capturing for loops into jaxpr."""
 
+    def test_error_if_wrong_number_of_outputs(self):
+        """Test that a helpful error is raised if the function has the wrong number of outputs."""
+
+        @qml.for_loop(3)
+        def f(i):  # pylint: disable=unused-argument
+            return 2
+
+        with pytest.raises(
+            ValueError, match="number of inputs must be one greater than the number of outputs"
+        ):
+            f()
+
     @pytest.mark.parametrize("array", [jax.numpy.zeros(0), jax.numpy.zeros(5)])
     def test_for_loop_identity(self, array):
         """Test simple for-loop primitive vs dynamic dimensions."""

--- a/tests/control_flow/test_for_loop.py
+++ b/tests/control_flow/test_for_loop.py
@@ -35,6 +35,17 @@ def test_early_exit():
     assert inner_loop(4) == 4
 
 
+def test_error_if_outputs_when_no_inputs():
+    """Test an error is raised if there is an output when there is no additional input."""
+
+    @qml.for_loop(3)
+    def f(i):  # pylint: disable=unused-argument
+        return 2
+
+    with pytest.raises(ValueError, match="should not return anything "):
+        f()
+
+
 def test_for_loop_python_fallback():
     """Test that qml.for_loop fallsback to Python
     interpretation if Catalyst is not available"""


### PR DESCRIPTION
**Context:**

```
@qml.for_loop(3)
def f(i):
    return i
f()
```

Should always raise an informative error. 

**Related Shortcut Stories:**

[sc-109555]