### PR TITLE
fix: remove special handling of final transforms from `CompilePipeline`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -18,6 +18,7 @@
 * Added a `qml.workflow.get_compile_pipeline(qnode, level)(*args, **kwargs)` function to extract the 
   compile pipeline of a given QNode at a specific level.
   [(#8979)](https://github.com/PennyLaneAI/pennylane/pull/8979)
+  [(#8987)](https://github.com/PennyLaneAI/pennylane/pull/8987)
 
 <h3>Improvements 🛠</h3>
 

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,17 +140,17 @@ def add_noise(tape, noise_model, level="user"):
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
         >>> qml.workflow.get_transform_program(circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables)
 
         >>> qml.workflow.get_transform_program(noisy_circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, add_noise, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables)
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
         transforming a ``QNode``, this transform can be added at a designated level within the compile pipeline, as determined using the
         :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
 
         >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise)
 
         Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
         to an empty compile pipeline, `"user"` will allow addition at the end of user-specified transforms, `"device"` will allow addition at the
@@ -160,10 +160,10 @@ def add_noise(tape, noise_model, level="user"):
         CompilePipeline(add_noise)
 
         >>> qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, add_noise)
 
         >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise)
 
         Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the compile pipeline. For example, one can do:
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -262,14 +262,12 @@ class CompilePipeline:
         *,
         cotransform_cache: CotransformCache | None = None,
     ): ...
-
     @overload
     def __init__(
         self,
         *transforms: CompilePipeline | BoundTransform | Transform,
         cotransform_cache: CotransformCache | None = None,
     ): ...
-
     def __init__(
         self,
         *transforms: CompilePipeline
@@ -309,10 +307,8 @@ class CompilePipeline:
 
     @overload
     def __getitem__(self, idx: int) -> BoundTransform: ...
-
     @overload
     def __getitem__(self, idx: slice) -> CompilePipeline: ...
-
     def __getitem__(self, idx):
         """(BoundTransform, List[BoundTransform]): Return the indexed transform container from underlying
         compile pipeline"""
@@ -369,9 +365,6 @@ class CompilePipeline:
 
         if not isinstance(other, BoundTransform):
             return NotImplemented
-
-        if self.has_final_transform and other.is_final_transform:
-            raise TransformError("The compile pipeline already has a terminal transform.")
 
         transforms = [other]
         if expand_transform := other.expand_transform:
@@ -494,10 +487,6 @@ class CompilePipeline:
         if not isinstance(transform, BoundTransform):
             transform = BoundTransform(transform)
 
-        # Program can only contain one informative transform and at the end of the program
-        if self.has_final_transform and transform.is_final_transform:
-            raise TransformError("The compile pipeline already has a terminal transform.")
-
         if expand_transform := transform.expand_transform:
             self._compile_pipeline.append(expand_transform)
         self._compile_pipeline.append(transform)
@@ -547,10 +536,6 @@ class CompilePipeline:
         """
         if not isinstance(transform, BoundTransform):
             transform = BoundTransform(transform)
-
-        # Program can only contain one informative transform and at the end of the program
-        if self and transform.is_final_transform:
-            raise TransformError("Terminal transform can only be added to the end of the pipeline.")
 
         self._compile_pipeline.insert(index, transform)
         if expand_transform := transform.expand_transform:
@@ -709,15 +694,12 @@ class CompilePipeline:
     def __call__(
         self, jaxpr: jax.extend.core.Jaxpr, consts: Sequence, *args
     ) -> jax.extend.core.ClosedJaxpr: ...
-
     @overload
     def __call__(self, qnode: qml.QNode, *args, **kwargs) -> qml.QNode: ...
-
     @overload
     def __call__(
         self, tape: QuantumScript | QuantumScriptBatch
     ) -> tuple[QuantumScriptBatch, BatchPostprocessingFn]: ...
-
     def __call__(self, *args, **kwargs):
         if type(args[0]).__name__ == "Jaxpr":
             return self.__call_jaxpr(*args, **kwargs)

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -324,7 +324,6 @@ class CompilePipeline:
         return bool(self._compile_pipeline)
 
     def __add__(self, other: CompilePipeline | BoundTransform | Transform) -> CompilePipeline:
-
         # Convert dispatcher to container if needed
         if isinstance(other, Transform):
             other = BoundTransform(other)
@@ -436,6 +435,21 @@ class CompilePipeline:
         return CompilePipeline(transforms, cotransform_cache=self.cotransform_cache)
 
     __rmul__ = __mul__
+
+    def __str__(self):
+        """Returns a user friendly representation of the compile pipeline class."""
+        if not self:
+            return "CompilePipeline()"
+
+        lines = []
+        for i, t in enumerate(self):
+            name = t.tape_transform.__name__ if t.tape_transform else t.pass_name
+            if name == "marker":
+                name += f'("{t.args[0]}")'
+            lines.append(f"  [{i}] {name}")
+
+        contents = ",\n".join(lines)
+        return f"CompilePipeline(\n{contents}\n)"
 
     def __repr__(self):
         """The string representation of the compile pipeline class."""

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -442,20 +442,30 @@ class CompilePipeline:
             return "CompilePipeline()"
 
         lines = []
-        for i, t in enumerate(self):
-            name = t.tape_transform.__name__ if t.tape_transform else t.pass_name
+        for i, transform in enumerate(self):
+            name = (
+                transform.tape_transform.__name__
+                if transform.tape_transform
+                else transform.pass_name
+            )
             if name == "marker":
-                name += f'("{t.args[0]}")'
+                name += f'("{transform.args[0]}")'
             lines.append(f"  [{i}] {name}")
 
         contents = ",\n".join(lines)
         return f"CompilePipeline(\n{contents}\n)"
 
     def __repr__(self):
-        """The string representation of the compile pipeline class."""
-        gen = (f"{t.tape_transform.__name__ if t.tape_transform else t.pass_name}" for t in self)
-        contents = ", ".join(gen)
-        return f"CompilePipeline({contents})"
+        """The detailed string representation of the compile pipeline class."""
+        if not self:
+            return "CompilePipeline()"
+
+        lines = []
+        for i, transform in enumerate(self):
+            lines.append(f"  [{i}] {repr(transform)}")
+
+        contents = ",\n".join(lines)
+        return f"CompilePipeline(\n{contents}\n)"
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, CompilePipeline):

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -436,36 +436,11 @@ class CompilePipeline:
 
     __rmul__ = __mul__
 
-    def __str__(self):
-        """Returns a user friendly representation of the compile pipeline class."""
-        if not self:
-            return "CompilePipeline()"
-
-        lines = []
-        for i, transform in enumerate(self):
-            name = (
-                transform.tape_transform.__name__
-                if transform.tape_transform
-                else transform.pass_name
-            )
-            if name == "marker":
-                name += f'("{transform.args[0]}")'
-            lines.append(f"  [{i}] {name}")
-
-        contents = ",\n".join(lines)
-        return f"CompilePipeline(\n{contents}\n)"
-
     def __repr__(self):
-        """The detailed string representation of the compile pipeline class."""
-        if not self:
-            return "CompilePipeline()"
-
-        lines = []
-        for i, transform in enumerate(self):
-            lines.append(f"  [{i}] {repr(transform)}")
-
-        contents = ",\n".join(lines)
-        return f"CompilePipeline(\n{contents}\n)"
+        """The string representation of the compile pipeline class."""
+        gen = (f"{t.tape_transform.__name__ if t.tape_transform else t.pass_name}" for t in self)
+        contents = ", ".join(gen)
+        return f"CompilePipeline({contents})"
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, CompilePipeline):

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -262,12 +262,14 @@ class CompilePipeline:
         *,
         cotransform_cache: CotransformCache | None = None,
     ): ...
+
     @overload
     def __init__(
         self,
         *transforms: CompilePipeline | BoundTransform | Transform,
         cotransform_cache: CotransformCache | None = None,
     ): ...
+
     def __init__(
         self,
         *transforms: CompilePipeline
@@ -307,8 +309,10 @@ class CompilePipeline:
 
     @overload
     def __getitem__(self, idx: int) -> BoundTransform: ...
+
     @overload
     def __getitem__(self, idx: slice) -> CompilePipeline: ...
+
     def __getitem__(self, idx):
         """(BoundTransform, List[BoundTransform]): Return the indexed transform container from underlying
         compile pipeline"""
@@ -365,6 +369,9 @@ class CompilePipeline:
 
         if not isinstance(other, BoundTransform):
             return NotImplemented
+
+        if self.has_final_transform and other.is_final_transform:
+            raise TransformError("The compile pipeline already has a terminal transform.")
 
         transforms = [other]
         if expand_transform := other.expand_transform:
@@ -487,6 +494,10 @@ class CompilePipeline:
         if not isinstance(transform, BoundTransform):
             transform = BoundTransform(transform)
 
+        # Program can only contain one informative transform and at the end of the program
+        if self.has_final_transform and transform.is_final_transform:
+            raise TransformError("The compile pipeline already has a terminal transform.")
+
         if expand_transform := transform.expand_transform:
             self._compile_pipeline.append(expand_transform)
         self._compile_pipeline.append(transform)
@@ -536,6 +547,10 @@ class CompilePipeline:
         """
         if not isinstance(transform, BoundTransform):
             transform = BoundTransform(transform)
+
+        # Program can only contain one informative transform and at the end of the program
+        if self and transform.is_final_transform:
+            raise TransformError("Terminal transform can only be added to the end of the pipeline.")
 
         self._compile_pipeline.insert(index, transform)
         if expand_transform := transform.expand_transform:
@@ -694,12 +709,15 @@ class CompilePipeline:
     def __call__(
         self, jaxpr: jax.extend.core.Jaxpr, consts: Sequence, *args
     ) -> jax.extend.core.ClosedJaxpr: ...
+
     @overload
     def __call__(self, qnode: qml.QNode, *args, **kwargs) -> qml.QNode: ...
+
     @overload
     def __call__(
         self, tape: QuantumScript | QuantumScriptBatch
     ) -> tuple[QuantumScriptBatch, BatchPostprocessingFn]: ...
+
     def __call__(self, *args, **kwargs):
         if type(args[0]).__name__ == "Jaxpr":
             return self.__call_jaxpr(*args, **kwargs)

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -18,6 +18,7 @@ This module contains the ``CompilePipeline`` class.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import contextmanager
 from copy import copy
 from functools import partial
 from typing import TYPE_CHECKING, overload
@@ -262,14 +263,12 @@ class CompilePipeline:
         *,
         cotransform_cache: CotransformCache | None = None,
     ): ...
-
     @overload
     def __init__(
         self,
         *transforms: CompilePipeline | BoundTransform | Transform,
         cotransform_cache: CotransformCache | None = None,
     ): ...
-
     def __init__(
         self,
         *transforms: CompilePipeline
@@ -309,10 +308,8 @@ class CompilePipeline:
 
     @overload
     def __getitem__(self, idx: int) -> BoundTransform: ...
-
     @overload
     def __getitem__(self, idx: slice) -> CompilePipeline: ...
-
     def __getitem__(self, idx):
         """(BoundTransform, List[BoundTransform]): Return the indexed transform container from underlying
         compile pipeline"""
@@ -324,6 +321,7 @@ class CompilePipeline:
         return bool(self._compile_pipeline)
 
     def __add__(self, other: CompilePipeline | BoundTransform | Transform) -> CompilePipeline:
+
         # Convert dispatcher to container if needed
         if isinstance(other, Transform):
             other = BoundTransform(other)
@@ -341,7 +339,8 @@ class CompilePipeline:
                 raise TransformError("The compile pipeline already has a terminal transform.")
 
             transforms = self._compile_pipeline[:]
-            transforms.extend(other._compile_pipeline)
+            with _exclude_terminal_transform(transforms):
+                transforms.extend(other._compile_pipeline)
 
             cotransform_cache = None
             if self.cotransform_cache:
@@ -401,7 +400,8 @@ class CompilePipeline:
             if self.has_final_transform and other.has_final_transform:
                 raise TransformError("The compile pipeline already has a terminal transform.")
 
-            self._compile_pipeline.extend(other._compile_pipeline)
+            with _exclude_terminal_transform(self._compile_pipeline):
+                self._compile_pipeline.extend(other._compile_pipeline)
 
             if other.cotransform_cache:
                 if self.cotransform_cache:
@@ -497,9 +497,10 @@ class CompilePipeline:
         if self.has_final_transform and transform.is_final_transform:
             raise TransformError("The compile pipeline already has a terminal transform.")
 
-        if expand_transform := transform.expand_transform:
-            self._compile_pipeline.append(expand_transform)
-        self._compile_pipeline.append(transform)
+        with _exclude_terminal_transform(self._compile_pipeline):
+            if expand_transform := transform.expand_transform:
+                self._compile_pipeline.append(expand_transform)
+            self._compile_pipeline.append(transform)
 
     def extend(self, transforms: CompilePipeline | Sequence[BoundTransform | Transform]):
         """Extend the pipeline by appending transforms from an iterable.
@@ -708,15 +709,12 @@ class CompilePipeline:
     def __call__(
         self, jaxpr: jax.extend.core.Jaxpr, consts: Sequence, *args
     ) -> jax.extend.core.ClosedJaxpr: ...
-
     @overload
     def __call__(self, qnode: qml.QNode, *args, **kwargs) -> qml.QNode: ...
-
     @overload
     def __call__(
         self, tape: QuantumScript | QuantumScriptBatch
     ) -> tuple[QuantumScriptBatch, BatchPostprocessingFn]: ...
-
     def __call__(self, *args, **kwargs):
         if type(args[0]).__name__ == "Jaxpr":
             return self.__call_jaxpr(*args, **kwargs)
@@ -738,6 +736,17 @@ def _apply_to_program(obj: CompilePipeline, transform, *targs, **tkwargs):
     program = copy(obj)
     program.append(BoundTransform(transform, args=targs, kwargs=tkwargs))
     return program
+
+
+@contextmanager
+def _exclude_terminal_transform(transforms: list[BoundTransform]):
+    terminal_transforms = []
+    if transforms and transforms[-1].is_informative:
+        terminal_transforms.append(transforms.pop())
+        if transforms and terminal_transforms[0].expand_transform == transforms[-1]:
+            terminal_transforms.insert(0, transforms.pop())
+    yield
+    transforms.extend(terminal_transforms)
 
 
 TransformProgram = CompilePipeline

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -274,7 +274,7 @@ def get_transform_program(
         By default, we get the full transform program. This can be explicitly specified by ``level="device"``.
 
         >>> qml.workflow.get_transform_program(circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, _expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, _expand_metric_tensor, metric_tensor, _expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand)
 
         The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
         :func:`~.merge_rotations` and :func:`~.metric_tensor`.
@@ -288,7 +288,7 @@ def get_transform_program(
         present at the very end of resulting program.
 
         >>> qml.workflow.get_transform_program(circuit, level="gradient")
-        CompilePipeline(cancel_inverses, merge_rotations, _expand_transform_param_shift, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, _expand_metric_tensor, metric_tensor, _expand_transform_param_shift)
 
         ``"top"`` and ``0`` both return empty transform programs.
 
@@ -307,9 +307,9 @@ def get_transform_program(
         For example, you can skip the first transform or reverse the order:
 
         >>> qml.workflow.get_transform_program(circuit, level=slice(1,3))
-        CompilePipeline(merge_rotations, _expand_transform_param_shift)
+        CompilePipeline(merge_rotations, _expand_metric_tensor)
         >>> qml.workflow.get_transform_program(circuit, level=slice(None, None, -1))
-        CompilePipeline(metric_tensor, _expand_metric_tensor, _conditional_broadcast_expand, validate_measurements, validate_device_wires, device_resolve_dynamic_wires, decompose, defer_measurements, _expand_transform_param_shift, merge_rotations, cancel_inverses)
+        CompilePipeline(_conditional_broadcast_expand, validate_measurements, validate_device_wires, device_resolve_dynamic_wires, decompose, defer_measurements, _expand_transform_param_shift, metric_tensor, _expand_metric_tensor, merge_rotations, cancel_inverses)
 
         You can get creative and pick a single category of transforms as follows, excluding
         any preceding transforms (and the final transform if it exists):
@@ -318,9 +318,9 @@ def get_transform_program(
         >>> grad_prog = qml.workflow.get_transform_program(circuit, level="gradient")
         >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
         >>> grad_prog[len(user_prog) - 1 : -1]
-        CompilePipeline(_expand_metric_tensor)
+        CompilePipeline(metric_tensor)
         >>> dev_prog[len(grad_prog) - 1 : -1]
-        CompilePipeline(decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand, _expand_metric_tensor)
+        CompilePipeline(_expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements)
 
     """
     _validate_level(level)
@@ -333,28 +333,14 @@ def get_transform_program(
     full_transform_program = _get_full_transform_program(qnode, gradient_fn)
 
     num_user = len(qnode.compile_pipeline)
-    if qnode.compile_pipeline.has_final_transform:
-        # final transform is placed after device transforms
-        num_user -= 1
-        if (
-            len(qnode.compile_pipeline) > 1
-            and qnode.compile_pipeline[-1].expand_transform == qnode.compile_pipeline[-2]
-        ):
-            # The expand transform associated with the final transform
-            num_user -= 1
-
-    readd_final_transform = False
-    final_transform_start = -1
 
     if level == "device":
         level = slice(0, None)
     elif level == "top":
         level = slice(0, 0)
     elif level == "user":
-        readd_final_transform = True
         level = slice(0, num_user)
     elif level == "gradient":
-        readd_final_transform = True
         level = num_user + 1 if has_gradient_expand else num_user
         level = slice(0, level)
     elif isinstance(level, str):
@@ -363,14 +349,6 @@ def get_transform_program(
         level = slice(0, level)
 
     resolved_program = full_transform_program[level]
-
-    if qnode.compile_pipeline.has_final_transform and readd_final_transform:
-        if (
-            len(qnode.compile_pipeline) > 1
-            and qnode.compile_pipeline[-1].expand_transform == qnode.compile_pipeline[-2]
-        ):
-            final_transform_start = -2
-        resolved_program += qnode.compile_pipeline[final_transform_start:]
 
     return resolved_program
 

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -201,9 +201,6 @@ def get_compile_pipeline(
         # Get full compile pipeline
         resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
         outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
-
-        # FIX: Cannot simply add the compile pipeline as final transforms are incorrectly appended at the end
-        # which do not represent their true execution pathway
         full_compile_pipeline = qnode.compile_pipeline + outer_pipeline + inner_pipeline
 
         num_user = len(qnode.compile_pipeline)

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -31,14 +31,6 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 
 
-def _has_terminal_expansion_pair(compile_pipeline: CompilePipeline) -> bool:
-    """Checks if the compile pipeline ends with a expansion + transform pair."""
-    return (
-        len(compile_pipeline) > 1
-        and getattr(compile_pipeline[-1], "expand_transform", None) == compile_pipeline[-2]
-    )
-
-
 def _find_level(program: CompilePipeline, level: str) -> int:
     """Retrieve the numerical level associated to a marker."""
     found_levels = []
@@ -201,11 +193,12 @@ def get_compile_pipeline(
         # Get full compile pipeline
         resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
         outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
-        full_compile_pipeline = qnode.compile_pipeline + outer_pipeline + inner_pipeline
-
-        num_user = len(qnode.compile_pipeline)
+        full_compile_pipeline: CompilePipeline = (
+            qnode.compile_pipeline + outer_pipeline + inner_pipeline
+        )
 
         # Slice out relevant section
+        num_user = len(qnode.compile_pipeline)
         level_slice: slice = _resolve_level(level, full_compile_pipeline, num_user, resolved_config)
         resolved_pipeline = full_compile_pipeline[level_slice]
 

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -202,7 +202,7 @@ def get_compile_pipeline(
 
         full_compile_pipeline = CompilePipeline()
         full_compile_pipeline += qnode.compile_pipeline
-        # Informative user pipelines bypass gradient and device transforms
+        # NOTE: User transforms that contain an informative transform by pass gradient + device transforms
         if not qnode.compile_pipeline.is_informative:
             full_compile_pipeline += outer_pipeline + inner_pipeline
 

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -197,17 +197,15 @@ def get_compile_pipeline(
 
     @wraps(qnode)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> CompilePipeline:
-        # Get full compile pipeline
         resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
-        outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
 
         full_compile_pipeline = CompilePipeline()
         full_compile_pipeline += qnode.compile_pipeline
         # NOTE: User transforms that contain an informative transform by pass gradient + device transforms
         if not qnode.compile_pipeline.is_informative:
+            outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
             full_compile_pipeline += outer_pipeline + inner_pipeline
 
-        # Slice out relevant section
         num_user = len(qnode.compile_pipeline)
         level_slice: slice = _resolve_level(level, full_compile_pipeline, num_user, resolved_config)
         resolved_pipeline = full_compile_pipeline[level_slice]

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -128,12 +128,13 @@ def get_compile_pipeline(
     .. details::
         :title: Usage Details
 
-        Consider the circuit below which has user applied transforms, a checkpoint marker and uses the parameter-shift gradient method,
+        Consider the circuit below which is loaded with user applied transforms, a checkpoint marker and uses the parameter-shift gradient method,
 
         .. code-block:: python
 
             dev = qml.device("default.qubit")
 
+            @qml.metric_tensor
             @qml.transforms.merge_rotations
             @qml.marker("checkpoint")
             @qml.transforms.cancel_inverses
@@ -149,18 +150,18 @@ def get_compile_pipeline(
         Note that this can also be retrieved by manually specifying ``level="device"``,
 
         >>> get_compile_pipeline(circuit)(3.14)
-        CompilePipeline(cancel_inverses, marker, merge_rotations, _expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand)
+        CompilePipeline(cancel_inverses, marker, merge_rotations, _expand_metric_tensor, metric_tensor, _expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand)
 
         As can be seen above, this not only includes the two transforms we manually applied, but also a set of transforms used by the device in order to execute the circuit.
         The ``"user"`` level will retrieve the portion of the compile pipeline that was manually applied by the user to the qnode,
 
         >>> get_compile_pipeline(circuit, level="user")(3.14)
-        CompilePipeline(cancel_inverses, marker, merge_rotations)
+        CompilePipeline(cancel_inverses, marker, merge_rotations, _expand_metric_tensor, metric_tensor)
 
         The ``"gradient"`` level builds on top of this to then add any relevant gradient transforms,
 
         >>> get_compile_pipeline(circuit, level="gradient")(3.14)
-        CompilePipeline(cancel_inverses, marker, merge_rotations, _expand_transform_param_shift)
+        CompilePipeline(cancel_inverses, marker, merge_rotations, _expand_metric_tensor, metric_tensor, _expand_transform_param_shift)
 
         which in this case is ``_expand_transform_param_shift``, a transform that expands all trainable operations
         to a state where the parameter shift transform can operate on them.
@@ -185,7 +186,7 @@ def get_compile_pipeline(
         Slice levels enable you to extract a specific range of transformations in the compile pipeline. For example, we can retrieve the second to fourth transform by using a slice,
 
         >>> get_compile_pipeline(circuit, level=slice(1,4))(3.14)
-        CompilePipeline(marker, merge_rotations, _expand_transform_param_shift)
+        CompilePipeline(marker, merge_rotations, _expand_metric_tensor)
 
     """
 

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -193,9 +193,12 @@ def get_compile_pipeline(
         # Get full compile pipeline
         resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
         outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
-        full_compile_pipeline: CompilePipeline = (
-            qnode.compile_pipeline + outer_pipeline + inner_pipeline
-        )
+
+        full_compile_pipeline = CompilePipeline()
+        full_compile_pipeline += qnode.compile_pipeline
+        # Informative user pipelines bypass gradient and device transforms
+        if not qnode.compile_pipeline.is_informative:
+            full_compile_pipeline += outer_pipeline + inner_pipeline
 
         # Slice out relevant section
         num_user = len(qnode.compile_pipeline)

--- a/tests/noise/test_add_noise.py
+++ b/tests/noise/test_add_noise.py
@@ -464,5 +464,5 @@ class TestAddNoiseLevels:
         transform_level2 = qml.workflow.get_transform_program(noisy_qnode)
 
         assert len(transform_level1) == len(transform_level2) - 1
-        assert transform_level2[3].tape_transform == add_noise.tape_transform
-        assert transform_level2[-1].tape_transform == qml.metric_tensor.tape_transform
+        assert transform_level2[5].tape_transform == add_noise.tape_transform
+        assert transform_level2[4].tape_transform == qml.metric_tensor.tape_transform

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -785,15 +785,25 @@ class TestCompilePipelineDunders:
         compile_pipeline.append(transform1)
         compile_pipeline.append(transform2)
 
-        str_pipeline = repr(compile_pipeline)
-        assert (
-            str_pipeline
-            == "CompilePipeline("
-            + str(first_valid_transform.__name__)
-            + ", "
-            + str(second_valid_transform.__name__)
-            + ")"
-        )
+        pipeline_repr = repr(compile_pipeline)
+        expected_repr = f"CompilePipeline(\n  [0] {repr(transform1)},\n  [1] {repr(transform2)}\n)"
+        assert pipeline_repr == expected_repr
+
+    def test_str_pipeline(self):
+        """Tests the string representation of a pipeline."""
+
+        compile_pipeline = CompilePipeline()
+        transform1 = BoundTransform(qml.transform(first_valid_transform))
+        marker = qml.marker("blah")
+        transform2 = BoundTransform(qml.transform(second_valid_transform))
+
+        compile_pipeline.append(transform1)
+        compile_pipeline.append(marker)
+        compile_pipeline.append(transform2)
+
+        pipeline_str = str(compile_pipeline)
+        expected_repr = 'CompilePipeline(\n  [0] first_valid_transform,\n  [1] marker("blah"),\n  [2] second_valid_transform\n)'
+        assert pipeline_str == expected_repr
 
     def test_equality(self):
         """Tests that we can compare CompilePipeline objects with the '==' and '!=' operators."""

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -14,7 +14,6 @@
 """Unit and integration tests for the compile pipeline."""
 # pylint: disable=no-member
 
-
 import pytest
 import rustworkx as rx
 
@@ -48,7 +47,8 @@ def first_valid_transform(
 
 
 def expand_transform(
-    tape: QuantumScript, index: int  # pylint:disable=unused-argument
+    tape: QuantumScript,
+    index: int,  # pylint:disable=unused-argument
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
     """A valid expand transform."""
     return [tape], lambda x: x
@@ -488,33 +488,10 @@ class TestCompilePipelineDunders:
         assert merged_pipeline2[0].tape_transform is first_valid_transform
 
         assert isinstance(merged_pipeline2[1], BoundTransform)
-        assert merged_pipeline2[1].tape_transform is first_valid_transform
+        assert merged_pipeline2[1].tape_transform is second_valid_transform
 
         assert isinstance(merged_pipeline2[2], BoundTransform)
-        assert merged_pipeline2[2].tape_transform is second_valid_transform
-
-    @pytest.mark.parametrize(
-        "right",
-        [
-            pytest.param(
-                BoundTransform(qml.transform(second_valid_transform)),
-                id="pipeline+container",
-            ),
-            pytest.param(qml.transform(second_valid_transform), id="pipeline+dispatcher"),
-        ],
-    )
-    def test_pipeline_add_maintains_final_transform_at_end(self, right):
-        """Test that adding to a pipeline with final_transform keeps final at end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        pipeline = CompilePipeline([container1])
-
-        result = pipeline + right
-        assert isinstance(result, CompilePipeline)
-        assert len(result) == 2
-        # Final transform should be at the end
-        assert result[0].tape_transform is second_valid_transform
-        assert result[1].tape_transform is first_valid_transform
-        assert result[1].is_final_transform
+        assert merged_pipeline2[2].tape_transform is first_valid_transform
 
     @pytest.mark.parametrize(
         "right",
@@ -654,19 +631,6 @@ class TestCompilePipelineDunders:
         assert pipeline1[0].tape_transform is first_valid_transform
         assert pipeline1[1].tape_transform is second_valid_transform
 
-    def test_pipeline_iadd_maintains_final_transform_at_end(self):
-        """Test that __iadd__ keeps final transform at the end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        container2 = BoundTransform(qml.transform(second_valid_transform))
-        pipeline = CompilePipeline([container1])
-
-        pipeline += container2
-
-        assert len(pipeline) == 2
-        assert pipeline[0].tape_transform is second_valid_transform
-        assert pipeline[1].tape_transform is first_valid_transform
-        assert pipeline[1].is_final_transform
-
     def test_pipeline_iadd_with_both_final_transform_error(self):
         """Test that __iadd__ raises error when adding final to pipeline with final."""
         container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
@@ -685,20 +649,6 @@ class TestCompilePipelineDunders:
 
         with pytest.raises(TransformError, match="already has a terminal transform"):
             pipeline1 += pipeline2
-
-    def test_pipeline_iadd_pipeline_maintains_final_transform_at_end(self):
-        """Test that __iadd__ with pipeline keeps final transform at the end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        container2 = BoundTransform(qml.transform(second_valid_transform))
-        pipeline1 = CompilePipeline([container1])
-        pipeline2 = CompilePipeline([container2])
-
-        pipeline1 += pipeline2
-
-        assert len(pipeline1) == 2
-        assert pipeline1[0].tape_transform is second_valid_transform
-        assert pipeline1[1].tape_transform is first_valid_transform
-        assert pipeline1[1].is_final_transform
 
     def test_pipeline_iadd_pipeline_with_cotransform_cache(self):
         """Test that __iadd__ correctly handles cotransform_cache when adding pipelines."""

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -785,25 +785,15 @@ class TestCompilePipelineDunders:
         compile_pipeline.append(transform1)
         compile_pipeline.append(transform2)
 
-        pipeline_repr = repr(compile_pipeline)
-        expected_repr = f"CompilePipeline(\n  [0] {repr(transform1)},\n  [1] {repr(transform2)}\n)"
-        assert pipeline_repr == expected_repr
-
-    def test_str_pipeline(self):
-        """Tests the string representation of a pipeline."""
-
-        compile_pipeline = CompilePipeline()
-        transform1 = BoundTransform(qml.transform(first_valid_transform))
-        marker = qml.marker("blah")
-        transform2 = BoundTransform(qml.transform(second_valid_transform))
-
-        compile_pipeline.append(transform1)
-        compile_pipeline.append(marker)
-        compile_pipeline.append(transform2)
-
-        pipeline_str = str(compile_pipeline)
-        expected_repr = 'CompilePipeline(\n  [0] first_valid_transform,\n  [1] marker("blah"),\n  [2] second_valid_transform\n)'
-        assert pipeline_str == expected_repr
+        str_pipeline = repr(compile_pipeline)
+        assert (
+            str_pipeline
+            == "CompilePipeline("
+            + str(first_valid_transform.__name__)
+            + ", "
+            + str(second_valid_transform.__name__)
+            + ")"
+        )
 
     def test_equality(self):
         """Tests that we can compare CompilePipeline objects with the '==' and '!=' operators."""

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -1104,14 +1104,14 @@ class TestCompilePipeline:
         t_normal = BoundTransform(qml.transform(second_valid_transform))
         compile_pipeline.append(t_normal)
         assert len(compile_pipeline) == 2
-        assert compile_pipeline[0] is t_normal
-        assert compile_pipeline[1] is transform1
+        assert compile_pipeline[0] is transform1
+        assert compile_pipeline[1] is t_normal
 
         t_normal2 = BoundTransform(qml.transform(first_valid_transform))
         compile_pipeline.append(t_normal2)
-        assert compile_pipeline[0] is t_normal
-        assert compile_pipeline[1] is t_normal2
-        assert compile_pipeline[2] is transform1
+        assert compile_pipeline[0] is transform1
+        assert compile_pipeline[1] is t_normal
+        assert compile_pipeline[2] is t_normal2
 
         with pytest.raises(
             TransformError, match="The compile pipeline already has a terminal transform."

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -285,9 +285,9 @@ class TestCompilePipelineGetter:
         grad_program = get_transform_program(circuit, level="gradient")
         assert len(grad_program) == 4
         assert grad_program[0].tape_transform == qml.compile.tape_transform
-        assert grad_program[1].tape_transform == qml.gradients.param_shift.expand_transform
-        assert grad_program[2].tape_transform == qml.metric_tensor.expand_transform
-        assert grad_program[3].tape_transform == qml.metric_tensor.tape_transform
+        assert grad_program[1].tape_transform == qml.metric_tensor.expand_transform
+        assert grad_program[2].tape_transform == qml.metric_tensor.tape_transform
+        assert grad_program[3].tape_transform == qml.gradients.param_shift.expand_transform
 
         dev_program = get_transform_program(circuit, level="device")
         config = qml.devices.ExecutionConfig(interface=getattr(circuit, "interface", None))
@@ -295,11 +295,8 @@ class TestCompilePipelineGetter:
         assert len(dev_program) == 4 + len(
             circuit.device.preprocess_transforms(config)
         )  # currently 8
-        assert dev_program[-1].tape_transform == qml.metric_tensor.tape_transform
 
         full_program = get_transform_program(circuit)
-        assert full_program[-1].tape_transform == qml.metric_tensor.tape_transform
-
         assert dev_program == full_program
 
 

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -292,3 +292,35 @@ def test_level_is_integer(level):
         assert cp == CompilePipeline(qml.transforms.cancel_inverses)
     elif level == 2:
         assert cp == CompilePipeline(qml.transforms.cancel_inverses, qml.transforms.merge_rotations)
+
+
+def test_informative_transforms():
+    """Tests that informative transforms are handled correctly."""
+
+    dev = qml.device("reference.qubit")
+
+    # Some random normalized state, no particular relevance
+    init_state = qml.numpy.array([0.16769259, 0.71277864, 0.54562903, 0.4075718])
+
+    def ansatz(angles, wires):
+        qml.StatePrep(init_state, wires=wires)
+        qml.Hadamard(wires[0])
+        qml.RX(angles[0], wires=wires[0])
+        qml.S(wires[1])
+        qml.RY(angles[1], wires=wires[1])
+
+    @qml.adjoint_metric_tensor  # INFORMATIVE!
+    @qml.transforms.merge_rotations
+    @qml.qnode(dev)
+    def circuit(angles):
+        ansatz(angles, wires=[0, 1])
+        return qml.expval(qml.Z(0) @ qml.X(1))
+
+    angles = qml.numpy.random.uniform(size=(2,), requires_grad=True)
+
+    pipeline = get_compile_pipeline(circuit)(angles)
+    # Informative transforms by pass the gradient and device transforms
+    assert len(pipeline) == 3
+    assert pipeline[0].tape_transform == qml.transforms.merge_rotations.tape_transform
+    assert pipeline[1].tape_transform == qml.gradients.adjoint_metric_tensor.expand_transform
+    assert pipeline[2].tape_transform == qml.gradients.adjoint_metric_tensor.tape_transform


### PR DESCRIPTION
Follow-up to https://github.com/PennyLaneAI/pennylane/pull/8979.

This PR fixes the patchy logic needed that removes and then reappends the final transforms in `get_compile_pipeline`.

To do that, this PR,

- Fixes the behaviour where final transforms are pushed to the end of the pipeline. Note that any informative transforms will still continue to be appended to the end of the pipeline.
- Updates `get_compile_pipeline` and gets rid of that patchy logic
- Removes and/or updates any tests that relied on the buggy logic

[sc-109715]