### PR TITLE
Add specs support for measurement data when level=device for QJIT'd workflows

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -51,7 +51,7 @@
 * Dropped support for NumPy 1.x following its end-of-life. NumPy 2.0 or higher is now required.
   [(#8914)](https://github.com/PennyLaneAI/pennylane/pull/8914)
   [(#8954)](https://github.com/PennyLaneAI/pennylane/pull/8954)
-  
+
 * ``compute_qfunc_decomposition`` and ``has_qfunc_decomposition`` have been removed from  :class:`~.Operator`
   and all subclasses that implemented them. The graph decomposition system should be used when capture is enabled.
   [(#8922)](https://github.com/PennyLaneAI/pennylane/pull/8922)
@@ -159,6 +159,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Specs can now return measurement information for QJIT'd workloads when passed ``level="device"``.
+  [(#8988)](https://github.com/PennyLaneAI/pennylane/pull/8988)
+
 * Seeded a test `tests/measurements/test_classical_shadow.py::TestClassicalShadow::test_return_distribution` to fix stochastic failures by adding a `seed` parameter to the circuit helper functions and the test method.
   [(#xxxx)](https://github.com/PennyLaneAI/pennylane/pull/xxxx)
 
@@ -219,3 +222,4 @@ Andrija Paurevic,
 Omkar Sarkar,
 Jay Soni,
 David Wierichs,
+Jake Zaia,

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -572,7 +572,7 @@ def specs(
             RX: 1
         <BLANKLINE>
           Measurements:
-            No measurements.
+            probs(all wires): 1
 
         **Pass-by-pass specs** analyze the intermediate representations of compiled circuits.
         This can be helpful for determining how circuit resources change after a given transform or compilation pass.

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -119,16 +119,10 @@ def _specs_qjit_device_level_tracking(
         with open(_RESOURCE_TRACKING_FILEPATH, encoding="utf-8") as f:
             resource_data = json.load(f)
 
-        # TODO: Once measurements are tracked for runtime specs, include that data here
-        warnings.warn(
-            "Measurement resource tracking is not yet supported for qjit'd QNodes. "
-            "The returned SpecsResources will have an empty measurements field.",
-            UserWarning,
-        )
         return SpecsResources(
             gate_types=resource_data["gate_types"],
             gate_sizes={int(k): v for (k, v) in resource_data["gate_sizes"].items()},
-            measurements={},  # Not tracked at the moment
+            measurements=resource_data["measurements"],
             num_allocs=resource_data["num_wires"],
             depth=resource_data["depth"],
         )
@@ -579,10 +573,6 @@ def specs(
         <BLANKLINE>
           Measurements:
             No measurements.
-
-        .. warning::
-            Measurement data is not currently supported with runtime resource tracking, so measurement
-            data may show as missing.
 
         **Pass-by-pass specs** analyze the intermediate representations of compiled circuits.
         This can be helpful for determining how circuit resources change after a given transform or compilation pass.


### PR DESCRIPTION
**Context:**
https://github.com/PennyLaneAI/catalyst/pull/2446 implements needed support within `null.qubit` resource tracking to enable `qml.specs` to begin reporting necessary measurement information.

Integration tests for this PR are introduced in https://github.com/PennyLaneAI/catalyst/pull/2448

**Description of the Change:**
* Returns measurement data when resource tracking is used within specs.
* No longer raises a warning that measurement data is not implemented for `qml.specs` with `level="device"` for QJIT'd workflows

Integration tests within Catalysts will be updated in a follow-on PR.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-109207]
Depends on https://github.com/PennyLaneAI/catalyst/pull/2446