### PR TITLE
feature: improve `__str__` and `__repr__` of `CompilePipeline`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -18,7 +18,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `CompilePipeline` object now has an improved `__str__` and `__repr__` allowing improved inspectibility.
+* The `CompilePipeline` object now has an improved `__str__`, `__repr__` and `_ipython_display_` allowing improved inspectibility.
   [(#8990)](https://github.com/PennyLaneAI/pennylane/pull/8990)
 
 * :class:`~.BBQRAM`, :class:`~.HybridQRAM`, :class:`SelectOnlyQRAM` and :class:`~.QROM` now accept 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -17,6 +17,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `CompilePipeline` object now has an improved `__str__` and `__repr__` allowing improved inspectibility.
+  [(#8990)](https://github.com/PennyLaneAI/pennylane/pull/8990)
+
 * `qml.vjp` can now be captured into plxpr.
   [(#8736)](https://github.com/PennyLaneAI/pennylane/pull/8736)
 

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -141,33 +141,33 @@ def add_noise(tape, noise_model, level="user"):
 
         >>> print(qml.workflow.get_transform_program(circuit))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] undo_swaps,
-          [3] defer_measurements,
-          [4] decompose,
-          [5] no_sampling,
-          [6] validate_device_wires,
-          [7] validate_measurements,
-          [8] validate_observables,
-          [9] _expand_metric_tensor,
-          [10] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] undo_swaps(),
+          [3] defer_measurements(allow_postselect=False),
+          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
+          [5] no_sampling(name=backprop + default.mixed),
+          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [8] validate_observables(stopping_condition=..., name=default.mixed),
+          [9] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [10] metric_tensor(device_wires=Wires([0, 1]))
         )
 
         >>> print(qml.workflow.get_transform_program(noisy_circuit))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] undo_swaps,
-          [3] add_noise,
-          [4] defer_measurements,
-          [5] decompose,
-          [6] no_sampling,
-          [7] validate_device_wires,
-          [8] validate_measurements,
-          [9] validate_observables,
-          [10] _expand_metric_tensor,
-          [11] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] undo_swaps(),
+          [3] add_noise(...),
+          [4] defer_measurements(allow_postselect=False),
+          [5] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
+          [6] no_sampling(name=backprop + default.mixed),
+          [7] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [8] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [9] validate_observables(stopping_condition=..., name=default.mixed),
+          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [11] metric_tensor(device_wires=Wires([0, 1]))
         )
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
@@ -176,18 +176,18 @@ def add_noise(tape, noise_model, level="user"):
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] undo_swaps,
-          [3] defer_measurements,
-          [4] decompose,
-          [5] no_sampling,
-          [6] validate_device_wires,
-          [7] validate_measurements,
-          [8] validate_observables,
-          [9] add_noise,
-          [10] _expand_metric_tensor,
-          [11] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] undo_swaps(),
+          [3] defer_measurements(allow_postselect=False),
+          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
+          [5] no_sampling(name=backprop + default.mixed),
+          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [8] validate_observables(stopping_condition=..., name=default.mixed),
+          [9] add_noise(..., level=device),
+          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [11] metric_tensor(device_wires=Wires([0, 1]))
         )
 
         Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
@@ -196,49 +196,49 @@ def add_noise(tape, noise_model, level="user"):
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="top").compile_pipeline)
         CompilePipeline(
-          [0] add_noise
+          [0] add_noise(..., level=top)
         )
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline)
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] undo_swaps,
-          [3] add_noise,
-          [4] _expand_metric_tensor,
-          [5] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] undo_swaps(),
+          [3] add_noise(..., level=user),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [5] metric_tensor(device_wires=Wires([0, 1]))
         )
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] undo_swaps,
-          [3] defer_measurements,
-          [4] decompose,
-          [5] no_sampling,
-          [6] validate_device_wires,
-          [7] validate_measurements,
-          [8] validate_observables,
-          [9] add_noise,
-          [10] _expand_metric_tensor,
-          [11] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] undo_swaps(),
+          [3] defer_measurements(allow_postselect=False),
+          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
+          [5] no_sampling(name=backprop + default.mixed),
+          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [8] validate_observables(stopping_condition=..., name=default.mixed),
+          [9] add_noise(..., level=device),
+          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [11] metric_tensor(device_wires=Wires([0, 1]))
         )
 
         Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the compile pipeline. For example, one can do:
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level=2).compile_pipeline)
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] add_noise
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] add_noise(..., level=2)
         )
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level=slice(1,3)).compile_pipeline)
         CompilePipeline(
-          [0] merge_rotations,
-          [1] undo_swaps,
-          [2] add_noise
+          [0] merge_rotations(),
+          [1] undo_swaps(),
+          [2] add_noise(..., level=slice(1, 3, None))
         )
 
     """

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -139,39 +139,107 @@ def add_noise(tape, noise_model, level="user"):
 
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
-        >>> qml.workflow.get_transform_program(circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.workflow.get_transform_program(circuit))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] undo_swaps,
+          [3] defer_measurements,
+          [4] decompose,
+          [5] no_sampling,
+          [6] validate_device_wires,
+          [7] validate_measurements,
+          [8] validate_observables,
+          [9] _expand_metric_tensor,
+          [10] metric_tensor
+        )
 
-        >>> qml.workflow.get_transform_program(noisy_circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.workflow.get_transform_program(noisy_circuit))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] undo_swaps,
+          [3] add_noise,
+          [4] defer_measurements,
+          [5] decompose,
+          [6] no_sampling,
+          [7] validate_device_wires,
+          [8] validate_measurements,
+          [9] validate_observables,
+          [10] _expand_metric_tensor,
+          [11] metric_tensor
+        )
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
         transforming a ``QNode``, this transform can be added at a designated level within the compile pipeline, as determined using the
         :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
 
-        >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] undo_swaps,
+          [3] defer_measurements,
+          [4] decompose,
+          [5] no_sampling,
+          [6] validate_device_wires,
+          [7] validate_measurements,
+          [8] validate_observables,
+          [9] add_noise,
+          [10] _expand_metric_tensor,
+          [11] metric_tensor
+        )
 
         Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
         to an empty compile pipeline, `"user"` will allow addition at the end of user-specified transforms, `"device"` will allow addition at the
         end of device-specific transforms, and `"gradient"` will allow addition at the end of transforms that expand trainable operations. For example:
 
-        >>> qml.noise.add_noise(circuit, noise_model, level="top").compile_pipeline
-        CompilePipeline(add_noise)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level="top").compile_pipeline)
+        CompilePipeline(
+          [0] add_noise
+        )
 
-        >>> qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline)
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] undo_swaps,
+          [3] add_noise,
+          [4] _expand_metric_tensor,
+          [5] metric_tensor
+        )
 
-        >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] undo_swaps,
+          [3] defer_measurements,
+          [4] decompose,
+          [5] no_sampling,
+          [6] validate_device_wires,
+          [7] validate_measurements,
+          [8] validate_observables,
+          [9] add_noise,
+          [10] _expand_metric_tensor,
+          [11] metric_tensor
+        )
 
         Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the compile pipeline. For example, one can do:
 
-        >>> qml.noise.add_noise(circuit, noise_model, level=2).compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, add_noise)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level=2).compile_pipeline)
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] add_noise
+        )
 
-        >>> qml.noise.add_noise(circuit, noise_model, level=slice(1,3)).compile_pipeline
-        CompilePipeline(merge_rotations, undo_swaps, add_noise)
+        >>> print(qml.noise.add_noise(circuit, noise_model, level=slice(1,3)).compile_pipeline)
+        CompilePipeline(
+          [0] merge_rotations,
+          [1] undo_swaps,
+          [2] add_noise
+        )
 
     """
     if not hasattr(noise_model, "model_map") or not hasattr(noise_model, "metadata"):

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,18 +140,18 @@ def add_noise(tape, noise_model, level="user"):
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
         >>> print(qml.workflow.get_transform_program(circuit))
-        CompilePipeline(
+         CompilePipeline(
           [0] cancel_inverses(),
           [1] merge_rotations(),
           [2] undo_swaps(),
-          [3] defer_measurements(allow_postselect=False),
-          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
-          [5] no_sampling(name=backprop + default.mixed),
-          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
-          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
-          [8] validate_observables(stopping_condition=..., name=default.mixed),
-          [9] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [10] metric_tensor(device_wires=Wires([0, 1]))
+          [3] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [4] metric_tensor(device_wires=Wires([0, 1])),
+          [5] defer_measurements(allow_postselect=False),
+          [6] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
+          [7] no_sampling(name=backprop + default.mixed),
+          [8] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [10] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
         >>> print(qml.workflow.get_transform_program(noisy_circuit))
@@ -159,15 +159,15 @@ def add_noise(tape, noise_model, level="user"):
           [0] cancel_inverses(),
           [1] merge_rotations(),
           [2] undo_swaps(),
-          [3] add_noise(...),
-          [4] defer_measurements(allow_postselect=False),
-          [5] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
-          [6] no_sampling(name=backprop + default.mixed),
-          [7] validate_device_wires(Wires([0, 1]), name=default.mixed),
-          [8] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
-          [9] validate_observables(stopping_condition=..., name=default.mixed),
-          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [11] metric_tensor(device_wires=Wires([0, 1]))
+          [3] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [4] metric_tensor(device_wires=Wires([0, 1])),
+          [5] add_noise(...),
+          [6] defer_measurements(allow_postselect=False),
+          [7] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
+          [8] no_sampling(name=backprop + default.mixed),
+          [9] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [11] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
@@ -179,15 +179,15 @@ def add_noise(tape, noise_model, level="user"):
           [0] cancel_inverses(),
           [1] merge_rotations(),
           [2] undo_swaps(),
-          [3] defer_measurements(allow_postselect=False),
-          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
-          [5] no_sampling(name=backprop + default.mixed),
-          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
-          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
-          [8] validate_observables(stopping_condition=..., name=default.mixed),
-          [9] add_noise(..., level=device),
-          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [11] metric_tensor(device_wires=Wires([0, 1]))
+          [3] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [4] metric_tensor(device_wires=Wires([0, 1])),
+          [5] defer_measurements(allow_postselect=False),
+          [6] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
+          [7] no_sampling(name=backprop + default.mixed),
+          [8] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [10] validate_observables(stopping_condition=..., name=default.mixed),
+          [11] add_noise(..., level=device)
         )
 
         Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
@@ -200,13 +200,13 @@ def add_noise(tape, noise_model, level="user"):
         )
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline)
-        CompilePipeline(
+         CompilePipeline(
           [0] cancel_inverses(),
           [1] merge_rotations(),
           [2] undo_swaps(),
-          [3] add_noise(..., level=user),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1]))
+          [3] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [4] metric_tensor(device_wires=Wires([0, 1])),
+          [5] add_noise(..., level=user)
         )
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
@@ -214,15 +214,15 @@ def add_noise(tape, noise_model, level="user"):
           [0] cancel_inverses(),
           [1] merge_rotations(),
           [2] undo_swaps(),
-          [3] defer_measurements(allow_postselect=False),
-          [4] decompose(target_gates=..., stopping_condition=<function stopping_condition at ...>, name=default.mixed),
-          [5] no_sampling(name=backprop + default.mixed),
-          [6] validate_device_wires(Wires([0, 1]), name=default.mixed),
-          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
-          [8] validate_observables(stopping_condition=..., name=default.mixed),
-          [9] add_noise(..., level=device),
-          [10] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [11] metric_tensor(device_wires=Wires([0, 1]))
+          [3] _expand_metric_tensor(device_wires=Wires([0, 1])),
+          [4] metric_tensor(device_wires=Wires([0, 1])),
+          [5] defer_measurements(allow_postselect=False),
+          [6] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
+          [7] no_sampling(name=backprop + default.mixed),
+          [8] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
+          [10] validate_observables(stopping_condition=..., name=default.mixed),
+          [11] add_noise(..., level=device)
         )
 
         Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the compile pipeline. For example, one can do:

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -298,8 +298,11 @@ will merge the two RX rotations into a single RX gate.
 Alternatively, multiple transforms can be chained together to create a :class:`~.CompilePipeline`:
 
 >>> pipeline = qml.transforms.cancel_inverses(recursive=True) + qml.transforms.merge_rotations
->>> pipeline
-CompilePipeline(cancel_inverses, merge_rotations)
+>>> print(pipeline)
+CompilePipeline(
+  [0] cancel_inverses,
+  [1] merge_rotations
+)
 
 The :class:`~.CompilePipeline` can also be applied on a ``QNode``, which will transform the
 circuit with each pass within the pipeline sequentially.

--- a/pennylane/transforms/__init__.py
+++ b/pennylane/transforms/__init__.py
@@ -300,8 +300,8 @@ Alternatively, multiple transforms can be chained together to create a :class:`~
 >>> pipeline = qml.transforms.cancel_inverses(recursive=True) + qml.transforms.merge_rotations
 >>> print(pipeline)
 CompilePipeline(
-  [0] cancel_inverses,
-  [1] merge_rotations
+  [0] cancel_inverses(recursive=True),
+  [1] merge_rotations()
 )
 
 The :class:`~.CompilePipeline` can also be applied on a ``QNode``, which will transform the

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -167,38 +167,59 @@ class CompilePipeline:
     example, the transforms can be added together with ``+``:
 
     >>> pipeline = qml.transforms.merge_rotations + qml.transforms.cancel_inverses(recursive=True)
-    >>> pipeline
-    CompilePipeline(merge_rotations, cancel_inverses)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses
+    )
 
     Or multiplied by a scalar via ``*``:
     >>> pipeline += 2 * qml.transforms.commute_controlled
-    >>> pipeline
-    CompilePipeline(merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses,
+      [2] commute_controlled,
+      [3] commute_controlled
+    )
 
     A compilation pipeline can also be easily modified using operations similar to Python lists, including
     ``insert``, ``append``, ``extend`` and ``pop``:
 
     >>> pipeline.insert(0, qml.transforms.remove_barrier)
-    >>> pipeline
-    CompilePipeline(remove_barrier, merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] remove_barrier,
+      [1] merge_rotations,
+      [2] cancel_inverses,
+      [3] commute_controlled,
+      [4] commute_controlled
+    )
 
     Additionally, multiple compilation pipelines can be concatenated:
 
     >>> another_pipeline = qml.transforms.decompose(gate_set={qml.RX, qml.RZ, qml.CNOT}) + qml.transforms.combine_global_phases
-    >>> another_pipeline + pipeline
-    CompilePipeline(decompose, combine_global_phases, remove_barrier, merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(another_pipeline + pipeline)
+    CompilePipeline(
+      [0] decompose,
+      [1] combine_global_phases,
+      [2] remove_barrier,
+      [3] merge_rotations,
+      [4] cancel_inverses,
+      [5] commute_controlled,
+      [6] commute_controlled
+    )
 
     We can create a new pipeline that will do multiple passes of the original with multiplication:
 
     >>> original = qml.transforms.merge_rotations + qml.transforms.cancel_inverses
-    >>> 2 * original
-    CompilePipeline(merge_rotations, cancel_inverses, merge_rotations, cancel_inverses)
-
-    We can create a new pipeline that will do multiple passes of the original with multiplication:
-
-    >>> original = qml.transforms.merge_rotations + qml.transforms.cancel_inverses
-    >>> 2 * original
-    CompilePipeline(merge_rotations, cancel_inverses, merge_rotations, cancel_inverses)
+    >>> print(2 * original)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses,
+      [2] merge_rotations,
+      [3] cancel_inverses
+    )
 
     You can specify a transform program (``pipeline``) by passing these transforms to the ``CompilePipeline``
     class. By applying the created ``pipeline`` directly on a quantum function as a decorator, the circuit will
@@ -233,26 +254,48 @@ class CompilePipeline:
     example, the transforms can be added toguether with ``+``:
 
     >>> pipeline = qml.transforms.merge_rotations + qml.transforms.cancel_inverses(recursive=True)
-    >>> pipeline
-    CompilePipeline(merge_rotations, cancel_inverses)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses
+    )
 
     Or multiplied by a scalar via ``*``:
     >>> pipeline += 2 * qml.transforms.commute_controlled
-    >>> pipeline
-    CompilePipeline(merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses,
+      [2] commute_controlled,
+      [3] commute_controlled
+    )
 
     A compilation pipeline can also be easily modified using operations similar to Python lists, including
     ``insert``, ``append``, ``extend`` and ``pop``:
 
     >>> pipeline.insert(0, qml.transforms.remove_barrier)
-    >>> pipeline
-    CompilePipeline(remove_barrier, merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(pipeline)
+    CompilePipeline(
+      [0] remove_barrier,
+      [1] merge_rotations,
+      [2] cancel_inverses,
+      [3] commute_controlled,
+      [4] commute_controlled
+    )
 
     Additionally, multiple compilation pipelines can be concatenated:
 
     >>> another_pipeline = qml.transforms.decompose(gate_set={qml.RX, qml.RZ, qml.CNOT}) + qml.transforms.combine_global_phases
-    >>> another_pipeline + pipeline
-    CompilePipeline(decompose, combine_global_phases, remove_barrier, merge_rotations, cancel_inverses, commute_controlled, commute_controlled)
+    >>> print(another_pipeline + pipeline)
+    CompilePipeline(
+      [0] decompose,
+      [1] combine_global_phases,
+      [2] remove_barrier,
+      [3] merge_rotations,
+      [4] cancel_inverses,
+      [5] commute_controlled,
+      [6] commute_controlled
+    )
     """
 
     @overload

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -401,6 +401,11 @@ class CompilePipeline:
 
     __rmul__ = __mul__
 
+    def _ipython_display_(self):
+        """Displays __str__ in ipython instead of __repr__"""
+        # See https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
+        print(str(self))
+
     def __str__(self) -> str:
         """Returns a user friendly representation of the compile pipeline."""
         if not self:

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -321,7 +321,6 @@ class CompilePipeline:
         return bool(self._compile_pipeline)
 
     def __add__(self, other: CompilePipeline | BoundTransform | Transform) -> CompilePipeline:
-
         # Convert dispatcher to container if needed
         if isinstance(other, Transform):
             other = BoundTransform(other)
@@ -436,11 +435,36 @@ class CompilePipeline:
 
     __rmul__ = __mul__
 
-    def __repr__(self):
-        """The string representation of the compile pipeline class."""
-        gen = (f"{t.tape_transform.__name__ if t.tape_transform else t.pass_name}" for t in self)
-        contents = ", ".join(gen)
-        return f"CompilePipeline({contents})"
+    def __str__(self) -> str:
+        """Returns a user friendly representation of the compile pipeline."""
+        if not self:
+            return "CompilePipeline()"
+
+        lines = []
+        for i, transform in enumerate(self):
+            name = (
+                transform.tape_transform.__name__
+                if transform.tape_transform
+                else transform.pass_name
+            )
+            if name == "marker":
+                name += f'("{transform.args[0]}")'
+            lines.append(f"  [{i}] {name}")
+
+        contents = ",\n".join(lines)
+        return f"CompilePipeline(\n{contents}\n)"
+
+    def __repr__(self) -> str:
+        """The detailed string representation of the compile pipeline."""
+        if not self:
+            return "CompilePipeline()"
+
+        lines = []
+        for i, transform in enumerate(self):
+            lines.append(f"  [{i}] {repr(transform)}")
+
+        contents = ",\n".join(lines)
+        return f"CompilePipeline(\n{contents}\n)"
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, CompilePipeline):

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -222,19 +222,6 @@ class CompilePipeline:
       [3] cancel_inverses
     )
 
-    Additionally, multiple compilation pipelines can be concatenated:
-
-    >>> another_pipeline = qml.transforms.decompose(gate_set={qml.RX, qml.RZ, qml.CNOT}) + qml.transforms.combine_global_phases
-    >>> print(another_pipeline + pipeline)
-    CompilePipeline(
-      [0] decompose,
-      [1] combine_global_phases,
-      [2] remove_barrier,
-      [3] merge_rotations,
-      [4] cancel_inverses,
-      [5] commute_controlled,
-      [6] commute_controlled
-    )
     """
 
     @overload

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -174,6 +174,7 @@ class CompilePipeline:
     )
 
     Or multiplied by a scalar via ``*``:
+
     >>> pipeline += 2 * qml.transforms.commute_controlled
     >>> print(pipeline)
     CompilePipeline(
@@ -219,68 +220,6 @@ class CompilePipeline:
       [1] cancel_inverses,
       [2] merge_rotations,
       [3] cancel_inverses
-    )
-
-    You can specify a transform program (``pipeline``) by passing these transforms to the ``CompilePipeline``
-    class. By applying the created ``pipeline`` directly on a quantum function as a decorator, the circuit will
-    be transformed with each pass within the pipeline sequentially:
-
-    .. code-block:: python
-
-        pipeline = qml.CompilePipeline(
-            qml.transforms.commute_controlled,
-            qml.transforms.cancel_inverses(recursive=True),
-            qml.transforms.merge_rotations,
-        )
-
-        @pipeline
-        @qml.qnode(qml.device("default.qubit"))
-        def circuit(x, y):
-            qml.CNOT([1, 0])
-            qml.X(0)
-            qml.CNOT([1, 0])
-            qml.H(0)
-            qml.H(0)
-            qml.X(0)
-            qml.RX(x, wires=0)
-            qml.RX(y, wires=0)
-            return qml.expval(qml.Z(1))
-
-    >>> print(qml.draw(circuit)(0.1, 0.2))
-    0: ──RX(0.30)─┤
-    1: ───────────┤  <Z>
-
-    Alternatively, the transform program can be constructed intuitively by combining multiple transforms. For
-    example, the transforms can be added toguether with ``+``:
-
-    >>> pipeline = qml.transforms.merge_rotations + qml.transforms.cancel_inverses(recursive=True)
-    >>> print(pipeline)
-    CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses
-    )
-
-    Or multiplied by a scalar via ``*``:
-    >>> pipeline += 2 * qml.transforms.commute_controlled
-    >>> print(pipeline)
-    CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses,
-      [2] commute_controlled,
-      [3] commute_controlled
-    )
-
-    A compilation pipeline can also be easily modified using operations similar to Python lists, including
-    ``insert``, ``append``, ``extend`` and ``pop``:
-
-    >>> pipeline.insert(0, qml.transforms.remove_barrier)
-    >>> print(pipeline)
-    CompilePipeline(
-      [0] remove_barrier,
-      [1] merge_rotations,
-      [2] cancel_inverses,
-      [3] commute_controlled,
-      [4] commute_controlled
     )
 
     Additionally, multiple compilation pipelines can be concatenated:

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -168,8 +168,8 @@ class CompilePipeline:
     >>> pipeline = qml.transforms.merge_rotations + qml.transforms.cancel_inverses(recursive=True)
     >>> print(pipeline)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses
+      [0] merge_rotations(),
+      [1] cancel_inverses(recursive=True)
     )
 
     Or multiplied by a scalar via ``*``:
@@ -177,10 +177,10 @@ class CompilePipeline:
     >>> pipeline += 2 * qml.transforms.commute_controlled
     >>> print(pipeline)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses,
-      [2] commute_controlled,
-      [3] commute_controlled
+      [0] merge_rotations(),
+      [1] cancel_inverses(recursive=True),
+      [2] commute_controlled(),
+      [3] commute_controlled()
     )
 
     A compilation pipeline can also be easily modified using operations similar to Python lists, including
@@ -189,11 +189,11 @@ class CompilePipeline:
     >>> pipeline.insert(0, qml.transforms.remove_barrier)
     >>> print(pipeline)
     CompilePipeline(
-      [0] remove_barrier,
-      [1] merge_rotations,
-      [2] cancel_inverses,
-      [3] commute_controlled,
-      [4] commute_controlled
+      [0] remove_barrier(),
+      [1] merge_rotations(),
+      [2] cancel_inverses(recursive=True),
+      [3] commute_controlled(),
+      [4] commute_controlled()
     )
 
     Additionally, multiple compilation pipelines can be concatenated:
@@ -201,13 +201,13 @@ class CompilePipeline:
     >>> another_pipeline = qml.transforms.decompose(gate_set={qml.RX, qml.RZ, qml.CNOT}) + qml.transforms.combine_global_phases
     >>> print(another_pipeline + pipeline)
     CompilePipeline(
-      [0] decompose,
-      [1] combine_global_phases,
-      [2] remove_barrier,
-      [3] merge_rotations,
-      [4] cancel_inverses,
-      [5] commute_controlled,
-      [6] commute_controlled
+      [0] decompose(gate_set=...),
+      [1] combine_global_phases(),
+      [2] remove_barrier(),
+      [3] merge_rotations(),
+      [4] cancel_inverses(recursive=True),
+      [5] commute_controlled(),
+      [6] commute_controlled()
     )
 
     We can create a new pipeline that will do multiple passes of the original with multiplication:
@@ -215,10 +215,10 @@ class CompilePipeline:
     >>> original = qml.transforms.merge_rotations + qml.transforms.cancel_inverses
     >>> print(2 * original)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses,
-      [2] merge_rotations,
-      [3] cancel_inverses
+      [0] merge_rotations(),
+      [1] cancel_inverses(),
+      [2] merge_rotations(),
+      [3] cancel_inverses()
     )
 
     """

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -226,7 +226,7 @@ class Transform:  # pylint: disable=too-many-instance-attributes
 
     >>> print(transformed_qnode.compile_pipeline)
     CompilePipeline(
-      [0] my_quantum_transform
+      [0] my_quantum_transform()
     )
 
     If we apply ``dispatched_transform`` a second time to the :class:`pennylane.QNode`, we would add
@@ -235,8 +235,8 @@ class Transform:  # pylint: disable=too-many-instance-attributes
     >>> transformed_qnode = dispatched_transform(transformed_qnode)
     >>> print(transformed_qnode.compile_pipeline)
     CompilePipeline(
-      [0] my_quantum_transform,
-      [1] my_quantum_transform
+      [0] my_quantum_transform(),
+      [1] my_quantum_transform()
     )
 
     When a transformed QNode is executed, the QNode's compile pipeline is applied to the generated tape
@@ -891,9 +891,9 @@ class BoundTransform:  # pylint: disable=too-many-instance-attributes
 
     >>> print(bound_t * 3)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] merge_rotations,
-      [2] merge_rotations
+      [0] merge_rotations(atol=0.0001),
+      [1] merge_rotations(atol=0.0001),
+      [2] merge_rotations(atol=0.0001)
     )
 
     And it can be used in conjunction with both individual transforms, bound transforms, and
@@ -901,14 +901,14 @@ class BoundTransform:  # pylint: disable=too-many-instance-attributes
 
     >>> print(bound_t + qml.transforms.cancel_inverses)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses
+      [0] merge_rotations(atol=0.0001),
+      [1] cancel_inverses()
     )
     >>> print(bound_t + qml.transforms.cancel_inverses + bound_t)
     CompilePipeline(
-      [0] merge_rotations,
-      [1] cancel_inverses,
-      [2] merge_rotations
+      [0] merge_rotations(atol=0.0001),
+      [1] cancel_inverses(),
+      [2] merge_rotations(atol=0.0001)
     )
 
     """

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -224,15 +224,20 @@ class Transform:  # pylint: disable=too-many-instance-attributes
     >>> transformed_qnode
     <QNode: device='<default.qubit device at ...>', interface='auto', diff_method='best', shots='Shots(total=None)'>
 
-    >>> transformed_qnode.compile_pipeline
-    CompilePipeline(my_quantum_transform)
+    >>> print(transformed_qnode.compile_pipeline)
+    CompilePipeline(
+      [0] my_quantum_transform
+    )
 
     If we apply ``dispatched_transform`` a second time to the :class:`pennylane.QNode`, we would add
     it to the compile pipeline again and therefore the transform would be applied twice before execution.
 
     >>> transformed_qnode = dispatched_transform(transformed_qnode)
-    >>> transformed_qnode.compile_pipeline
-    CompilePipeline(my_quantum_transform, my_quantum_transform)
+    >>> print(transformed_qnode.compile_pipeline)
+    CompilePipeline(
+      [0] my_quantum_transform,
+      [1] my_quantum_transform
+    )
 
     When a transformed QNode is executed, the QNode's compile pipeline is applied to the generated tape
     and creates a sequence of tapes to be executed. The execution results are then post-processed in the
@@ -265,7 +270,7 @@ class Transform:  # pylint: disable=too-many-instance-attributes
             ...
         TypeError: <transform: my_pass> missing 1 required positional argument: 'a'
         >>> new_circuit = my_transform(circuit, a=2)
-        >>> new_circuit.transform_program[0]
+        >>> new_circuit.compile_pipeline[0]
         <my_pass(2, 1, metadata=my_value)>
 
         We will also have a docstring and signature. If a tape transform is present, the signature will
@@ -884,16 +889,27 @@ class BoundTransform:  # pylint: disable=too-many-instance-attributes
 
     Repeated versions of the bound transform can be created with multiplication:
 
-    >>> bound_t * 3
-    CompilePipeline(merge_rotations, merge_rotations, merge_rotations)
+    >>> print(bound_t * 3)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] merge_rotations,
+      [2] merge_rotations
+    )
 
     And it can be used in conjunction with both individual transforms, bound transforms, and
     compile pipelines.
 
-    >>> bound_t + qml.transforms.cancel_inverses
-    CompilePipeline(merge_rotations, cancel_inverses)
-    >>> bound_t + qml.transforms.cancel_inverses + bound_t
-    CompilePipeline(merge_rotations, cancel_inverses, merge_rotations)
+    >>> print(bound_t + qml.transforms.cancel_inverses)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses
+    )
+    >>> print(bound_t + qml.transforms.cancel_inverses + bound_t)
+    CompilePipeline(
+      [0] merge_rotations,
+      [1] cancel_inverses,
+      [2] merge_rotations
+    )
 
     """
 

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -277,15 +277,15 @@ def get_transform_program(
         CompilePipeline(
           [0] cancel_inverses(),
           [1] merge_rotations(),
-          [2] _expand_transform_param_shift(shifts=0.7853981633974483),
-          [3] defer_measurements(allow_postselect=True),
-          [4] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [5] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [6] validate_device_wires(None, name=default.qubit),
-          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-          [8] _conditional_broadcast_expand(),
-          [9] _expand_metric_tensor(device_wires=None),
-          [10] metric_tensor(device_wires=None)
+          [2] _expand_metric_tensor(device_wires=None),
+          [3] metric_tensor(device_wires=None),
+          [4] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [5] defer_measurements(allow_postselect=True),
+          [6] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [7] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [8] validate_device_wires(None, name=default.qubit),
+          [9] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [10] _conditional_broadcast_expand()
         )
 
         The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
@@ -308,9 +308,9 @@ def get_transform_program(
         CompilePipeline(
           [0] cancel_inverses(),
           [1] merge_rotations(),
-          [2] _expand_transform_param_shift(shifts=0.7853981633974483),
-          [3] _expand_metric_tensor(device_wires=None),
-          [4] metric_tensor(device_wires=None)
+          [2] _expand_metric_tensor(device_wires=None),
+          [3] metric_tensor(device_wires=None),
+          [4] _expand_transform_param_shift(shifts=0.7853981633974483)
         )
 
         ``"top"`` and ``0`` both return empty transform programs.
@@ -335,19 +335,19 @@ def get_transform_program(
         >>> print(qml.workflow.get_transform_program(circuit, level=slice(1,3)))
         CompilePipeline(
           [0] merge_rotations(),
-          [1] _expand_transform_param_shift(shifts=0.7853981633974483)
+          [1] _expand_metric_tensor(device_wires=None)
         )
         >>> print(qml.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
         CompilePipeline(
-          [0] metric_tensor(device_wires=None),
-          [1] _expand_metric_tensor(device_wires=None),
-          [2] _conditional_broadcast_expand(),
-          [3] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-          [4] validate_device_wires(None, name=default.qubit),
-          [5] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [6] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [7] defer_measurements(allow_postselect=True),
-          [8] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [0] _conditional_broadcast_expand(),
+          [1] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [2] validate_device_wires(None, name=default.qubit),
+          [3] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [4] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [5] defer_measurements(allow_postselect=True),
+          [6] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [7] metric_tensor(device_wires=None),
+          [8] _expand_metric_tensor(device_wires=None),
           [9] merge_rotations(),
           [10] cancel_inverses()
         )
@@ -360,16 +360,16 @@ def get_transform_program(
         >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
         >>> print(grad_prog[len(user_prog) - 1 : -1])
         CompilePipeline(
-          [0] _expand_metric_tensor(device_wires=None)
+          [0] metric_tensor(device_wires=None)
         )
         >>> print(dev_prog[len(grad_prog) - 1 : -1])
         CompilePipeline(
-          [0] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [1] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [2] validate_device_wires(None, name=default.qubit),
-          [3] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-          [4] _conditional_broadcast_expand(),
-          [5] _expand_metric_tensor(device_wires=None)
+          [0] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [1] defer_measurements(allow_postselect=True),
+          [2] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [3] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [4] validate_device_wires(None, name=default.qubit),
+          [5] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit)
         )
 
     """

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -275,17 +275,17 @@ def get_transform_program(
 
         >>> print(qml.workflow.get_transform_program(circuit))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] _expand_transform_param_shift,
-          [3] defer_measurements,
-          [4] decompose,
-          [5] device_resolve_dynamic_wires,
-          [6] validate_device_wires,
-          [7] validate_measurements,
-          [8] _conditional_broadcast_expand,
-          [9] _expand_metric_tensor,
-          [10] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [3] defer_measurements(allow_postselect=True),
+          [4] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [5] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [6] validate_device_wires(None, name=default.qubit),
+          [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [8] _conditional_broadcast_expand(),
+          [9] _expand_metric_tensor(device_wires=None),
+          [10] metric_tensor(device_wires=None)
         )
 
         The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
@@ -293,10 +293,10 @@ def get_transform_program(
 
         >>> print(qml.workflow.get_transform_program(circuit, level="user"))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] _expand_metric_tensor,
-          [3] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] _expand_metric_tensor(device_wires=None),
+          [3] metric_tensor(device_wires=None)
         )
 
         The ``_expand_transform_param_shift`` is the ``"gradient"`` transform.
@@ -306,11 +306,11 @@ def get_transform_program(
 
         >>> print(qml.workflow.get_transform_program(circuit, level="gradient"))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations,
-          [2] _expand_transform_param_shift,
-          [3] _expand_metric_tensor,
-          [4] metric_tensor
+          [0] cancel_inverses(),
+          [1] merge_rotations(),
+          [2] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [3] _expand_metric_tensor(device_wires=None),
+          [4] metric_tensor(device_wires=None)
         )
 
         ``"top"`` and ``0`` both return empty transform programs.
@@ -324,8 +324,8 @@ def get_transform_program(
 
         >>> print(qml.workflow.get_transform_program(circuit, level=2))
         CompilePipeline(
-          [0] cancel_inverses,
-          [1] merge_rotations
+          [0] cancel_inverses(),
+          [1] merge_rotations()
         )
 
         ``level`` can also accept a ``slice`` object to select out any arbitrary subset of the
@@ -334,22 +334,22 @@ def get_transform_program(
 
         >>> print(qml.workflow.get_transform_program(circuit, level=slice(1,3)))
         CompilePipeline(
-          [0] merge_rotations,
-          [1] _expand_transform_param_shift
+          [0] merge_rotations(),
+          [1] _expand_transform_param_shift(shifts=0.7853981633974483)
         )
         >>> print(qml.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
         CompilePipeline(
-          [0] metric_tensor,
-          [1] _expand_metric_tensor,
-          [2] _conditional_broadcast_expand,
-          [3] validate_measurements,
-          [4] validate_device_wires,
-          [5] device_resolve_dynamic_wires,
-          [6] decompose,
-          [7] defer_measurements,
-          [8] _expand_transform_param_shift,
-          [9] merge_rotations,
-          [10] cancel_inverses
+          [0] metric_tensor(device_wires=None),
+          [1] _expand_metric_tensor(device_wires=None),
+          [2] _conditional_broadcast_expand(),
+          [3] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [4] validate_device_wires(None, name=default.qubit),
+          [5] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [6] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [7] defer_measurements(allow_postselect=True),
+          [8] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [9] merge_rotations(),
+          [10] cancel_inverses()
         )
 
         You can get creative and pick a single category of transforms as follows, excluding
@@ -360,16 +360,16 @@ def get_transform_program(
         >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
         >>> print(grad_prog[len(user_prog) - 1 : -1])
         CompilePipeline(
-          [0] _expand_metric_tensor
+          [0] _expand_metric_tensor(device_wires=None)
         )
         >>> print(dev_prog[len(grad_prog) - 1 : -1])
         CompilePipeline(
-          [0] decompose,
-          [1] device_resolve_dynamic_wires,
-          [2] validate_device_wires,
-          [3] validate_measurements,
-          [4] _conditional_broadcast_expand,
-          [5] _expand_metric_tensor
+          [0] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [1] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [2] validate_device_wires(None, name=default.qubit),
+          [3] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [4] _conditional_broadcast_expand(),
+          [5] _expand_metric_tensor(device_wires=None)
         )
 
     """

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -273,43 +273,84 @@ def get_transform_program(
 
         By default, we get the full transform program. This can be explicitly specified by ``level="device"``.
 
-        >>> qml.workflow.get_transform_program(circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, _expand_transform_param_shift, defer_measurements, decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.workflow.get_transform_program(circuit))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] _expand_transform_param_shift,
+          [3] defer_measurements,
+          [4] decompose,
+          [5] device_resolve_dynamic_wires,
+          [6] validate_device_wires,
+          [7] validate_measurements,
+          [8] _conditional_broadcast_expand,
+          [9] _expand_metric_tensor,
+          [10] metric_tensor
+        )
 
         The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
         :func:`~.merge_rotations` and :func:`~.metric_tensor`.
 
-        >>> qml.workflow.get_transform_program(circuit, level="user")
-        CompilePipeline(cancel_inverses, merge_rotations, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.workflow.get_transform_program(circuit, level="user"))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] _expand_metric_tensor,
+          [3] metric_tensor
+        )
 
         The ``_expand_transform_param_shift`` is the ``"gradient"`` transform.
         This expands all trainable operations to a state where the parameter shift transform can operate on them. For example,
         it will decompose any parametrized templates into operators that have generators. Note how ``metric_tensor`` is still
         present at the very end of resulting program.
 
-        >>> qml.workflow.get_transform_program(circuit, level="gradient")
-        CompilePipeline(cancel_inverses, merge_rotations, _expand_transform_param_shift, _expand_metric_tensor, metric_tensor)
+        >>> print(qml.workflow.get_transform_program(circuit, level="gradient"))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations,
+          [2] _expand_transform_param_shift,
+          [3] _expand_metric_tensor,
+          [4] metric_tensor
+        )
 
         ``"top"`` and ``0`` both return empty transform programs.
 
-        >>> qml.workflow.get_transform_program(circuit, level="top")
+        >>> print(qml.workflow.get_transform_program(circuit, level="top"))
         CompilePipeline()
-        >>> qml.workflow.get_transform_program(circuit, level=0)
+        >>> print(qml.workflow.get_transform_program(circuit, level=0))
         CompilePipeline()
 
         The ``level`` can also be any integer, corresponding to a number of transforms in the program.
 
-        >>> qml.workflow.get_transform_program(circuit, level=2)
-        CompilePipeline(cancel_inverses, merge_rotations)
+        >>> print(qml.workflow.get_transform_program(circuit, level=2))
+        CompilePipeline(
+          [0] cancel_inverses,
+          [1] merge_rotations
+        )
 
         ``level`` can also accept a ``slice`` object to select out any arbitrary subset of the
         transform program.  This allows you to select different starting transforms or strides.
         For example, you can skip the first transform or reverse the order:
 
-        >>> qml.workflow.get_transform_program(circuit, level=slice(1,3))
-        CompilePipeline(merge_rotations, _expand_transform_param_shift)
-        >>> qml.workflow.get_transform_program(circuit, level=slice(None, None, -1))
-        CompilePipeline(metric_tensor, _expand_metric_tensor, _conditional_broadcast_expand, validate_measurements, validate_device_wires, device_resolve_dynamic_wires, decompose, defer_measurements, _expand_transform_param_shift, merge_rotations, cancel_inverses)
+        >>> print(qml.workflow.get_transform_program(circuit, level=slice(1,3)))
+        CompilePipeline(
+          [0] merge_rotations,
+          [1] _expand_transform_param_shift
+        )
+        >>> print(qml.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
+        CompilePipeline(
+          [0] metric_tensor,
+          [1] _expand_metric_tensor,
+          [2] _conditional_broadcast_expand,
+          [3] validate_measurements,
+          [4] validate_device_wires,
+          [5] device_resolve_dynamic_wires,
+          [6] decompose,
+          [7] defer_measurements,
+          [8] _expand_transform_param_shift,
+          [9] merge_rotations,
+          [10] cancel_inverses
+        )
 
         You can get creative and pick a single category of transforms as follows, excluding
         any preceding transforms (and the final transform if it exists):
@@ -317,10 +358,19 @@ def get_transform_program(
         >>> user_prog = qml.workflow.get_transform_program(circuit, level="user")
         >>> grad_prog = qml.workflow.get_transform_program(circuit, level="gradient")
         >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
-        >>> grad_prog[len(user_prog) - 1 : -1]
-        CompilePipeline(_expand_metric_tensor)
-        >>> dev_prog[len(grad_prog) - 1 : -1]
-        CompilePipeline(decompose, device_resolve_dynamic_wires, validate_device_wires, validate_measurements, _conditional_broadcast_expand, _expand_metric_tensor)
+        >>> print(grad_prog[len(user_prog) - 1 : -1])
+        CompilePipeline(
+          [0] _expand_metric_tensor
+        )
+        >>> print(dev_prog[len(grad_prog) - 1 : -1])
+        CompilePipeline(
+          [0] decompose,
+          [1] device_resolve_dynamic_wires,
+          [2] validate_device_wires,
+          [3] validate_measurements,
+          [4] _conditional_broadcast_expand,
+          [5] _expand_metric_tensor
+        )
 
     """
     _validate_level(level)

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -1833,14 +1833,9 @@ class TestCompilePipelineIntegration:
         new_qnode = dispatched_transform(dispatched_transform(qnode_circuit, 0), 0)
 
         pipeline = new_qnode.compile_pipeline
-        transformed_qnode_rep = repr(pipeline)
-        assert (
-            transformed_qnode_rep
-            == "CompilePipeline("
-            + str(first_valid_transform.__name__)
-            + ", "
-            + str(first_valid_transform.__name__)
-            + ")"
+        assert pipeline == CompilePipeline(
+            BoundTransform(dispatched_transform, args=(0,)),
+            BoundTransform(dispatched_transform, args=(0,)),
         )
 
         assert pipeline
@@ -1866,16 +1861,9 @@ class TestCompilePipelineIntegration:
             return qml.expval(qml.PauliZ(wires=0))
 
         new_qnode = dispatched_transform_2(dispatched_transform_1(qnode_circuit, 0))
-
         pipeline = new_qnode.compile_pipeline
-        transformed_qnode_rep = repr(pipeline)
-        assert (
-            transformed_qnode_rep
-            == "CompilePipeline("
-            + str(first_valid_transform.__name__)
-            + ", "
-            + str(informative_transform.__name__)
-            + ")"
+        assert pipeline == CompilePipeline(
+            BoundTransform(dispatched_transform_1, args=(0,)), dispatched_transform_2
         )
 
         assert pipeline
@@ -1906,16 +1894,10 @@ class TestCompilePipelineIntegration:
         new_qnode = dispatched_transform_2(dispatched_transform_1(qnode_circuit, 0), 0)
 
         pipeline = new_qnode.compile_pipeline
-        transformed_qnode_rep = repr(pipeline)
-        assert (
-            transformed_qnode_rep
-            == "CompilePipeline("
-            + str(first_valid_transform.__name__)
-            + ", "
-            + str(second_valid_transform.__name__)
-            + ")"
+        assert pipeline == CompilePipeline(
+            BoundTransform(dispatched_transform_1, args=(0,)),
+            BoundTransform(dispatched_transform_2, args=(0,)),
         )
-
         assert pipeline
         assert len(pipeline) == 2
         assert pipeline[0].tape_transform is first_valid_transform

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -804,8 +804,8 @@ class TestCompilePipelineDunders:
         compile_pipeline.append(
             BoundTransform(
                 verbose_transform,
-                args=("x" * _CURRENT_THRESHOLD + 1,),
-                kwargs={"verbose_kwarg": "x" * _CURRENT_THRESHOLD + 1},
+                args=("x" * (_CURRENT_THRESHOLD + 1),),
+                kwargs={"verbose_kwarg": "x" * (_CURRENT_THRESHOLD + 1)},
             )
         )
 

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -779,6 +779,8 @@ class TestCompilePipelineDunders:
         """Test the string representation of a pipeline."""
         compile_pipeline = CompilePipeline()
 
+        assert repr(compile_pipeline) == "CompilePipeline()"
+
         transform1 = BoundTransform(qml.transform(first_valid_transform))
         transform2 = BoundTransform(qml.transform(second_valid_transform))
 

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -741,6 +741,22 @@ class TestCompilePipelineDunders:
         expected_repr = f"CompilePipeline(\n  [0] {repr(transform1)},\n  [1] {repr(transform2)}\n)"
         assert pipeline_repr == expected_repr
 
+    def test_ipython_display(self, capsys):
+        """Test that the ipython display prints the string representation of a CompilePipeline instance."""
+
+        transform1 = BoundTransform(qml.transform(first_valid_transform))
+        marker = qml.marker("blah")
+        transform2 = BoundTransform(qml.transform(second_valid_transform))
+
+        compile_pipeline = CompilePipeline()
+        compile_pipeline.append(transform1)
+        compile_pipeline.append(marker)
+        compile_pipeline.append(transform2)
+
+        compile_pipeline._ipython_display_()  # pylint: disable=protected-access
+        captured = capsys.readouterr()
+        assert str(compile_pipeline) + "\n" == captured.out
+
     def test_str_pipeline(self):
         """Tests the string representation of a pipeline."""
 

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -25,7 +25,6 @@ from pennylane.transforms.core import (
     BoundTransform,
     CompilePipeline,
     TransformError,
-    compile_pipeline,
     transform,
 )
 from pennylane.transforms.core.compile_pipeline import (

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -757,7 +757,7 @@ class TestCompilePipelineDunders:
         compile_pipeline.append(transform2)
 
         pipeline_str = str(compile_pipeline)
-        expected_repr = 'CompilePipeline(\n  [0] first_valid_transform,\n  [1] marker("blah"),\n  [2] second_valid_transform\n)'
+        expected_repr = "CompilePipeline(\n  [0] first_valid_transform(),\n  [1] marker(blah),\n  [2] second_valid_transform()\n)"
         assert pipeline_str == expected_repr
 
     def test_equality(self):

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -795,6 +795,9 @@ class TestCompilePipelineDunders:
         """Tests the string representation of a pipeline."""
 
         compile_pipeline = CompilePipeline()
+
+        assert str(compile_pipeline) == "CompilePipeline()"
+
         transform1 = BoundTransform(qml.transform(first_valid_transform))
         marker = qml.marker("blah")
         transform2 = BoundTransform(qml.transform(second_valid_transform))

--- a/tests/transforms/core/test_transform_dispatcher.py
+++ b/tests/transforms/core/test_transform_dispatcher.py
@@ -26,6 +26,7 @@ from pennylane.transforms.core import (
     Transform,
     TransformError,
 )
+from pennylane.transforms.core.compile_pipeline import CompilePipeline
 from pennylane.typing import PostprocessingFn, TensorLike
 
 dev = qml.device("default.qubit", wires=2)
@@ -1104,7 +1105,7 @@ class TestPassName:
         assert repr(expected_container) == "<my_pass_name()>"
         assert expected_container.tape_transform is None
         assert c.compile_pipeline[-1] == expected_container
-        assert repr(c.compile_pipeline) == "CompilePipeline(my_pass_name)"
+        assert c.compile_pipeline == CompilePipeline(t)
 
         with pytest.raises(NotImplementedError, match="has no defined tape transform"):
             c.compile_pipeline((tape,))


### PR DESCRIPTION
While working on https://github.com/PennyLaneAI/pennylane/pull/8979, I found the `repr` (and lack of `str`) making it hard to debug and inspect. 😢 

This PR fixes that,

```python
import pennylane as qml
from pennylane.transforms.core import CompilePipeline

cp = CompilePipeline(qml.transforms.merge_rotations(atol=1e-5), qml.marker("between"), qml.transforms.cancel_inverses)

>>> print(cp)
CompilePipeline(
  [0] merge_rotations(atol=1e-05),
  [1] marker(between),
  [2] cancel_inverses()
)
>>> print(repr(cp))
CompilePipeline(
  [0] <merge_rotations(atol=1e-05)>,
  [1] <marker('between')>,
  [2] <cancel_inverses()>
)
```

[sc-109623]