### PR TITLE
Fix Catalyst test from updated behaviour

### DIFF
--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -788,7 +788,7 @@ class TestCatalystGrad:
         res = vjp(x, dy)
         assert len(res) == 2
         assert jnp.allclose(res[0], jnp.array([0.09983342, 0.04, 0.02]))
-        assert jnp.allclose(res[1][0], jnp.array([-0.43750208, 0.07000001]))
+        assert jnp.allclose(res[1], jnp.array([-0.43750208, 0.07000001]))
 
 
 class TestCatalystSample:


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/catalyst/pull/2279 changed the behaviour of argnums in `qml.vjp` with catalyst.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
