### PR TITLE
Fix int overflow in decomp_int_to_powers_of_two

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -218,6 +218,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Decompose integers into powers of two while adhering to standard 64-bit C integer bounds and avoid overflow in the decomposition system.
+  [(#8993)](https://github.com/PennyLaneAI/pennylane/pull/8993)
+
 * `CompilePipeline` no longer automatically pushes final transforms to the end of the pipeline as it's being built.
   [(#8995)](https://github.com/PennyLaneAI/pennylane/pull/8995)
 
@@ -243,6 +246,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Ali Asadi,
 Astral Cai,
 Yushao Chen,
 Marcus Edwards,

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -254,7 +254,7 @@ def decomp_int_to_powers_of_two(k: int, n: int) -> list[int]:
     s = 0
     powers = 2 ** np.arange(n)
     for p in powers:  # p = 2**(n-1-i)
-        if s & p == k & p:
+        if not ((s ^ k) & p):
             # Equal bit, move on
             factor = 0
         else:
@@ -264,8 +264,9 @@ def decomp_int_to_powers_of_two(k: int, n: int) -> list[int]:
                 factor = 1
             else:
                 # Table entry from documentation
-                in_middle_rows = (s & (p + 2 * p)).bit_count() == 1  # two bits of s are 01 or 10
-                in_last_cols = bool(k & (2 * p))  # latter bit of k is 1
+                mask_middle = p | (p << 1)
+                in_middle_rows = (s & mask_middle).bit_count() == 1
+                in_last_cols = bool(k & (p << 1))
                 if in_middle_rows != in_last_cols:  # xor between in_middle_rows and in_last_cols
                     factor = -1
                 else:

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -265,8 +265,8 @@ def decomp_int_to_powers_of_two(k: int, n: int) -> list[int]:
             else:
                 # Table entry from documentation
                 mask_middle = p | (p << 1)
-                in_middle_rows = (s & mask_middle).bit_count() == 1
-                in_last_cols = bool(k & (p << 1))
+                in_middle_rows = (s & mask_middle).bit_count() == 1  # two bits of s are 01 or 10
+                in_last_cols = bool(k & (p << 1))  # latter bit of k is 1
                 if in_middle_rows != in_last_cols:  # xor between in_middle_rows and in_last_cols
                     factor = -1
                 else:

--- a/pennylane/math/decomposition.py
+++ b/pennylane/math/decomposition.py
@@ -254,7 +254,7 @@ def decomp_int_to_powers_of_two(k: int, n: int) -> list[int]:
     s = 0
     powers = 2 ** np.arange(n)
     for p in powers:  # p = 2**(n-1-i)
-        if not ((s ^ k) & p):
+        if not (s ^ k) & p:
             # Equal bit, move on
             factor = 0
         else:

--- a/tests/math/test_decomposition_math.py
+++ b/tests/math/test_decomposition_math.py
@@ -14,6 +14,8 @@
 """
 This submodule tests mathematical decomposition functions, for example of matrices or integers.
 """
+import warnings
+
 import pytest
 
 from pennylane.math.decomposition import decomp_int_to_powers_of_two
@@ -51,3 +53,22 @@ def test_decomp_int_to_powers_of_two(k, n, exp_R):
     R = decomp_int_to_powers_of_two(k, n)
     assert R == exp_R, f"\n{R}\n{exp_R}"
     assert sum(val != 0 for val in R) == (k ^ (3 * k)).bit_count()
+
+
+def test_decomp_int_to_powers_of_two_overflow():
+    """Tests that ``decomp_int_to_powers_of_two`` raises an error
+    when ``k`` is too large for the given ``n``."""
+    n = 4
+    k = 2 ** (n - 1) + 1  # too large
+
+    with pytest.raises(AssertionError):
+        decomp_int_to_powers_of_two(k, n)
+
+
+def test_decomp_int_to_powers_of_two_int_overflow_check():
+    """Tests that ``decomp_int_to_powers_of_two`` does not raise overflow warnings
+    when ``k`` is large but valid for the given ``n``."""
+
+    with warnings.catch_warnings(record=True) as w:
+        decomp_int_to_powers_of_two(2**62, 2**7)
+    assert len(w) == 0


### PR DESCRIPTION
**Context:**
Fix int overflow in decomp_int_to_powers_of_two

**Description of the Change:**

**Benefits:**
- Decompose larger circuits to a level that maintains compatibility with C integer types

**Possible Drawbacks:**

**Related Issue:**

``` python
from pennylane.math import decomposition
decomposition.decomp_int_to_powers_of_two(2**62, 2**7)
```

```
/lib/python3.12/site-packages/pennylane/math/decomposition.py:269: RuntimeWarning: overflow encountered in scalar multiply
  in_middle_rows = (s & (p + 2 * p)).bit_count() == 1  # two bits of s are 01 or 10
lib/python3.12/site-packages/pennylane/math/decomposition.py:270: RuntimeWarning: overflow encountered in scalar multiply
  in_last_cols = bool(k & (2 * p))  # latter bit of k is 1
```

[sc-110019]