### PR TITLE
fix: `CompilePipeline` no longer automatically pushes "final transforms" to the end

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,6 +209,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `CompilePipeline` no longer automatically pushes final transforms to the end of the pipeline as it's being built.
+  [(#8995)](https://github.com/PennyLaneAI/pennylane/pull/8995)
+
 * Improves the error messages when the inputs and outputs to a `qml.for_loop` function do not match.
   [(#8984)](https://github.com/PennyLaneAI/pennylane/pull/8984)
 

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,17 +140,17 @@ def add_noise(tape, noise_model, level="user"):
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
         >>> qml.workflow.get_transform_program(circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables)
 
         >>> qml.workflow.get_transform_program(noisy_circuit)
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, add_noise, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables)
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
         transforming a ``QNode``, this transform can be added at a designated level within the compile pipeline, as determined using the
         :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
 
         >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise)
 
         Other acceptable values for ``level`` are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``. Among these, `"top"` will allow addition
         to an empty compile pipeline, `"user"` will allow addition at the end of user-specified transforms, `"device"` will allow addition at the
@@ -160,10 +160,10 @@ def add_noise(tape, noise_model, level="user"):
         CompilePipeline(add_noise)
 
         >>> qml.noise.add_noise(circuit, noise_model, level="user").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, add_noise)
 
         >>> qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline
-        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise, _expand_metric_tensor, metric_tensor)
+        CompilePipeline(cancel_inverses, merge_rotations, undo_swaps, _expand_metric_tensor, metric_tensor, defer_measurements, decompose, no_sampling, validate_device_wires, validate_measurements, validate_observables, add_noise)
 
         Finally, more precise control over the insertion of the transform can be achieved by specifying an integer or slice for indexing when extracting the compile pipeline. For example, one can do:
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -741,7 +741,7 @@ def _apply_to_program(obj: CompilePipeline, transform, *targs, **tkwargs):
 @contextmanager
 def _exclude_terminal_transform(transforms: list[BoundTransform]):
     terminal_transforms = []
-    if transforms and transforms[-1].is_final_transform:
+    if transforms and transforms[-1].is_informative:
         terminal_transforms.append(transforms.pop())
         if transforms and terminal_transforms[0].expand_transform == transforms[-1]:
             terminal_transforms.insert(0, transforms.pop())

--- a/tests/noise/test_add_noise.py
+++ b/tests/noise/test_add_noise.py
@@ -464,5 +464,5 @@ class TestAddNoiseLevels:
         transform_level2 = qml.workflow.get_transform_program(noisy_qnode)
 
         assert len(transform_level1) == len(transform_level2) - 1
-        assert transform_level2[3].tape_transform == add_noise.tape_transform
-        assert transform_level2[-1].tape_transform == qml.metric_tensor.tape_transform
+        assert transform_level2[4].tape_transform == qml.metric_tensor.tape_transform
+        assert transform_level2[5].tape_transform == add_noise.tape_transform

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -14,7 +14,6 @@
 """Unit and integration tests for the compile pipeline."""
 # pylint: disable=no-member
 
-
 import pytest
 import rustworkx as rx
 
@@ -48,7 +47,8 @@ def first_valid_transform(
 
 
 def expand_transform(
-    tape: QuantumScript, index: int  # pylint:disable=unused-argument
+    tape: QuantumScript,
+    index: int,  # pylint:disable=unused-argument
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
     """A valid expand transform."""
     return [tape], lambda x: x
@@ -488,33 +488,10 @@ class TestCompilePipelineDunders:
         assert merged_pipeline2[0].tape_transform is first_valid_transform
 
         assert isinstance(merged_pipeline2[1], BoundTransform)
-        assert merged_pipeline2[1].tape_transform is first_valid_transform
+        assert merged_pipeline2[1].tape_transform is second_valid_transform
 
         assert isinstance(merged_pipeline2[2], BoundTransform)
-        assert merged_pipeline2[2].tape_transform is second_valid_transform
-
-    @pytest.mark.parametrize(
-        "right",
-        [
-            pytest.param(
-                BoundTransform(qml.transform(second_valid_transform)),
-                id="pipeline+container",
-            ),
-            pytest.param(qml.transform(second_valid_transform), id="pipeline+dispatcher"),
-        ],
-    )
-    def test_pipeline_add_maintains_final_transform_at_end(self, right):
-        """Test that adding to a pipeline with final_transform keeps final at end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        pipeline = CompilePipeline([container1])
-
-        result = pipeline + right
-        assert isinstance(result, CompilePipeline)
-        assert len(result) == 2
-        # Final transform should be at the end
-        assert result[0].tape_transform is second_valid_transform
-        assert result[1].tape_transform is first_valid_transform
-        assert result[1].is_final_transform
+        assert merged_pipeline2[2].tape_transform is first_valid_transform
 
     @pytest.mark.parametrize(
         "right",
@@ -654,19 +631,6 @@ class TestCompilePipelineDunders:
         assert pipeline1[0].tape_transform is first_valid_transform
         assert pipeline1[1].tape_transform is second_valid_transform
 
-    def test_pipeline_iadd_maintains_final_transform_at_end(self):
-        """Test that __iadd__ keeps final transform at the end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        container2 = BoundTransform(qml.transform(second_valid_transform))
-        pipeline = CompilePipeline([container1])
-
-        pipeline += container2
-
-        assert len(pipeline) == 2
-        assert pipeline[0].tape_transform is second_valid_transform
-        assert pipeline[1].tape_transform is first_valid_transform
-        assert pipeline[1].is_final_transform
-
     def test_pipeline_iadd_with_both_final_transform_error(self):
         """Test that __iadd__ raises error when adding final to pipeline with final."""
         container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
@@ -685,20 +649,6 @@ class TestCompilePipelineDunders:
 
         with pytest.raises(TransformError, match="already has a terminal transform"):
             pipeline1 += pipeline2
-
-    def test_pipeline_iadd_pipeline_maintains_final_transform_at_end(self):
-        """Test that __iadd__ with pipeline keeps final transform at the end."""
-        container1 = BoundTransform(qml.transform(first_valid_transform, final_transform=True))
-        container2 = BoundTransform(qml.transform(second_valid_transform))
-        pipeline1 = CompilePipeline([container1])
-        pipeline2 = CompilePipeline([container2])
-
-        pipeline1 += pipeline2
-
-        assert len(pipeline1) == 2
-        assert pipeline1[0].tape_transform is second_valid_transform
-        assert pipeline1[1].tape_transform is first_valid_transform
-        assert pipeline1[1].is_final_transform
 
     def test_pipeline_iadd_pipeline_with_cotransform_cache(self):
         """Test that __iadd__ correctly handles cotransform_cache when adding pipelines."""

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -1104,14 +1104,14 @@ class TestCompilePipeline:
         t_normal = BoundTransform(qml.transform(second_valid_transform))
         compile_pipeline.append(t_normal)
         assert len(compile_pipeline) == 2
-        assert compile_pipeline[0] is t_normal
-        assert compile_pipeline[1] is transform1
+        assert compile_pipeline[0] is transform1
+        assert compile_pipeline[1] is t_normal
 
         t_normal2 = BoundTransform(qml.transform(first_valid_transform))
         compile_pipeline.append(t_normal2)
-        assert compile_pipeline[0] is t_normal
-        assert compile_pipeline[1] is t_normal2
-        assert compile_pipeline[2] is transform1
+        assert compile_pipeline[0] is transform1
+        assert compile_pipeline[1] is t_normal
+        assert compile_pipeline[2] is t_normal2
 
         with pytest.raises(
             TransformError, match="The compile pipeline already has a terminal transform."

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -285,9 +285,9 @@ class TestCompilePipelineGetter:
         grad_program = get_transform_program(circuit, level="gradient")
         assert len(grad_program) == 4
         assert grad_program[0].tape_transform == qml.compile.tape_transform
-        assert grad_program[1].tape_transform == qml.gradients.param_shift.expand_transform
-        assert grad_program[2].tape_transform == qml.metric_tensor.expand_transform
-        assert grad_program[3].tape_transform == qml.metric_tensor.tape_transform
+        assert grad_program[1].tape_transform == qml.metric_tensor.expand_transform
+        assert grad_program[2].tape_transform == qml.metric_tensor.tape_transform
+        assert grad_program[3].tape_transform == qml.gradients.param_shift.expand_transform
 
         dev_program = get_transform_program(circuit, level="device")
         config = qml.devices.ExecutionConfig(interface=getattr(circuit, "interface", None))
@@ -295,11 +295,8 @@ class TestCompilePipelineGetter:
         assert len(dev_program) == 4 + len(
             circuit.device.preprocess_transforms(config)
         )  # currently 8
-        assert dev_program[-1].tape_transform == qml.metric_tensor.tape_transform
 
         full_program = get_transform_program(circuit)
-        assert full_program[-1].tape_transform == qml.metric_tensor.tape_transform
-
         assert dev_program == full_program
 
 


### PR DESCRIPTION
**Context:**

We need an alternative to `get_transform_program` which returns the *exact* pipeline used during execution. 

https://github.com/PennyLaneAI/pennylane/pull/8979 adds this feature but, like its legacy counterpart (`get_transform_program`), it requires this patchy removal / insertion of final transforms due to the way `CompilePipeline` automatically pushes these final transforms to the end.

Furthermore, it was discovered that this is *not* how the actual pipeline is executed. Instead it goes: `user -> final -> gradient -> device`. 

**Description of the Change:**

This PR removes this logic.

**Benefits:**

- Accurately reflects the true execution pipeline.
- Improves simplicity of `get_transform_program`

**Possible Drawbacks:**

Unexpected interactions? 🤷🏼 

[sc-109715]
