### PR TITLE
Fix aliasing bug in local_decomps

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,6 +14,7 @@
 * Added a `qml.decomposition.local_decomps` context
   manager that allows one to add decomposition rules to an operator, only taking effect within the context.
   [(#8955)](https://github.com/PennyLaneAI/pennylane/pull/8955)
+  [(#8998)](https://github.com/PennyLaneAI/pennylane/pull/8998)
 
 <h3>Improvements 🛠</h3>
 

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -605,7 +605,7 @@ def local_decomps():
     This context manager is thread-safe because it uses ``ContextVar`` under the hood.
 
     """
-    _new_decompositions = _decompositions_private.copy()
+    _new_decompositions = defaultdict(list, {k: v[:] for k, v in _decompositions_private.items()})
     token = _decompositions_var.set(_new_decompositions)
     try:
         yield

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -276,14 +276,17 @@ class TestDecompositionRule:
 
             qml.add_decomps(CustomOp, custom_decomp)
             qml.add_decomps(CustomOp, custom_decomp2, custom_decomp3)
+            qml.add_decomps(qml.CRX, custom_decomp)
 
             assert qml.decomposition.has_decomp(CustomOp)
             assert qml.decomposition.has_decomp(CustomOp(wires=[0, 1]))
             assert qml.list_decomps(CustomOp) == [custom_decomp, custom_decomp2, custom_decomp3]
+            assert custom_decomp in qml.list_decomps(qml.CRX)
 
         # test that the context properly cleans up.
         assert qml.list_decomps(CustomOp) == []
         assert not qml.decomposition.has_decomp(CustomOp)
+        assert custom_decomp not in qml.list_decomps(qml.CRX)
 
     def test_custom_symbolic_decomposition(self):
         """Tests that custom decomposition rules for symbolic operators can be registered."""


### PR DESCRIPTION
The local_decomps context makes a copy of the decompositions dict, but it's a shallow copy so the lists nested in the dict are still aliases of the original lists
