### PR TITLE
fix: `expand_fn` in `qnode_spectrum` to update `trainable_params` correctly

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -181,6 +181,7 @@
   Instead, please use the :func:`qml.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
   [(#8941)](https://github.com/PennyLaneAI/pennylane/pull/8941)
   [(#8977)](https://github.com/PennyLaneAI/pennylane/pull/8977)
+  [(#9006)](https://github.com/PennyLaneAI/pennylane/pull/9006)
 
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -430,6 +430,9 @@ def qnode_spectrum(qnode, encoding_args=None, argnum=None, decimals=8, validatio
                 gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
                 stopping_condition=_multipar_stopping_fn,
             )(*args, **kwargs)
+            tape.trainable_params = math.get_trainable_indices(
+                tape.get_parameters(trainable_only=False)
+            )
             return tape
 
         jac_fn = gradients.classical_jacobian(qnode, argnum=argnum, expand_fn=expand_fn)

--- a/tests/fourier/test_qnode_spectrum.py
+++ b/tests/fourier/test_qnode_spectrum.py
@@ -545,6 +545,7 @@ class TestJax:
         Since the Hermitian matrix has shape (2, 2) while rotation parameters
         have shape (), math.stack() in classical_jacobian would fail with
         'All input arrays must have the same shape'.
+        See https://pennylane.ai/qml/demos/tutorial_general_parshift for a realistic usage.
 
         """
 


### PR DESCRIPTION
https://github.com/PennyLaneAI/pennylane/pull/8977 accidentally forgot to update trainable params in the `expand_fn` of `qnode_spectrum`. This created weird shape mismatch errors.

⚠️ Tested the demo locally and everything works 👍🏼 

[sc-110085]