### PR TITLE
add argnums validation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -74,6 +74,7 @@
 * `qml.vjp` and `qml.jvp` can now be captured into plxpr.
   [(#8736)](https://github.com/PennyLaneAI/pennylane/pull/8736)
   [(#8788)](https://github.com/PennyLaneAI/pennylane/pull/8788)
+  [(#9019)](https://github.com/PennyLaneAI/pennylane/pull/9019)
 
 * :func:`~.matrix` can now also be applied to a sequence of operators.
   [(#8861)](https://github.com/PennyLaneAI/pennylane/pull/8861)

--- a/pennylane/_grad/grad.py
+++ b/pennylane/_grad/grad.py
@@ -17,6 +17,7 @@ This submodule contains the autograd wrappers :class:`grad` and :func:`jacobian`
 import inspect
 import numbers
 import warnings
+from collections.abc import Sequence
 from functools import lru_cache, wraps
 
 from autograd import jacobian as _jacobian
@@ -91,6 +92,21 @@ def _shape(shape, dtype, weak_type=False):
     return jax.core.ShapedArray(shape, dtype, weak_type=weak_type)
 
 
+def _setup_argnums(argnums):
+    if argnums is None:
+        argnums = 0
+    if argnums_is_int := isinstance(argnums, int):
+        argnums = (argnums,)
+    if not isinstance(argnums, Sequence):
+        raise ValueError(
+            f"argnums should be an integer or a Sequence of integers, got type {type(argnums)}"
+        )
+    argnums = tuple(argnums)
+    if not all(isinstance(a, int) for a in argnums):
+        raise ValueError(f"argnums should be an integer or a Sequence of integers, got {argnums}")
+    return argnums, argnums_is_int
+
+
 def _args_and_argnums(args, argnums):
     """
     Perform some setup for args and argnums that are consistent between grad and vjp.
@@ -108,11 +124,7 @@ def _args_and_argnums(args, argnums):
     * extracting out the pytree just for the trainable args
 
     """
-    if argnums is None:
-        argnums = 0
-    if argnums_is_int := isinstance(argnums, int):
-        argnums = (argnums,)
-    argnums = tuple(argnums)
+    argnums, argnums_is_int = _setup_argnums(argnums)
 
     if max(argnums) >= len(args):
         raise ValueError(
@@ -284,6 +296,9 @@ class grad:
 
         self._func = func
         self._argnums = argnums
+
+        # just the validation
+        _setup_argnums(argnums)
 
         if self._argnums is not None:
             # If the differentiable argnum is provided, we can construct

--- a/pennylane/_grad/grad.py
+++ b/pennylane/_grad/grad.py
@@ -92,7 +92,7 @@ def _shape(shape, dtype, weak_type=False):
     return jax.core.ShapedArray(shape, dtype, weak_type=weak_type)
 
 
-def _setup_argnums(argnums):
+def _setup_argnums(argnums: int | Sequence[int] | None) -> tuple[tuple[int,...], bool]:
     if argnums is None:
         argnums = 0
     if argnums_is_int := isinstance(argnums, int):

--- a/pennylane/_grad/grad.py
+++ b/pennylane/_grad/grad.py
@@ -92,7 +92,7 @@ def _shape(shape, dtype, weak_type=False):
     return jax.core.ShapedArray(shape, dtype, weak_type=weak_type)
 
 
-def _setup_argnums(argnums: int | Sequence[int] | None) -> tuple[tuple[int,...], bool]:
+def _setup_argnums(argnums: int | Sequence[int] | None) -> tuple[tuple[int, ...], bool]:
     if argnums is None:
         argnums = 0
     if argnums_is_int := isinstance(argnums, int):

--- a/tests/capture/gradients/test_capture_diff.py
+++ b/tests/capture/gradients/test_capture_diff.py
@@ -84,6 +84,13 @@ class TestGradJacobian:
         with pytest.raises(ValueError, match="Invalid value"):
             grad_fn(lambda x: x**2, method="fd")(0.5)
 
+    @pytest.mark.parametrize("argnums", (4.5, "abc"))
+    def test_error_bad_argnums(self, grad_fn, argnums):
+        """Test that an error is raised if the argnums is not a collection."""
+
+        with pytest.raises(ValueError, match="argnums should be an integer or a Sequence"):
+            grad_fn(lambda x: x**2, argnums=argnums)(0.5)
+
     def test_dynamic_kwarg(self, grad_fn):
         """Test that numerical kwargs are still treated like inputs."""
 

--- a/tests/capture/gradients/test_capture_jvp.py
+++ b/tests/capture/gradients/test_capture_jvp.py
@@ -82,6 +82,13 @@ class TestErrors:
         with pytest.raises(ValueError, match="tangents must be a Sequence"):
             qml.jvp(lambda x: x**2, (1.0,), 1.0)
 
+    @pytest.mark.parametrize("argnums", (4.5, "abc"))
+    def test_error_bad_argnums(self, argnums):
+        """Test that an error is raised if the argnums is not a collection."""
+
+        with pytest.raises(ValueError, match="argnums should be an integer or a Sequence"):
+            qml.jvp(lambda x: x**2, (0.5,), (1.0,), argnums=argnums)
+
 
 class TestCapturingJVP:
 

--- a/tests/capture/gradients/test_capture_vjp.py
+++ b/tests/capture/gradients/test_capture_vjp.py
@@ -85,6 +85,13 @@ class TestErrors:
         with pytest.raises(ValueError, match=r"got function output params shape"):
             qml.vjp(f, params, cotangents)
 
+    @pytest.mark.parametrize("argnums", (4.5, "abc"))
+    def test_error_bad_argnums(self, argnums):
+        """Test that an error is raised if the argnums is not a collection."""
+
+        with pytest.raises(ValueError, match="argnums should be an integer or a Sequence"):
+            qml.vjp(lambda x: x**2, (0.5,), (1.0,), argnums=argnums)
+
 
 class TestCapturingVJP:
 


### PR DESCRIPTION
**Context:**

Found I needed to add this in: https://github.com/PennyLaneAI/catalyst/pull/2316

**Description of the Change:**

Adds an informative error if the argnums is not an integer or sequence of integers.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-110418]