### PR TITLE
The DecompositionGraph supports strict=False

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,10 @@
   [(#8955)](https://github.com/PennyLaneAI/pennylane/pull/8955)
   [(#8998)](https://github.com/PennyLaneAI/pennylane/pull/8998)
 
+* Added a `strict` keyword to the :func:`~pennylane.transforms.decompose` transform that, when set to ``False``,
+  allows the decomposition graph to treat operators without a decomposition as part of the gate set.
+  [(#9025)](https://github.com/PennyLaneAI/pennylane/pull/9025)
+
 <h3>Improvements 🛠</h3>
 
 * New lightweight representations of the :class:`~.SelectOnlyQRAM`, :class:`~.BasisEmbedding`, and :class:`~.BasisState` templates have 
@@ -100,6 +104,10 @@
 
 * The `to_zx` transform is now compatible with the new graph-based decomposition system.
   [(#8994)](https://github.com/PennyLaneAI/pennylane/pull/8994)
+
+* When the new graph-based decomposition system is enabled, the :func:`~pennylane.transforms.decompose`
+  transform no longer raise duplicate warnings about operators that cannot be decomposed.
+  [(#9025)](https://github.com/PennyLaneAI/pennylane/pull/9025)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -25,6 +25,7 @@ implementation of the basis translator, the Boost Graph library, and RustworkX.
 
 from __future__ import annotations
 
+import math
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Set
@@ -315,11 +316,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         # Treat ops that does not have a decomposition as supported if strict=False
         if not rules and not self._strict:
-            max_cost = max(self._gate_set_weights.values())
             # Assign a prohibitively high cost to this operator so that nothing decomposes to
             # this op unless there is no other choice.
-            self._gate_set_weights |= GateSet({_to_name(op): max_cost * 1000})
-            self._graph.add_edge(self._start, op_node_idx, max_cost * 1000)
+            self._gate_set_weights |= GateSet({_to_name(op): math.inf})
+            self._graph.add_edge(self._start, op_node_idx, math.inf)
             return op_node_idx
 
         work_wire_dependent = known_work_wire_dependent
@@ -766,7 +766,8 @@ class DecompositionSearchVisitor(DijkstraVisitor):  # pylint: disable=too-many-i
         if not isinstance(edge_obj, tuple):
             return float(edge_obj)
         op_node_idx, d_node_idx = edge_obj
-        return self.distances[d_node_idx].weighted_cost - self.distances[op_node_idx].weighted_cost
+        cost = self.distances[d_node_idx].weighted_cost - self.distances[op_node_idx].weighted_cost
+        return math.inf if math.isnan(cost) else cost
 
     def discover_vertex(self, v, score):  # pylint: disable=unused-argument
         """Triggered when a vertex is about to be explored during the Dijkstra search."""

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -314,7 +314,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         rules = [rule for rule in self._get_decompositions(op) if rule.is_applicable(**op.params)]
 
-        # Treat ops that does not have a decomposition as supported if strict=False
+        # Treat ops that do not have a decomposition as supported if strict=False
         if not rules and not self._strict:
             # Assign a prohibitively high cost to this operator so that nothing decomposes to
             # this op unless there is no other choice.

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -193,7 +193,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             mapping gates in the target gate set to their respective weights. All weights must be positive.
         fixed_decomps (dict): A dictionary mapping operator names to fixed decompositions.
         alt_decomps (dict): A dictionary mapping operator names to alternative decompositions.
-        strict (bool): If ``False``, treat operators that does not define a decomposition as supported.
+        strict (bool): If ``False``, treat operators that do not define a decomposition as supported.
             Defaults to ``True``.
 
     **Example**

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -192,6 +192,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             mapping gates in the target gate set to their respective weights. All weights must be positive.
         fixed_decomps (dict): A dictionary mapping operator names to fixed decompositions.
         alt_decomps (dict): A dictionary mapping operator names to alternative decompositions.
+        strict (bool): If ``False``, treat operators that does not define a decomposition as supported.
+            Defaults to ``True``.
 
     **Example**
 
@@ -220,18 +222,20 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         operations: list[Operator | CompressedResourceOp],
         gate_set: Set[type | str] | Mapping[type | str, float] | GateSet,
         fixed_decomps: dict | None = None,
         alt_decomps: dict | None = None,
+        strict: bool = True,
     ):
 
         if not isinstance(gate_set, GateSet):
             gate_set = GateSet(gate_set)
 
         self._gate_set_weights = gate_set
+        self._strict = strict
 
         # The list of operator indices for every op in the original list of operators that the
         # graph is initialized with. This is used to check whether we have found a decomposition
@@ -307,9 +311,20 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             self._graph.add_edge(self._start, op_node_idx, self._gate_set_weights[op.name])
             return op_node_idx
 
+        rules = [rule for rule in self._get_decompositions(op) if rule.is_applicable(**op.params)]
+
+        # Treat ops that does not have a decomposition as supported if strict=False
+        if not rules and not self._strict:
+            max_cost = max(self._gate_set_weights.values())
+            # Assign a prohibitively high cost to this operator so that nothing decomposes to
+            # this op unless there is no other choice.
+            self._gate_set_weights |= GateSet({_to_name(op): max_cost * 1000})
+            self._graph.add_edge(self._start, op_node_idx, max_cost * 1000)
+            return op_node_idx
+
         work_wire_dependent = known_work_wire_dependent
         min_work_wires = -1  # use -1 to represent undetermined work wire requirement
-        for decomposition in self._get_decompositions(op):
+        for decomposition in rules:
             d_node = self._add_decomp(decomposition, op_node, op_node_idx, num_used_work_wires)
             # If any of the operator's decompositions depend on work wires, this operator
             # should also depend on work wires.
@@ -725,7 +740,7 @@ class DecompositionSearchVisitor(DijkstraVisitor):  # pylint: disable=too-many-i
     def __init__(  # pylint: disable=too-many-arguments
         self,
         graph: rx.PyDiGraph,
-        gate_set: dict,
+        gate_set: Mapping,
         original_op_indices: set[int],
         num_available_work_wires: int | None = None,
         lazy: bool = True,

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -382,6 +382,7 @@ def decompose(  # pylint: disable = too-many-positional-arguments
             minimize_work_wires=False,
             fixed_decomps=None,
             alt_decomps=None,
+            strict=True,
         )
 
     if tape.operations and isinstance(tape[0], StatePrepBase) and skip_initial_state_prep:

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -37,6 +37,36 @@ from pennylane.operation import Operation
 # pylint: disable=protected-access,no-name-in-module
 
 
+class CustomOp(Operation):  # pylint: disable=too-few-public-methods
+    """A custom operation."""
+
+    resource_keys = set()
+
+    @property
+    def resource_params(self):
+        return {}
+
+
+class MultiWireOp(Operation):  # pylint: disable=too-few-public-methods
+    """A custom op"""
+
+    resource_keys = {"num_wires"}
+
+    @property
+    def resource_params(self):
+        return {"num_wires": len(self.wires)}
+
+
+class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
+    """A custom operation."""
+
+    resource_keys = set()
+
+    @property
+    def resource_params(self):
+        return {}
+
+
 @pytest.mark.unit
 @patch(
     "pennylane.decomposition.decomposition_graph.list_decomps",
@@ -154,15 +184,6 @@ class TestDecompositionGraph:
     def test_graph_construction_non_applicable_rules(self, _):
         """Tests rules which are not applicable are skipped."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom op"""
-
-            resource_keys = {"num_wires"}
-
-            @property
-            def resource_params(self):
-                return {"num_wires": len(self.wires)}
-
         @qml.register_condition(lambda num_wires: num_wires == 1)
         @qml.register_resources({qml.RZ: 1, qml.CNOT: 1})
         def some_rule(*_, **__):
@@ -177,11 +198,11 @@ class TestDecompositionGraph:
             raise NotImplementedError
 
         graph = DecompositionGraph(
-            [CustomOp(wires=[0, 1])],
+            [MultiWireOp(wires=[0, 1])],
             gate_set={"CNOT", "RZ"},
-            alt_decomps={CustomOp: [some_rule, some_other_rule]},
+            alt_decomps={MultiWireOp: [some_rule, some_other_rule]},
         )
-        # 3 ops (CustomOp, CNOT, RZ) and 1 decompositions (only some_other_rule),
+        # 3 ops (MultiWireOp, CNOT, RZ) and 1 decompositions (only some_other_rule),
         # and the dummy starting node
         assert len(graph._graph.nodes()) == 5
         # 2 edges from ops to decompositions, 1 from decompositions to ops,
@@ -190,15 +211,6 @@ class TestDecompositionGraph:
 
     def test_gate_set(self, _):
         """Tests that graph construction stops at the target gate set."""
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
 
         @qml.register_resources(
             {
@@ -263,25 +275,7 @@ class TestDecompositionGraph:
     def test_graph_strict(self, _, recwarn):
         """Test the graph with strict=False."""
 
-        class NoDecompOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
-        @qml.register_resources({NoDecompOp: 1})
+        @qml.register_resources({AnotherOp: 1})
         def _decomp(wires):
             raise NotImplementedError
 
@@ -299,25 +293,7 @@ class TestDecompositionGraph:
         """Tests that when strict=False, ops without decompositions are not chosen
         if there is an alternative pathway available."""
 
-        class NoDecompOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
-        @qml.register_resources({NoDecompOp: 1})
+        @qml.register_resources({AnotherOp: 1})
         def _decomp(wires):
             raise NotImplementedError
 
@@ -359,24 +335,6 @@ class TestDecompositionGraph:
     def test_lazy_solve(self, _):
         """Tests the lazy keyword argument."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
-        class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
-            """Another custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
         @qml.register_resources({qml.RZ: 1, qml.CNOT: 1})
         def _custom_decomp(*_, **__):
             raise NotImplementedError
@@ -412,15 +370,6 @@ class TestDecompositionGraph:
     def test_decomposition_with_resource_params(self, _):
         """Tests operators with non-empty resource params."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = {"num_wires"}
-
-            @property
-            def resource_params(self):
-                return {"num_wires": len(self.wires)}
-
         def _custom_resource(num_wires):
             return {
                 qml.resource_rep(qml.MultiRZ, num_wires=num_wires): 1,
@@ -431,11 +380,11 @@ class TestDecompositionGraph:
         def _custom_decomp(*_, **__):
             raise NotImplementedError
 
-        op = CustomOp(wires=[0, 1, 2, 3])
+        op = MultiWireOp(wires=[0, 1, 2, 3])
         graph = DecompositionGraph(
             operations=[op],
             gate_set={"RX", "RZ", "CZ", "GlobalPhase"},
-            alt_decomps={CustomOp: [_custom_decomp]},
+            alt_decomps={MultiWireOp: [_custom_decomp]},
         )
         # 10 ops (CustomOp, MultiRZ(4), MultiRZ(3), CNOT, CZ, RX, RY, RZ, Hadamard, GlobalPhase)
         # 7 decompositions (1 for CustomOp, 1 for each of the two MultiRZs, 1 for CNOT, 2 for Hadamard, and 1 for RY)
@@ -461,15 +410,6 @@ class TestDecompositionGraph:
 
     def test_work_wire_requirement(self, _):
         """Tests that the graph respects the work wire requirement."""
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
 
         @qml.register_resources({qml.Toffoli: 2, qml.CRot: 1}, work_wires={"zeroed": 1})
         def _decomp_with_work_wire(*_, **__):
@@ -498,15 +438,6 @@ class TestDecompositionGraph:
         """Tests that the same operator produced under different work wire budgets
         are stored as different nodes in the graph, and results can be queried."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
         @qml.register_resources({qml.Toffoli: 2, qml.CRot: 1}, work_wires={"zeroed": 2})
         def _decomp_with_work_wire(*_, **__):
             raise NotImplementedError
@@ -514,15 +445,6 @@ class TestDecompositionGraph:
         @qml.register_resources({qml.Toffoli: 4, qml.CRot: 3})
         def _decomp_without_work_wire(*_, **__):
             raise NotImplementedError
-
-        class LargeOp(Operation):  # pylint: disable=too-few-public-methods
-            """A larger custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
 
         @qml.register_resources({qml.Toffoli: 2, CustomOp: 2}, work_wires={"zeroed": 1})
         def _decomp2_with_work_wire(*_, **__):
@@ -532,7 +454,7 @@ class TestDecompositionGraph:
         def _decomp2_without_work_wire(*_, **__):
             raise NotImplementedError
 
-        op = LargeOp(wires=[0, 1, 2, 3])
+        op = AnotherOp(wires=[0, 1, 2, 3])
         small_op = CustomOp(wires=[0, 1, 2])
 
         graph = DecompositionGraph(
@@ -540,7 +462,7 @@ class TestDecompositionGraph:
             gate_set={qml.Toffoli, qml.RZ, qml.RY, qml.CNOT},
             alt_decomps={
                 CustomOp: [_decomp_without_work_wire, _decomp_with_work_wire],
-                LargeOp: [_decomp2_without_work_wire, _decomp2_with_work_wire],
+                AnotherOp: [_decomp2_without_work_wire, _decomp2_with_work_wire],
             },
         )
 
@@ -589,9 +511,6 @@ class TestDecompositionGraph:
         def _simple_decomp(_):
             raise NotImplementedError
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """Another operation."""
-
         @qml.register_resources({SimpleOp: 1}, work_wires={"zeroed": 1})
         def _custom_decomp(_):
             raise NotImplementedError
@@ -618,15 +537,9 @@ class TestDecompositionGraph:
         def _simple_decomp(_):
             raise NotImplementedError
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """Another operation."""
-
         @qml.register_resources({SimpleOp: 1, qml.CNOT: 4}, work_wires={"zeroed": 2})
         def _custom_decomp(_):
             raise NotImplementedError
-
-        class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
-            """Some other op."""
 
         @qml.register_resources({CustomOp: 1, qml.CNOT: 4}, work_wires={"zeroed": 2})
         def _another_decomp(_):
@@ -709,15 +622,6 @@ class TestControlledDecompositions:
 
     def test_controlled_base_decomposition(self, _):
         """Tests applying control on the decomposition of the target operator."""
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
 
         @qml.register_resources({qml.X: 1, qml.GlobalPhase: 1})
         def custom_decomp(wires):
@@ -858,15 +762,6 @@ class TestSymbolicDecompositions:
     def test_adjoint_general(self, _):
         """Tests decomposition of a generalized adjoint operation."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
         @qml.register_resources({qml.H: 1, qml.CNOT: 2, qml.RX: 1, qml.T: 1})
         def custom_decomp(phi, wires):
             qml.H(wires[0])
@@ -971,15 +866,6 @@ class TestSymbolicDecompositions:
     def test_special_pow_decomps(self, _):
         """Tests special cases for decomposing a power."""
 
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
-
         graph = DecompositionGraph(
             operations=[qml.pow(CustomOp(0), 0), qml.pow(CustomOp(1), 1)], gate_set={"CustomOp"}
         )
@@ -1006,15 +892,6 @@ class TestSymbolicDecompositions:
 
     def test_general_pow_decomps(self, _):
         """Tests the more general power decomposition rules."""
-
-        class CustomOp(Operation):  # pylint: disable=too-few-public-methods
-            """A custom operation."""
-
-            resource_keys = set()
-
-            @property
-            def resource_params(self):
-                return {}
 
         graph = DecompositionGraph(
             operations=[qml.pow(CustomOp(0), 2), qml.pow(qml.adjoint(CustomOp(1)), 2)],


### PR DESCRIPTION
**Context:**

Sometimes if certain operators don't define a decomposition, we want to keep them in the circuit instead of erroring out. This is possible with graph disabled by having the stopping condition return True for any op that doesn't define a decomposition, but the graph currently cannot handle this. We want to add an option to the graph that allows the graph to treat ops without a decomposition as an implicit part of the gate set.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-110564]