### PR TITLE
Improve readability when printing an ExecutionConfig

### DIFF
--- a/pennylane/devices/execution_config.py
+++ b/pennylane/devices/execution_config.py
@@ -17,6 +17,7 @@ Contains the :class:`ExecutionConfig` and :class:`MCMConfig` data classes.
 
 from __future__ import annotations
 
+import pprint
 from collections.abc import MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -280,3 +281,24 @@ class ExecutionConfig:
 
         if self.executor_backend is None:
             object.__setattr__(self, "executor_backend", get_executor(backend=ExecBackends.MP_Pool))
+
+    def __str__(self):
+        """Return a human-readable, multiline string representation of the ExecutionConfig.
+
+        This improves readability when printing an ExecutionConfig, making it easier
+        to inspect and debug configurations.
+
+        Returns:
+            str: A formatted string representation using pprint.
+
+        **Example**
+
+        >>> config = ExecutionConfig(gradient_method="best", interface="jax")
+        >>> print(config)
+        ExecutionConfig(grad_on_execution=None,
+                        use_device_gradient=None,
+                        use_device_jacobian_product=None,
+                        gradient_method='best',
+                        ...
+        """
+        return pprint.pformat(self)

--- a/tests/devices/test_execution_config.py
+++ b/tests/devices/test_execution_config.py
@@ -271,6 +271,39 @@ class TestExecutionConfig:
         )
         assert isinstance(hash(config), int)
 
+    def test_str_multiline_format(self):
+        """Test that __str__ returns a human-readable multiline format."""
+        config = ExecutionConfig(
+            gradient_method="best",
+            device_options={"option1": 42},
+        )
+        str_output = str(config)
+
+        # Check that output is multiline (contains newlines)
+        assert "\n" in str_output
+
+        # Check that key field names appear in the output
+        assert "grad_on_execution" in str_output
+        assert "gradient_method" in str_output
+        assert "device_options" in str_output
+        assert "mcm_config" in str_output
+
+        # Check that our custom values appear
+        assert "'best'" in str_output
+        assert "'option1'" in str_output
+
+    def test_str_vs_repr_difference(self):
+        """Test that str() produces different output from repr() for readability."""
+        config = ExecutionConfig(gradient_method="parameter-shift")
+
+        str_output = str(config)
+        repr_output = repr(config)
+
+        # str should be multiline and more readable
+        assert "\n" in str_output
+        # repr (default dataclass) is single line
+        assert str_output != repr_output
+
 
 class TestMCMConfig:
     """Tests for the MCMConfig class."""


### PR DESCRIPTION
## Summary

This PR adds a custom `__str__` method to the `ExecutionConfig` class that uses `pprint.pformat()` to provide a human-readable, multiline string representation.

## Changes

- Added `import pprint` to `execution_config.py`
- Added `__str__` method to `ExecutionConfig` class
- Added tests for the new `__str__` method

## Before

```python
>>> print(config)
ExecutionConfig(grad_on_execution=False, use_device_gradient=None, use_device_jacobian_product=False, gradient_method='best', gradient_keyword_arguments={}, device_options={}, interface=<Interface.JAX: 'jax'>, derivative_order=1, mcm_config=MCMConfig(mcm_method=None, postselect_mode=None), convert_to_numpy=True)
```

## After

```python
>>> print(config)
ExecutionConfig(grad_on_execution=False,
                use_device_gradient=None,
                use_device_jacobian_product=False,
                gradient_method='best',
                gradient_keyword_arguments={},
                device_options={},
                interface=<Interface.JAX: 'jax'>,
                derivative_order=1,
                mcm_config=MCMConfig(mcm_method=None, postselect_mode=None),
                convert_to_numpy=True)
```

Much easier to read! 🥰

Closes #7007