### PR TITLE
Fix a bug with queuing of `LinearCombination`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -330,7 +330,7 @@ def c():
 
 * Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents
   of an operator product computed via ``@``, i.e. the dunder method ``__matmul__``. 
-  [(#9___)](https://github.com/PennyLaneAI/pennylane/pull/9___)
+  [(#9029)](https://github.com/PennyLaneAI/pennylane/pull/9029)
 
 * Fixed :attr:`~.ops.Controlled.map_wires` and :func:`~.equal` with ``Controlled`` instances
   to handle the ``work_wire_type`` correctly within ``map_wires``. Also fixed 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -321,8 +321,8 @@ def expval(x: float):
 
 * Setting ``_queue_category=None`` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom ``queue`` method for the respective class instead.
-  Operator classes that used to have ``_queue_category=None`` have been updated to 
-  ``_queue_category="_ops"``, so that they are queued now.
+  Operator classes that used to have ``_queue_category=None`` have been updated
+  to ``_queue_category="_ops"`` , so that they are queued now.
   [(#8131)](https://github.com/PennyLaneAI/pennylane/pull/8131)
 
 * The ``BoundTransform.transform`` property has been deprecated. Use ``BoundTransform.tape_transform`` instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -216,6 +216,10 @@
 
 <h3>Deprecations 👋</h3>
 
+* Setting ``_queue_category=None`` in an operator class in order to deactivate its instances being
+  queued has been deprecated. Implement a custom ``queue`` method for the respective class instead.
+  [(#8131)](https://github.com/PennyLaneAI/pennylane/pull/8131)
+
 * The ``BoundTransform.transform`` property has been deprecated. Use ``BoundTransform.tape_transform`` instead.
   [(#8985)](https://github.com/PennyLaneAI/pennylane/pull/8985)
 
@@ -291,6 +295,10 @@
 <h3>Documentation 📝</h3>
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents
+  of an operator product computed via ``@``, i.e. the dunder method ``__matmul__``. 
+  [(#9___)](https://github.com/PennyLaneAI/pennylane/pull/9___)
 
 * Fixed :attr:`~.ops.Controlled.map_wires` and :func:`~.equal` with ``Controlled`` instances
   to handle the ``work_wire_type`` correctly within ``map_wires``. Also fixed 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -145,6 +145,68 @@ def c():
 
 <h3>Breaking changes 💔</h3>
 
+* All operator classes are now queued by default, unless they implement a custom ``queue`` 
+  method that changes this behaviour.
+  
+  ** Operator math**
+
+  This change also affects operators commonly used for operator math, such as 
+  
+  - :class:`~.Hermitian`
+  - :class:`~.ops.op_math.SProd`
+  - :class:`~.ops.op_math.Sum`
+  - :class:`~.SparseHamiltonian`
+  - :class:`~.Projector`
+  - :class:`~.BasisStateProjector`
+
+  All operators are de-queued when used to construct new operators, so the following example
+  does *not* show changed behaviour (creating ``B`` removes ``A`` from the queue):
+  
+  .. code-block:: python3
+
+    import pennylane as qml
+    import numpy as np
+    coeff = np.array([0.2, 0.1])
+
+    @qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
+    def expval(x: float):
+        qml.RX(x, 1)
+        A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
+        B = A @ qml.Z(2)  
+        return qml.expval(B)
+
+  >>> print(qml.draw(expval)(0.4))
+  0: ───────────┤ ╭<𝓗(0.20,0.10)>
+  1: ──RX(0.40)─┤ ├<𝓗(0.20,0.10)>
+  2: ───────────┤ ╰<𝓗(0.20,0.10)>
+
+  However, if we convert an operator ``A`` to numerical data, from which a new 
+  operator ``B`` is constructed, the chain of operator dependencies is broken and de-queuing will
+  not work as expected:
+  
+  .. code-block:: python3
+    
+    coeff = np.array([0.2, 0.1])
+
+    @qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
+    def expval(x: float):
+        qml.RX(x, 1)
+        A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
+        numerical_data = A.matrix()
+        B = qml.Hermitian(numerical_data, wires=[2, 0])
+        return qml.expval(B)
+
+  >>> print(qp.draw(expval)(0.4))
+  0: ───────────╭𝓗(0.20,0.10)─┤ ╭<𝓗(M0)>
+  1: ──RX(0.40)─╰𝓗(0.20,0.10)─┤ │       
+  2: ─────────────────────────┤ ╰<𝓗(M0)>
+
+  As we can see, the ``Hamiltonian`` instance ``A`` remained in the queue.
+  In cases where such a conversion to numerical data is unavoidable, perform the conversion
+  outside of the quantum circuit.
+  [(#8131)](https://github.com/PennyLaneAI/pennylane/pull/8131)
+  [(#9029)](https://github.com/PennyLaneAI/pennylane/pull/9029)
+
 * Dropped support for NumPy 1.x following its end-of-life. NumPy 2.0 or higher is now required.
   [(#8914)](https://github.com/PennyLaneAI/pennylane/pull/8914)
   [(#8954)](https://github.com/PennyLaneAI/pennylane/pull/8954)
@@ -247,6 +309,8 @@ def c():
 
 * Setting ``_queue_category=None`` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom ``queue`` method for the respective class instead.
+  Operator classes that used to have ``_queue_category=None`` have been updated to 
+  ``_queue_category="_ops"``, so that they are queued now.
   [(#8131)](https://github.com/PennyLaneAI/pennylane/pull/8131)
 
 * The ``BoundTransform.transform`` property has been deprecated. Use ``BoundTransform.tape_transform`` instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -170,44 +170,48 @@ def c():
   All operators are de-queued when used to construct new operators, so the following example
   does *not* show changed behaviour (creating ``B`` removes ``A`` from the queue):
   
-  .. code-block:: python3
+```python
+import pennylane as qml
+import numpy as np
+coeff = np.array([0.2, 0.1])
 
-    import pennylane as qml
-    import numpy as np
-    coeff = np.array([0.2, 0.1])
+@qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
+def expval(x: float):
+    qml.RX(x, 1)
+    A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
+    B = A @ qml.Z(2)  
+    return qml.expval(B)
+```
 
-    @qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
-    def expval(x: float):
-        qml.RX(x, 1)
-        A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
-        B = A @ qml.Z(2)  
-        return qml.expval(B)
-
-  >>> print(qml.draw(expval)(0.4))
-  0: ───────────┤ ╭<𝓗(0.20,0.10)>
-  1: ──RX(0.40)─┤ ├<𝓗(0.20,0.10)>
-  2: ───────────┤ ╰<𝓗(0.20,0.10)>
+```pycon
+>>> print(qml.draw(expval)(0.4))
+0: ───────────┤ ╭<𝓗(0.20,0.10)>
+1: ──RX(0.40)─┤ ├<𝓗(0.20,0.10)>
+2: ───────────┤ ╰<𝓗(0.20,0.10)>
+```
 
   However, if we convert an operator ``A`` to numerical data, from which a new 
   operator ``B`` is constructed, the chain of operator dependencies is broken and de-queuing will
   not work as expected:
   
-  .. code-block:: python3
-    
-    coeff = np.array([0.2, 0.1])
+```python
+coeff = np.array([0.2, 0.1])
 
-    @qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
-    def expval(x: float):
-        qml.RX(x, 1)
-        A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
-        numerical_data = A.matrix()
-        B = qml.Hermitian(numerical_data, wires=[2, 0])
-        return qml.expval(B)
+@qml.qnode(qml.device("lightning.qubit", wires=3))                                                        
+def expval(x: float):
+    qml.RX(x, 1)
+    A = qml.Hamiltonian(coeff, [qml.Y(1), qml.X(0)])
+    numerical_data = A.matrix()
+    B = qml.Hermitian(numerical_data, wires=[2, 0])
+    return qml.expval(B)
+```
 
-  >>> print(qp.draw(expval)(0.4))
-  0: ───────────╭𝓗(0.20,0.10)─┤ ╭<𝓗(M0)>
-  1: ──RX(0.40)─╰𝓗(0.20,0.10)─┤ │       
-  2: ─────────────────────────┤ ╰<𝓗(M0)>
+```pycon
+>>> print(qp.draw(expval)(0.4))
+0: ───────────╭𝓗(0.20,0.10)─┤ ╭<𝓗(M0)>
+1: ──RX(0.40)─╰𝓗(0.20,0.10)─┤ │       
+2: ─────────────────────────┤ ╰<𝓗(M0)>
+```
 
   As we can see, the ``Hamiltonian`` instance ``A`` remained in the queue.
   In cases where such a conversion to numerical data is unavoidable, perform the conversion
@@ -403,7 +407,7 @@ def c():
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents
-  of an operator product computed via ``@``, i.e. the dunder method ``__matmul__``. 
+  of an operator product via the dunder method ``__matmul__``. 
   [(#9029)](https://github.com/PennyLaneAI/pennylane/pull/9029)
 
 * Fixed :attr:`~.ops.Controlled.map_wires` and :func:`~.equal` with ``Controlled`` instances

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -337,8 +337,11 @@ class LinearCombination(Sum):
 
         if isinstance(other, Operator):
             if other.arithmetic_depth == 0:
-                # other will be de-queued in the following line, if it is in the current queue.
+                # `other` will be de-queued in the following line, if it is in the current queue
+                # and len(self.ops) > 0. If len(self.ops)==0, we de-queue manually.
                 new_ops = [op @ other for op in self.ops]
+                if len(self.ops) == 0:
+                    qml.QueuingManager.remove(other)
 
                 # build new pauli rep using old pauli rep
                 if (pr1 := self.pauli_rep) is not None and (pr2 := other.pauli_rep) is not None:

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -345,6 +345,11 @@ class LinearCombination(Sum):
                     new_pr = pr1 @ pr2
                 else:
                     new_pr = None
+                if qml.QueuingManager.recording():
+                    # pylint: disable=not-context-manager
+                    with qml.QueuingManager.active_context() as context:
+                        context.remove(self)
+                        context.remove(other)
                 return LinearCombination(self.coeffs, new_ops, _pauli_rep=new_pr)
             return qml.prod(self, other)
 

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -329,6 +329,11 @@ class LinearCombination(Sum):
             coeffs = qml.math.kron(coeffs1, coeffs2)
             ops_list = itertools.product(ops1, ops2)
             terms = [qml.prod(t[0], t[1], lazy=False) for t in ops_list]
+            if qml.QueuingManager.recording():
+                # pylint: disable=not-context-manager
+                with qml.QueuingManager.active_context() as context:
+                    context.remove(self)
+                    context.remove(other)
             return qml.ops.LinearCombination(coeffs, terms)
 
         if isinstance(other, Operator):

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -337,6 +337,7 @@ class LinearCombination(Sum):
 
         if isinstance(other, Operator):
             if other.arithmetic_depth == 0:
+                # other will be de-queued in the following line, if it is in the current queue.
                 new_ops = [op @ other for op in self.ops]
 
                 # build new pauli rep using old pauli rep
@@ -344,6 +345,7 @@ class LinearCombination(Sum):
                     new_pr = pr1 @ pr2
                 else:
                     new_pr = None
+                # other already has been removed above, as mentioned
                 qml.QueuingManager.remove(self)
                 return LinearCombination(self.coeffs, new_ops, _pauli_rep=new_pr)
             return qml.prod(self, other)

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -329,11 +329,10 @@ class LinearCombination(Sum):
             coeffs = qml.math.kron(coeffs1, coeffs2)
             ops_list = itertools.product(ops1, ops2)
             terms = [qml.prod(t[0], t[1], lazy=False) for t in ops_list]
-            if qml.QueuingManager.recording():
-                # pylint: disable=not-context-manager
-                with qml.QueuingManager.active_context() as context:
-                    context.remove(self)
-                    context.remove(other)
+            # Need to explicitly dequeue self and other, because only the operators in their
+            # ``ops`` attributes are entering ``prod`` calls above and thus are being de-queued
+            qml.QueuingManager.remove(self)
+            qml.QueuingManager.remove(other)
             return qml.ops.LinearCombination(coeffs, terms)
 
         if isinstance(other, Operator):
@@ -345,11 +344,7 @@ class LinearCombination(Sum):
                     new_pr = pr1 @ pr2
                 else:
                     new_pr = None
-                if qml.QueuingManager.recording():
-                    # pylint: disable=not-context-manager
-                    with qml.QueuingManager.active_context() as context:
-                        context.remove(self)
-                        context.remove(other)
+                qml.QueuingManager.remove(self)
                 return LinearCombination(self.coeffs, new_ops, _pauli_rep=new_pr)
             return qml.prod(self, other)
 

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -515,6 +515,28 @@ class TestQueueing:
         assert len(q) == 1
         assert q.queue[0] is op
 
+    def test_queueing_observable(self):
+        """Test queuing and metadata when both Adjoint and a Hermitian
+        base defined inside a recording context."""
+
+        with qml.queuing.AnnotatedQueue() as q:
+            base = qml.Hermitian(np.eye(4), wires=[0, "x"])
+            _ = Adjoint(base)
+
+        assert base not in q
+        assert len(q) == 1
+
+    def test_queuing_base_defined_outside_observable(self):
+        """Test that a Hermitian base isn't added to queue if it's
+        defined outside the recording context."""
+
+        base = qml.Hermitian(np.eye(4), wires=[0, "x"])
+        with qml.queuing.AnnotatedQueue() as q:
+            op = Adjoint(base)
+
+        assert len(q) == 1
+        assert q.queue[0] is op
+
 
 class TestMatrix:
     """Test the matrix method for a variety of interfaces."""

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -26,7 +26,6 @@ import scipy
 import pennylane as qml
 from pennylane import X, Y, Z
 from pennylane import numpy as pnp
-from pennylane.exceptions import DeviceError
 from pennylane.ops import LinearCombination
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.wires import Wires
@@ -378,6 +377,16 @@ mul_LinearCombinations = [
 
 matmul_LinearCombinations = [
     (
+        qml.ops.LinearCombination([1], [X(0)]),
+        qml.ops.LinearCombination([0.5], [Z(3)]),
+        qml.ops.LinearCombination(
+            [0.5],
+            [
+                X(0) @ Z(3),
+            ],
+        ),
+    ),
+    (
         qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),
         qml.ops.LinearCombination([0.5, 0.5], [Z(2), Z(3)]),
         qml.ops.LinearCombination(
@@ -408,9 +417,6 @@ matmul_LinearCombinations = [
         X(2),
         qml.ops.LinearCombination([1, 1], [X(0) @ X(2), Z(1) @ X(2)]),
     ),
-]
-
-rmatmul_LinearCombinations = [
     (
         qml.ops.LinearCombination([0.5, 0.5], [Z(2), Z(3)]),
         qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),
@@ -437,10 +443,10 @@ rmatmul_LinearCombinations = [
             ],
         ),
     ),
-    (
-        qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),
+    (  # This does not use __matmul__ of LinearCombination but of Operator
         X(2),
-        qml.ops.LinearCombination([1, 1], [X(2) @ X(0), X(2) @ Z(1)]),
+        qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),
+        X(2) @ (1 * X(0) + 1 * Z(1)),
     ),
 ]
 
@@ -771,12 +777,11 @@ class TestLinearCombination:
     @pytest.mark.parametrize(("H1", "H2", "H"), matmul_LinearCombinations)
     def test_LinearCombination_matmul(self, H1, H2, H):
         """Tests that LinearCombinations are tensored correctly"""
-        assert H == (H1 @ H2)
-
-    @pytest.mark.parametrize(("H1", "H2", "H"), rmatmul_LinearCombinations)
-    def test_LinearCombination_rmatmul(self, H1, H2, H):
-        """Tests that LinearCombinations are tensored correctly when using __rmatmul__"""
-        assert H == (H1 @ H2)
+        with qml.queuing.AnnotatedQueue() as q:
+            H1.queue()
+            H2.queue()
+            assert H == (H1 @ H2)
+        assert len(q.queue) == 1
 
     def test_arithmetic_errors(self):
         """Tests that the arithmetic operations thrown the correct errors"""
@@ -1926,8 +1931,6 @@ class TestLinearCombinationDifferentiation:
         assert grad[0] is None
         assert np.allclose(grad[1], grad_expected[1])
 
-    # TODO: update logic of adjoint differentiation to catch attempt to differentiate lincomb coeffs
-    @pytest.mark.xfail
     def test_not_supported_by_adjoint_differentiation(self):
         """Test that error is raised when attempting the adjoint differentiation method."""
         device = qml.device("default.qubit", wires=2)
@@ -1947,10 +1950,7 @@ class TestLinearCombinationDifferentiation:
             )
 
         grad_fn = qml.grad(circuit)
-        with pytest.raises(
-            DeviceError,
-            match="not supported on adjoint",
-        ):
+        with pytest.warns(UserWarning, match="not supported with the adjoint differentiation"):
             grad_fn(coeffs, param)
 
 

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -408,6 +408,16 @@ matmul_LinearCombinations = [
         ),
     ),
     (
+        qml.ops.LinearCombination([], []),
+        X(2),
+        qml.ops.LinearCombination([], []),
+    ),
+    (
+        qml.ops.LinearCombination([0.2], [Z(1)]),
+        X(2),
+        qml.ops.LinearCombination([0.2], [Z(1) @ X(2)]),
+    ),
+    (
         qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),
         X(2),
         qml.ops.LinearCombination([1, 1], [X(0) @ X(2), Z(1) @ X(2)]),

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -379,12 +379,7 @@ matmul_LinearCombinations = [
     (
         qml.ops.LinearCombination([1], [X(0)]),
         qml.ops.LinearCombination([0.5], [Z(3)]),
-        qml.ops.LinearCombination(
-            [0.5],
-            [
-                X(0) @ Z(3),
-            ],
-        ),
+        qml.ops.LinearCombination([0.5], [X(0) @ Z(3)]),
     ),
     (
         qml.ops.LinearCombination([1, 1], [X(0), Z(1)]),


### PR DESCRIPTION
**Context:**
In #8131 we changed some queuing behaviour. `LinearCombination.__matmul__` was not updated accordingly.

**Description of the Change:**
Update `LinearCombination.__matmul__` to de-queue the input operators.

**Benefits:**
Bugfix

**Possible Drawbacks:**

**Related GitHub Issues:**
