### PR TITLE
fix: update pennylane[docker] `tach` version to match remaining `pyproject.toml`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -307,7 +307,8 @@ def c():
 
 * Updated internal dependencies `autoray` (to 0.8.4), `tach` (to 0.32.2).
   [(#8911)](https://github.com/PennyLaneAI/pennylane/pull/8911)
-  [(#)]()
+  [(#8962)](https://github.com/PennyLaneAI/pennylane/pull/8962)
+  [(#9030)](https://github.com/PennyLaneAI/pennylane/pull/9030)
 
 * Relaxed the `torch` dependency from `==2.9.0` to `~=2.9.0` to allow for compatible patch updates.
   [(#8911)](https://github.com/PennyLaneAI/pennylane/pull/8911)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -305,8 +305,9 @@ def c():
 * Updated test helper `get_device` to correctly seed lightning devices.
   [(#8942)](https://github.com/PennyLaneAI/pennylane/pull/8942)
 
-* Updated internal dependencies `autoray` (to 0.8.4), `tach` (to 0.33).
+* Updated internal dependencies `autoray` (to 0.8.4), `tach` (to 0.32.2).
   [(#8911)](https://github.com/PennyLaneAI/pennylane/pull/8911)
+  [(#)]()
 
 * Relaxed the `torch` dependency from `==2.9.0` to `~=2.9.0` to allow for compatible patch updates.
   [(#8911)](https://github.com/PennyLaneAI/pennylane/pull/8911)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ docker = [
     "cachetools~=5.3.0", # this should be at least v5.3.0 because qualtran v0.6 (as of 2025/01/14) requires it, no known reason for why it cannot be anything higher.
     "matplotlib~=3.5",
     "opt_einsum~=3.3",
-    "tach~=0.33",
+    "tach==0.32.2",
 ]
 upload-reports = [
     "pydantic==2.10.6",


### PR DESCRIPTION
See https://github.com/PennyLaneAI/pennylane/pull/8962 for context, but that PR forgot to update another section in the `pyproject.toml`.