### PR TITLE
Fix type in docs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -404,6 +404,9 @@ def expval(x: float):
 
 <h3>Documentation 📝</h3>
 
+* The type of a parameter is fixed in the docstring of :class:`~.templates.layers.BasicEntanglerLayers`.
+  [(#9046)](https://github.com/PennyLaneAI/pennylane/pull/9046)
+
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -173,7 +173,7 @@ class BasicEntanglerLayers(Operation):
             weights (tensor_like): Weight tensor of shape ``(L, len(wires))``. Each weight is used as a parameter
                 for the rotation.
             wires (Any or Iterable[Any]): wires that the operator acts on
-            rotation (pennylane.ops.Operation): one-parameter single-qubit gate to use
+            rotation (Type[pennylane.ops.Operation]): one-parameter single-qubit gate to use
 
         Returns:
             list[.Operator]: decomposition of the operator

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -52,7 +52,7 @@ class BasicEntanglerLayers(Operation):
         weights (tensor_like): Weight tensor of shape ``(L, len(wires))``. Each weight is used as a parameter
             for the rotation.
         wires (Iterable): wires that the template acts on
-        rotation (pennylane.ops.Operation): one-parameter single-qubit gate to use,
+        rotation (Type[pennylane.operation.Operation]): one-parameter single-qubit gate to use,
             if ``None``, :class:`~pennylane.ops.RX` is used as default
 
     Raises:

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -55,8 +55,8 @@ class RandomLayers(Operation):
         weights (tensor_like): weight tensor of shape ``(L, k)``,
         wires (Iterable): wires that the template acts on
         ratio_imprim (float): value between 0 and 1 that determines the ratio of imprimitive to rotation gates
-        imprimitive (pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
-        rotations (tuple[pennylane.ops.Operation]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates. The frequency
+        imprimitive (Type[pennylane.ops.Operation]): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
+        rotations (tuple[Type[pennylane.ops.Operation]]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates. The frequency
             determines how often a particular rotation type is used. Defaults to the use of all three
             rotations with equal frequency.
         seed (int): seed to generate random architecture, defaults to 42
@@ -197,8 +197,8 @@ class RandomLayers(Operation):
             weights (tensor_like): weight tensor
             wires (Any or Iterable[Any]): wires that the operator acts on
             ratio_imprim (float): value between 0 and 1 that determines the ratio of imprimitive to rotation gates
-            imprimitive (pennylane.ops.Operation): two-qubit gate to use
-            rotations (list[pennylane.ops.Operation]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates.
+            imprimitive (Type[pennylane.ops.Operation]): two-qubit gate to use
+            rotations (list[Type[pennylane.ops.Operation]]): List of Pauli-X, Pauli-Y and/or Pauli-Z gates.
             seed (int): seed to generate random architecture
 
         Returns:


### PR DESCRIPTION
**Context:** We noticed a mistake in the docstring of `BasicEntanglerLayers`.

**Description of the Change:** Fixes the type in the docstring.

**Benefits:** The docstring is now accurate.

**Possible Drawbacks:** N/A
