### PR TITLE
Cast rotation angle to real in exp decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,6 +47,7 @@ def c():
 
 * New decomposition rules are added to `Evolution` and `RZ`.
   [(#9001)](https://github.com/PennyLaneAI/pennylane/pull/9001)
+  [(#9049)](https://github.com/PennyLaneAI/pennylane/pull/9049)
 
 <h3>Improvements 🛠</h3>
 

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -182,6 +182,7 @@ def pauli_rot_decomp(*params, wires, base, **_):  # pylint: disable=unused-argum
     if isinstance(base, qml.ops.SProd):
         coeff, base = coeff * base.scalar, base.base
     coeff = 2j * coeff  # The 2j cancels the coefficient added by PauliRot
+    coeff = math.real_if_close(coeff)  # only cast to real if close
     pauli_word = qml.pauli.pauli_word_to_string(base)
     qml.PauliRot(coeff, pauli_word, wires)
 

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -182,7 +182,11 @@ def pauli_rot_decomp(*params, wires, base, **_):  # pylint: disable=unused-argum
     if isinstance(base, qml.ops.SProd):
         coeff, base = coeff * base.scalar, base.base
     coeff = 2j * coeff  # The 2j cancels the coefficient added by PauliRot
-    coeff = math.real_if_close(coeff)  # only cast to real if close
+    coeff = (
+        math.real_if_close(coeff)
+        if math.get_interface(coeff) not in ("torch", "jax")
+        else math.real(coeff)
+    )
     pauli_word = qml.pauli.pauli_word_to_string(base)
     qml.PauliRot(coeff, pauli_word, wires)
 

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -188,7 +188,7 @@ def pauli_rot_decomp(*params, wires, base, **_):  # pylint: disable=unused-argum
         else math.real(coeff)
     )
     pauli_word = qml.pauli.pauli_word_to_string(base)
-    qml.PauliRot(coeff, pauli_word, wires)
+    qml.PauliRot(coeff, pauli_word, base.wires)
 
 
 qml.add_decomps(Evolution, pauli_rot_decomp)

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -500,7 +500,11 @@ def pauli_rot_decomp(*params, wires, base, **_):  # pylint: disable=unused-argum
     if isinstance(base, qml.ops.SProd):
         coeff, base = params[0] * base.scalar, base.base
     coeff = 2j * coeff  # The 2j cancels the coefficient added by PauliRot
-    coeff = math.real_if_close(coeff)  # only cast to real if close
+    coeff = (
+        math.real_if_close(coeff)
+        if math.get_interface(coeff) not in ("torch", "jax")
+        else math.real(coeff)
+    )
     pauli_word = qml.pauli.pauli_word_to_string(base)
     qml.PauliRot(coeff, pauli_word, base.wires)
 

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -500,6 +500,7 @@ def pauli_rot_decomp(*params, wires, base, **_):  # pylint: disable=unused-argum
     if isinstance(base, qml.ops.SProd):
         coeff, base = params[0] * base.scalar, base.base
     coeff = 2j * coeff  # The 2j cancels the coefficient added by PauliRot
+    coeff = math.real_if_close(coeff)  # only cast to real if close
     pauli_word = qml.pauli.pauli_word_to_string(base)
     qml.PauliRot(coeff, pauli_word, base.wires)
 

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -535,6 +535,7 @@ class TestDecomposition:
 
         [decomp_tape], _ = qml.transforms.decompose(tape, gate_set={"PauliRot"})
         assert len(decomp_tape) == 1
+        assert not qml.math.iscomplex(decomp_tape[0].data[0])
         actual_matrix = qml.matrix(decomp_tape, wire_order=op.wires)
         expected_matrix = qml.matrix(op, wire_order=op.wires)
         assert qml.math.allclose(actual_matrix, expected_matrix)


### PR DESCRIPTION
**Context:**
The decomposition of `Exp` and `Evolution` need to cast complex angles to real before passing them to the `PauliRot`. This is always what we've been doing in `Exp.decomposition()`, but we missed it when we migrated to the new system.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-111269]
