### PR TITLE
Add Catalyst version to qp.about

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,9 @@
 
 <h3>New features since last release</h3>
 
+* Added the Catalyst version to :func:`~.about`.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+
 * Added a convenience function :func:`~.math.ceil_log2` that computes the ceiling of the base-2
   logarithm of its input and casts the result to an ``int``. It is equivalent to 
   ``int(np.ceil(np.log2(n)))``.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -3,7 +3,7 @@
 <h3>New features since last release</h3>
 
 * Added the Catalyst version to :func:`~.about`.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)
+  [(#9050)](https://github.com/PennyLaneAI/pennylane/pull/9050)
 
 * Added a convenience function :func:`~.math.ceil_log2` that computes the ceiling of the base-2
   logarithm of its input and casts the result to an ``int``. It is equivalent to 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -48,9 +48,6 @@ def _pkg_location():
 
 def catalyst_version() -> str | None:
     """Get the version of the installed Catalyst package, if available."""
-    if not find_spec("catalyst"):
-        return None
-
     if find_spec("catalyst"):
         return version("pennylane_catalyst")
     return None

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -47,7 +47,7 @@ def _pkg_location():
 
 
 def catalyst_version() -> str | None:
-    """Catalyst version if installed."""
+    """Get the version of the installed `pennylane-catalyst` package, if available."""
     try:
         return str(version("pennylane_catalyst"))
     except PackageNotFoundError:

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -51,10 +51,9 @@ def catalyst_version() -> str | None:
     if not find_spec("catalyst"):
         return None
 
-    try:
-        return str(version("pennylane_catalyst"))
-    except PackageNotFoundError:
-        return None
+    if find_spec("catalyst"):
+        return version("pennylane_catalyst")
+    return None
 
 
 def about():

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -46,6 +46,14 @@ def _pkg_location():
         return "(unknown)"
 
 
+def catalyst_version() -> str | None:
+    """Catalyst version if installed."""
+    try:
+        return str(version("pennylane_catalyst"))
+    except PackageNotFoundError:
+        return None
+
+
 def about():
     """
     Prints the information for pennylane installation.
@@ -103,6 +111,9 @@ def about():
     print(f"Numpy version:           {numpy.__version__}")
     print(f"Scipy version:           {scipy.__version__}")
     print(f"JAX version:             {jax_version}")
+
+    if version := catalyst_version():
+        print(f"Catalyst version:        {version}")
 
     print("Installed devices:")
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -112,8 +112,8 @@ def about():
     print(f"Scipy version:           {scipy.__version__}")
     print(f"JAX version:             {jax_version}")
 
-    if version := catalyst_version():
-        print(f"Catalyst version:        {version}")
+    if cat_version := catalyst_version():
+        print(f"Catalyst version:        {cat_version}")
 
     print("Installed devices:")
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -47,7 +47,10 @@ def _pkg_location():
 
 
 def catalyst_version() -> str | None:
-    """Get the version of the installed `pennylane-catalyst` package, if available."""
+    """Get the version of the installed Catalyst package, if available."""
+    if not find_spec("catalyst"):
+        return None
+
     try:
         return str(version("pennylane_catalyst"))
     except PackageNotFoundError:
@@ -112,9 +115,10 @@ def about():
     print(f"Scipy version:           {scipy.__version__}")
     print(f"JAX version:             {jax_version}")
 
-    if cat_version := catalyst_version():
-        print(f"Catalyst version:        {cat_version}")
+    # Compiler information
+    print(f"Catalyst version:        {catalyst_version()}")
 
+    # Plugin devices
     print("Installed devices:")
 
     for d in plugin_devices:

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -80,3 +80,19 @@ def test_about_shows_editable_location(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Editable project location: /tmp/pl" in out
     assert re.search(r"Location:\s*/site-packages/pennylane", out)
+
+
+def test_catalyst_version(monkeypatch):
+    """Tests the catalyst_version function."""
+    about = importlib.import_module("pennylane.about")
+
+    # Test when catalyst is not found
+    monkeypatch.setattr(about, "find_spec", lambda name: None if name == "catalyst" else True)
+    assert about.catalyst_version() is None
+
+    # Test when catalyst is found but version is not available
+    monkeypatch.setattr(about, "find_spec", lambda name: True)
+    monkeypatch.setattr(
+        about, "version", lambda name: "0.1.0" if name == "pennylane_catalyst" else None
+    )
+    assert about.catalyst_version() == "0.1.0"


### PR DESCRIPTION
**Context:**
Add Catalyst version to `qp.about()`

**Benefits:**
```
$ python -c "import pennylane as qp; qp.about()"
Name: pennylane
Version: 0.45.0.dev27
Summary: PennyLane is a cross-platform Python library for quantum computing, quantum machine learning, and quantum chemistry. Train a quantum computer the same way as a neural network.
Home-page:
Author:
License:
Platform info:           Linux-6.8.0-90-generic-x86_64-with-glibc2.35
Python version:          3.13.12
Numpy version:           2.3.5
Scipy version:           1.17.0
JAX version:             0.7.1
Catalyst version:        0.15.0.dev27
Installed devices:
- default.clifford (pennylane-0.45.0.dev27)
- default.gaussian (pennylane-0.45.0.dev27)
- default.mixed (pennylane-0.45.0.dev27)
- default.qubit (pennylane-0.45.0.dev27)
- default.qutrit (pennylane-0.45.0.dev27)
- default.qutrit.mixed (pennylane-0.45.0.dev27)
- default.tensor (pennylane-0.45.0.dev27)
- null.qubit (pennylane-0.45.0.dev27)
- reference.qubit (pennylane-0.45.0.dev27)
- lightning.qubit (pennylane_lightning-0.45.0.dev8)
- nvidia.custatevec (pennylane_catalyst-0.15.0.dev27)
- nvidia.cutensornet (pennylane_catalyst-0.15.0.dev27)
- oqc.cloud (pennylane_catalyst-0.15.0.dev27)
- softwareq.qpp (pennylane_catalyst-0.15.0.dev27)
- braket.aws.ahs (amazon-braket-pennylane-plugin-1.34.0)
- braket.aws.qubit (amazon-braket-pennylane-plugin-1.34.0)
- braket.local.ahs (amazon-braket-pennylane-plugin-1.34.0)
- braket.local.qubit (amazon-braket-pennylane-plugin-1.34.0)
- lightning.kokkos (pennylane_lightning_kokkos-0.45.0.dev8)
```

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-111321]