### PR TITLE
Register adjoint decomposition rules for qutrit ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -52,6 +52,10 @@ def c():
   [(#9001)](https://github.com/PennyLaneAI/pennylane/pull/9001)
   [(#9049)](https://github.com/PennyLaneAI/pennylane/pull/9049)
 
+* The custom `adjoint` method of qutrit operators are implemented as decomposition rules compatible with the
+  new grpah-based decomposition system.
+  [(#9056)](https://github.com/PennyLaneAI/pennylane/pull/9056)
+
 <h3>Improvements 🛠</h3>
 
 * New lightweight representations of the :class:`~.HybridQRAM`, :class:`~.SelectOnlyQRAM`, :class:`~.BasisEmbedding`, and :class:`~.BasisState` templates have 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,7 +54,7 @@ def c():
   [(#9049)](https://github.com/PennyLaneAI/pennylane/pull/9049)
 
 * The custom `adjoint` method of qutrit operators are implemented as decomposition rules compatible with the
-  new grpah-based decomposition system.
+  new graph-based decomposition system.
   [(#9056)](https://github.com/PennyLaneAI/pennylane/pull/9056)
 
 <h3>Improvements 🛠</h3>

--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -24,7 +24,7 @@ from functools import lru_cache
 import numpy as np
 
 from pennylane.boolean_fn import BooleanFn
-from pennylane.decomposition import gate_sets
+from pennylane.decomposition.gate_set import GateSet
 from pennylane.exceptions import DeviceError, QuantumFunctionError, WireError
 from pennylane.measurements import (
     ExpectationMP,
@@ -594,7 +594,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
         if expand_state_prep:  # expand mid-circuit StatePrepBase operations
             [circuit], _ = decompose(
                 circuit,
-                gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
+                gate_set=GateSet(self.operations),
                 stopping_condition=lambda op: not isinstance(op, StatePrepBase),
             )
 
@@ -607,7 +607,7 @@ class Device(abc.ABC, metaclass=_LegacyMeta):
         )
         [circuit], _ = decompose(
             circuit,
-            gate_set=gate_sets.ROTATIONS_PLUS_CNOT,
+            gate_set=GateSet(self.operations),
             max_expansion=max_expansion,
             stopping_condition=self.stopping_condition,
         )

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -19,6 +19,8 @@ accept a unitary matrix as a parameter.
 import warnings
 
 import pennylane as qml
+from pennylane.decomposition import add_decomps, register_resources
+from pennylane.decomposition.resources import resource_rep
 from pennylane.operation import Operation
 from pennylane.wires import Wires
 
@@ -59,6 +61,8 @@ class QutritUnitary(Operation):
     grad_method = None
     """Gradient computation method."""
 
+    resource_keys = {"num_wires"}
+
     def __init__(self, *params, wires):
         wires = Wires(wires)
 
@@ -93,6 +97,10 @@ class QutritUnitary(Operation):
                 )
 
         super().__init__(*params, wires=wires)
+
+    @property
+    def resource_params(self) -> dict:
+        return {"num_wires": len(self.wires)}
 
     @staticmethod
     def compute_matrix(U):  # pylint: disable=arguments-differ
@@ -135,6 +143,18 @@ class QutritUnitary(Operation):
 
     def label(self, decimals=None, base_label=None, cache=None):
         return super().label(decimals=decimals, base_label=base_label or "U", cache=cache)
+
+
+def _adjoint_qutrit_unitary_resource(base_class, base_params):  # pylint: disable=unused-argument
+    return {resource_rep(QutritUnitary, num_wires=base_params["num_wires"]): 1}
+
+
+@qml.register_resources(_adjoint_qutrit_unitary_resource)
+def _adjoint_qutrit_unitary(U, wires):
+    QutritUnitary(qml.math.conj(qml.math.moveaxis(U, -2, -1)), wires=wires)
+
+
+add_decomps("Adjoint(QutritUnitary)", _adjoint_qutrit_unitary)
 
 
 class ControlledQutritUnitary(QutritUnitary):
@@ -198,6 +218,8 @@ class ControlledQutritUnitary(QutritUnitary):
     grad_method = None
     """Gradient computation method."""
 
+    resource_keys = {"num_u_wires", "num_control_wires"}
+
     def __init__(self, *params, control_wires=None, wires=None, control_values=None):
         if control_wires is None:
             raise ValueError("Must specify control wires")
@@ -218,6 +240,13 @@ class ControlledQutritUnitary(QutritUnitary):
 
         total_wires = control_wires + wires
         super().__init__(*params, wires=total_wires)
+
+    @property
+    def resource_params(self) -> dict:
+        return {
+            "num_u_wires": len(self._hyperparameters["u_wires"]),
+            "num_control_wires": len(self._hyperparameters["control_wires"]),
+        }
 
     @staticmethod
     def compute_matrix(
@@ -334,3 +363,27 @@ class ControlledQutritUnitary(QutritUnitary):
             wires=self.hyperparameters["u_wires"],
             control_values=values,
         )
+
+
+def _adjoint_controlled_qu_resource(base_class, base_params):  # pylint: disable=unused-argument
+    return {
+        resource_rep(
+            ControlledQutritUnitary,
+            num_u_wires=base_params["num_u_wires"],
+            num_control_wires=base_params["num_control_wires"],
+        ): 1
+    }
+
+
+# pylint: disable=unused-argument
+@register_resources(_adjoint_controlled_qu_resource)
+def _adjoint_controlled_qu(U, wires, u_wires, control_wires, control_values):
+    ControlledQutritUnitary(
+        qml.math.conj(qml.math.moveaxis(U, -2, -1)),
+        wires=u_wires,
+        control_wires=control_wires,
+        control_values=control_values,
+    )
+
+
+add_decomps("Adjoint(ControlledQutritUnitary)", _adjoint_controlled_qu)

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -150,7 +150,7 @@ def _adjoint_qutrit_unitary_resource(base_class, base_params):  # pylint: disabl
 
 
 @qml.register_resources(_adjoint_qutrit_unitary_resource)
-def _adjoint_qutrit_unitary(U, wires):
+def _adjoint_qutrit_unitary(U, wires, **_):
     QutritUnitary(qml.math.conj(qml.math.moveaxis(U, -2, -1)), wires=wires)
 
 
@@ -377,12 +377,12 @@ def _adjoint_controlled_qu_resource(base_class, base_params):  # pylint: disable
 
 # pylint: disable=unused-argument
 @register_resources(_adjoint_controlled_qu_resource)
-def _adjoint_controlled_qu(U, wires, u_wires, control_wires, control_values):
+def _adjoint_controlled_qu(U, wires, base, **_):
     ControlledQutritUnitary(
         qml.math.conj(qml.math.moveaxis(U, -2, -1)),
-        wires=u_wires,
-        control_wires=control_wires,
-        control_values=control_values,
+        wires=base.hyperparameters["u_wires"],
+        control_wires=base.hyperparameters["control_wires"],
+        control_values=base.hyperparameters["control_values"],
     )
 
 

--- a/pennylane/ops/qutrit/non_parametric_ops.py
+++ b/pennylane/ops/qutrit/non_parametric_ops.py
@@ -18,6 +18,8 @@ that do not depend on any parameters.
 # pylint:disable=arguments-differ
 import numpy as np
 
+from pennylane.decomposition import add_decomps
+from pennylane.decomposition.symbolic_decomposition import self_adjoint
 from pennylane.exceptions import AdjointUndefinedError
 from pennylane.operation import Operation
 from pennylane.wires import Wires
@@ -408,6 +410,9 @@ class TSWAP(Operation):
         return TSWAP(wires=self.wires)
 
 
+add_decomps("Adjoint(TSWAP)", self_adjoint)
+
+
 class THadamard(Operation):
     r"""THadamard(wires, subspace)
     The ternary Hadamard operator
@@ -475,9 +480,7 @@ class THadamard(Operation):
 
     def __init__(self, wires, subspace=None):
         self._subspace = validate_subspace(subspace) if subspace is not None else None
-        self._hyperparameters = {
-            "subspace": self.subspace,
-        }
+        self._hyperparameters = {"subspace": self.subspace}
 
         super().__init__(wires=wires)
 

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -21,6 +21,8 @@ import functools
 import numpy as np
 
 import pennylane as qml
+from pennylane.decomposition import add_decomps
+from pennylane.decomposition.symbolic_decomposition import adjoint_rotation
 from pennylane.operation import Operation
 
 stack_last = functools.partial(qml.math.stack, axis=-1)
@@ -198,6 +200,9 @@ class TRX(Operation):
         return [TRX(self.data[0] * z, wires=self.wires, subspace=self.subspace)]
 
 
+add_decomps("Adjoint(TRX)", adjoint_rotation)
+
+
 class TRY(Operation):
     r"""
     The single qutrit Y rotation
@@ -344,6 +349,9 @@ class TRY(Operation):
         return [TRY(self.data[0] * z, wires=self.wires, subspace=self.subspace)]
 
 
+add_decomps("Adjoint(TRY)", adjoint_rotation)
+
+
 class TRZ(Operation):
     r"""The single qutrit Z rotation
 
@@ -485,3 +493,6 @@ class TRZ(Operation):
 
     def pow(self, z):
         return [TRZ(self.data[0] * z, wires=self.wires, subspace=self.subspace)]
+
+
+add_decomps("Adjoint(TRZ)", adjoint_rotation)

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -844,8 +844,10 @@ class TestDefaultQutritIntegration:
         state = circuit(mat)
         assert np.allclose(state, expected_out, atol=tol)
 
+    @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     def test_qutrit_circuit_adjoint_integration(self):
         """Test that using qml.adjoint in a `default.qutrit` qnode works as expected."""
+
         dev = qml.device("default.qutrit", wires=3)
 
         def ansatz(phi, theta, omega, U):

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -858,6 +858,7 @@ class TestDefaultQutritIntegration:
             qml.TRY(theta, wires=0, subspace=(1, 2))
             qml.TSWAP([0, 2])
             qml.QutritUnitary(U, wires=[2, 1])
+            qml.ControlledQutritUnitary(U, wires=[2, 1], control_wires=[0])
             qml.TRZ(omega, wires=1, subspace=(0, 2))
 
         @qml.qnode(dev)

--- a/tests/devices/test_legacy_device.py
+++ b/tests/devices/test_legacy_device.py
@@ -574,7 +574,7 @@ class TestInternalFunctions:  # pylint:disable=too-many-public-methods
             [qml.expval(qml.PauliZ(0))],
         )
         dev = mock_device_supporting_paulis(wires=1)
-        expanded_tape = dev.expand_fn(invalid_tape, max_expansion=3)
+        expanded_tape = dev.expand_fn(invalid_tape, max_expansion=2)
         qml.assert_equal(expanded_tape, expected_tape)
 
     def test_stopping_condition_passes_with_non_obs_mp(self, mock_device_with_identity, recwarn):


### PR DESCRIPTION
**Context:**
Implement custom `adjoint` methods of qutrit ops as decomposition rules.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-111324]