### PR TITLE
fix: add `sybil` to `pyproject.toml`

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install -e ".[dev]"
+          pip install --group dev -e .
 
       - name: Install external packages
         run: |

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,11 +58,15 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install --group dev -e .
+          pip install -e .
 
-      - name: Install external packages
+      - name: Install testing packages
         run: |
-          pip install "jax==0.7.1" "jaxlib==0.7.1" torch pyzx
+          pip install sybil pytest
+
+      - name: Install additional packages
+        run: |
+          pip install "jax==0.7.1" "jaxlib==0.7.1" torch pyzx matplotlib
 
       - name: Print Dependencies
         run: |

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install -e ".[ci]"
+          pip install -e ".[ci,dev]"
 
       - name: Install external packages
         run: |

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install -e ".[ci,dev]"
+          pip install -e ".[dev]"
 
       - name: Install external packages
         run: |

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,11 +58,11 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install -e .
+          pip install -e ".[ci]"
 
       - name: Install external packages
         run: |
-          pip install sybil pytest "jax==0.7.1" "jaxlib==0.7.1" torch matplotlib pyzx
+          pip install "jax==0.7.1" "jaxlib==0.7.1" torch pyzx
 
       - name: Print Dependencies
         run: |

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -404,6 +404,9 @@ def expval(x: float):
 
 <h3>Internal changes ⚙️</h3>
 
+* Add `sybil` to `dev` dependency group in `pyproject.toml`.
+  [(#9060)](https://github.com/PennyLaneAI/pennylane/pull/9060)
+
 * `qml.counts` of mid circuit measurements can now be captured into jaxpr.
   [(#9022)](https://github.com/PennyLaneAI/pennylane/pull/9022)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ci = [
     "build"
 ]
 dev = [
+    "sybil",
     "pre-commit>=2.19.0",
     "pytest>=8.4.1",
     "pytest-cov>=3.0.0",


### PR DESCRIPTION
We should add `sybil` to our `dev` dependency group.

[sc-111529]