### PR TITLE
[Prototype] Add `MultiTargetX` and `FanOut` to PennyLane `labs`.

### DIFF
--- a/pennylane/labs/dla/__init__.py
+++ b/pennylane/labs/dla/__init__.py
@@ -42,9 +42,7 @@ Utility functions
 
 """
 
-from .recursive_cartan_decomp import (
-    recursive_cartan_decomp,
-)
+from .recursive_cartan_decomp import recursive_cartan_decomp
 from .dense_util import (
     check_orthonormal,
     pauli_coefficients,


### PR DESCRIPTION
**Context:**
While uninteresting at a first glance, the multi-target Pauli X operator, and its singly and multiply controlled variants (often referred to as fan out operation) are a frequently used subroutine.

**Description of the Change:**
Implement operators for these primitives and register some not entirely trivial decomposition for the (multi-)controlled variant (`FanOut`).

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
