### PR TITLE
 Add ToroidalDephasing noise channel  

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,12 @@
 
 <h3>New features since last release</h3>
 
+* Added `ToroidalDephasing` noise channel — a single-qubit dephasing channel with
+  toroidal spectral-gap suppression. The dephasing probability is reduced by the
+  spectral gap of an :math:`n \times n` toroidal lattice Laplacian, modelling
+  topological noise filtering on qubits arranged in a :math:`T^2` geometry.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Prepared new state preparation template :class:`~.SumOfSlatersStatePrep`.
   It prepares sparse states using a smaller dense state preparation, :class:`~.QROM`\ s and 
   reversible bit encodings. For now, only classical preprocessing required to implement the


### PR DESCRIPTION
 ## Summary                             

  - Adds `qml.ToroidalDephasing(gamma, grid_n=12, alpha=1.0, wires=0)` — single-qubit dephasing channel with toroidal spectral-gap suppression
  - Effective dephasing: γ_eff = γ × λ₁/(λ₁ + α), where λ₁ = 2 − 2cos(2π/n) is the spectral gap of the n×n torus Laplacian
  - 12×12 lattice: 4.7× suppression, 32×32: 27×
  - Relevant to toric code architectures and ring resonator arrays

  ## Motivation

  Qubits on a toroidal lattice experience reduced dephasing because the lattice Laplacian's spectral gap filters low-frequency noise. Simulation results show T₂ coherence improvement from 848 µs to 12.85 ms on toroidal resonator geometries.
Reference: https://doi.org/10.5281/zenodo.18516477
  ## Test plan

  - [x] 12 dedicated tests (trace preservation, boundary conditions, grid scaling, gradients,
  parameter validation)
  - [x] Added to shared `channels_and_args` trace-preserving parametric test
  - [ ] CI passes all interface tests (autograd, JAX, torch, tf)