### PR TITLE
improve error message

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -83,6 +83,7 @@
 
 * Raises a more informative error if something that is not a measurement process is returned from a 
   QNode when program capture is turned on.
+  [(#9072)](https://github.com/PennyLaneAI/pennylane/pull/9072)
 
 * New lightweight representations of the :class:`~.HybridQRAM`, :class:`~.SelectOnlyQRAM`, :class:`~.BasisEmbedding`, and :class:`~.BasisState` templates have 
   been added for fast and efficient resource estimation. These operations are available under the `qp.estimator` module as:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -81,6 +81,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Raises a more informative error if something that is not a measurement process is returned from a 
+  QNode when program capture is turned on.
+
 * New lightweight representations of the :class:`~.HybridQRAM`, :class:`~.SelectOnlyQRAM`, :class:`~.BasisEmbedding`, and :class:`~.BasisState` templates have 
   been added for fast and efficient resource estimation. These operations are available under the `qp.estimator` module as:
   ``qp.estimator.HybridQRAM``, ``qp.estimator.SelectOnlyQRAM``, ``qp.estimator.BasisEmbedding``, and  ``qp.estimator.BasisState``.

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -153,7 +153,15 @@ def _get_shapes_for(*measurements, shots=None, num_device_wires=0, batch_shape=(
     for s in shots:
         for m in measurements:
             s = s.val if isinstance(s, jax.extend.core.Literal) else s
-            shape, dtype = m.aval.abstract_eval(shots=s, num_device_wires=num_device_wires)
+            try:
+                shape, dtype = m.aval.abstract_eval(shots=s, num_device_wires=num_device_wires)
+            except AttributeError as e:
+                raise ValueError(
+                    "Only Measurement Processes can be returned from QNode's. Got returned"
+                    f" value of abstract type {m.aval}."
+                    "\nNote that raw mid circuit measurements can no longer be returned with"
+                    " Catalyst when capture is turned on. Please use qp.sample(mcm) instead for accurate results."
+                ) from e
             if all(isinstance(si, int) for si in shape):
                 aval_type = jax.core.ShapedArray
             else:

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -297,6 +297,17 @@ def test_qnode_pytree_output():
     assert list(out.keys()) == ["a", "b"]
 
 
+def test_informative_error_raw_mcm_return():
+    """Test that a more informative error is raised when returning a raw mcm."""
+
+    @qml.qnode(qml.device("default.qubit", wires=2))
+    def c():
+        return qml.measure(0)
+
+    with pytest.raises(ValueError, match="Only Measurement Processes can be returned from QNode"):
+        jax.make_jaxpr(c)()
+
+
 class TestShots:
     """Tests for the number of shots."""
 


### PR DESCRIPTION
**Context:**

In core-PL, qnode's can only return measurement processes. This restriction is also reflected in program capture.  But the error message when capture is turned on is extremely useless.

**Description of the Change:**

Adds a better error message.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-111843]