### PR TITLE
fix: remove `doctest: +SKIP` from `specs.py`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -128,6 +128,7 @@
   0: ──X─┤  Probs
   ```
   [(#9007)](https://github.com/PennyLaneAI/pennylane/pull/9007)
+  [(#9076)](https://github.com/PennyLaneAI/pennylane/pull/9076)
   
 * Raises a more informative error if something that is not a measurement process is returned from a 
   QNode when program capture is turned on.

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -623,8 +623,8 @@ def specs(
 
         Here is an example using ``level="all"`` on the circuit from the previous code example:
 
-        >>> all_specs = qml.specs(circuit, level="all")(1.23) # doctest: +SKIP
-        >>> print(all_specs) # doctest: +SKIP
+        >>> all_specs = qml.specs(circuit, level="all")(1.23)
+        >>> print(all_specs)
         Device: lightning.qubit
         Device wires: 3
         Shots: Shots(total=None)
@@ -692,12 +692,12 @@ def specs(
         object. The keys to this dictionary are returned as the ``level`` attribute of the :class:`~.resource.CircuitSpecs`
         object.
 
-        >>> print(all_specs.level) # doctest: +SKIP
+        >>> print(all_specs.level)
         ['Before transforms', 'Before MLIR Passes (MLIR-0)', 'cancel-inverses (MLIR-1)', 'merge-rotations (MLIR-2)']
 
         The resources associated with a particular level can be accessed using the returned level name as follows:
 
-        >>> print(all_specs.resources['merge-rotations (MLIR-2)']) # doctest: +SKIP
+        >>> print(all_specs.resources['merge-rotations (MLIR-2)'])
         Total wire allocations: 3
         Total gates: 2
         Circuit depth: Not computed

--- a/pennylane/transforms/decompositions/pauli_based_computation.py
+++ b/pennylane/transforms/decompositions/pauli_based_computation.py
@@ -431,7 +431,7 @@ def ppr_to_ppm_setup_inputs(decompose_method="pauli-corrected", avoid_y_measure=
         PPM-w3: 1
         PPR-pi/2-w1: 6
         PPR-pi/2-w2: 1
-        qec.fabricate: 1
+        pbc.fabricate: 1
     <BLANKLINE>
     Measurements:
         expval(PauliZ): 1
@@ -542,7 +542,7 @@ def ppm_compilation_setup_inputs(
     <BLANKLINE>
     Gate types:
         GlobalPhase: 3
-        qec.fabricate: 1
+        pbc.fabricate: 1
         PPM-w2: 6
         PPM-w1: 7
         PPM-w3: 1
@@ -741,7 +741,7 @@ def decompose_arbitrary_ppr_setup_inputs():
       Circuit depth: Not computed
     <BLANKLINE>
     Gate types:
-      qec.prepare: 1
+      pbc.prepare: 1
       PPM-w3: 1
       PPM-w1: 1
       PPR-pi/2-w1: 1


### PR DESCRIPTION
This PR removes the `doctest: +SKIP` that were added in https://github.com/PennyLaneAI/pennylane/pull/9007 which should now pass with https://github.com/PennyLaneAI/catalyst/pull/2464 being merged.

⚠️ NOTE: QEC operations were recently re-named to PBC which resulted in some additional changes needed

[sc-110163]