### PR TITLE
deprecate: `get_transform_program` in favour of `get_compile_pipeline`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,6 +9,13 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
+* The :func:`~pennylane.workflow.get_transform_program` function has been deprecated and will be removed in v0.46.
+  Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
+  of a QNode.
+
+  - Deprecated in v0.45
+  - Will be removed in v0.46
+
 * Deactivating queuing of an ``Operator`` by setting its
   :attr:`~pennylane.operation.Operator._queue_category` to ``None``
   has been deprecated and will be removed in v0.46. If necessary, the

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -427,6 +427,11 @@
 
 <h3>Deprecations 👋</h3>
 
+* The :func:`~pennylane.workflow.get_transform_program` function has been deprecated and will be removed in v0.46.
+  Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
+  of a QNode.
+  [(#9077)](https://github.com/PennyLaneAI/pennylane/pull/9077)
+
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.
   Operator classes that used to have `_queue_category=None` have been updated

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -63,7 +63,7 @@ def draw(
         show_matrices (bool): Show matrix valued parameters below all circuit diagrams. Defaults to ``False``.
         show_wire_labels (bool): Whether or not to show the wire labels. Defaults to ``True``.
         level (str, int, slice): An indication of what transforms to apply before drawing. Defaults to ``"gradient"``.
-            Check :func:`~.workflow.get_transform_program` for more information on the allowed values and usage details of
+            Check :func:`~.workflow.get_compile_pipeline` for more information on the allowed values and usage details of
             this argument.
 
     Returns:
@@ -432,7 +432,7 @@ def draw_mpl(
         active_wire_notches (bool): whether or not to add notches indicating active wires.
             Defaults to ``True``.
         level (str, int, slice): An indication of what transforms to apply before drawing.
-            Check :func:`~.workflow.get_transform_program` for more information on the allowed values and usage details of
+            Check :func:`~.workflow.get_compile_pipeline` for more information on the allowed values and usage details of
             this argument.
 
     Returns:

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -123,7 +123,7 @@ def add_noise(tape, noise_model, level="user"):
 
         .. code-block:: python
 
-            dev = qml.device("default.mixed", wires=2)
+            dev = qml.device("default.mixed", wires=3)
 
             @qml.metric_tensor
             @qml.transforms.undo_swaps
@@ -140,52 +140,52 @@ def add_noise(tape, noise_model, level="user"):
 
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
-        >>> print(qml.workflow.get_transform_program(circuit))
+        >>> print(qml.workflow.get_compile_pipeline(circuit)(1,2,3,4))
          CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
           [3] undo_swaps(),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1])),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1, 2])),
+          [5] metric_tensor(device_wires=Wires([0, 1, 2])),
           [6] defer_measurements(allow_postselect=False),
           [7] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
           [8] no_sampling(name=backprop + default.mixed),
-          [9] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_device_wires(Wires([0, 1, 2]), name=default.mixed),
           [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
           [11] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
-        >>> print(qml.workflow.get_transform_program(noisy_circuit))
+        >>> print(qml.workflow.get_compile_pipeline(noisy_circuit)(1,2,3,4))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
           [3] undo_swaps(),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1])),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1, 2])),
+          [5] metric_tensor(device_wires=Wires([0, 1, 2])),
           [6] add_noise(...),
           [7] defer_measurements(allow_postselect=False),
           [8] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
           [9] no_sampling(name=backprop + default.mixed),
-          [10] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [10] validate_device_wires(Wires([0, 1, 2]), name=default.mixed),
           [11] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
           [12] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
         However, one can request to insert the ``add_noise`` transform at any specific point in the compile pipeline. By specifying the ``level`` keyword argument while
         transforming a ``QNode``, this transform can be added at a designated level within the compile pipeline, as determined using the
-        :func:`get_transform_program <pennylane.workflow.get_transform_program>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
+        :func:`get_compile_pipeline<pennylane.workflow.get_compile_pipeline>`. For example, specifying ``None`` will add it at the end, ensuring that the tape is expanded to have no ``Adjoint`` and ``Templates``:
 
         >>> print(qml.noise.add_noise(circuit, noise_model, level="device").compile_pipeline)
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
           [3] undo_swaps(),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1])),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1, 2])),
+          [5] metric_tensor(device_wires=Wires([0, 1, 2])),
           [6] defer_measurements(allow_postselect=False),
           [7] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
           [8] no_sampling(name=backprop + default.mixed),
-          [9] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_device_wires(Wires([0, 1, 2]), name=default.mixed),
           [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
           [11] validate_observables(stopping_condition=..., name=default.mixed),
           [12] add_noise(..., level=device)
@@ -205,8 +205,8 @@ def add_noise(tape, noise_model, level="user"):
           [1] cancel_inverses(),
           [2] merge_rotations(),
           [3] undo_swaps(),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1])),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1, 2])),
+          [5] metric_tensor(device_wires=Wires([0, 1, 2])),
           [6] add_noise(..., level=user)
         )
 
@@ -215,12 +215,12 @@ def add_noise(tape, noise_model, level="user"):
           [1] cancel_inverses(),
           [2] merge_rotations(),
           [3] undo_swaps(),
-          [4] _expand_metric_tensor(device_wires=Wires([0, 1])),
-          [5] metric_tensor(device_wires=Wires([0, 1])),
+          [4] _expand_metric_tensor(device_wires=Wires([0, 1, 2])),
+          [5] metric_tensor(device_wires=Wires([0, 1, 2])),
           [6] defer_measurements(allow_postselect=False),
           [7] decompose(target_gates=..., stopping_condition=<function stopping_condition at 0x...>, name=default.mixed),
           [8] no_sampling(name=backprop + default.mixed),
-          [9] validate_device_wires(Wires([0, 1]), name=default.mixed),
+          [9] validate_device_wires(Wires([0, 1, 2]), name=default.mixed),
           [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.mixed),
           [11] validate_observables(stopping_condition=..., name=default.mixed),
           [12] add_noise(..., level=device)

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,7 +140,8 @@ def add_noise(tape, noise_model, level="user"):
 
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
-        >>> print(_get_transform_program(circuit)(1,2,3,4))
+        >>> from pennylane.workflow import get_compile_pipeline
+        >>> print(get_compile_pipeline(circuit)(1,2,3,4))
          CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -155,7 +156,7 @@ def add_noise(tape, noise_model, level="user"):
           [11] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
-        >>> print(_get_transform_program(noisy_circuit)(1,2,3,4))
+        >>> print(get_compile_pipeline(noisy_circuit)(1,2,3,4))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -49,7 +49,7 @@ def add_noise(tape, noise_model, level="user"):
         noise_model (~pennylane.NoiseModel): noise model according to which noise has to be inserted.
         level (str, int, slice): An indication of which stage in the compile pipeline the
             noise model should be applied to. Only relevant when transforming a ``QNode``. More details
-            on the following permissible values can be found in the :func:`~.workflow.get_transform_program` -
+            on the following permissible values can be found in the :func:`~.workflow.get_compile_pipeline` -
 
             * ``str``: acceptable keys are ``"top"``, ``"user"``, ``"device"``, and ``"gradient"``.
             * ``int``: how many transforms to include, starting from the front of the program.

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -324,6 +324,7 @@ def add_noise(tape, noise_model, level="user"):
 
     return new_tapes, post_processing_fn
 
+
 def _get_full_transform_program(qnode, gradient_fn):
     # NOTE: Copy so as to not mutate
     program = copy(qnode.compile_pipeline)

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,7 +140,7 @@ def add_noise(tape, noise_model, level="user"):
 
             noisy_circuit = qml.noise.add_noise(circuit, noise_model)
 
-        >>> print(qml.workflow.get_compile_pipeline(circuit)(1,2,3,4))
+        >>> print(_get_transform_program(circuit)(1,2,3,4))
          CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -155,7 +155,7 @@ def add_noise(tape, noise_model, level="user"):
           [11] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
-        >>> print(qml.workflow.get_compile_pipeline(noisy_circuit)(1,2,3,4))
+        >>> print(_get_transform_program(noisy_circuit)(1,2,3,4))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -432,7 +432,7 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
 
         By default, we get the full transform program. This can be explicitly specified by ``level="device"``.
 
-        >>> print(qml.workflow.get_transform_program(circuit))
+        >>> print(_get_transform_program(circuit))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -450,7 +450,7 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
         The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
         :func:`~.merge_rotations` and :func:`~.metric_tensor`.
 
-        >>> print(qml.workflow.get_transform_program(circuit, level="user"))
+        >>> print(_get_transform_program(circuit, level="user"))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -463,7 +463,7 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
         it will decompose any parametrized templates into operators that have generators. Note how ``metric_tensor`` is still
         present at the very end of resulting program.
 
-        >>> print(qml.workflow.get_transform_program(circuit, level="gradient"))
+        >>> print(_get_transform_program(circuit, level="gradient"))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -474,14 +474,14 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
 
         ``"top"`` and ``0`` both return empty transform programs.
 
-        >>> print(qml.workflow.get_transform_program(circuit, level="top"))
+        >>> print(_get_transform_program(circuit, level="top"))
         CompilePipeline()
-        >>> print(qml.workflow.get_transform_program(circuit, level=0))
+        >>> print(_get_transform_program(circuit, level=0))
         CompilePipeline()
 
         The ``level`` can also be any integer, corresponding to a number of transforms in the program.
 
-        >>> print(qml.workflow.get_transform_program(circuit, level=2))
+        >>> print(_get_transform_program(circuit, level=2))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations()
@@ -491,12 +491,12 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
         transform program.  This allows you to select different starting transforms or strides.
         For example, you can skip the first transform or reverse the order:
 
-        >>> print(qml.workflow.get_transform_program(circuit, level=slice(1,3)))
+        >>> print(_get_transform_program(circuit, level=slice(1,3)))
         CompilePipeline(
           [1] merge_rotations(),
           [2] _expand_metric_tensor(device_wires=None)
         )
-        >>> print(qml.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
+        >>> print(_get_transform_program(circuit, level=slice(None, None, -1)))
         CompilePipeline(
           [1] _conditional_broadcast_expand(),
           [2] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
@@ -514,9 +514,9 @@ def _get_transform_program(qnode, level="device", gradient_fn="unset"):
         You can get creative and pick a single category of transforms as follows, excluding
         any preceding transforms (and the final transform if it exists):
 
-        >>> user_prog = qml.workflow.get_transform_program(circuit, level="user")
-        >>> grad_prog = qml.workflow.get_transform_program(circuit, level="gradient")
-        >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
+        >>> user_prog = _get_transform_program(circuit, level="user")
+        >>> grad_prog = _get_transform_program(circuit, level="gradient")
+        >>> dev_prog = _get_transform_program(circuit, level="device")
         >>> print(grad_prog[len(user_prog) - 1 : -1])
         CompilePipeline(
           [1] metric_tensor(device_wires=None)

--- a/pennylane/resource/error/error.py
+++ b/pennylane/resource/error/error.py
@@ -202,7 +202,7 @@ def algo_error(
         qnode (.QNode): the QNode to calculate the algorithmic errors for.
 
         level (str | int | slice | iter[int]): An indication of which transforms to apply before computing the errors.
-            See :func:`~pennylane.workflow.get_transform_program` for more information about allowable levels.
+            See :func:`~pennylane.workflow.get_compile_pipeline` for more information about allowable levels.
 
     Returns:
         A function that has the same argument signature as ``qnode``. When called,

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -385,7 +385,7 @@ def specs(
 
     Keyword Args:
         level (str | int | slice | iter[int]): An indication of which transforms, expansions, and passes to apply before
-            computing the resource information. See :func:`~pennylane.workflow.get_transform_program` for more details
+            computing the resource information. See :func:`~pennylane.workflow.get_compile_pipeline` for more details
             on the available levels. Default is ``"device"`` for qjit-compiled workflows or ``"gradient"`` otherwise.
         compute_depth (bool): Whether to compute the depth of the circuit. If ``False``, circuit
             depth will not be included in the output. By default, ``specs`` will always attempt to calculate circuit

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -26,7 +26,6 @@ Execution functions and utilities
     ~workflow.construct_tape
     ~workflow.construct_batch
     ~workflow.construct_execution_config
-    ~workflow.get_transform_program
     ~workflow.get_compile_pipeline
     ~workflow.get_best_diff_method
     ~workflow.set_shots
@@ -45,21 +44,41 @@ Jacobian Product Calculation
 .. include:: ../../pennylane/workflow/return_types_spec.rst
 
 """
-from .construct_batch import construct_batch, get_transform_program
-from .marker import marker
-from .construct_tape import construct_tape
-from .construct_execution_config import construct_execution_config
-from .get_compile_pipeline import get_compile_pipeline
-from .execution import execute
-from .get_best_diff_method import get_best_diff_method
-from .qnode import QNode, qnode
-from .resolution import (
-    _resolve_execution_config,
-    _resolve_mcm_config,
-    _resolve_diff_method,
-    _resolve_interface,
-)
-from .set_shots import set_shots
+import warnings
+from pennylane.exceptions import PennyLaneDeprecationWarning
+
 from ._cache_transform import _cache_transform
 from ._setup_transform_program import _setup_transform_program
+from .construct_batch import construct_batch
+from .construct_execution_config import construct_execution_config
+from .construct_tape import construct_tape
+from .execution import execute
+from .get_best_diff_method import get_best_diff_method
+from .get_compile_pipeline import get_compile_pipeline
+from .marker import marker
+from .qnode import QNode, qnode
+from .resolution import (
+    _resolve_diff_method,
+    _resolve_execution_config,
+    _resolve_interface,
+    _resolve_mcm_config,
+)
 from .run import run
+from .set_shots import set_shots
+
+
+def __getattr__(name):
+    if name == "get_transform_program":
+        # pylint: disable=import-outside-toplevel
+        from pennylane.noise.add_noise import _get_transform_program
+
+        warnings.warn(
+            "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
+            "To retrieve the execution pipeline of a QNode, please consider using "
+            "'pennylane.workflow.get_compile_pipeline'.",
+            PennyLaneDeprecationWarning,
+        )
+
+        return _get_transform_program
+
+    raise AttributeError(f"module 'workflow' has no attribute '{name}'")

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -44,12 +44,10 @@ Jacobian Product Calculation
 .. include:: ../../pennylane/workflow/return_types_spec.rst
 
 """
-import warnings
-from pennylane.exceptions import PennyLaneDeprecationWarning
 
 from ._cache_transform import _cache_transform
 from ._setup_transform_program import _setup_transform_program
-from .construct_batch import construct_batch
+from .construct_batch import construct_batch, get_transform_program
 from .construct_execution_config import construct_execution_config
 from .construct_tape import construct_tape
 from .execution import execute
@@ -71,13 +69,6 @@ def __getattr__(name):
     if name == "get_transform_program":
         # pylint: disable=import-outside-toplevel
         from pennylane.noise.add_noise import _get_transform_program
-
-        warnings.warn(
-            "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
-            "To retrieve the execution pipeline of a QNode, please consider using "
-            "'pennylane.workflow.get_compile_pipeline'.",
-            PennyLaneDeprecationWarning,
-        )
 
         return _get_transform_program
 

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -64,13 +64,3 @@ from .resolution import (
 )
 from .run import run
 from .set_shots import set_shots
-
-
-def __getattr__(name):
-    if name == "get_transform_program":
-        # pylint: disable=import-outside-toplevel
-        from pennylane.noise.add_noise import _get_transform_program
-
-        return _get_transform_program
-
-    raise AttributeError(f"module 'workflow' has no attribute '{name}'")

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -26,6 +26,7 @@ Execution functions and utilities
     ~workflow.construct_tape
     ~workflow.construct_batch
     ~workflow.construct_execution_config
+    ~workflow.get_transform_program
     ~workflow.get_compile_pipeline
     ~workflow.get_best_diff_method
     ~workflow.set_shots

--- a/pennylane/workflow/_setup_transform_program.py
+++ b/pennylane/workflow/_setup_transform_program.py
@@ -77,10 +77,16 @@ def _setup_transform_program(
             cache = True
     if cache is True:
         cache = LRUCache(maxsize=cachesize)
-
     # Ensure that ``cache`` is not a Boolean to simplify downstream code.
     elif cache is False:
         cache = None
+
+    # NOTE: For the AUTOGRAD interface, tape-level caching should be skipped
+    # because AUTOGRAD uses it's own caching which caches the entire Jacobian
+    # rather than re-executing individual tapes.
+    # Adding _cache_transform here would result in stale executions when using finite shots.
+    if cache is not None and resolved_execution_config.interface is not Interface.AUTOGRAD:
+        inner_transform_program.add_transform(_cache_transform, cache=cache)
 
     # changing this set of conditions causes a bunch of tests to break.
     interface_data_supported = (
@@ -90,7 +96,5 @@ def _setup_transform_program(
     )
     if not interface_data_supported:
         inner_transform_program.add_transform(convert_to_numpy_parameters)
-    if cache is not None:
-        inner_transform_program.add_transform(_cache_transform, cache=cache)
 
     return outer_transform_program, inner_transform_program

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -15,10 +15,12 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
 from pennylane import math
+from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.tape import make_qscript
 
 from ._setup_transform_program import _setup_transform_program
@@ -134,6 +136,170 @@ def _get_inner_transform_slice(
     start = max(0, (level.start or 0) - num_user_transforms)
     stop = None if level.stop is None else max(0, level.stop - num_user_transforms)
     return slice(start, stop, level.step)
+
+
+def get_transform_program(qnode, level="device", gradient_fn="unset"):
+    """Extract a transform program at a designated level.
+
+    .. warning::
+        This function has been deprecated and is superceded by :func:`~.workflow.get_compile_pipeline`. Access to this function will be removed in v0.46.
+
+    Args:
+        qnode (QNode): the qnode to get the transform program for.
+        level (str, int, slice): An indication of what transforms to use from the full program.
+
+            - ``"device"``: Uses the entire transformation pipeline.
+            - ``"top"``: Ignores transformations and returns the original tape as defined.
+            - ``"user"``: Includes transformations that are manually applied by the user.
+            - ``"gradient"``: Extracts the gradient-level tape.
+            - ``int``: Can also accept an integer, corresponding to a number of transforms in the program. ``level=0`` corresponds to the start of the program.
+            - ``slice``: Can also accept a ``slice`` object to select an arbitrary subset of the transform program.
+
+        gradient_fn (None, str, Transform): The processed gradient fn for the workflow.
+
+    Returns:
+        CompilePipeline: the transform program corresponding to the requested level.
+
+    .. details::
+        :title: Usage Details
+
+        The transforms are organized as:
+
+        .. image:: ../../_static/transforms_order.png
+            :align: center
+            :width: 800px
+            :target: javascript:void(0);
+
+        where ``transform1`` is first applied to the ``QNode`` followed by ``transform2``.  First, user transforms are run on the tapes,
+        followed by the gradient expansion, followed by the device expansion. "Final" transforms, like ``param_shift`` and ``metric_tensor``,
+        always occur at the end of the program, despite being part of user transforms. Note that when requesting a level by name
+        (e.g. "gradient" or "device"), the preceding levels would be applied as well.
+
+        .. code-block:: python
+
+            dev = qml.device('default.qubit')
+
+            @qml.metric_tensor # final transform
+            @qml.transforms.merge_rotations # transform 2
+            @qml.transforms.cancel_inverses # transform 1
+            @qml.qnode(dev, diff_method="parameter-shift", gradient_kwargs={"shifts": np.pi / 4})
+            def circuit():
+                return qml.expval(qml.Z(0))
+
+        By default, we get the full transform program. This can be explicitly specified by ``level="device"``.
+
+        >>> print(qml.workflow.get_transform_program(circuit))
+        CompilePipeline(
+          [1] cancel_inverses(),
+          [2] merge_rotations(),
+          [3] _expand_metric_tensor(device_wires=None),
+          [4] metric_tensor(device_wires=None),
+          [5] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [6] defer_measurements(allow_postselect=True),
+          [7] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [8] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [9] validate_device_wires(None, name=default.qubit),
+          [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [11] _conditional_broadcast_expand()
+        )
+
+        The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
+        :func:`~.merge_rotations` and :func:`~.metric_tensor`.
+
+        >>> print(qml.workflow.get_transform_program(circuit, level="user"))
+        CompilePipeline(
+          [1] cancel_inverses(),
+          [2] merge_rotations(),
+          [3] _expand_metric_tensor(device_wires=None),
+          [4] metric_tensor(device_wires=None)
+        )
+
+        The ``_expand_transform_param_shift`` is the ``"gradient"`` transform.
+        This expands all trainable operations to a state where the parameter shift transform can operate on them. For example,
+        it will decompose any parametrized templates into operators that have generators. Note how ``metric_tensor`` is still
+        present at the very end of resulting program.
+
+        >>> print(qml.workflow.get_transform_program(circuit, level="gradient"))
+        CompilePipeline(
+          [1] cancel_inverses(),
+          [2] merge_rotations(),
+          [3] _expand_metric_tensor(device_wires=None),
+          [4] metric_tensor(device_wires=None),
+          [5] _expand_transform_param_shift(shifts=0.7853981633974483)
+        )
+
+        ``"top"`` and ``0`` both return empty transform programs.
+
+        >>> print(qml.workflow.get_transform_program(circuit, level="top"))
+        CompilePipeline()
+        >>> print(qml.workflow.get_transform_program(circuit, level=0))
+        CompilePipeline()
+
+        The ``level`` can also be any integer, corresponding to a number of transforms in the program.
+
+        >>> print(qml.workflow.get_transform_program(circuit, level=2))
+        CompilePipeline(
+          [1] cancel_inverses(),
+          [2] merge_rotations()
+        )
+
+        ``level`` can also accept a ``slice`` object to select out any arbitrary subset of the
+        transform program.  This allows you to select different starting transforms or strides.
+        For example, you can skip the first transform or reverse the order:
+
+        >>> print(qml.workflow.get_transform_program(circuit, level=slice(1,3)))
+        CompilePipeline(
+          [1] merge_rotations(),
+          [2] _expand_metric_tensor(device_wires=None)
+        )
+        >>> print(qml.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
+        CompilePipeline(
+          [1] _conditional_broadcast_expand(),
+          [2] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
+          [3] validate_device_wires(None, name=default.qubit),
+          [4] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [5] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [6] defer_measurements(allow_postselect=True),
+          [7] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [8] metric_tensor(device_wires=None),
+          [9] _expand_metric_tensor(device_wires=None),
+          [10] merge_rotations(),
+          [11] cancel_inverses()
+        )
+
+        You can get creative and pick a single category of transforms as follows, excluding
+        any preceding transforms (and the final transform if it exists):
+
+        >>> user_prog = qml.workflow.get_transform_program(circuit, level="user")
+        >>> grad_prog = qml.workflow.get_transform_program(circuit, level="gradient")
+        >>> dev_prog = qml.workflow.get_transform_program(circuit, level="device")
+        >>> print(grad_prog[len(user_prog) - 1 : -1])
+        CompilePipeline(
+          [1] metric_tensor(device_wires=None)
+        )
+        >>> print(dev_prog[len(grad_prog) - 1 : -1])
+        CompilePipeline(
+          [1] _expand_transform_param_shift(shifts=0.7853981633974483),
+          [2] defer_measurements(allow_postselect=True),
+          [3] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
+          [4] device_resolve_dynamic_wires(wires=None, allow_resets=False),
+          [5] validate_device_wires(None, name=default.qubit),
+          [6] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit)
+        )
+
+    """
+    # pylint: disable=import-outside-toplevel
+
+    # NOTE: Remove once deprecation cycle is complete
+    from pennylane.noise.add_noise import _get_transform_program
+
+    warnings.warn(
+        "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
+        "To retrieve the execution pipeline of a QNode, please consider using "
+        "'pennylane.workflow.get_compile_pipeline'.",
+        PennyLaneDeprecationWarning,
+    )
+    return _get_transform_program(qnode, level, gradient_fn)
 
 
 def construct_batch(

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -47,7 +47,7 @@ def _validate_level(
         ValueError: If the level is not recognized
     """
 
-    if isinstance(level, (int, slice, str)):
+    if isinstance(level, (int, slice, str)) and not isinstance(level, bool):
         return
 
     raise ValueError(f"level {level} not recognized. Acceptable types are int, str, and slice.")

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -15,10 +15,12 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
 import pennylane as qml
+from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.transforms.core import CompilePipeline
 
 from ._setup_transform_program import _setup_transform_program
@@ -161,6 +163,11 @@ def get_transform_program(
     gradient_fn="unset",
 ) -> CompilePipeline:
     """Extract a transform program at a designated level.
+
+    .. warning::
+
+        This function is deprecated and will be removed in v0.46. To retrieve the execution
+        pipeline of a QNode, please use :func:`~.workflow.get_compile_pipeline`.
 
     Args:
         qnode (QNode): the qnode to get the transform program for.
@@ -306,6 +313,13 @@ def get_transform_program(
         )
 
     """
+    warnings.warn(
+        "This function is deprecated and will be removed in v0.46. "
+        "To retrieve the execution pipeline of a QNode, please consider using "
+        "'pennylane.workflow.get_compile_pipeline'.",
+        PennyLaneDeprecationWarning,
+    )
+
     _validate_level(level)
     if gradient_fn == "unset":
         config = qml.workflow.construct_execution_config(qnode, resolve=False)()

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -314,7 +314,7 @@ def get_transform_program(
 
     """
     warnings.warn(
-        "This function is deprecated and will be removed in v0.46. "
+        "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
         "To retrieve the execution pipeline of a QNode, please consider using "
         "'pennylane.workflow.get_compile_pipeline'.",
         PennyLaneDeprecationWarning,

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -164,10 +164,12 @@ def construct_batch(
 
             from pennylane.workflow import construct_batch
 
+            dev = qml.device('default.qubit')
+
             @qml.transforms.undo_swaps
             @qml.transforms.merge_rotations
             @qml.transforms.cancel_inverses
-            @qml.qnode(qml.device('default.qubit'), diff_method="parameter-shift", gradient_kwargs = {"shifts": np.pi/4})
+            @qml.qnode(dev, diff_method="parameter-shift", gradient_kwargs = {"shifts": np.pi/4})
             def circuit(x):
                 qml.RandomLayers(qml.numpy.array([[1.0, 2.0]]), wires=(0,1))
                 qml.RX(x, wires=0)

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -288,17 +288,17 @@ def get_transform_program(qnode, level="device", gradient_fn="unset"):
         )
 
     """
-    # pylint: disable=import-outside-toplevel
-
-    # NOTE: Remove once deprecation cycle is complete
-    from pennylane.noise.add_noise import _get_transform_program
-
     warnings.warn(
         "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
         "To retrieve the execution pipeline of a QNode, please consider using "
         "'pennylane.workflow.get_compile_pipeline'.",
         PennyLaneDeprecationWarning,
     )
+    # pylint: disable=import-outside-toplevel
+
+    # NOTE: Remove once deprecation cycle is complete
+    from pennylane.noise.add_noise import _get_transform_program
+
     return _get_transform_program(qnode, level, gradient_fn)
 
 

--- a/pennylane/workflow/construct_tape.py
+++ b/pennylane/workflow/construct_tape.py
@@ -32,7 +32,7 @@ def construct_tape(qnode: QNode, level: str | int | slice = "user") -> Callable[
     Args:
         qnode (QNode): the qnode we want to get the tapes and post-processing for.
         level (str, int, slice): An indication of what transforms to apply before
-            drawing. Check :func:`~.workflow.get_transform_program` for more
+            drawing. Check :func:`~.workflow.get_compile_pipeline` for more
             information on the allowed values and usage details of this argument.
 
     Returns:
@@ -41,7 +41,7 @@ def construct_tape(qnode: QNode, level: str | int | slice = "user") -> Callable[
     Raises:
         ValueError: if the ``level`` argument corresponds to more than one tape.
 
-    .. seealso:: :func:`pennylane.workflow.get_transform_program` to inspect the contents of the transform program for a specified level.
+    .. seealso:: :func:`pennylane.workflow.get_compile_pipeline` to inspect the contents of the transform program for a specified level.
 
     **Example**
 

--- a/pennylane/workflow/marker.py
+++ b/pennylane/workflow/marker.py
@@ -25,14 +25,12 @@ def marker(obj: QNode | None = None, label: str | None = None) -> QNode | Callab
         obj (QNode | None): The ``QNode`` containing the compilation pipeline to be marked.
             If ``None``, this function acts as a decorator for a ``QNode``.
         label (str | None): A descriptive label for this specific stage in the compilation process.
-            Check :func:`~.workflow.get_compile_pipeline` for more information on the allowed values and usage details of this argument.
-
 
     Returns:
         QNode | Callable: The marked ``QNode`` or a decorator function if ``obj`` is not provided.
 
     Raises:
-        ValueError: If the 'label' argument is not provided.
+        ValueError: If the 'label' argument is not provided or the 'label' is a protected level.
 
     .. seealso::
 

--- a/pennylane/workflow/marker.py
+++ b/pennylane/workflow/marker.py
@@ -25,7 +25,7 @@ def marker(obj: QNode | None = None, label: str | None = None) -> QNode | Callab
         obj (QNode | None): The ``QNode`` containing the compilation pipeline to be marked.
             If ``None``, this function acts as a decorator for a ``QNode``.
         label (str | None): A descriptive label for this specific stage in the compilation process.
-            Check :func:`~.workflow.get_transform_program` for more information on the allowed values and usage details of this argument.
+            Check :func:`~.workflow.get_compile_pipeline` for more information on the allowed values and usage details of this argument.
 
 
     Returns:

--- a/tests/noise/test_add_noise.py
+++ b/tests/noise/test_add_noise.py
@@ -646,3 +646,17 @@ class TestGetTransformProgramHelper:
 
         full_program = _get_transform_program(circuit)
         assert dev_program == full_program
+
+    def test_marker_integration(self):
+        """Tests marker integration."""
+
+        @qml.marker("after-merge-rotations")
+        @qml.transforms.merge_rotations
+        @qml.qnode(qml.device("null.qubit"))
+        def c():
+            return qml.state()
+
+        program = _get_transform_program(c, level="after-merge-rotations")
+        expected_program = 1 * qml.transforms.merge_rotations
+        assert len(program) == 1
+        assert program == expected_program

--- a/tests/noise/test_add_noise.py
+++ b/tests/noise/test_add_noise.py
@@ -17,10 +17,12 @@ Tests for the add_noise transform.
 
 import numpy as np
 import pytest
+from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
-from pennylane.noise.add_noise import add_noise
+from pennylane.noise.add_noise import _get_transform_program, add_noise
 from pennylane.tape import QuantumScript
+from pennylane.transforms.core import BoundTransform, CompilePipeline
 
 # pylint:disable = no-member
 
@@ -428,7 +430,7 @@ class TestAddNoiseLevels:
         noisy_qnode = add_noise(f, noise_model=noise_model, level=level1)
 
         transform_level1 = noisy_qnode.compile_pipeline
-        transform_level2 = qml.workflow.get_transform_program(f, level=level2)
+        transform_level2 = _get_transform_program(f, level=level2)
         transform_level2.add_transform(add_noise, noise_model=noise_model, level=level1)
 
         assert len(transform_level1) == len(transform_level2) + bool(level1 == "user")
@@ -460,9 +462,187 @@ class TestAddNoiseLevels:
 
         noisy_qnode = add_noise(f, noise_model=noise_model)
 
-        transform_level1 = qml.workflow.get_transform_program(f)
-        transform_level2 = qml.workflow.get_transform_program(noisy_qnode)
+        transform_level1 = _get_transform_program(f)
+        transform_level2 = _get_transform_program(noisy_qnode)
 
         assert len(transform_level1) == len(transform_level2) - 1
         assert transform_level2[4].tape_transform == qml.metric_tensor.tape_transform
         assert transform_level2[5].tape_transform == add_noise.tape_transform
+
+
+class TestGetTransformProgramHelper:
+    """Tests the private _get_transform_program helper."""
+
+    def test_bad_string_key(self):
+        """Test a value error is raised if a bad string key is provided."""
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit():
+            return qml.state()
+
+        with pytest.raises(ValueError, match=r"Level bla not found in transform program."):
+            _get_transform_program(circuit, level="bla")
+
+    def test_bad_other_key(self):
+        """Test a value error is raised if a bad, unrecognized key is provided."""
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit():
+            return qml.state()
+
+        with pytest.raises(ValueError, match=r"not recognized."):
+            _get_transform_program(circuit, level=["bah"])
+
+    def test_get_transform_program_diff_method_transform(self):
+        """Tests for the transform program when the diff_method is a transform."""
+
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.transforms.compile(num_passes=2)
+        @qml.transforms.merge_rotations(atol=1e-5)
+        @qml.transforms.cancel_inverses
+        @qml.qnode(dev, diff_method="parameter-shift", gradient_kwargs={"shifts": 2})
+        def circuit():
+            return qml.expval(qml.PauliZ(0))
+
+        expected_p0 = BoundTransform(qml.transforms.cancel_inverses)
+        expected_p1 = BoundTransform(qml.transforms.merge_rotations, kwargs={"atol": 1e-5})
+        expected_p2 = BoundTransform(qml.transforms.compile, kwargs={"num_passes": 2})
+
+        ps_expand_fn = BoundTransform(
+            qml.transform(qml.gradients.param_shift.expand_transform), kwargs={"shifts": 2}
+        )
+
+        p0 = _get_transform_program(circuit, level=0)
+        assert isinstance(p0, CompilePipeline)
+        assert len(p0) == 0
+
+        p0 = _get_transform_program(circuit, level="top")
+        assert isinstance(p0, CompilePipeline)
+        assert len(p0) == 0
+
+        p_grad = _get_transform_program(circuit, level="gradient")
+        assert isinstance(p_grad, CompilePipeline)
+        assert len(p_grad) == 4
+        assert p_grad == CompilePipeline(expected_p0, expected_p1, expected_p2, ps_expand_fn)
+
+        p_dev = _get_transform_program(circuit, level="device")
+        assert isinstance(p_grad, CompilePipeline)
+        p_default = _get_transform_program(circuit)
+        assert p_dev == p_default
+
+        assert len(p_dev) == 10
+        config = qml.devices.ExecutionConfig(
+            interface=getattr(circuit, "interface", None),
+            mcm_config=qml.devices.MCMConfig(mcm_method="deferred"),
+        )
+        assert p_dev == p_grad + dev.preprocess_transforms(config)
+
+        # slicing
+        p_sliced = _get_transform_program(circuit, slice(2, 7, 2))
+        assert len(p_sliced) == 3
+        assert p_sliced[0].tape_transform == qml.compile.tape_transform
+        assert (
+            p_sliced[2].tape_transform
+            == qml.devices.preprocess.device_resolve_dynamic_wires.tape_transform
+        )
+        assert p_sliced[1].tape_transform == qml.defer_measurements.tape_transform
+
+    def test_diff_method_device_gradient(self):
+        """Test that if level="gradient" but the gradient does not have preprocessing, the program is strictly user transforms."""
+
+        @qml.transforms.cancel_inverses
+        @qml.qnode(qml.device("default.qubit"), diff_method="backprop")
+        def circuit():
+            return qml.state()
+
+        prog = _get_transform_program(circuit, level="gradient")
+        assert len(prog) == 1
+        assert qml.transforms.cancel_inverses in prog
+
+    def test_get_transform_program_device_gradient(self):
+        """Test the trnsform program contents when using a device derivative."""
+
+        dev = qml.device("default.qubit")
+
+        @qml.transforms.split_non_commuting
+        @qml.qnode(dev, diff_method="adjoint", device_vjp=False)
+        def circuit(x):
+            qml.RX(x, 0)
+            return qml.expval(qml.PauliZ(0))
+
+        full_prog = _get_transform_program(circuit)
+        assert len(full_prog) == 14
+
+        config = qml.devices.ExecutionConfig(
+            interface=getattr(circuit, "interface", None),
+            gradient_method="adjoint",
+            use_device_jacobian_product=False,
+        )
+        config = dev.setup_execution_config(config)
+        dev_program = dev.preprocess_transforms(config)
+
+        expected = CompilePipeline()
+        expected.add_transform(qml.transforms.split_non_commuting)
+        expected += dev_program
+        assert full_prog == expected
+
+    def test_get_transform_program_legacy_device_interface(self):
+        """Test the contents of the transform program with the legacy device interface."""
+
+        dev = DefaultQubitLegacy(wires=5)
+
+        @qml.transforms.merge_rotations
+        @qml.qnode(dev, diff_method="backprop")
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        program = _get_transform_program(circuit)
+
+        m1 = BoundTransform(qml.transforms.merge_rotations)
+        assert program[:1] == CompilePipeline([m1])
+
+        m2 = BoundTransform(qml.devices.legacy_facade.legacy_device_batch_transform)
+        assert program[1].tape_transform == m2.tape_transform
+        assert program[1].kwargs["device"] == dev
+
+        # a little hard to check the contents of a expand_fn transform
+        # this is the best proxy I can find
+        assert (
+            program[2].tape_transform
+            == qml.devices.legacy_facade.legacy_device_expand_fn.tape_transform
+        )
+
+    def test_get_transform_program_final_transform(self):
+        """Test that gradient preprocessing and device transform occur before a final transform."""
+
+        @qml.metric_tensor
+        @qml.compile
+        @qml.qnode(qml.device("default.qubit"), diff_method="parameter-shift")
+        def circuit():
+            qml.IsingXX(1.234, wires=(0, 1))
+            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(0))
+
+        user_program = _get_transform_program(circuit, level="user")
+        assert len(user_program) == 3
+        assert user_program[0].tape_transform == qml.compile.tape_transform
+        assert user_program[1].tape_transform == qml.metric_tensor.expand_transform
+        assert user_program[2].tape_transform == qml.metric_tensor.tape_transform
+
+        grad_program = _get_transform_program(circuit, level="gradient")
+        assert len(grad_program) == 4
+        assert grad_program[0].tape_transform == qml.compile.tape_transform
+        assert grad_program[1].tape_transform == qml.metric_tensor.expand_transform
+        assert grad_program[2].tape_transform == qml.metric_tensor.tape_transform
+        assert grad_program[3].tape_transform == qml.gradients.param_shift.expand_transform
+
+        dev_program = _get_transform_program(circuit, level="device")
+        config = qml.devices.ExecutionConfig(interface=getattr(circuit, "interface", None))
+        config = qml.device("default.qubit").setup_execution_config(config)
+        assert len(dev_program) == 4 + len(
+            circuit.device.preprocess_transforms(config)
+        )  # currently 8
+
+        full_program = _get_transform_program(circuit)
+        assert dev_program == full_program

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,12 +1401,13 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = qml.device("default.qubit", wires=1)
 
         @qml.set_shots(5)
-        @qml.qnode(dev, cache=True)
+        @qml.qnode(dev, interface="autograd", cache=True)
         def circuit(x):
             qml.RZ(x, wires=0)
             return qml.probs(wires=0)

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,6 +1401,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.xfail(reason="Bug in cache handling with autograd.")
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,7 +1401,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.xfail(reason="Bug in cache handling with autograd.")
+    @pytest.mark.xfail(reason="Bug in cache handling with autograd.", strict=True)
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,7 +1401,6 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = qml.device("default.qubit", wires=1)

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,13 +1401,12 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = qml.device("default.qubit", wires=1)
 
         @qml.set_shots(5)
-        @qml.qnode(dev, interface="autograd", cache=True)
+        @qml.qnode(dev, cache=True)
         def circuit(x):
             qml.RZ(x, wires=0)
             return qml.probs(wires=0)

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,6 +1401,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = qml.device("default.qubit", wires=1)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,7 +1014,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.xfail(reason="Bug in cache handling with autograd.")
+    @pytest.mark.xfail(reason="Bug in cache handling with autograd.", strict=True)
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,6 +1014,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.xfail(reason="Bug in cache handling with autograd.")
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,6 +1014,7 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = DefaultQubitLegacy(wires=1)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,7 +1014,6 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = DefaultQubitLegacy(wires=1)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,12 +1014,13 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
+    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = DefaultQubitLegacy(wires=1)
 
         @qml.set_shots(5)
-        @qml.qnode(dev, cache=True)
+        @qml.qnode(dev, interface="autograd", cache=True)
         def circuit(x):
             qml.RZ(x, wires=0)
             return qml.probs(wires=0)

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,13 +1014,12 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = DefaultQubitLegacy(wires=1)
 
         @qml.set_shots(5)
-        @qml.qnode(dev, interface="autograd", cache=True)
+        @qml.qnode(dev, cache=True)
         def circuit(x):
             qml.RZ(x, wires=0)
             return qml.probs(wires=0)

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Contains tests for the `qml.workflow.get_transform_program` getter and `construct_batch`.
+Contains tests for `construct_batch`.
 
 """
 
-import warnings
 
 import numpy as np
 import pytest
@@ -24,8 +23,7 @@ from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.transforms.core import BoundTransform, CompilePipeline
-from pennylane.workflow import construct_batch, get_transform_program
+from pennylane.workflow import construct_batch
 
 
 class TestMarker:
@@ -97,18 +95,6 @@ class TestMarker:
         assert qml.math.allclose(res, np.cos(0.5))
 
 
-@pytest.fixture
-def ignore_get_transform_program_deprecation():
-    """Fixture to suppress PennyLaneDeprecationWarning for 'get_transform_program' tests."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=PennyLaneDeprecationWarning,
-            message="The 'get_transform_program' function is deprecated",
-        )
-        yield
-
-
 def test_get_transform_program_is_deprecated():
     """Tests that the 'get_transform_program' function is deprecated."""
 
@@ -119,184 +105,7 @@ def test_get_transform_program_is_deprecated():
     with pytest.warns(
         PennyLaneDeprecationWarning, match="The 'get_transform_program' function is deprecated"
     ):
-        get_transform_program(circuit)
-
-
-@pytest.mark.usefixtures("ignore_get_transform_program_deprecation")
-class TestCompilePipelineGetter:
-    def test_bad_string_key(self):
-        """Test a value error is raised if a bad string key is provided."""
-
-        @qml.qnode(qml.device("default.qubit"))
-        def circuit():
-            return qml.state()
-
-        with pytest.raises(ValueError, match=r"Level bla not found in transform program."):
-            get_transform_program(circuit, level="bla")
-
-    def test_bad_other_key(self):
-        """Test a value error is raised if a bad, unrecognized key is provided."""
-
-        @qml.qnode(qml.device("default.qubit"))
-        def circuit():
-            return qml.state()
-
-        with pytest.raises(ValueError, match=r"not recognized."):
-            get_transform_program(circuit, level=["bah"])
-
-    def test_get_transform_program_diff_method_transform(self):
-        """Tests for the transform program when the diff_method is a transform."""
-
-        dev = qml.device("default.qubit", wires=4)
-
-        @qml.transforms.compile(num_passes=2)
-        @qml.transforms.merge_rotations(atol=1e-5)
-        @qml.transforms.cancel_inverses
-        @qml.qnode(dev, diff_method="parameter-shift", gradient_kwargs={"shifts": 2})
-        def circuit():
-            return qml.expval(qml.PauliZ(0))
-
-        expected_p0 = BoundTransform(qml.transforms.cancel_inverses)
-        expected_p1 = BoundTransform(qml.transforms.merge_rotations, kwargs={"atol": 1e-5})
-        expected_p2 = BoundTransform(qml.transforms.compile, kwargs={"num_passes": 2})
-
-        ps_expand_fn = BoundTransform(
-            qml.transform(qml.gradients.param_shift.expand_transform), kwargs={"shifts": 2}
-        )
-
-        p0 = get_transform_program(circuit, level=0)
-        assert isinstance(p0, CompilePipeline)
-        assert len(p0) == 0
-
-        p0 = get_transform_program(circuit, level="top")
-        assert isinstance(p0, CompilePipeline)
-        assert len(p0) == 0
-
-        p_grad = get_transform_program(circuit, level="gradient")
-        assert isinstance(p_grad, CompilePipeline)
-        assert len(p_grad) == 4
-        assert p_grad == CompilePipeline(expected_p0, expected_p1, expected_p2, ps_expand_fn)
-
-        p_dev = get_transform_program(circuit, level="device")
-        assert isinstance(p_grad, CompilePipeline)
-        p_default = get_transform_program(circuit)
-        assert p_dev == p_default
-
-        assert len(p_dev) == 10
-        config = qml.devices.ExecutionConfig(
-            interface=getattr(circuit, "interface", None),
-            mcm_config=qml.devices.MCMConfig(mcm_method="deferred"),
-        )
-        assert p_dev == p_grad + dev.preprocess_transforms(config)
-
-        # slicing
-        p_sliced = get_transform_program(circuit, slice(2, 7, 2))
-        assert len(p_sliced) == 3
-        assert p_sliced[0].tape_transform == qml.compile.tape_transform
-        assert (
-            p_sliced[2].tape_transform
-            == qml.devices.preprocess.device_resolve_dynamic_wires.tape_transform
-        )
-        assert p_sliced[1].tape_transform == qml.defer_measurements.tape_transform
-
-    def test_diff_method_device_gradient(self):
-        """Test that if level="gradient" but the gradient does not have preprocessing, the program is strictly user transforms."""
-
-        @qml.transforms.cancel_inverses
-        @qml.qnode(qml.device("default.qubit"), diff_method="backprop")
-        def circuit():
-            return qml.state()
-
-        prog = get_transform_program(circuit, level="gradient")
-        assert len(prog) == 1
-        assert qml.transforms.cancel_inverses in prog
-
-    def test_get_transform_program_device_gradient(self):
-        """Test the trnsform program contents when using a device derivative."""
-
-        dev = qml.device("default.qubit")
-
-        @qml.transforms.split_non_commuting
-        @qml.qnode(dev, diff_method="adjoint", device_vjp=False)
-        def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
-
-        full_prog = get_transform_program(circuit)
-        assert len(full_prog) == 14
-
-        config = qml.devices.ExecutionConfig(
-            interface=getattr(circuit, "interface", None),
-            gradient_method="adjoint",
-            use_device_jacobian_product=False,
-        )
-        config = dev.setup_execution_config(config)
-        dev_program = dev.preprocess_transforms(config)
-
-        expected = CompilePipeline()
-        expected.add_transform(qml.transforms.split_non_commuting)
-        expected += dev_program
-        assert full_prog == expected
-
-    def test_get_transform_program_legacy_device_interface(self):
-        """Test the contents of the transform program with the legacy device interface."""
-
-        dev = DefaultQubitLegacy(wires=5)
-
-        @qml.transforms.merge_rotations
-        @qml.qnode(dev, diff_method="backprop")
-        def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        program = get_transform_program(circuit)
-
-        m1 = BoundTransform(qml.transforms.merge_rotations)
-        assert program[:1] == CompilePipeline([m1])
-
-        m2 = BoundTransform(qml.devices.legacy_facade.legacy_device_batch_transform)
-        assert program[1].tape_transform == m2.tape_transform
-        assert program[1].kwargs["device"] == dev
-
-        # a little hard to check the contents of a expand_fn transform
-        # this is the best proxy I can find
-        assert (
-            program[2].tape_transform
-            == qml.devices.legacy_facade.legacy_device_expand_fn.tape_transform
-        )
-
-    def test_get_transform_program_final_transform(self):
-        """Test that gradient preprocessing and device transform occur before a final transform."""
-
-        @qml.metric_tensor
-        @qml.compile
-        @qml.qnode(qml.device("default.qubit"), diff_method="parameter-shift")
-        def circuit():
-            qml.IsingXX(1.234, wires=(0, 1))
-            return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliX(0))
-
-        user_program = get_transform_program(circuit, level="user")
-        assert len(user_program) == 3
-        assert user_program[0].tape_transform == qml.compile.tape_transform
-        assert user_program[1].tape_transform == qml.metric_tensor.expand_transform
-        assert user_program[2].tape_transform == qml.metric_tensor.tape_transform
-
-        grad_program = get_transform_program(circuit, level="gradient")
-        assert len(grad_program) == 4
-        assert grad_program[0].tape_transform == qml.compile.tape_transform
-        assert grad_program[1].tape_transform == qml.metric_tensor.expand_transform
-        assert grad_program[2].tape_transform == qml.metric_tensor.tape_transform
-        assert grad_program[3].tape_transform == qml.gradients.param_shift.expand_transform
-
-        dev_program = get_transform_program(circuit, level="device")
-        config = qml.devices.ExecutionConfig(interface=getattr(circuit, "interface", None))
-        config = qml.device("default.qubit").setup_execution_config(config)
-        assert len(dev_program) == 4 + len(
-            circuit.device.preprocess_transforms(config)
-        )  # currently 8
-
-        full_program = get_transform_program(circuit)
-        assert dev_program == full_program
+        qml.workflow.get_transform_program(circuit)
 
 
 @qml.transforms.merge_rotations

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -124,6 +124,17 @@ def circuit1(weights, order):
 class TestConstructBatch:
     """Tests for the construct_batch function."""
 
+    @pytest.mark.parametrize("level", [[], 0.5, True])
+    def test_level_not_recognized(self, level):
+        """Tests when the level is not recognized."""
+
+        @qml.qnode(qml.device("null.qubit"))
+        def c():
+            return qml.state()
+
+        with pytest.raises(ValueError, match=r"level .* not recognized"):
+            construct_batch(c, level=level)()
+
     def test_level_zero(self):
         """Test that level zero is purely the queued circuit."""
 

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -16,11 +16,14 @@ Contains tests for the `qml.workflow.get_transform_program` getter and `construc
 
 """
 
+import warnings
+
 import numpy as np
 import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qml
+from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.transforms.core import BoundTransform, CompilePipeline
 from pennylane.workflow import construct_batch, get_transform_program
 
@@ -94,6 +97,32 @@ class TestMarker:
         assert qml.math.allclose(res, np.cos(0.5))
 
 
+@pytest.fixture
+def ignore_get_transform_program_deprecation():
+    """Fixture to suppress PennyLaneDeprecationWarning for 'get_transform_program' tests."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=PennyLaneDeprecationWarning,
+            message="The 'get_transform_program' function is deprecated",
+        )
+        yield
+
+
+def test_get_transform_program_is_deprecated():
+    """Tests that the 'get_transform_program' function is deprecated."""
+
+    @qml.qnode(qml.device("default.qubit"))
+    def circuit():
+        return qml.state()
+
+    with pytest.warns(
+        PennyLaneDeprecationWarning, match="The 'get_transform_program' function is deprecated"
+    ):
+        get_transform_program(circuit)
+
+
+@pytest.mark.usefixtures("ignore_get_transform_program_deprecation")
 class TestCompilePipelineGetter:
     def test_bad_string_key(self):
         """Test a value error is raised if a bad string key is provided."""

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -105,7 +105,7 @@ def test_get_transform_program_is_deprecated():
     with pytest.warns(
         PennyLaneDeprecationWarning, match="The 'get_transform_program' function is deprecated"
     ):
-        qml.workflow.get_transform_program(circuit)
+        _ = qml.workflow.get_transform_program(circuit)
 
 
 @qml.transforms.merge_rotations


### PR DESCRIPTION
Now that we have the new and improved `get_compile_pipeline`, we can deprecated `get_transform_program`. 

Note that this is used by `add_noise` and cannot be replaced with `get_compile_pipeline` so we decided to move it to a private helper instead.

📖 : https://xanaduai-pennylane--9077.com.readthedocs.build/en/9077/code/api/pennylane.workflow.get_transform_program.html

[sc-105432]
[sc-108742]