### PR TITLE
feat: add `drawer.label` and `fourier.mark` functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,11 +4,11 @@
 
 * Added the function :func:`~.drawer.label` to attach custom labels to operator instances
   for circuit drawing.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)  
+  [(#9078)](https://github.com/PennyLaneAI/pennylane/pull/9078)  
 
 * Added the function :func:`~.fourier.mark` to mark an operator as an input-encoding gate
   for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`.
-  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)  
+  [(#9078)](https://github.com/PennyLaneAI/pennylane/pull/9078)  
 
 * Prepared new state preparation template :class:`~.SumOfSlatersStatePrep`.
   It prepares sparse states using a smaller dense state preparation, :class:`~.QROM`\ s and 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,14 @@
 
 <h3>New features since last release</h3>
 
+* Added the function :func:`~.drawer.label` to attach custom labels to operator instances
+  for circuit drawing.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)  
+
+* Added the function :func:`~.fourier.mark` to mark an operator as an input-encoding gate
+  for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`.
+  [(#)](https://github.com/PennyLaneAI/pennylane/pull/)  
+
 * Prepared new state preparation template :class:`~.SumOfSlatersStatePrep`.
   It prepares sparse states using a smaller dense state preparation, :class:`~.QROM`\ s and 
   reversible bit encodings. For now, only classical preprocessing required to implement the

--- a/pennylane/drawer/__init__.py
+++ b/pennylane/drawer/__init__.py
@@ -21,6 +21,7 @@ This module provides the circuit drawing functionality used to display circuits 
 """
 
 from .draw import draw, draw_mpl
+from .label import label
 from .mpldrawer import MPLDrawer
 from .style import available_styles, use_style
 from .tape_mpl import tape_mpl

--- a/pennylane/drawer/label.py
+++ b/pennylane/drawer/label.py
@@ -1,0 +1,161 @@
+# Copyright 2018-2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Contains the 'label' function for customizing operator labels.
+"""
+# pylint: disable=unused-argument
+
+from pennylane.decomposition import add_decomps, register_resources, resource_rep
+from pennylane.operation import Operator
+from pennylane.ops.functions.equal import (
+    BASE_OPERATION_MISMATCH_ERROR_MESSAGE,
+    _equal,
+    _equal_dispatch,
+)
+from pennylane.ops.op_math import SymbolicOp
+from pennylane.queuing import apply
+
+
+class LabelledOp(SymbolicOp):
+    """Creates a labelled operator.
+
+    Args:
+        base (Operator): The operator you wish to label.
+        custom_label (str): The custom label to label your operator with.
+
+    **Example:**
+
+    >>> op = qml.RX(1.23456, wires=0)
+    >>> labelled_op = LabelledOp(op, "my-rx")
+    >>> print(labelled_op.hyperparameters["custom_label"])
+    my-rx
+    >>> labelled_op.label()
+    'RX("my-rx")'
+    >>> labelled_op.label(decimals=2)
+    'RX\\n(1.23, "my-rx")'
+
+    """
+
+    resource_keys = {"base_class", "base_params"}
+
+    @property
+    def resource_params(self) -> dict:
+        return {"base_class": type(self.base), "base_params": self.base.resource_params}
+
+    def _flatten(self):
+        hyperparameters = (("custom_label", self.hyperparameters["custom_label"]),)
+        return (self.base,), hyperparameters
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        hyperparams_dict = dict(metadata)
+        return cls(data[0], **hyperparams_dict)
+
+    def __init__(self, base: Operator, custom_label: str):
+        super().__init__(base)
+        self.hyperparameters["custom_label"] = custom_label
+
+    def __repr__(self):
+        return f'LabelledOp({self.base}, custom_label="{self.custom_label}")'
+
+    @property
+    def custom_label(self) -> str:
+        """Retrieve the custom label set on this operator."""
+        return self.hyperparameters["custom_label"]
+
+    def label(self, decimals=None, base_label=None, cache=None) -> str:
+        """Retrieve the label for this operator.
+
+        Args:
+            decimals=None (int): If ``None``, no parameters are included. Else,
+                specifies how to round the parameters.
+            base_label=None (str): overwrite the non-parameter component of the label
+            cache=None (dict): dictionary that carries information between label calls
+                in the same drawing
+
+        Returns:
+            str: label to use in drawings
+        """
+        base_label = self.base.label(decimals, base_label, cache)
+        custom_label = self.hyperparameters["custom_label"]
+
+        # If base label already has parameters, e.g., "RX(0.5)"
+        if base_label.endswith(")"):
+            return f'{base_label[:-1]}, "{custom_label}")'
+
+        # If base label is a simple label, e.g., "X"
+        return f'{base_label}("{custom_label}")'
+
+    def matrix(self, wire_order=None):
+        return self.base.matrix(wire_order=wire_order)
+
+
+def _resources(base_class, base_params):
+    return {resource_rep(base_class, **base_params): 1}
+
+
+@register_resources(_resources)
+def _custom_label_decomp(*params, wires, base, **_):
+    apply(base)
+
+
+add_decomps(LabelledOp, _custom_label_decomp)
+
+
+@_equal_dispatch.register
+def _equal_labelled_op(op1: LabelledOp, op2: LabelledOp, **kwargs):
+    if op1.custom_label != op2.custom_label:
+        return f"op1 and op2 have different custom labels. Got {op1.custom_label} and {op2.custom_label} respectively."
+
+    base_equal_check = _equal(op1.base, op2.base, **kwargs)
+    if isinstance(base_equal_check, str):
+        return BASE_OPERATION_MISMATCH_ERROR_MESSAGE + base_equal_check
+
+    return True
+
+
+def label(op: Operator, new_label: str) -> LabelledOp:
+    """Labels an operator with a custom label.
+
+    .. warning::
+
+        This function is not currently supported inside :func:`~.qjit`-compiled circuits.
+
+    Args:
+        op (Operator): The operator you wish to mark.
+        new_label (str): The label you wish to give to the operator.
+
+    **Example:**
+
+    >>> op = qml.X(0)
+    >>> labelled_op = qml.drawer.label(op, "my-x")
+    >>> print(labelled_op.custom_label)
+    my-x
+
+    The custom label will be displayed in the circuit diagram when using :func:`~.draw`
+
+    .. code-block:: python
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit():
+            qml.drawer.label(qml.H(0), "my-h")
+            qml.CNOT([0,1])
+            return qml.probs()
+
+    >>> print(qml.draw(circuit)())
+    0: ──H("my-h")─╭●─┤  Probs
+    1: ────────────╰X─┤  Probs
+
+    """
+    return LabelledOp(op, new_label)

--- a/pennylane/fourier/__init__.py
+++ b/pennylane/fourier/__init__.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 """This module contains functions to analyze the Fourier representation
 of quantum circuits."""
-import warnings
-
 from .circuit_spectrum import circuit_spectrum
+from .mark import mark
 from .coefficients import coefficients
 from .qnode_spectrum import qnode_spectrum
 from .reconstruct import reconstruct

--- a/pennylane/fourier/mark.py
+++ b/pennylane/fourier/mark.py
@@ -1,0 +1,142 @@
+# Copyright 2018-2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Contains the 'label' function for customizing operator labels.
+"""
+# pylint: disable=unused-argument
+
+from pennylane.decomposition import add_decomps, register_resources, resource_rep
+from pennylane.operation import Operator
+from pennylane.ops.functions.equal import (
+    BASE_OPERATION_MISMATCH_ERROR_MESSAGE,
+    _equal,
+    _equal_dispatch,
+)
+from pennylane.ops.op_math import SymbolicOp
+from pennylane.queuing import apply
+
+
+class MarkedOp(SymbolicOp):
+    """Create a marked operator.
+
+    Args:
+        base (Operator): The operator you wish to mark.
+        marker (str): The custom marker to give to your operator.
+
+    **Example:**
+
+    >>> op = qml.RX(1.23456, wires=0)
+    >>> marked_op = MarkedOp(op, "my-rx")
+    >>> print(marked_op.marker)
+    my-rx
+
+    """
+
+    def _flatten(self):
+        hyperparameters = (("marker", self.hyperparameters["marker"]),)
+        return (self.base,), hyperparameters
+
+    @classmethod
+    def _unflatten(cls, data, metadata):
+        hyperparams_dict = dict(metadata)
+        return cls(data[0], **hyperparams_dict)
+
+    resource_keys = {"base_class", "base_params"}
+
+    def __init__(self, base: Operator, marker: str):
+        super().__init__(base)
+        self.hyperparameters["marker"] = marker
+
+    def __repr__(self):
+        return f'MarkedOp({self.base}, marker="{self.marker}")'
+
+    @property
+    def resource_params(self) -> dict:
+        return {"base_class": type(self.base), "base_params": self.base.resource_params}
+
+    # pylint: disable=arguments-renamed, invalid-overridden-method
+    @property
+    def has_generator(self) -> bool:
+        return self.base.has_generator
+
+    def generator(self):
+        return self.base.generator()
+
+    @property
+    def marker(self) -> str:
+        """Retrieve the marker set on this operator."""
+        return self.hyperparameters["marker"]
+
+    def label(self, decimals=None, base_label=None, cache=None):
+        base_label = self.base.label(decimals, base_label, cache)
+        marker = self.hyperparameters["marker"]
+
+        # If base label already has parameters, e.g., "RX(0.5)"
+        if base_label.endswith(")"):
+            return f'{base_label[:-1]}, "{marker}")'
+
+        # If base label is a simple label, e.g., "X"
+        return f'{base_label}("{marker}")'
+
+    def matrix(self, wire_order=None):
+        return self.base.matrix(wire_order=wire_order)
+
+
+def _resources(base_class, base_params):
+    return {resource_rep(base_class, **base_params): 1}
+
+
+@register_resources(_resources)
+def _custom_marked_decomp(*params, wires, base, **_):
+    apply(base)
+
+
+add_decomps(MarkedOp, _custom_marked_decomp)
+
+
+@_equal_dispatch.register
+def _equal_marked_op(op1: MarkedOp, op2: MarkedOp, **kwargs):
+    if op1.marker != op2.marker:
+        return (
+            f"op1 and op2 have different markers. Got {op1.marker} and {op2.marker} respectively."
+        )
+
+    base_equal_check = _equal(op1.base, op2.base, **kwargs)
+    if isinstance(base_equal_check, str):
+        return BASE_OPERATION_MISMATCH_ERROR_MESSAGE + base_equal_check
+
+    return True
+
+
+def mark(op: Operator, marker: str) -> MarkedOp:
+    """Mark an operator with a custom tag.
+
+    .. warning::
+
+        This function is not currently supported inside :func:`~.qjit`-compiled circuits.
+
+    Args:
+        op (Operator): The operator you wish to mark.
+        marker (str): The marker to give to the operator.
+
+    **Example:**
+
+    >>> op = qml.X(0)
+    >>> marked_op = mark(op, "my-x")
+    >>> print(marked_op.marker)
+    my-x
+
+    .. seealso:: :func:`~.fourier.circuit_spectrum`
+    """
+    return MarkedOp(op, marker)

--- a/tests/drawer/test_label.py
+++ b/tests/drawer/test_label.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the 'label' functionality.
+"""
+
+
+import pennylane as qml
+from pennylane.drawer.label import LabelledOp, label
+
+
+class TestLabelledOp:
+    """Tests for the 'LabelledOp' operator."""
+
+    # pylint:disable=protected-access
+    def test_flatten_unflatten(self):
+        """Tests the unflatten and flatten methods."""
+
+        op = LabelledOp(qml.X(0), custom_label="my-x")
+        data, metadata = op._flatten()
+        assert data[0] == qml.X(0)
+        assert metadata[0] == ("custom_label", "my-x")
+
+        unflattened_op = LabelledOp._unflatten(data, metadata)
+        assert unflattened_op == op
+
+    def test_repr(self):
+        """Tests the 'repr'."""
+
+        op = LabelledOp(qml.X(0), custom_label="my-x")
+        assert repr(op) == 'LabelledOp(X(0), custom_label="my-x")'
+
+    def test_label(self):
+        """Tests the 'label' method."""
+
+        op = LabelledOp(qml.X(0), custom_label="my-x")
+        assert op.label() == 'X("my-x")'
+
+        op = LabelledOp(qml.RX(1.2345, wires=0), custom_label="my-x")
+        assert op.label() == 'RX("my-x")'
+        assert op.label(decimals=2) == 'RX\n(1.23, "my-x")'
+
+    def test_custom_label_property(self):
+        """Tests the 'custom_label' property."""
+
+        op = LabelledOp(qml.X(0), custom_label="my-x")
+        assert hasattr(op, "custom_label")
+        assert op.custom_label == "my-x"
+
+
+def test_label():
+    """Tests the label function."""
+
+    op = qml.X(0)
+    labelled_op = label(op, new_label="my-x")
+    assert isinstance(labelled_op, LabelledOp)
+    assert hasattr(labelled_op, "custom_label")
+    assert labelled_op.custom_label == "my-x"

--- a/tests/fourier/test_mark.py
+++ b/tests/fourier/test_mark.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the 'mark' functionality.
+"""
+
+
+import pennylane as qml
+from pennylane.fourier.mark import MarkedOp, mark
+
+
+class TestMarkedOp:
+    """Tests for the 'MarkedOp' operator."""
+
+    # pylint:disable=protected-access
+    def test_flatten_unflatten(self):
+        """Tests the unflatten and flatten methods."""
+
+        op = MarkedOp(qml.X(0), marker="my-x")
+        data, metadata = op._flatten()
+        assert data[0] == qml.X(0)
+        assert metadata[0] == ("marker", "my-x")
+
+        unflattened_op = MarkedOp._unflatten(data, metadata)
+        assert unflattened_op == op
+
+    def test_repr(self):
+        """Tests the 'repr'."""
+
+        op = MarkedOp(qml.X(0), marker="my-x")
+        assert repr(op) == 'MarkedOp(X(0), marker="my-x")'
+
+    def test_label(self):
+        """Tests the 'label' method."""
+
+        op = MarkedOp(qml.X(0), marker="my-x")
+        assert op.label() == 'X("my-x")'
+
+        op = MarkedOp(qml.RX(1.2345, wires=0), marker="my-x")
+        assert op.label() == 'RX("my-x")'
+        assert op.label(decimals=2) == 'RX\n(1.23, "my-x")'
+
+    def test_marker_property(self):
+        """Tests the 'custom_label' property."""
+
+        op = MarkedOp(qml.X(0), marker="my-x")
+        assert hasattr(op, "marker")
+        assert op.marker == "my-x"
+
+
+def test_mark():
+    """Tests for the 'mark' function."""
+
+    op = qml.X(0)
+    marked_op = mark(op, marker="my-x")
+    assert isinstance(marked_op, MarkedOp)
+    assert hasattr(marked_op, "marker")
+    assert marked_op.marker == "my-x"

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -23,7 +23,9 @@ import numpy as np
 import pytest
 
 import pennylane as qml
+from pennylane.drawer.label import LabelledOp
 from pennylane.exceptions import DeviceError
+from pennylane.fourier.mark import MarkedOp
 from pennylane.operation import Channel, Operation, Operator, StatePrepBase
 from pennylane.ops.op_math import ChangeOpBasis
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
@@ -39,6 +41,8 @@ def _trotterize_qfunc_dummy(time, theta, phi, wires, flip=False):
 
 
 _INSTANCES_TO_TEST = [
+    (LabelledOp(qml.X(0), "my-x"), {}),
+    (MarkedOp(qml.X(0), "my-x"), {}),
     (qml.ops.MidMeasure(wires=0), {"skip_capture": True}),
     (qml.ops.PauliMeasure("X", wires=0), {"skip_capture": True}),
     (ChangeOpBasis(qml.T(0), qml.PauliZ(0)), {}),
@@ -169,6 +173,8 @@ These operators need to break PL conventions, and each one's reason is specified
 
 
 _ABSTRACT_OR_META_TYPES = {
+    MarkedOp,
+    LabelledOp,
     Adjoint,
     AdjointOperation,
     Operator,

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -28,6 +28,8 @@ import pytest
 
 import pennylane as qml
 from pennylane import numpy as npp
+from pennylane.drawer.label import LabelledOp
+from pennylane.fourier.mark import MarkedOp
 from pennylane.measurements import ExpectationMP
 from pennylane.measurements.probs import ProbabilityMP
 from pennylane.operation import Operator
@@ -3225,3 +3227,35 @@ class TestCompareSubroutines:
         op4 = qml.tape.make_qscript(f)(qml.numpy.array(0.5), 0)[0]
         assert not qml.equal(op3, op4)
         assert qml.equal(op3, op4, check_trainability=False)
+
+    @pytest.mark.parametrize("base", PARAMETRIZED_OPERATIONS)
+    def test_labelled_op_comparison(self, base):
+        """Test that equal compares two objects of the LabelledOp class"""
+        op1 = LabelledOp(base, "my-base")
+        op2 = LabelledOp(base, "my-base")
+        op3 = LabelledOp(qml.PauliX(15), "my-base")
+        op4 = LabelledOp(base, "blah")
+
+        assert qml.equal(op1, op2) is True
+        assert qml.equal(op1, op3) is False
+        with pytest.raises(AssertionError, match=BASE_OPERATION_MISMATCH_ERROR_MESSAGE):
+            assert_equal(op1, op3)
+        assert qml.equal(op1, op4) is False
+        with pytest.raises(AssertionError, match="op1 and op2 have different custom labels"):
+            assert_equal(op1, op4)
+
+    @pytest.mark.parametrize("base", PARAMETRIZED_OPERATIONS)
+    def test_marked_op_comparison(self, base):
+        """Test that equal compares two objects of the MarkedOp class"""
+        op1 = MarkedOp(base, "my-base")
+        op2 = MarkedOp(base, "my-base")
+        op3 = MarkedOp(qml.PauliX(15), "my-base")
+        op4 = MarkedOp(base, "blah")
+
+        assert qml.equal(op1, op2) is True
+        assert qml.equal(op1, op3) is False
+        with pytest.raises(AssertionError, match=BASE_OPERATION_MISMATCH_ERROR_MESSAGE):
+            assert_equal(op1, op3)
+        assert qml.equal(op1, op4) is False
+        with pytest.raises(AssertionError, match="op1 and op2 have different markers"):
+            assert_equal(op1, op4)


### PR DESCRIPTION
> :mega: :mega: Note to reviewers: This PR is heavily inspired from https://github.com/PennyLaneAI/pennylane/pull/9027 😄 

> This PR is a copy of https://github.com/PennyLaneAI/pennylane/pull/9051 but targets master rather than the base deprecation branch.

### Context

This PR is a companion to https://github.com/PennyLaneAI/pennylane/pull/8951 (the core `id` deprecation). This PR acts to **first** provide alternatives in `master` to the two user-facing features that `id` supported:

1. *Custom labels on circuits*: For example, `qml.RX(0.5, 0, id="my-rx")` would render with the label when drawing your circuit. Again, this feature isn't even fully fleshed out and fails for multi-wire gates.
2. *Fourier Spectrum Tagging*: The `id` property was used by some fourier module utilities to tag encoding gates.

Both use cases are now handled by dedicated functions that live in their respective modules. 

### Description of changes

#### 1. qml.drawer.label()

New file: `pennylane/drawer/label.py`
Render: https://xanaduai-pennylane--9078.com.readthedocs.build/en/9051/code/api/pennylane.drawer.label.html

- Adds `LabelledOp(SymbolicOp)` and `label(op, new_label)`
- The custom label is rendered in circuit drawings via an overridden `.label()` method

#### 1. qml.fourier.mark()

New file: `pennylane/fourier/mark.py`
Render: https://xanaduai-pennylane--9078.com.readthedocs.build/en/9051/code/api/pennylane.fourier.mark.html

- Adds `MarkedOp(SymbolicOp)` and `mark(op, marker)`
- Adds a `marker` property that can be picked up the `fourier` module

### :warning: Limitations ⚠️ 

Neither of these functions are currently supported inside `qjit`-compiled circuits.

For `mark` that's fine, things in the `fourier` module were already not supported.

For `label`, we are technically introducing a breaking change as setting `id` didn't prevent us from `qjit`ing the circuit.

[sc-111990]