### PR TITLE
fix: Jacobian-level caching with autograd ML execution

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -587,15 +587,13 @@
 
 <h3>Bug fixes 🐛</h3>
 
-<<<<<<< fix-cache-bug
 * Jacobian-level caching is now unconditionally enabled for `autograd` interface,
   preventing redundant derivative tape executions during the backward pass.
   [(#9081)](https://github.com/PennyLaneAI/pennylane/pull/9081)
-=======
+
 * Fixed a bug where `qml.transforms.transpile` would fail when `qml.GlobalPhase` gates
   were present in a circuit.
   [(#9041)](https://github.com/PennyLaneAI/pennylane/pull/9041)
->>>>>>> master
 
 * Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents
   of an operator product via the dunder method ``__matmul__``. 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -538,6 +538,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Jacobian-level caching is now unconditionally enabled for `autograd` interface,
+  preventing redundant derivative tape executions during the backward pass.
+  [(#9081)](https://github.com/PennyLaneAI/pennylane/pull/9081)
+
 * Fixed a bug where :class:`~.ops.LinearCombination` did not correctly de-queue the constituents
   of an operator product via the dunder method ``__matmul__``. 
   [(#9029)](https://github.com/PennyLaneAI/pennylane/pull/9029)

--- a/pennylane/workflow/_setup_transform_program.py
+++ b/pennylane/workflow/_setup_transform_program.py
@@ -93,7 +93,7 @@ def _setup_transform_program(
 
     # NOTE: For the AUTOGRAD interface, tape-level caching should be skipped
     # because AUTOGRAD uses it's own caching which caches the entire Jacobian
-    # rather than re-executing individual tapes.
+    # rather than re-executing individual tapes (see run.py).
     # Adding _cache_transform here would result in stale executions when using finite shots.
     if cache is not None and resolved_execution_config.interface is not Interface.AUTOGRAD:
         inner_transform_program.add_transform(_cache_transform, cache=cache)

--- a/pennylane/workflow/_setup_transform_program.py
+++ b/pennylane/workflow/_setup_transform_program.py
@@ -90,7 +90,12 @@ def _setup_transform_program(
     )
     if not interface_data_supported:
         inner_transform_program.add_transform(convert_to_numpy_parameters)
-    if cache is not None:
+
+    # NOTE: For the AUTOGRAD interface, tape-level caching should be skipped
+    # because AUTOGRAD uses it's own caching which caches the entire Jacobian
+    # rather than re-executing individual tapes.
+    # Adding _cache_transform here would result in stale executions when using finite shots.
+    if cache is not None and resolved_execution_config.interface is not Interface.AUTOGRAD:
         inner_transform_program.add_transform(_cache_transform, cache=cache)
 
     return outer_transform_program, inner_transform_program

--- a/pennylane/workflow/_setup_transform_program.py
+++ b/pennylane/workflow/_setup_transform_program.py
@@ -91,11 +91,7 @@ def _setup_transform_program(
     if not interface_data_supported:
         inner_transform_program.add_transform(convert_to_numpy_parameters)
 
-    # NOTE: For the AUTOGRAD interface, tape-level caching should be skipped
-    # because AUTOGRAD uses it's own caching which caches the entire Jacobian
-    # rather than re-executing individual tapes (see run.py).
-    # Adding _cache_transform here would result in stale executions when using finite shots.
-    if cache is not None and resolved_execution_config.interface is not Interface.AUTOGRAD:
+    if cache is not None:
         inner_transform_program.add_transform(_cache_transform, cache=cache)
 
     return outer_transform_program, inner_transform_program

--- a/pennylane/workflow/_setup_transform_program.py
+++ b/pennylane/workflow/_setup_transform_program.py
@@ -90,7 +90,6 @@ def _setup_transform_program(
     )
     if not interface_data_supported:
         inner_transform_program.add_transform(convert_to_numpy_parameters)
-
     if cache is not None:
         inner_transform_program.add_transform(_cache_transform, cache=cache)
 

--- a/pennylane/workflow/run.py
+++ b/pennylane/workflow/run.py
@@ -25,7 +25,7 @@ import pennylane as qml
 from pennylane import math
 from pennylane.exceptions import QuantumFunctionError
 from pennylane.math import Interface
-from pennylane.workflow import _cache_transform
+from pennylane.workflow._cache_transform import _cache_transform
 
 from .jacobian_products import (
     DeviceDerivatives,

--- a/pennylane/workflow/run.py
+++ b/pennylane/workflow/run.py
@@ -14,6 +14,7 @@
 """
 This module contains a developer focused execution function for internal executions
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -25,7 +26,6 @@ import pennylane as qml
 from pennylane import math
 from pennylane.exceptions import QuantumFunctionError
 from pennylane.math import Interface
-from pennylane.workflow._cache_transform import _cache_transform
 
 from .jacobian_products import (
     DeviceDerivatives,
@@ -72,7 +72,6 @@ def _construct_tf_autograph_pipeline(
     execute_fn = inner_execute_with_empty_jac
 
     if config.use_device_gradient:
-
         if config.grad_on_execution:
 
             def wrap_execute_and_compute_derivatives(internal_tapes):
@@ -132,7 +131,6 @@ def _construct_ml_execution_pipeline(
         ValueError: If gradients are computed on execution (`grad_on_execution=True`).
     """
     inner_execute = _make_inner_execute(device, inner_transform_program, config)
-    cache = _cache_transform in inner_transform_program
 
     execute_fn = inner_execute
 
@@ -153,7 +151,7 @@ def _construct_ml_execution_pipeline(
     if config.grad_on_execution is True:
         raise ValueError("Gradient transforms cannot be used with grad_on_execution=True")
 
-    cache_full_jacobian = (config.interface == Interface.AUTOGRAD) and not cache
+    cache_full_jacobian = config.interface == Interface.AUTOGRAD
     jpc = TransformJacobianProducts(
         execute_fn,
         config.gradient_method,
@@ -302,7 +300,6 @@ def run(
     if (
         config.interface == Interface.TF_AUTOGRAPH
     ):  # pragma: no cover (TensorFlow tests were disabled during deprecation)
-
         execute_fn, diff_method = _construct_tf_autograph_pipeline(
             config, device, inner_transform_program
         )

--- a/pennylane/workflow/run.py
+++ b/pennylane/workflow/run.py
@@ -151,12 +151,11 @@ def _construct_ml_execution_pipeline(
     if config.grad_on_execution is True:
         raise ValueError("Gradient transforms cannot be used with grad_on_execution=True")
 
-    cache_full_jacobian = config.interface == Interface.AUTOGRAD
     jpc = TransformJacobianProducts(
         execute_fn,
         config.gradient_method,
         config.gradient_keyword_arguments,
-        cache_full_jacobian,
+        cache_full_jacobian=config.interface == Interface.AUTOGRAD,
     )
     for i in range(1, config.derivative_order):
         differentiable = i > 1

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1401,7 +1401,6 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.xfail(reason="Bug in cache handling with autograd.", strict=True)
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1014,7 +1014,6 @@ class TestShots:
             circuit(0.3)
             circuit(0.3)
 
-    @pytest.mark.xfail(reason="Bug in cache handling with autograd.", strict=True)
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""


### PR DESCRIPTION
#### Context

We have two caching mechanisms:

1. Tape-level caching (`_cache_transform`)
2. Jacobian-level caching (`cache_full_jacobian`)

These two mechanisms are coupled in `run.py` with,
```
cache = _cache_transform in inner_transform_program
cache_full_jacobian = (config.interface == Interface.AUTOGRAD) and not cache
```

#### The 🐛

On master, `_cache_transform` in `inner_transform_program` was always returning `False`, even when `_cache_transform` was present in the pipeline. 

This is because the way `workflow/__init__.py` is set-up, `_cache_transform` in `run.py` is imported as a module rather then the transform.

This caused `cache_full_jacobian` to accidentally always be `True` for `autograd` (which just so happens to be the correct behavior).

#### How it was uncovered

This [PR](https://github.com/PennyLaneAI/pennylane/pull/9077) shuffled the imports in `workflow/__init__.py` (moving `_cache_transform` to the top). 

This fixed the import issue, causing `_cache_transform` in `inner_transform_program` to correctly return `True` for the failing test case (`test_no_warning_internal_cache_reuse` in `test_qnode.py`). 

This in turn set `cache_full_jacobian = False`, causing `autograd` to re-execute derivative tapes through `inner_execute` on every `compute_vjp` call. This caused the `UserWarning` to be raised in a test where it is explicitly ensuring *nothing* gets raised.

#### The fix

Basically, now we *always* `cache_full_jacobian` if we are using `autograd`.

This gives `autograd` both tape-level caching in the forward pass (execution) AND Jacobian-level caching in the backward pass. This matches master's *accidental* behavior, but now intentionally. 😅 

[sc-112069]