### PR TITLE
[QML RENAMING] Update link to demo

### DIFF
--- a/pennylane/kernels/postprocessing.py
+++ b/pennylane/kernels/postprocessing.py
@@ -250,7 +250,7 @@ def mitigate_depolarizing_noise(K, num_wires, method, use_entries=None):
     **Example:**
 
     For an example usage of ``mitigate_depolarizing_noise`` please refer to the
-    `PennyLane demo on the kernel module <https://pennylane.ai/demos/tutorial_kernel_based_training>`_ or `the postprocessing demo for arXiv:2105.02276 <https://github.com/thubregtsen/qhack/blob/master/paper/post_processing_demo.py>`_.
+    `PennyLane demo on the kernel module <https://github.com/PennyLaneAI/demos/tree/master/demonstrations_v2/tutorial_kernel_based_training/demo.py>`_ or `the postprocessing demo for arXiv:2105.02276 <https://github.com/thubregtsen/qhack/blob/master/paper/post_processing_demo.py>`_.
     """
     dim = 2**num_wires
 


### PR DESCRIPTION
This PR updates the link to the kernel based training demo to reflect the name change of the qml repo.