### PR TITLE
Allow to pass `num_work_wires`, `alt_decomps` and `fixed_decomps` to `devices.preprocess.decompose`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -93,10 +93,10 @@
 
 <h3>Improvements 🛠</h3>
 
-* Allow to pass ``alt_decomps`` and ``fixed_decomps`` to the device preprocessing function 
-  :func:`~.devices.preprocess.decompose` , which are then passed through to the 
-  graph-based decomposition system.
-  [(#9___)](https://github.com/PennyLaneAI/pennylane/pull/9___)
+* Allow to pass ``num_work_wires``, ``alt_decomps`` and ``fixed_decomps`` to the device 
+  preprocessing function :func:`~.devices.preprocess.decompose` , which are then passed through 
+  to the graph-based decomposition system.
+  [(#9094)](https://github.com/PennyLaneAI/pennylane/pull/9094)
 
 * When inspecting a circuit with an integer ``level`` argument in `qml.draw` or `qml.specs`,
   markers in the compilation pipeline are no longer counted towards the level, making inspection more intuitive. 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -93,6 +93,11 @@
 
 <h3>Improvements 🛠</h3>
 
+* Allow to pass ``alt_decomps`` and ``fixed_decomps`` to the device preprocessing function 
+  :func:`~.devices.preprocess.decompose` , which are then passed through to the 
+  graph-based decomposition system.
+  [(#9___)](https://github.com/PennyLaneAI/pennylane/pull/9___)
+
 * When inspecting a circuit with an integer ``level`` argument in `qml.draw` or `qml.specs`,
   markers in the compilation pipeline are no longer counted towards the level, making inspection more intuitive. 
   Integer levels now exclusively refer to transforms, so `level=1` means "after the first transform" regardless 

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -275,6 +275,7 @@ def decompose(  # pylint: disable = too-many-positional-arguments
     skip_initial_state_prep: bool = True,
     decomposer: Callable[[Operator], Sequence[Operator]] | None = None,
     device_wires: Wires | None = None,
+    num_work_wires: int | None = None,
     target_gates: set | dict | None = None,
     fixed_decomps: dict | None = None,
     alt_decomps: dict | None = None,
@@ -300,10 +301,17 @@ def decompose(  # pylint: disable = too-many-positional-arguments
         decomposer (Callable): an optional callable that takes an operator and implements the
             relevant decomposition. If ``None``, defaults to using a callable returning
             ``op.decomposition()`` for any :class:`~.Operator` .
-        device_wires (Wires): The device wires. If provided along with ``target_gates``, will be
-            used to automatically set up graph decomposition when enabled.
-        target_gates (set): The target gate set for graph decomposition. If provided along with
-            ``device_wires``, will automatically enable graph-based decomposition when available.
+        device_wires (Wires): The device wires. If provided along with ``target_gates`` and
+            graph-based decomposition is enabled, will be used to infer available work wires.
+        num_work_wires (int): Number of work wires to be used if the graph-based decomposition
+            is enabled. If ``device_wires`` are given, they take precedence over ``num_work_wires``
+        target_gates (set or dict): Target gate set to be used if the graph-based decomposition
+            is enabled. See :func:`qml.decompose <pennylane.transforms.decompose>` for more details.
+        fixed_decomps (dict): Fixed decomposition rules to be used if the graph-based decomposition
+            is enabled. See :func:`qml.decompose <pennylane.transforms.decompose>` for more details.
+        alt_decomps (dict): Alternative decomposition rules to be used if the graph-based
+            decomposition is enabled. See :func:`qml.decompose <pennylane.transforms.decompose>`
+            for more details.
         name (str): The name of the transform, process or device using decompose. Used in the
             error message. Defaults to "device".
         error (type): An error type to raise if it is not possible to obtain a decomposition that
@@ -316,7 +324,11 @@ def decompose(  # pylint: disable = too-many-positional-arguments
 
         The decomposed circuit. The output type is explained in :func:`qml.transform <pennylane.transform>`.
 
-    .. seealso:: This transform is intended for device developers. See :func:`qml.transforms.decompose <pennylane.transforms.decompose>` for a more user-friendly interface.
+    .. seealso::
+
+        This transform is intended for device developers. See
+        :func:`qml.decompose <pennylane.transforms.decompose>` for a more user-friendly
+        interface.
 
     Raises:
         Exception: Type defaults to ``DeviceError`` but can be modified via keyword argument.
@@ -366,15 +378,17 @@ def decompose(  # pylint: disable = too-many-positional-arguments
     if stopping_condition_shots is not None and tape.shots:
         stopping_condition = stopping_condition_shots
 
-    # Compute parameters for graph decomposition if device_wires and target_gates are provided
-    if device_wires is None:
-        num_available_work_wires = device_wires  # no constraint on work wires
-    else:
-        # Calculate work wires as device wires that are not used by the tape
-        num_available_work_wires = len(set(device_wires) - set(tape.wires))
-
+    num_available_work_wires = None  # no constraint on work wires / not applicable with old system
     graph_solution = None
+
     if target_gates is not None and enabled_graph():
+        # Compute parameters for graph decomposition if device_wires and target_gates are provided
+        if device_wires is not None:
+            # Calculate work wires as device wires that are not used by the tape
+            num_available_work_wires = len(set(device_wires) - set(tape.wires))
+        else:
+            num_available_work_wires = num_work_wires
+
         # Filter out instances of ops that don't need to be decomposed
         decomposable_ops = [op for op in tape.operations if not stopping_condition(op)]
 

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -275,7 +275,9 @@ def decompose(  # pylint: disable = too-many-positional-arguments
     skip_initial_state_prep: bool = True,
     decomposer: Callable[[Operator], Sequence[Operator]] | None = None,
     device_wires: Wires | None = None,
-    target_gates: set | None = None,
+    target_gates: set | dict | None = None,
+    fixed_decomps: dict | None = None,
+    alt_decomps: dict | None = None,
     name: str = "device",
     error: type[Exception] | None = None,
     strict: bool = True,
@@ -382,8 +384,8 @@ def decompose(  # pylint: disable = too-many-positional-arguments
             target_gates=target_gates,
             num_work_wires=num_available_work_wires,
             minimize_work_wires=False,
-            fixed_decomps=None,
-            alt_decomps=None,
+            fixed_decomps=fixed_decomps,
+            alt_decomps=alt_decomps,
             strict=strict,
         )
 

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -380,13 +380,13 @@ def decompose(  # pylint: disable = too-many-positional-arguments
 
     num_available_work_wires = None  # no constraint on work wires / not applicable with old system
     graph_solution = None
+    if device_wires is not None:
+        # Calculate work wires as device wires that are not used by the tape
+        num_available_work_wires = len(set(device_wires) - set(tape.wires))
 
     if target_gates is not None and enabled_graph():
         # Compute parameters for graph decomposition if device_wires and target_gates are provided
-        if device_wires is not None:
-            # Calculate work wires as device wires that are not used by the tape
-            num_available_work_wires = len(set(device_wires) - set(tape.wires))
-        else:
+        if num_available_work_wires is None:
             num_available_work_wires = num_work_wires
 
         # Filter out instances of ops that don't need to be decomposed

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -404,6 +404,12 @@ def dummy_rz_decomp_1(theta, wires):
     qml.RX(theta, wires)
 
 
+@qml.register_resources({qml.H: 1}, work_wires={"zeroed": 1})
+def dummy_rz_decomp_2(theta, wires):
+    # pylint: disable=unused-argument
+    qml.H(wires)
+
+
 @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestDecomposeTransformations:
     """Tests for the behavior of the `decompose` helper."""
@@ -532,21 +538,76 @@ class TestDecomposeTransformations:
         assert all(op.name in target_gates for op in legacy_tape.operations)
 
     @pytest.mark.parametrize(
-        "fixed_decomps, alt_decomps, exp_len",
+        "num_work_wires, fixed_decomps, alt_decomps, exp_types",
         [
-            ({qml.RZ: dummy_rz_decomp_0}, {qml.RZ: [dummy_rz_decomp_1]}, 7),  #
-            ({qml.RZ: dummy_rz_decomp_0}, None, 7),  # fixed decomp HHH RX HHH
             (
+                0,
+                {qml.RZ: dummy_rz_decomp_0},
+                {qml.RZ: [dummy_rz_decomp_1, dummy_rz_decomp_2]},
+                [qml.H, qml.H, qml.H, qml.RX, qml.H, qml.H, qml.H],
+            ),
+            (
+                1,
+                {qml.RZ: dummy_rz_decomp_0},
+                {qml.RZ: [dummy_rz_decomp_1, dummy_rz_decomp_2]},
+                [qml.H, qml.H, qml.H, qml.RX, qml.H, qml.H, qml.H],
+            ),
+            (
+                0,
+                {qml.RZ: dummy_rz_decomp_0},
+                None,
+                [qml.H, qml.H, qml.H, qml.RX, qml.H, qml.H, qml.H],
+            ),  # fixed decomp HHH RX HHH
+            (
+                1,
+                {qml.RZ: dummy_rz_decomp_0},
+                None,
+                [qml.H, qml.H, qml.H, qml.RX, qml.H, qml.H, qml.H],
+            ),  # fixed decomp HHH RX HHH
+            (
+                0,
                 None,
                 {qml.RZ: [dummy_rz_decomp_0]},
-                2,
+                [qml.PhaseShift, qml.GlobalPhase],
             ),  # standard PhaseShift-GlobalPhase decomposition
-            (None, {qml.RZ: [dummy_rz_decomp_1]}, 1),  # use fake extra cheap RX decomposition
+            (
+                0,
+                None,
+                {qml.RZ: [dummy_rz_decomp_0, dummy_rz_decomp_2]},
+                [qml.PhaseShift, qml.GlobalPhase],
+            ),  # standard PhaseShift-GlobalPhase decomposition
+            (
+                1,
+                None,
+                {qml.RZ: [dummy_rz_decomp_0, dummy_rz_decomp_2]},
+                [qml.H],
+            ),  # fake single-Hadamard decomposition "using" a work wire
+            (
+                None,
+                None,
+                {qml.RZ: [dummy_rz_decomp_0, dummy_rz_decomp_2]},
+                [qml.H],
+            ),  # fake single-Hadamard decomposition "using" a work wire
+            (
+                0,
+                None,
+                {qml.RZ: [dummy_rz_decomp_1]},
+                [qml.RX],
+            ),  # use fake extra cheap RX decomposition
+            (
+                1,
+                None,
+                {qml.RZ: [dummy_rz_decomp_1]},
+                [qml.RX],
+            ),  # use fake extra cheap RX decomposition
         ],
     )
-    def test_decompose_with_pass_through_kwargs(self, fixed_decomps, alt_decomps, exp_len):
+    def test_decompose_with_pass_through_kwargs(
+        self, num_work_wires, fixed_decomps, alt_decomps, exp_types
+    ):
         """Test that decompose works correctly when passing through ``fixed_decomps``
         and/or ``alt_decomps`` with the graph-based decomposer."""
+        # pylint: disable=too-many-arguments
         if not qml.decomposition.enabled_graph():
             pytest.skip("This test only is expected to work with the graph-based system.")
 
@@ -560,13 +621,15 @@ class TestDecomposeTransformations:
             tape,
             lambda obj: obj.name in target_gates,
             device_wires=None,
+            num_work_wires=num_work_wires,
             target_gates=target_gates,
             fixed_decomps=fixed_decomps,
             alt_decomps=alt_decomps,
         )
         new_tape = batch[0]
 
-        assert len(new_tape.operations) == exp_len
+        for op, exp_t in zip(new_tape.operations, exp_types, strict=True):
+            assert isinstance(op, exp_t)
         assert all(op.name in target_gates for op in new_tape.operations)
 
     @pytest.mark.parametrize(

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -388,6 +388,22 @@ class TestValidateMeasurements:
             validate_measurements(tape, lambda obj: True)
 
 
+@qml.register_resources({qml.H: 6, qml.RX: 1})
+def dummy_rz_decomp_0(theta, wires):
+    qml.H(wires)
+    qml.H(wires)
+    qml.H(wires)
+    qml.RX(theta, wires)
+    qml.H(wires)
+    qml.H(wires)
+    qml.H(wires)
+
+
+@qml.register_resources({qml.RX: 1})
+def dummy_rz_decomp_1(theta, wires):
+    qml.RX(theta, wires)
+
+
 @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 class TestDecomposeTransformations:
     """Tests for the behavior of the `decompose` helper."""
@@ -514,6 +530,44 @@ class TestDecomposeTransformations:
         # Should still work correctly
         assert len(legacy_tape.operations) > len(tape.operations)
         assert all(op.name in target_gates for op in legacy_tape.operations)
+
+    @pytest.mark.parametrize(
+        "fixed_decomps, alt_decomps, exp_len",
+        [
+            ({qml.RZ: dummy_rz_decomp_0}, {qml.RZ: [dummy_rz_decomp_1]}, 7),  #
+            ({qml.RZ: dummy_rz_decomp_0}, None, 7),  # fixed decomp HHH RX HHH
+            (
+                None,
+                {qml.RZ: [dummy_rz_decomp_0]},
+                2,
+            ),  # standard PhaseShift-GlobalPhase decomposition
+            (None, {qml.RZ: [dummy_rz_decomp_1]}, 1),  # use fake extra cheap RX decomposition
+        ],
+    )
+    def test_decompose_with_pass_through_kwargs(self, fixed_decomps, alt_decomps, exp_len):
+        """Test that decompose works correctly when passing through ``fixed_decomps``
+        and/or ``alt_decomps`` with the graph-based decomposer."""
+        if not qml.decomposition.enabled_graph():
+            pytest.skip("This test only is expected to work with the graph-based system.")
+
+        # Mock a simple target gate set
+        target_gates = {"Hadamard": 1, "RX": 5, "RY": 5, "PhaseShift": 5, "GlobalPhase": 0}
+
+        # Create a tape with an operation that needs decomposition
+        tape = qml.tape.QuantumScript([qml.RZ(0.2, 0)])
+
+        batch, _ = decompose(
+            tape,
+            lambda obj: obj.name in target_gates,
+            device_wires=None,
+            target_gates=target_gates,
+            fixed_decomps=fixed_decomps,
+            alt_decomps=alt_decomps,
+        )
+        new_tape = batch[0]
+
+        assert len(new_tape.operations) == exp_len
+        assert all(op.name in target_gates for op in new_tape.operations)
 
     @pytest.mark.parametrize(
         "device_wires_list,tape_wires_list,expected_work_wires",


### PR DESCRIPTION
**Context:**
There is a`catalyst_decompose` function in the Catalyst repository that makes use of `devices.preprocess.decompose`.
I would like to be able to pass `num_work_wires`, `fixed_decomps` and `alt_decomps` through to the graph-based decomposer when using this `catalyst_decompose` transform.

Note that even though `device_wires` can be passed already to the preprocessing transform to infer the work wires from, it is not easy to use with `catalyst_decompose`, which can't mock device wires to include a desired number of work wires due to abstract wire labels.
Instead, we just want to pass through the number of work wires we have in `catalyst_decompose` in the first place.

**Description of the Change:**
Add kwargs to ``preprocess.decompose`` and pass them to the graph-based system instead of the current hardcoded `None` values.

**Benefits:**
enhances the impact of [Catalyst PR #2501](https://github.com/PennyLaneAI/catalyst/pull/2501)

**Possible Drawbacks:**

**Related GitHub Issues:**
