### PR TITLE
Adds documentation page for Subroutine abstractions

### DIFF
--- a/doc/code/qml_templates_core.rst
+++ b/doc/code/qml_templates_core.rst
@@ -3,4 +3,8 @@ qml.templates.core
 
 .. currentmodule:: pennylane.templates.core
 
+.. warning::
+
+    Unless you are a PennyLane developer, you likely do not need to use these classes directly.
+
 .. automodule:: pennylane.templates.core

--- a/doc/code/qml_templates_core.rst
+++ b/doc/code/qml_templates_core.rst
@@ -1,5 +1,5 @@
 qml.templates.core
-===============
+==================
 
 .. currentmodule:: pennylane.templates.core
 

--- a/doc/code/qml_templates_core.rst
+++ b/doc/code/qml_templates_core.rst
@@ -1,0 +1,6 @@
+qml.templates.core
+===============
+
+.. currentmodule:: pennylane.templates.core
+
+.. automodule:: pennylane.templates.core

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -241,5 +241,6 @@ PennyLane is **free** and **open source**, released under the Apache License, Ve
    code/qml_operation
    code/qml_queuing
    code/qml_tape
+   code/qml_templates_core
    code/qml_wires
    code/qml_workflow

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -50,6 +50,7 @@
   of `Operator`/ `Operation`.
   [(#8929)](https://github.com/PennyLaneAI/pennylane/pull/8929)
   [(#9070)](https://github.com/PennyLaneAI/pennylane/pull/9070)
+  [(#9097)](https://github.com/PennyLaneAI/pennylane/pull/9097)
 
   ```python
   from pennylane.templates import Subroutine

--- a/pennylane/templates/__init__.py
+++ b/pennylane/templates/__init__.py
@@ -15,7 +15,7 @@
 This module contains templates, which are pre-coded routines that can be used in a quantum node.
 """
 
-from .subroutine import Subroutine, SubroutineOp
+from .core import Subroutine, SubroutineOp
 from .embeddings import *
 from .layer import layer
 from .state_preparations import *

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Contains the abstractions for subroutines.
+Contains the abstractions for defining subroutines.
+
+.. currentmodule:: pennylane.templates.core
+
+.. autosummary::
+    :toctree: api
+
+    ~Subroutine
+    ~SubroutineOp
+
 """
 import copy
 from collections.abc import Callable
@@ -462,3 +471,6 @@ class Subroutine:
             return self._capture_subroutine(*bound_args.args, **bound_args.kwargs)
         op = self.operator(*args, id=id, **kwargs)
         return op.output
+
+
+__all__ = ["Subroutine", "SubroutineOp"]

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Contains the abstractions for defining subroutines.
+This module contains the abstractions for defining subroutines.
 
 .. currentmodule:: pennylane.templates.core
 


### PR DESCRIPTION
**Context:**

Since there was no module documentation for `qml.templates`, the abstractions for `Subroutine`'s weren't rendering in the docs anywhere.  This just adds a block under internals to display these abstractions.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
