### PR TITLE
fix: `CompilePipeline`'s `str` dunder to accomodate unified transform API

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -153,6 +153,7 @@
   ```
   [(#9007)](https://github.com/PennyLaneAI/pennylane/pull/9007)
   [(#9076)](https://github.com/PennyLaneAI/pennylane/pull/9076)
+  [(#9102)](https://github.com/PennyLaneAI/pennylane/pull/9102)
   
 * Raises a more informative error if something that is not a measurement process is returned from a 
   QNode when program capture is turned on.

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -610,10 +610,11 @@ class CompilePipeline:
 
             sep = ", " if args_str and kwargs_str else ""
             # Prefer pass name if both tape and MLIR implementation exists
-            if getattr(transform, "pass_name", None) is not None:
-                transform_name = transform.pass_name
-            else:
-                transform_name = transform.tape_transform.__name__
+            transform_name = (
+                transform.pass_name
+                if transform.pass_name is not None
+                else transform.tape_transform.__name__
+            )
             transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -609,10 +609,9 @@ class CompilePipeline:
             kwargs_str = ", ".join(f"{k}={truncate(v)}" for k, v in transform.kwargs.items())
 
             sep = ", " if args_str and kwargs_str else ""
-            if (name := getattr(transform.tape_transform, "__name__", None)) is not None:
-                transform_name = name
-            else:
-                transform_name = transform.pass_name
+            transform_name = (
+                getattr(transform.tape_transform, "__name__", None) or transform.pass_name
+            )
             transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -610,7 +610,9 @@ class CompilePipeline:
 
             sep = ", " if args_str and kwargs_str else ""
             transform_name = (
-                getattr(transform.tape_transform, "__name__", None) or transform.pass_name
+                transform.tape_transform.__name__
+                if transform.tape_transform
+                else transform.pass_name
             )
             transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -609,12 +609,10 @@ class CompilePipeline:
             kwargs_str = ", ".join(f"{k}={truncate(v)}" for k, v in transform.kwargs.items())
 
             sep = ", " if args_str and kwargs_str else ""
-            # Prefer pass name if both tape and MLIR implementation exists
-            transform_name = (
-                transform.pass_name
-                if transform.pass_name is not None
-                else transform.tape_transform.__name__
-            )
+            if (name := getattr(transform.tape_transform, "__name__", None)) is not None:
+                transform_name = name
+            else:
+                transform_name = transform.pass_name
             transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -609,10 +609,11 @@ class CompilePipeline:
             kwargs_str = ", ".join(f"{k}={truncate(v)}" for k, v in transform.kwargs.items())
 
             sep = ", " if args_str and kwargs_str else ""
-            if getattr(transform, "tape_transform", None) is not None:
-                transform_name = transform.tape_transform.__name__
-            else:
+            # Prefer pass name if both tape and MLIR implementation exists
+            if getattr(transform, "pass_name", None) is not None:
                 transform_name = transform.pass_name
+            else:
+                transform_name = transform.tape_transform.__name__
             transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -609,7 +609,11 @@ class CompilePipeline:
             kwargs_str = ", ".join(f"{k}={truncate(v)}" for k, v in transform.kwargs.items())
 
             sep = ", " if args_str and kwargs_str else ""
-            transform_str = f"{transform.tape_transform.__name__}({args_str}{sep}{kwargs_str})"
+            if getattr(transform, "tape_transform", None) is not None:
+                transform_name = transform.tape_transform.__name__
+            else:
+                transform_name = transform.pass_name
+            transform_str = f"{transform_name}({args_str}{sep}{kwargs_str})"
             lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
 
             if marker := inv_marker_map.get(i + 1):

--- a/tests/transforms/core/test_compile_pipeline.py
+++ b/tests/transforms/core/test_compile_pipeline.py
@@ -766,15 +766,17 @@ class TestCompilePipelineDunders:
 
         assert str(compile_pipeline) == "CompilePipeline()"
 
+        # Tape transform
         transform1 = BoundTransform(qml.transform(first_valid_transform))
-        transform2 = BoundTransform(qml.transform(second_valid_transform))
+        # MLIR pass
+        transform2 = BoundTransform(qml.transform(pass_name="cancel-inverses"))
 
         compile_pipeline.append(transform1)
         compile_pipeline.append(transform2)
 
         pipeline_str = str(compile_pipeline)
         expected_str = (
-            "CompilePipeline(\n  [1] first_valid_transform(),\n  [2] second_valid_transform()\n)"
+            "CompilePipeline(\n  [1] first_valid_transform(),\n  [2] cancel-inverses()\n)"
         )
         assert pipeline_str == expected_str
 


### PR DESCRIPTION
Quick bug fix PR that accounts for the unified transform API in the `str` render of a `CompilePipeline` 🤦🏼 

```
>>> print(qp.CompilePipeline(qp.transform(pass_name="merge-rotations")))
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 7
      4     return tape, lambda x: x
      6 print(qp.CompilePipeline(tape_transform))
----> 7 print(qp.CompilePipeline(qp.transform(pass_name="merge-rotations")))

File ~/Documents/pl-ecosystem/pennylane/pennylane/transforms/core/compile_pipeline.py:612, in CompilePipeline.__str__(self)
    609 kwargs_str = ", ".join(f"{k}={truncate(v)}" for k, v in transform.kwargs.items())
    611 sep = ", " if args_str and kwargs_str else ""
--> 612 transform_str = f"{transform.tape_transform.__name__}({args_str}{sep}{kwargs_str})"
    613 lines.append(f"  [{i + 1}] {transform_str}" + "," * bool(i != len(self) - 1))
    615 if marker := inv_marker_map.get(i + 1):

AttributeError: 'NoneType' object has no attribute '__name__'
```

[sc-112678]