### PR TITLE
Fix changelog by de-indenting twice two python code blocks

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -491,31 +491,30 @@
   These are now handled by dedicated functions:
 
   .. warning::
-
     Neither of these functions are supported in a :func:`~.qjit`-compiled circuit,
     as the original behaviour was never supported.
 
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="my-rx")
+  ```python
+  # Legacy method (deprecated):
+  qml.RX(0.5, wires=0, id="my-rx")
 
-    # New method:
-    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-    ```
+  # New method:
+  qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+  ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="x0")
+  ```python
+  # Legacy method (deprecated):
+  qml.RX(0.5, wires=0, id="x0")
 
-    # New method:
-    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-    ```
+  # New method:
+  qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+  ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,24 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-      ```python
-      # Legacy method (deprecated):
-      qml.RX(0.5, wires=0, id="my-rx")
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="my-rx")
 
-      # New method:
-      qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-      ```
+    # New method:
+    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+    ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-      ```python
-      # Legacy method (deprecated):
-      qml.RX(0.5, wires=0, id="x0")
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="x0")
 
-      # New method:
-      qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-      ```
+    # New method:
+    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+    ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -517,7 +517,8 @@
       qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
       ````
 
-  
+
+
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.
   Operator classes that used to have `_queue_category=None` have been updated

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,24 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-  ```python
-  # Legacy method (deprecated):
-  qml.RX(0.5, wires=0, id="my-rx")
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="my-rx")
 
-  # New method:
-  qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-  ```
+    # New method:
+    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+    ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-  ```python
-  # Legacy method (deprecated):
-  qml.RX(0.5, wires=0, id="x0")
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="x0")
 
-  # New method:
-  qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-  ```
+    # New method:
+    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+    ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,24 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="my-rx")
+  ```python
+  # Legacy method (deprecated):
+  qml.RX(0.5, wires=0, id="my-rx")
 
-    # New method:
-    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-    ```
+  # New method:
+  qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+  ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="x0")
+  ```python
+  # Legacy method (deprecated):
+  qml.RX(0.5, wires=0, id="x0")
 
-    # New method:
-    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-    ```
+  # New method:
+  qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+  ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,24 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-  ```python
-  # Legacy method (deprecated):
-  qml.RX(0.5, wires=0, id="my-rx")
+      ````python
+      # Legacy method (deprecated):
+      qml.RX(0.5, wires=0, id="my-rx")
 
-  # New method:
-  qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-  ```
+      # New method:
+      qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+      ````
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-  ```python
-  # Legacy method (deprecated):
-  qml.RX(0.5, wires=0, id="x0")
+      ````python
+      # Legacy method (deprecated):
+      qml.RX(0.5, wires=0, id="x0")
 
-  # New method:
-  qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-  ```
+      # New method:
+      qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+      ````
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -491,18 +491,31 @@
   These are now handled by dedicated functions:
 
   .. warning::
+
     Neither of these functions are supported in a :func:`~.qjit`-compiled circuit,
     as the original behaviour was never supported.
 
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="my-rx")
 
+    # New method:
+    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+    ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
+    ```python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="x0")
 
+    # New method:
+    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+    ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -515,6 +515,7 @@
     # New method:
     qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
     ````
+
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,24 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-      ````python
-      # Legacy method (deprecated):
-      qml.RX(0.5, wires=0, id="my-rx")
+    ````python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="my-rx")
 
-      # New method:
-      qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-      ````
+    # New method:
+    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+    ````
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-      ````python
-      # Legacy method (deprecated):
-      qml.RX(0.5, wires=0, id="x0")
+    ````python
+    # Legacy method (deprecated):
+    qml.RX(0.5, wires=0, id="x0")
 
-      # New method:
-      qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-      ````
+    # New method:
+    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+    ````
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,25 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-    ````python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="my-rx")
+      ````python
+      # Legacy method (deprecated):
+      qml.RX(0.5, wires=0, id="my-rx")
 
-    # New method:
-    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-    ````
+      # New method:
+      qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
+      ````
+
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-    ````python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="x0")
+      ````python
+      # Legacy method (deprecated):
+      qml.RX(0.5, wires=0, id="x0")
 
-    # New method:
-    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-    ````
+      # New method:
+      qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
+      ````
 
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -497,24 +497,12 @@
   - Use :func:`~.drawer.label` to attach a custom label to an operator instance
   for circuit drawing:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="my-rx")
 
-    # New method:
-    qml.drawer.label(qml.RX(0.5, wires=0), "my-rx")
-    ```
 
   - Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
     for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
 
-    ```python
-    # Legacy method (deprecated):
-    qml.RX(0.5, wires=0, id="x0")
 
-    # New method:
-    qml.fourier.mark(qml.RX(0.5, wires=0), "x0")
-    ```
   
 * Setting `_queue_category=None` in an operator class in order to deactivate its instances being
   queued has been deprecated. Implement a custom `queue` method for the respective class instead.


### PR DESCRIPTION
Not even possible by only de-indenting once:
<img width="2564" height="1322" alt="Screenshot from 2026-02-27 13-53-55" src="https://github.com/user-attachments/assets/5a06108f-a513-45c8-bc0a-34753be1a944" />
