### PR TITLE
add Subroutine exact_resources

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,7 @@
   [(#9096)](https://github.com/PennyLaneAI/pennylane/pull/9096)
   [(#9070)](https://github.com/PennyLaneAI/pennylane/pull/9070)
   [(#9097)](https://github.com/PennyLaneAI/pennylane/pull/9097)
+  [(#9119)](https://github.com/PennyLaneAI/pennylane/pull/9119)
 
   ```python
   from pennylane.templates import Subroutine

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -163,7 +163,9 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         resource_rep = qml.resource_rep(type(_op), **_op.resource_params)
         actual_gate_counts[resource_rep] += 1
 
-    if rule.exact_resources:
+    if rule.exact_resources and not (
+        isinstance(op, qml.templates.SubroutineOp) and not op.subroutine.exact_resources
+    ):
         non_zero_gate_counts = {k: v for k, v in gate_counts.items() if v > 0}
         assert non_zero_gate_counts == actual_gate_counts, (
             f"\nGate counts expected from resource function:\n{non_zero_gate_counts}"

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -346,7 +346,7 @@ add_decomps(SubroutineOp, _Subroutine_decomp)
 P = ParamSpec("P")
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-instance-attributes
 class Subroutine:
     """The definition of a Subroutine, compatible both with program capture and backwards
     compatible with operators.
@@ -365,6 +365,8 @@ class Subroutine:
             It should only calculate the resources from the static arguments, the length of the wire registers,
             and the shape and dtype of the dynamic arguments. In the case of the specific resources
             depending on the specifics of a dynamic argument, a worse case scenario can be used.
+        exact_resources (bool): whether or not ``compute_resources`` is exact. Similar to ``register_resources``,
+            this option is used purely for testing purposes.
 
     For simple cases, a ``Subroutine`` can simply be created from a single quantum function, like:
 
@@ -638,11 +640,13 @@ class Subroutine:
         static_argnames: str | tuple[str, ...] = tuple(),
         wire_argnames: str | tuple[str, ...] = ("wires",),
         compute_resources: None | Callable[P, dict] = None,
+        exact_resources: bool = True,
     ):
         self._definition = capture.disable_autograph(definition)
         self._setup_inputs = setup_inputs
         self._compute_resources = compute_resources
         self._signature = signature(definition)
+        self._exact_resources = exact_resources
         update_wrapper(self, definition)
         if isinstance(static_argnames, str):
             static_argnames = (static_argnames,)
@@ -659,6 +663,11 @@ class Subroutine:
     def name(self) -> str:
         """A string representation to label the Subroutine."""
         return getattr(self._definition, "__name__", str(self._definition))
+
+    @property
+    def exact_resources(self) -> bool:
+        """Whether or not the ``compute_resources`` function provides the exact resources. Used for testing."""
+        return self._exact_resources
 
     @property
     def signature(self) -> Signature:

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -44,6 +44,7 @@ class TestInitialization:
         assert S.static_argnames == tuple()
         assert S.wire_argnames == ("wires",)
         assert S.dynamic_argnames == ("x",)
+        assert S.exact_resources
 
         with qml.queuing.AnnotatedQueue() as q:
             S.definition(0.5, 0)
@@ -119,6 +120,16 @@ class TestInitialization:
         # test wires setup properly
         out2 = HasResources.compute_resources(0.5, 0)
         assert out2 == {qml.RX: 1}
+
+    @pytest.mark.parametrize("exact_resources", (True, False))
+    def test_setting_exact_resources(self, exact_resources):
+        """Test that exact_resources can be set."""
+
+        @partial(Subroutine, exact_resources=exact_resources)
+        def f(wires):
+            qml.X(wires)
+
+        assert f.exact_resources == exact_resources
 
 
 def Example1(x, y, reg1, reg2, pauli_words):
@@ -786,3 +797,16 @@ class TestGraphDecomposition:
         qml.assert_equal(tape_ry[0], qml.RY(0.0, 0))
         qml.assert_equal(tape_ry[1], qml.RY(1.0, 1))
         qml.assert_equal(tape_ry[2], qml.RY(2.0, 2))
+
+    def test_inexact_resources_testing(self):
+        """Test that assert_valid will work on a Subroutine with inexact resources."""
+
+        def r(wires):
+            return {qml.X: 2}
+
+        @partial(Subroutine, compute_resources=r, exact_resources=False)
+        def f(wires):
+            qml.X(wires)
+
+        op = f.operator(0)
+        qml.ops.functions.assert_valid(op, skip_pickle=True, skip_capture=True)


### PR DESCRIPTION
**Context:**

In #9026 there were failures due to an inability to specify that the resources are inexact. 

**Description of the Change:**

Allows us to specify that the resources are inexact.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-112871]
