### PR TITLE
fix: add `setup_inputs` for `merge_rotations` and `cancel_inverses`

### DIFF
--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -319,7 +319,8 @@ def _try_to_cancel_with_next(current_gate, list_copy):
     return list_copy, cancelled
 
 
-def cancel_inverses_setup_inputs():
+# pylint: disable=unused-argument
+def cancel_inverses_setup_inputs(recursive: bool = True) -> tuple[tuple, dict]:
     """Pass options for the 'cancel-inverses' MLIR pass."""
     return (), {}
 

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -250,7 +250,8 @@ def _get_plxpr_merge_rotations():
 MergeRotationsInterpreter, merge_rotations_plxpr_to_plxpr = _get_plxpr_merge_rotations()
 
 
-def merge_rotations_setup_inputs():
+# pylint: disable=unused-argument
+def merge_rotations_setup_inputs(atol: float = 1e-8, include_gates=None):
     """Pass options for the 'merge-rotations' MLIR pass."""
     return (), {}
 


### PR DESCRIPTION
Because these transforms use `pass_name` we need them to have their corresponding `setup_inputs` as well.

[sc-]