### PR TITLE
Fix the fixture enque logic

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -556,6 +556,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Improved marker `capture` modification logic in `pytest_collection_modifyitems` to create a new list to avoid mutating the shared `item.fixturenames`.
+
 * Remove duplicate transforms found in both `ftqc/catalyst_pass_aliases.py` and `transforms/decompositions/pauli_based_computation.py`.
   [(#9090)](https://github.com/PennyLaneAI/pennylane/pull/9090)
   

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -557,6 +557,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Improved marker `capture` modification logic in `pytest_collection_modifyitems` to create a new list to avoid mutating the shared `item.fixturenames`.
+  [(#9126)](https://github.com/PennyLaneAI/pennylane/pull/9126)
 
 * Remove duplicate transforms found in both `ftqc/catalyst_pass_aliases.py` and `transforms/decompositions/pauli_based_computation.py`.
   [(#9090)](https://github.com/PennyLaneAI/pennylane/pull/9090)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,7 +316,7 @@ def pytest_collection_modifyitems(items, config):
         ):
             item.add_marker(pytest.mark.core)
         if "capture" in markers:
-            item.fixturenames.append("enable_disable_plxpr")
+            item.fixturenames = [*item.fixturenames, "enable_disable_plxpr"]
             if "jax" not in markers:
                 item.add_marker(pytest.mark.jax)
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for ensuring that fixtures are working as expected
+"""
+import pytest
+
+import pennylane as qp
+
+
+@pytest.mark.parametrize(
+    "use_capture",
+    (
+        pytest.param(True, marks=pytest.mark.capture, id="capture"),
+        pytest.param(False, id="no_capture"),
+    ),
+)
+def test_stuff(use_capture):
+    """Different marked params should not interfere with each other."""
+    if qp.capture.enabled() and not use_capture:
+        raise ValueError("WHY IS CAPTURE TURNED ON HERE!!!")


### PR DESCRIPTION
**Context:**
The newly added test pretty much self-explained our motivation. Before this fix, the test will fail due to two parametrized tests share the same item list.

Later in the future we can push more tests into the new file if similar issues happen again

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
