### PR TITLE
feat: link `dynamic_one_shot` and `split_to_single_terms` transforms to their passes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -98,6 +98,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `dynamic_one_shot` and `split_to_single_terms` transforms are now compatible with `qml.qjit`.
+  [(#9129)](https://github.com/PennyLaneAI/pennylane/pull/9129)
+
 * When using :func:`~.specs` with multiple levels, printing the returned
   :class:`~.resource.CircuitSpecs` object will provide a table detailing relevant information at each requested level,
   for convenient comparison of circuit specifications between compilation passes.
@@ -594,9 +597,6 @@
   [(#8945)](https://github.com/PennyLaneAI/pennylane/pull/8945)
 
 <h3>Internal changes ⚙️</h3>
-
-* The `dynamic_one_shot` and `split_non_commuting` transforms are now compatible with `qml.qjit`.
-  [(#9129)](https://github.com/PennyLaneAI/pennylane/pull/9129)
 
 * Update nightly RC builds to not be a schedule triggered in Pennylane anymore. Instead, it will be triggered in the order Lightning —> Catalyst —> Pennylane. 
   [(#9092)](https://github.com/PennyLaneAI/pennylane/pull/9092)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -595,6 +595,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `dynamic_one_shot` and `split_non_commuting` transforms are now compatible with `qml.qjit`.
+  [(#9129)](https://github.com/PennyLaneAI/pennylane/pull/9129)
+
 * Update nightly RC builds to not be a schedule triggered in Pennylane anymore. Instead, it will be triggered in the order Lightning —> Catalyst —> Pennylane. 
   [(#9092)](https://github.com/PennyLaneAI/pennylane/pull/9092)
   

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -166,7 +166,7 @@ def dynamic_one_shot(
         To apply the MLIR pass version simply decorate your ``QNode`` with ``@qml.qjit``:
 
         >>> circ_qjit = qml.qjit(circ)
-        >>> circ_qjit()
+        >>> circ_qjit() # doctest: +SKIP
         Array(0.4, dtype=float64)
 
     """

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -167,6 +167,7 @@ def dynamic_one_shot(
 
         >>> circ_qjit = qml.qjit(circ)
         >>> circ_qjit()
+        Array(0.4, dtype=float64)
 
     """
     if not any(is_mcm(o) for o in tape.operations):

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -81,7 +81,7 @@ def _add_shot_vector_support(fn: PostprocessingFn, shots: Shots) -> Postprocessi
     return new_fn
 
 
-@partial(transform, expand_transform=_expand_fn)
+@partial(transform, expand_transform=_expand_fn, pass_name="dynamic-one-shot")
 def dynamic_one_shot(
     tape: QuantumScript, postselect_mode=None, **_
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -133,7 +133,7 @@ def dynamic_one_shot(
 
         This transform is compatible with ``qjit``, where it will be applied as an MLIR pass
         rather than a tape-level transform.
-        That being said, there are a few differences to be aware of when using the MLIR pass,
+        That being said, there are a few differences to be aware of when using the MLIR pass:
 
         - Shot vectors or broadcasting are not supported
         - VJP/VJP pipelines are not supported

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -136,7 +136,7 @@ def dynamic_one_shot(
         That being said, there are a few differences to be aware of when using the MLIR pass:
 
         - Shot vectors or broadcasting are not supported
-        - VJP/VJP pipelines are not supported
+        - Workflows involving gradients are not supported
         - ``qml.var()`` on observables (non-MCM) are unsupported
 
         To apply the MLIR pass version simply decorate your ``QNode`` with ``@qml.qjit``:

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -139,34 +139,17 @@ def dynamic_one_shot(
         - VJP/VJP pipelines are not supported
         - ``qml.var()`` on observables (non-MCM) are unsupported
 
-        Consider the following ``QNode`` using `dynamic-one-shot`:
+        To apply the MLIR pass version simply decorate your ``QNode`` with ``@qml.qjit``:
 
         .. code-block:: python
 
+            @qml.qjit
             @qml.set_shots(10)
             @qml.qnode(qml.device("lightning.qubit", wires=2), mcm_method="one-shot")
             def circ():
                 return qml.expval(qml.X(0)+2*qml.Y(1))
 
-        We can inspect the compilation pipeline to indeed verify our transform exists:
-
-        >>> print(qml.workflow.get_compile_pipeline(circ, level="device")())
-        CompilePipeline(
-          [1] _expand_transform_param_shift(),
-          [2] validate_measurements(name=lightning.qubit),
-          [3] validate_observables(..., name=lightning.qubit),
-          [4] decompose(stopping_condition=..., skip_initial_state_prep=True, name=lightning.qubit, device_wires=Wires([0, 1]), target_gates=...),
-          [5] device_resolve_dynamic_wires(wires=Wires([0, 1]), allow_resets=True),
-          [6] validate_device_wires(Wires([0, 1]), name=lightning.qubit),
-          [7] _expand_fn(postselect_mode=None),
-          [8] dynamic_one_shot(postselect_mode=None),
-          [9] broadcast_expand()
-        )
-
-        To apply the MLIR pass version simply decorate your ``QNode`` with ``@qml.qjit``:
-
-        >>> circ_qjit = qml.qjit(circ)
-        >>> circ_qjit() # doctest: +SKIP
+        >>> circ() # doctest: +SKIP
         Array(0.4, dtype=float64)
 
     """

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -128,6 +128,46 @@ def dynamic_one_shot(
             qml.cond(m0, qml.RY)(y, wires=1)
             return qml.expval(op=m0)
 
+    ..details::
+        :title: Usage with Catalyst (qjit)
+
+        This transform is compatible with qjit where it will be applied as an MLIR pass
+        rather than a tape-level transform.
+        That being said, there are a few differences to be aware of when using the MLIR pass,
+
+        - Shot vectors or broadcasting are not supported
+        - VJP/VJP pipelines are not supported
+        - ``qml.var()`` on observables (non-MCM) are unsupported
+
+        Consider the following ``QNode`` using `dynamic-one-shot`:
+
+        .. code-block:: python
+
+            @qml.set_shots(10)
+            @qml.qnode(qml.device("lightning.qubit", wires=2), mcm_method="one-shot")
+            def circ():
+                return qml.expval(qml.X(0)+2*qml.Y(1))
+
+        We can inspect the compilation pipeline to indeed verify our transform exists:
+
+        >>> qml.workflow.get_compile_pipeline(circ, level="device")()
+        CompilePipeline(
+          [1] _expand_transform_param_shift(),
+          [2] validate_measurements(name=lightning.qubit),
+          [3] validate_observables(..., name=lightning.qubit),
+          [4] decompose(stopping_condition=..., skip_initial_state_prep=True, name=lightning.qubit, device_wires=Wires([0, 1]), target_gates=...),
+          [5] device_resolve_dynamic_wires(wires=Wires([0, 1]), allow_resets=True),
+          [6] validate_device_wires(Wires([0, 1]), name=lightning.qubit),
+          [7] _expand_fn(postselect_mode=None),
+          [8] dynamic_one_shot(postselect_mode=None),
+          [9] broadcast_expand()
+        )
+
+        To apply the MLIR pass version simply decorate your ``QNode`` with ``@qml.qjit``:
+
+        >>> circ_qjit = qml.qjit(circ)
+        >>> circ_qjit()
+
     """
     if not any(is_mcm(o) for o in tape.operations):
         return (tape,), null_postprocessing

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -131,7 +131,7 @@ def dynamic_one_shot(
     ..details::
         :title: Usage with Catalyst (qjit)
 
-        This transform is compatible with qjit where it will be applied as an MLIR pass
+        This transform is compatible with ``qjit``, where it will be applied as an MLIR pass
         rather than a tape-level transform.
         That being said, there are a few differences to be aware of when using the MLIR pass,
 

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -150,7 +150,7 @@ def dynamic_one_shot(
 
         We can inspect the compilation pipeline to indeed verify our transform exists:
 
-        >>> qml.workflow.get_compile_pipeline(circ, level="device")()
+        >>> print(qml.workflow.get_compile_pipeline(circ, level="device")())
         CompilePipeline(
           [1] _expand_transform_param_shift(),
           [2] validate_measurements(name=lightning.qubit),

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -35,7 +35,7 @@ def null_postprocessing(results):
     return results[0]
 
 
-@transform
+@transform(pass_name="split-to-single-terms")
 def split_to_single_terms(tape):
     """Splits any expectation values of multi-term observables in a circuit into single term
     expectation values for devices that don't natively support measuring expectation values

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -142,7 +142,7 @@ def split_to_single_terms(tape):
     .. details::
         :title: Usage with Catalyst (qjit)
 
-        This transform is compatible with qjit with a few minor differences to be aware of.
+        This transform is compatible with ``qjit`` with a few minor differences to be aware of.
         Currently, when combined with ``qjit``, this transform will not work with shot vectors
         and will not simplify any tensor products like ``X(0) @ Y(0)`` contained in measurements.
 

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -145,8 +145,7 @@ def split_to_single_terms(tape):
         Currently, when combined with ``qjit``, this transform will not work with shot vectors
         and will not simplify any tensor products like ``X(0) @ Y(0)`` contained in measurements.
 
-        For example, by decorating our ``QNode`` with ``qml.qjit``, we will be applying the MLIR pass
-        associated with this transform.
+        We can apply the MLIR pass by simply decorating our ``QNode`` with ``@qml.qjit``:
 
         .. code-block::
 

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -139,6 +139,7 @@ def split_to_single_terms(tape):
         >>> processing_fn(results)
         (np.float64(2.0), np.float64(2.0), np.float64(1.0))
 
+    ..details::
         :title: Usage with Catalyst (qjit)
 
         This transform is compatible with qjit with a few minor differences to be aware of.

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -139,6 +139,23 @@ def split_to_single_terms(tape):
         >>> processing_fn(results)
         (np.float64(2.0), np.float64(2.0), np.float64(1.0))
 
+        :title: Usage with Catalyst (qjit)
+
+        This transform is compatible with qjit with a few minor differences to be aware of.
+        Currently, when combined with ``qjit``, this transform will not work with shot vectors
+        and will not simplify any tensor products like ``X(0) @ Y(0)`` contained in measurements.
+
+        For example, by decorating our ``QNode`` with ``qml.qjit``, we will be applying the MLIR pass
+        associated with this transform.
+
+        .. code-block::
+
+            @qml.qjit
+            @qml.transforms.split_to_single_terms
+            @qml.qnode(qml.device("lightning.qubit", wires=2))
+            def circ():
+                return qml.expval(qml.X(0)+2*qml.Y(1))
+
     """
 
     if len(tape.measurements) == 0:

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -139,7 +139,7 @@ def split_to_single_terms(tape):
         >>> processing_fn(results)
         (np.float64(2.0), np.float64(2.0), np.float64(1.0))
 
-    ..details::
+    .. details::
         :title: Usage with Catalyst (qjit)
 
         This transform is compatible with qjit with a few minor differences to be aware of.

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -148,7 +148,7 @@ def split_to_single_terms(tape):
 
         We can apply the MLIR pass by simply decorating our ``QNode`` with ``@qml.qjit``:
 
-        .. code-block::
+        .. code-block:: python
 
             @qml.qjit
             @qml.transforms.split_to_single_terms

--- a/pennylane/transforms/split_to_single_terms.py
+++ b/pennylane/transforms/split_to_single_terms.py
@@ -35,7 +35,7 @@ def null_postprocessing(results):
     return results[0]
 
 
-@transform(pass_name="split-to-single-terms")
+@partial(transform, pass_name="split-to-single-terms")
 def split_to_single_terms(tape):
     """Splits any expectation values of multi-term observables in a circuit into single term
     expectation values for devices that don't natively support measuring expectation values

--- a/tests/transforms/test_dynamic_one_shot.py
+++ b/tests/transforms/test_dynamic_one_shot.py
@@ -28,6 +28,7 @@ from pennylane.measurements import (
     SampleMP,
 )
 from pennylane.ops import MeasurementValue, MidMeasure
+from pennylane.transforms import dynamic_one_shot
 from pennylane.transforms.dynamic_one_shot import (
     _supports_one_shot,
     fill_in_value,
@@ -37,6 +38,12 @@ from pennylane.transforms.dynamic_one_shot import (
 )
 
 # pylint: disable=too-few-public-methods, too-many-arguments
+
+
+def test_pass_name():
+    """Makes sure that the pass_name is set correctly. Must match Catalyst pass name."""
+
+    assert dynamic_one_shot.pass_name == "dynamic-one-shot"
 
 
 def test_gather_non_mcm_unsupported_measurement():

--- a/tests/transforms/test_split_to_single_terms.py
+++ b/tests/transforms/test_split_to_single_terms.py
@@ -61,6 +61,11 @@ class NoTermsDevice(qml.devices.DefaultQubit):
 class TestUnits:
     """Unit tests for components of the ``split_to_single_terms`` transform"""
 
+    def test_pass_name(self):
+        """Makes sure that the pass_name is set correctly. Must match Catalyst pass name."""
+
+        assert split_to_single_terms.pass_name == "split-to-single-terms"
+
     def test_single_term_observable(self):
         """Test that the transform does not affect a circuit that
         contains only an observable with a single term"""


### PR DESCRIPTION
**Context:**

We added two new passes to Catalyst and we want to "link" them to their PL counterparts using the new unified API.

**Description of the Change:**

Simply add `pass_name=` for both and record any differences with `QJIT`.

[sc-103777]