### PR TITLE
Fix bug in power decompositions in the decomposition graph

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -809,6 +809,9 @@ The following classes have been ported over:
 * Fixes a discontinuity in the gradient of the single-qubit unitary decompositions.
   [(#9036)](https://github.com/PennyLaneAI/pennylane/pull/9036)
 
+* Fixes a bug where the decomposition graph is unable to find trivial decompositions of `qp.X(0) ** 1` and `qp.X(0) ** 0`.
+  [(#9152)](https://github.com/PennyLaneAI/pennylane/pull/9152)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -424,7 +424,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             # involutory or if it has a single rotation angle that can be trivially multiplied
             # with the power, we would've already retrieved `pow_involutory` or `pow_rotation`
             # as a potential decomposition rule for this operator, so there is no need to consider
-            # the general case.
+# Similar to the adjoint case, the `_get_pow_decompositions` contains the general
+# approach we take to decompose powers of operators. 
             decomps.extend(self._get_pow_decompositions(op))
 
         elif op.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -51,8 +51,6 @@ from .symbolic_decomposition import (
     make_adjoint_decomp,
     make_controlled_decomp,
     merge_powers,
-    pow_involutory,
-    pow_rotation,
     repeat_pow_base,
     self_adjoint,
     to_controlled_qubit_unitary,
@@ -420,11 +418,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             # operator, so there is no need to consider the general case.
             decomps.extend(self._get_adjoint_decompositions(op))
 
-        elif (
-            issubclass(op.op_type, qml.ops.Pow)
-            and pow_rotation not in decomps
-            and pow_involutory not in decomps
-        ):
+        elif issubclass(op.op_type, qml.ops.Pow):
             # Similar to the adjoint case, the `_get_pow_decompositions` contains the general
             # approach we take to decompose powers of operators. However, if the operator is
             # involutory or if it has a single rotation angle that can be trivially multiplied

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -420,12 +420,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         elif issubclass(op.op_type, qml.ops.Pow):
             # Similar to the adjoint case, the `_get_pow_decompositions` contains the general
-            # approach we take to decompose powers of operators. However, if the operator is
-            # involutory or if it has a single rotation angle that can be trivially multiplied
-            # with the power, we would've already retrieved `pow_involutory` or `pow_rotation`
-            # as a potential decomposition rule for this operator, so there is no need to consider
-# Similar to the adjoint case, the `_get_pow_decompositions` contains the general
-# approach we take to decompose powers of operators. 
+            # approach we take to decompose powers of operators.
             decomps.extend(self._get_pow_decompositions(op))
 
         elif op.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -805,13 +805,13 @@ class TestSymbolicDecompositions:
         op = qml.pow(qml.pow(qml.H(0), 3), 2)
         graph = DecompositionGraph(operations=[op], gate_set={"H"})
         # 3 operator nodes: Pow(Pow(H)), Pow(H), and H
-        # 1 decomposition nodes for Pow(Pow(H)) and 1 nodes for Pow(H)
+        # 2 decomposition nodes for Pow(Pow(H)) and 2 nodes for Pow(H)
         # and the dummy starting node
-        assert len(graph._graph.nodes()) == 5
-        # 2 edges from decompositions to ops and 1 edge from ops to decompositions
+        assert len(graph._graph.nodes()) == 7
+        # 4 edges from decompositions to ops and 2 edge from ops to decompositions
         # and 1 edge from the dummy starting node to the target gate set. Note that
         # H**6 decomposes to nothing, so H isn't counted.
-        assert len(graph._graph.edges()) == 4
+        assert len(graph._graph.edges()) == 7
 
         solution = graph.solve()
         with qml.queuing.AnnotatedQueue() as q:
@@ -826,6 +826,25 @@ class TestSymbolicDecompositions:
 
         assert q.queue == []
         assert solution.resource_estimate(op2) == to_resources({})
+
+    def test_trivial_powers(self, _):
+        """Tests trivial powers of 1 or 0."""
+
+        op = qml.pow(qml.X(0), 1)
+        op2 = qml.pow(qml.X(0), 0)
+
+        graph = DecompositionGraph(operations=[op, op2], gate_set={"PauliX"})
+        solution = graph.solve()
+
+        with qml.queuing.AnnotatedQueue() as q:
+            solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
+
+        assert q.queue == [qml.X(0)]
+
+        with qml.queuing.AnnotatedQueue() as q:
+            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
+
+        assert q.queue == []
 
     def test_custom_symbolic_decompositions(self, _):
         """Tests that custom symbolic decompositions are used."""

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -827,24 +827,19 @@ class TestSymbolicDecompositions:
         assert q.queue == []
         assert solution.resource_estimate(op2) == to_resources({})
 
-    def test_trivial_powers(self, _):
+    @pytest.mark.parametrize("z,expected", [(0, []), (1, [qml.X(0)])])
+    def test_trivial_powers(self, _, z, expected):
         """Tests trivial powers of 1 or 0."""
 
-        op = qml.pow(qml.X(0), 1)
-        op2 = qml.pow(qml.X(0), 0)
+        op = qml.pow(qml.X(0), z)
 
-        graph = DecompositionGraph(operations=[op, op2], gate_set={"PauliX"})
+        graph = DecompositionGraph(operations=[op], gate_set={"PauliX"})
         solution = graph.solve()
 
         with qml.queuing.AnnotatedQueue() as q:
             solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
 
-        assert q.queue == [qml.X(0)]
-
-        with qml.queuing.AnnotatedQueue() as q:
-            solution.decomposition(op2)(*op2.parameters, wires=op2.wires, **op2.hyperparameters)
-
-        assert q.queue == []
+        assert q.queue == expected
 
     def test_custom_symbolic_decompositions(self, _):
         """Tests that custom symbolic decompositions are used."""


### PR DESCRIPTION
**Context:**
The default decomposition rules that decomposes `Pow` should be applied to all `Pow` ops instead of added only as a backup plan when nothing else is available.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/9150
[sc-113495]
