### PR TITLE
Add gast dep

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -37,3 +37,4 @@ sphinxext-opengraph==0.9.0
 sphinx-sitemap
 matplotlib==3.10.0
 diastatic-malt
+gast>=0.6.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -37,4 +37,4 @@ sphinxext-opengraph==0.9.0
 sphinx-sitemap
 matplotlib==3.10.0
 diastatic-malt
-gast>=0.6.0
+gast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "packaging",
     "diastatic-malt",
     "numpy>=2.0",
-    "gast>=0.6.0"
+    "gast"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "typing_extensions",
     "packaging",
     "diastatic-malt",
-    "numpy>=2.0"
+    "numpy>=2.0",
+    "gast>=0.6.0"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
**Context:**
`diastatic-malt` removed its dependency on `gast` [here](https://github.com/PennyLaneAI/diastatic-malt/commit/37d629ea93ed2f8d2eed811219615bc1d63fcebf#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7)
PennyLane is not explicitly depending on `gast`.

**Description of the Change:**
Add explicit `gast` dependency to `pyproject` and `doc/requirements.txt`.

**Benefits:**
Unblock CI

**Possible Drawbacks:**

**Related GitHub Issues:**
