### PR TITLE
[v0.44 Bug Fix] Pin `diastatic-malt` and add `gast` as a hard dependency on PennyLane

### DIFF
--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -63,11 +63,11 @@ jobs:
       
       - name: Nightly Catalyst Version
         id: catalyst
-        run: echo "nightly=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
+        run: echo "nightly=--upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
       
       - name: PennyLane-Lightning Latest Version
         id: pennylane-lightning
-        run: echo "latest=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
+        run: echo "latest=--upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
     
     outputs:
       catalyst-jax-version: jax==${{ steps.catalyst-jax.outputs.version }} jaxlib==${{ steps.catalyst-jax.outputs.version }}

--- a/doc/development/release_notes.md
+++ b/doc/development/release_notes.md
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for PennyLane.
 
+.. mdinclude:: ../releases/changelog-0.44.1.md
+
 .. mdinclude:: ../releases/changelog-0.44.0.md
 
 .. mdinclude:: ../releases/changelog-0.43.2.md

--- a/doc/releases/changelog-0.44.0.md
+++ b/doc/releases/changelog-0.44.0.md
@@ -1,4 +1,4 @@
-# Release 0.44.0 (current release)
+# Release 0.44.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.44.1.md
+++ b/doc/releases/changelog-0.44.1.md
@@ -5,13 +5,12 @@
 * Add `gast` as an explicit dependency to fix `ModuleNotFoundError: No module named 'gast'`
   on import when `diastatic-malt>=2.15.3` is installed. The `gast` package was previously
   pulled in transitively by `diastatic-malt`, but version 2.15.3 dropped it as a dependency.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#9160)](https://github.com/PennyLaneAI/pennylane/pull/9160)
 
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Yushao Chen,
-
-View dwierichs's full-sized avatar
+Andrija Paurević,
 David Wierichs

--- a/doc/releases/changelog-0.44.1.md
+++ b/doc/releases/changelog-0.44.1.md
@@ -2,9 +2,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Add `gast` as an explicit dependency to fix `ModuleNotFoundError: No module named 'gast'`
-  on import when `diastatic-malt>=2.15.3` is installed. The `gast` package was previously
-  pulled in transitively by `diastatic-malt`, but version 2.15.3 dropped it as a dependency.
+* The ``gast`` package is now an explicit dependency in PennyLane. The ``gast`` package was previously
+  pulled in transitively by ``diastatic-malt``, but ``diastatic-malt==2.15.3`` dropped ``gast`` as a dependency, which caused an error when importing PennyLane.
   [(#9160)](https://github.com/PennyLaneAI/pennylane/pull/9160)
 
 <h3>Contributors ✍️</h3>

--- a/doc/releases/changelog-0.44.1.md
+++ b/doc/releases/changelog-0.44.1.md
@@ -1,4 +1,4 @@
-# Release 0.44.1
+# Release 0.44.1 (current release)
 
 <h3>Bug fixes 🐛</h3>
 
@@ -11,4 +11,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jerry
+Yushao Chen,
+
+View dwierichs's full-sized avatar
+David Wierichs

--- a/doc/releases/changelog-0.44.1.md
+++ b/doc/releases/changelog-0.44.1.md
@@ -1,0 +1,14 @@
+# Release 0.44.1
+
+<h3>Bug fixes 🐛</h3>
+
+* Add `gast` as an explicit dependency to fix `ModuleNotFoundError: No module named 'gast'`
+  on import when `diastatic-malt>=2.15.3` is installed. The `gast` package was previously
+  pulled in transitively by `diastatic-malt`, but version 2.15.3 dropped it as a dependency.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Jerry

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.44.0"
+__version__ = "0.44.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tomlkit",
     "typing_extensions",
     "packaging",
-    "diastatic-malt",
+    "diastatic-malt==2.15.2",
     "gast",
     "numpy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ci = [
 ]
 dev = [
     "pre-commit>=2.19.0",
-    "pytest>=8.4.1",
+    "pytest==8.4.1",
     "pytest-cov>=3.0.0",
     "pytest-mock>=3.7.0",
     "pytest-xdist>=2.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "typing_extensions",
     "packaging",
     "diastatic-malt",
+    "gast",
     "numpy"
 ]
 classifiers = [

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -79,7 +79,7 @@ class TestFromBloq:
 
         from qualtran.bloqs.basic_gates import XGate
 
-        assert repr(qml.FromBloq(XGate(), 1)) == "FromBloq(XGate, wires=Wires([1]))"
+        assert repr(qml.FromBloq(XGate(), 1)) == "FromBloq(X, wires=Wires([1]))"
         with pytest.raises(TypeError, match="bloq must be an instance of"):
             qml.FromBloq("123", 1)
 

--- a/tests/noise/test_mitigate.py
+++ b/tests/noise/test_mitigate.py
@@ -380,13 +380,6 @@ class TestMitiqIntegration:
         assert res_mitigated.shape == res_ideal.shape
         assert not np.allclose(res_mitigated, res_ideal)
 
-    @pytest.mark.xfail(
-        reason="Mitiq 0.47.0 uses removed QuantumScript.to_openqasm. Note that Mitiq 0.48.1 "
-        "no longer raises this error as per https://github.com/unitaryfoundation/mitiq/issues/2814. "
-        "However, as there is no stable dependency resolution for qualtran, cirq and mitiq==0.48.1, "
-        "we cannot test this case for the time being. Qualtran should update soon and enable this "
-        "test case to pass."
-    )
     def test_with_reps_per_factor(self):
         """Tests if the expected shape is returned when mitigating a circuit with a reps_per_factor
         set not equal to 1"""


### PR DESCRIPTION
# Context

Since 0.43, we [introduced](https://github.com/PennyLaneAI/pennylane/pull/8076) an implicit dependency on `gast` without adding it into `pyproject.toml`. Its dependency used to be automatically resolved by our dependency over `diastatic-malt`, version of which unbound. However, this package [removed](https://github.com/PennyLaneAI/diastatic-malt/commit/37d629ea93ed2f8d2eed811219615bc1d63fcebf#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) its dependency over `gast`! Then the stable `0.43` and `0.44` started to fail.

[sc-113713]