### PR TITLE
Controlled `ChangeOpBasis` always take the optimized decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -809,6 +809,9 @@ The following classes have been ported over:
 * Fixes a discontinuity in the gradient of the single-qubit unitary decompositions.
   [(#9036)](https://github.com/PennyLaneAI/pennylane/pull/9036)
 
+* Fixes a bug where a controlled `ChangeOpBasis` is sometimes not decomposed optimally when graph is enabled.
+  [(#9161)](https://github.com/PennyLaneAI/pennylane/pull/9161)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -485,19 +485,11 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             return [flip_control_adjoint]
 
         # Special case: when the base is GlobalPhase, none of the following automatically
-        # generated decomposition rules apply.
-        if base_class is qml.GlobalPhase:
+        # generated decomposition rules apply. Also, controlled ChangeOpBasis defines its
+        # own decomposition, which applies the control on the middle op only. This should
+        # always be applied.
+        if base_class in {qml.GlobalPhase, qml.ops.ChangeOpBasis}:
             return []
-
-        # Special case: controlled ChangeOpBasis defines its own decomposition, which applies
-        # the control on the middle op only. This should always be applied.
-        if base_class is qml.ops.ChangeOpBasis:
-# Special case: when the base is GlobalPhase, none of the following automatically
-# generated decomposition rules apply.
-        # Special case: controlled ChangeOpBasis defines its own decomposition, which applies
-        # the control on the middle op only. This should always be applied.
-if base_class in {qml.GlobalPhase, qml.ops.ChangeOpBasis}:
-return []
 
         # General case: apply control to the base op's decomposition rules.
         base = resource_rep(base_class, **base_params)

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -492,7 +492,12 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         # Special case: controlled ChangeOpBasis defines its own decomposition, which applies
         # the control on the middle op only. This should always be applied.
         if base_class is qml.ops.ChangeOpBasis:
-            return []
+# Special case: when the base is GlobalPhase, none of the following automatically
+# generated decomposition rules apply.
+        # Special case: controlled ChangeOpBasis defines its own decomposition, which applies
+        # the control on the middle op only. This should always be applied.
+if base_class in {qml.GlobalPhase, qml.ops.ChangeOpBasis}:
+return []
 
         # General case: apply control to the base op's decomposition rules.
         base = resource_rep(base_class, **base_params)

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -489,6 +489,11 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         if base_class is qml.GlobalPhase:
             return []
 
+        # Special case: controlled ChangeOpBasis defines its own decomposition, which applies
+        # the control on the middle op only. This should always be applied.
+        if base_class is qml.ops.ChangeOpBasis:
+            return []
+
         # General case: apply control to the base op's decomposition rules.
         base = resource_rep(base_class, **base_params)
         rules = [make_controlled_decomp(decomp) for decomp in self._get_decompositions(base)]

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -428,6 +428,24 @@ class TestDecomposeGraphEnabled:
         ]
 
     @pytest.mark.integration
+    def test_controlled_change_op_basis(self):
+        """Tests that a controlled ChangeOpBasis is correctly decomposed."""
+
+        op = qml.ctrl(
+            qml.change_op_basis(qml.SWAP([1, 2]), qml.PhaseAdder(1, x_wires=[1, 2])), control=0
+        )
+        tape = qml.tape.QuantumScript([op])
+        [new_tape], _ = qml.transforms.decompose(
+            tape, gate_set=qml.gate_sets.ALL_OPS, max_expansion=1
+        )
+
+        assert new_tape.operations == [
+            qml.SWAP([1, 2]),
+            qml.ctrl(qml.PhaseAdder(1, x_wires=[1, 2]), control=0),
+            qml.adjoint(qml.SWAP([1, 2])),
+        ]
+
+    @pytest.mark.integration
     def test_adjoint_decomp(self):
         """Tests decomposing an adjoint operation."""
 


### PR DESCRIPTION
**Context:**
Enforce the optimal decomposition for `ChangeOpBasis` in the decomposition graph so that with a controlled `ChangeOpBasis`, the decomposition **always** apply the control on the middle op only.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/9153
[sc-113511]