### PR TITLE
Minor doctest fix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -159,6 +159,7 @@ The following classes have been ported over:
   level ``0`` corresponds to ``"Before Tape Transforms"`` and ``"Before MLIR passes"``
   is the level after all tape transforms but before the first MLIR pass.
   [(#9091)](https://github.com/PennyLaneAI/pennylane/pull/9091)
+  [(#9166)](https://github.com/PennyLaneAI/pennylane/pull/9166)
 
 * When using :func:`~.specs` with Catalyst and with multiple levels, printing the returned
   :class:`~.resource.CircuitSpecs` object will provide a table detailing relevant information at each requested level,
@@ -183,8 +184,8 @@ The following classes have been ported over:
   Shots: Shots(total=None)
   Levels:
   - 0: Before transforms
-  - 1: Before MLIR Passes (MLIR-0)
-  - 2: cancel-inverses (MLIR-1)
+  - 1: Before MLIR Passes
+  - 2: cancel-inverses
   <BLANKLINE>
   ↓Metric     Level→ |  0 |  1 |  2
   ---------------------------------

--- a/pennylane/transforms/decompositions/pauli_based_computation.py
+++ b/pennylane/transforms/decompositions/pauli_based_computation.py
@@ -90,7 +90,7 @@ def to_ppr_setup_inputs():
     Device: null.qubit
     Device wires: 2
     Shots: Shots(total=None)
-    Level: to-ppr (MLIR-1)
+    Level: to-ppr
     <BLANKLINE>
     Wire allocations: 2
     Total gates: 11
@@ -193,7 +193,7 @@ def commute_ppr_setup_inputs(max_pauli_size: int = 0):
     Device: null.qubit
     Device wires: 2
     Shots: Shots(total=None)
-    Level: commute-ppr (MLIR-2)
+    Level: commute-ppr
     <BLANKLINE>
     Wire allocations: 2
     Total gates: 7
@@ -295,7 +295,7 @@ def merge_ppr_ppm_setup_inputs(max_pauli_size: int = 0):
     Device: null.qubit
     Device wires: 2
     Shots: Shots(total=None)
-    Level: merge-ppr-ppm (MLIR-2)
+    Level: merge-ppr-ppm
     <BLANKLINE>
     Wire allocations: 2
     Total gates: 1
@@ -409,7 +409,7 @@ def ppr_to_ppm_setup_inputs(decompose_method="pauli-corrected", avoid_y_measure=
     Device: null.qubit
     Device wires: 2
     Shots: Shots(total=None)
-    Level: ppr-to-ppm (MLIR-2)
+    Level: ppr-to-ppm
     <BLANKLINE>
     Wire allocations: 9
     Total gates: 24
@@ -521,7 +521,7 @@ def ppm_compilation_setup_inputs(
     Device: null.qubit
     Device wires: 2
     Shots: Shots(total=None)
-    Level: ppm-compilation (MLIR-1)
+    Level: ppm-compilation
     <BLANKLINE>
     Wire allocations: 8
     Total gates: 25
@@ -718,7 +718,7 @@ def decompose_arbitrary_ppr_setup_inputs():
     Device: null.qubit
     Device wires: 3
     Shots: Shots(total=None)
-    Level: decompose-arbitrary-ppr (MLIR-2)
+    Level: decompose-arbitrary-ppr
     <BLANKLINE>
     Wire allocations: 3
     Total gates: 6


### PR DESCRIPTION
**Context:**
Printing of the transform level in specs changed due to https://github.com/PennyLaneAI/catalyst/pull/2533

**Description of the Change:**
Adjust expected output in docstring examples.

**Benefits:**
unblock CI

**Possible Drawbacks:**

**Related GitHub Issues:**
