### PR TITLE
fix: remove `2.0<=NumPy<=2.3` bound in `external-libraries-test`

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -483,9 +483,6 @@ jobs:
         ${{ needs.default-dependency-versions.outputs.jax-version }}
         ${{ needs.default-dependency-versions.outputs.catalyst-nightly }}
         ${{ inputs.additional_python_packages }}
-      # TODO: Remove once Numba supports NumPy>2.3 
-      additional_pip_packages_post: |
-        numpy>=2.0,<=2.3
 
   qcut-tests:
     needs:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -471,6 +471,7 @@ The following classes have been ported over:
   [(#8914)](https://github.com/PennyLaneAI/pennylane/pull/8914)
   [(#8954)](https://github.com/PennyLaneAI/pennylane/pull/8954)
   [(#9017)](https://github.com/PennyLaneAI/pennylane/pull/9017)
+  [(#9167)](https://github.com/PennyLaneAI/pennylane/pull/9167)
 
 * ``compute_qfunc_decomposition`` and ``has_qfunc_decomposition`` have been removed from  :class:`~.Operator`
   and all subclasses that implemented them. The graph decomposition system should be used when capture is enabled.


### PR DESCRIPTION
**Context:**

Numba [released](https://github.com/numba/numba/releases/tag/0.64.0) and supports numpy 2.4 🎉 

**Description of the Change:**

Update external libraries tests to unbound `numpy`.

**Benefits:**

Broader range of support

**Possible Drawbacks:** None identified

[sc-113730]