### PR TITLE
Fix nightly main to master sync

### DIFF
--- a/.github/workflows/sync-main-to-master.yml
+++ b/.github/workflows/sync-main-to-master.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           ref: master
           token: ${{ secrets.PENNYLANE_MASTER_MAIN_WRITE }}
+          fetch-depth: 0 
 
       - name: Sync main to master
         run: |

--- a/.github/workflows/sync-main-to-master.yml
+++ b/.github/workflows/sync-main-to-master.yml
@@ -24,7 +24,6 @@ jobs:
           if git merge --no-commit --ff-only origin/main; then
             echo "Synching from main to master."
             echo "merge_conflict=false" >> $GITHUB_ENV
-            git commit -m "Sync main to master"
             git push origin master 
           else
             echo "Merge conflict detected. Creating a PR ..."
@@ -50,3 +49,4 @@ jobs:
           else
             echo "No new changes to sync from main to master."
           fi 
+          exit 1


### PR DESCRIPTION
**Context:**
The sync of main to main [failed](https://github.com/PennyLaneAI/pennylane/actions/runs/22935446990/job/66565695517) due to the `git commit` command after the rebase.

**Description of the Change:**
Remove git commit, add pipeline failure if a pr is created.

**Benefits:**
workflow runs properly.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
