### PR TITLE
Add error if wire argnames incorrect in Subroutine

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -95,6 +95,7 @@
   [(#9070)](https://github.com/PennyLaneAI/pennylane/pull/9070)
   [(#9097)](https://github.com/PennyLaneAI/pennylane/pull/9097)
   [(#9119)](https://github.com/PennyLaneAI/pennylane/pull/9119)
+  [(#9172)](https://github.com/PennyLaneAI/pennylane/pull/9172)
 
   ```python
   from pennylane.templates import Subroutine

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -668,7 +668,7 @@ class Subroutine:
             if argname not in self._signature.parameters:
                 raise ValueError(
                     f"wire argname '{argname}' not present in function signature. "
-                    "Please update wire_argnames."
+                    "Please update the function's signature or 'wire_argnames'."
                 )
 
     @property

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -667,7 +667,7 @@ class Subroutine:
         for argname in self._wire_argnames:
             if argname not in self._signature.parameters:
                 raise ValueError(
-                    f"wire argname {argname} not present in function signature. "
+                    f"wire argname '{argname}' not present in function signature. "
                     "Please update wire_argnames."
                 )
 

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -664,6 +664,13 @@ class Subroutine:
 
         self._capture_subroutine = capture_subroutine(definition, static_argnames=static_argnames)
 
+        for argname in self._wire_argnames:
+            if argname not in self._signature.parameters:
+                raise ValueError(
+                    f"wire argname {argname} not present in function signature. "
+                    "Please update wire_argnames."
+                )
+
     @property
     def name(self) -> str:
         """A string representation to label the Subroutine."""

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -138,7 +138,7 @@ class TestInitialization:
             pass
 
         with pytest.raises(
-            ValueError, match="wire argname wires not present in function signature."
+            ValueError, match="wire argname 'wires' not present in function signature."
         ):
             Subroutine(f)
 

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -131,6 +131,17 @@ class TestInitialization:
 
         assert f.exact_resources == exact_resources
 
+    def test_error_if_wire_argnames_not_present(self):
+        """Test that an error is raised if a wire argname is not present in the signature."""
+
+        def f(register):
+            pass
+
+        with pytest.raises(
+            ValueError, match="wire argname wires not present in function signature."
+        ):
+            Subroutine(f)
+
 
 def Example1(x, y, reg1, reg2, pauli_words):
     qml.PauliRot(x, pauli_words[0], reg1)


### PR DESCRIPTION
**Context:**

There was some confusion around errors when the `wire_argnames` property is incorrect for the `Subroutine`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
