### PR TITLE
Bound `pyzx<0.10.0` in pyproject.toml

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,15 +58,7 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install -e .
-
-      - name: Install testing packages
-        run: |
-          pip install sybil pytest
-
-      - name: Install additional packages
-        run: |
-          pip install "jax==0.7.1" "jaxlib==0.7.1" torch pyzx matplotlib
+          pip install --group docs --group dev -e . 
 
       - name: Print Dependencies
         run: |

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -660,6 +660,9 @@ The following classes have been ported over:
 
 <h3>Internal changes ⚙️</h3>
 
+* Pin `pyzx<0.10` for compatibility.
+  [(#9175)](https://github.com/PennyLaneAI/pennylane/pull/9175)
+
 * Remove usage of `PassPipelineWrapper` due to `removal <https://github.com/PennyLaneAI/catalyst/pull/2525>`) in Catalyst.
   [(#9123)](https://github.com/PennyLaneAI/pennylane/pull/9123)
   

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -660,7 +660,7 @@ The following classes have been ported over:
 
 <h3>Internal changes ⚙️</h3>
 
-* Pin `pyzx<0.10` for compatibility.
+* Upper bound `pyzx<0.10` dependency to ensure compatibility.
   [(#9175)](https://github.com/PennyLaneAI/pennylane/pull/9175)
 
 * Remove usage of `PassPipelineWrapper` due to `removal <https://github.com/PennyLaneAI/catalyst/pull/2525>`) in Catalyst.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ docs = [
     # TODO: Remove once galois becomes compatible with latest numpy
     "numpy>=2.0,<=2.2",
     "pygments-github-lexers",
-    "pyzx",
+    "pyzx==0.9.0",
     "docutils==0.20",
     "sphinx==8.1",
     "sphinx-automodapi==0.19",
@@ -122,7 +122,7 @@ docs = [
     "openfermionpyscf"
 ]
 external-libraries = [
-    "pyzx",
+    "pyzx==0.9.0",
     "stim",
     "quimb",
     "optax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ docs = [
     # TODO: Remove once galois becomes compatible with latest numpy
     "numpy>=2.0,<=2.2",
     "pygments-github-lexers",
-    "pyzx==0.9.0",
+    "pyzx<0.10.0",
     "docutils==0.20",
     "sphinx==8.1",
     "sphinx-automodapi==0.19",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ docs = [
     "openfermionpyscf"
 ]
 external-libraries = [
-    "pyzx==0.9.0",
+    "pyzx<0.10.0",
     "stim",
     "quimb",
     "optax",


### PR DESCRIPTION
0.10 [breaks](https://github.com/PennyLaneAI/pennylane/actions/runs/23007495715/job/66809164580?pr=9159) us: https://github.com/zxcalc/pyzx/releases/tag/v0.10.0

[sc-113863]