### PR TITLE
Create fallback for calculating Subroutine resources

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -96,6 +96,7 @@
   [(#9097)](https://github.com/PennyLaneAI/pennylane/pull/9097)
   [(#9119)](https://github.com/PennyLaneAI/pennylane/pull/9119)
   [(#9172)](https://github.com/PennyLaneAI/pennylane/pull/9172)
+  [(#9176)](https://github.com/PennyLaneAI/pennylane/pull/9176)
 
   ```python
   from pennylane.templates import Subroutine

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -346,10 +346,10 @@ def _default_resources(subroutine: "Subroutine", *args, **kwargs) -> defaultdict
         if isinstance(sig.arguments[arg], AbstractArray):
             sig.arguments[arg] = list(range(sig.arguments[arg].shape[0]))
     with queuing.AnnotatedQueue() as q:
-        subroutine(**sig.arguments)
+        subroutine.definition(**sig.arguments)
 
     resources = defaultdict(int)
-    for op in q.queue[0].decomposition():
+    for op in q.queue:
         resources[resource_rep(type(op), **op.resource_params)] += 1
     return resources
 

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -402,7 +402,7 @@ class Subroutine:
         from functools import partial
         from pennylane.templates import Subroutine
 
-        @pSubroutine
+        @Subroutine
         def MyTemplate(x, y, wires):
             qml.RX(x, wires[0])
             qml.RY(y, wires[0])

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -709,7 +709,13 @@ class Subroutine:
     def compute_resources(self, *args, **kwargs) -> dict:
         """Calculate a condensed representation for the resources required for the Subroutine."""
         if self._compute_resources is None:
-            return _default_resources(self, *args, **kwargs)
+            try:
+                return _default_resources(self, *args, **kwargs)
+            except Exception as e:
+                raise type(e)(
+                    f"Fallback for computing resources for {self} failed. "
+                    f"Please add a compute_resources definition to {self}."
+                ) from e
         bound_args = self._full_setup_inputs(*args, **kwargs)
         return self._compute_resources(*bound_args.args, **bound_args.kwargs)
 

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -26,6 +26,7 @@ This module contains the abstractions for defining subroutines.
 
 """
 import copy
+from collections import defaultdict
 from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
@@ -334,6 +335,25 @@ class SubroutineOp(Operation):
         return super().label(decimals, base_label=self.name, cache=cache)
 
 
+def _default_resources(subroutine: "Subroutine", *args, **kwargs) -> defaultdict:
+    sig = subroutine.signature.bind(*args, **kwargs)
+    for arg in subroutine.dynamic_argnames:
+        avals, struct = flatten(sig.arguments[arg])
+        if avals and isinstance(avals[0], AbstractArray):
+            params = (np.empty(shape=aval.shape, dtype=aval.dtype) for aval in avals)
+            sig.arguments[arg] = unflatten(params, struct)
+    for arg in subroutine.wire_argnames:
+        if isinstance(sig.arguments[arg], AbstractArray):
+            sig.arguments[arg] = list(range(sig.arguments[arg].shape[0]))
+    with queuing.AnnotatedQueue() as q:
+        subroutine(**sig.arguments)
+
+    resources = defaultdict(int)
+    for op in q.queue[0].decomposition():
+        resources[resource_rep(type(op), **op.resource_params)] += 1
+    return resources
+
+
 def _calculate_resources(subroutine: "Subroutine", signature_key):
     sig = subroutine.signature.bind(*signature_key)
     for arg in subroutine.dynamic_argnames:
@@ -382,10 +402,7 @@ class Subroutine:
         from functools import partial
         from pennylane.templates import Subroutine
 
-        def resources(x, y, wires):
-            return {qml.RX: 1, qml.RY: 1}
-
-        @partial(Subroutine, compute_resources=resources)
+        @pSubroutine
         def MyTemplate(x, y, wires):
             qml.RX(x, wires[0])
             qml.RY(y, wires[0])
@@ -506,8 +523,11 @@ class Subroutine:
         that decompose to ``Subroutine``, in Catalyst.
 
 
-    To use ``Subroutine`` with graph-based decompositions, a function to compute the resources must
-    be provided.
+    To use ``Subroutine`` with graph-based decompositions, we need a function to compute the resources.
+    A default fallback calculates the resources by calling the subroutine with
+    dummy parameters created with ``np.empty``. This will be inefficient
+    and will only work if the dynamic parameters have no additional constraints, such as normalization
+    or unitarity.
     The calculation of resources should only depend on the static arguments, the number of wires
     in each register, and the shape and ``dtype`` of the dynamic arguments. This will allow
     the calculation of the resources to performed in an abstract way.
@@ -689,7 +709,7 @@ class Subroutine:
     def compute_resources(self, *args, **kwargs) -> dict:
         """Calculate a condensed representation for the resources required for the Subroutine."""
         if self._compute_resources is None:
-            raise NotImplementedError(f"{self} does not have a defined compute_resources function.")
+            return _default_resources(self, *args, **kwargs)
         bound_args = self._full_setup_inputs(*args, **kwargs)
         return self._compute_resources(*bound_args.args, **bound_args.kwargs)
 

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -221,6 +221,19 @@ def test_fallback_creating_resources_AbstractArray():
     assert resources == expected
 
 
+def test_fallback_resources_error():
+    """Test that is an error occurs when using the resources fallback, we an more informative error."""
+
+    @qml.templates.Subroutine
+    def f(wires):
+        raise ValueError("AHHHH")
+
+    with pytest.raises(
+        ValueError, match="Fallback for computing resources for <Subroutine: f> failed."
+    ):
+        f.compute_resources(qml.templates.AbstractArray((2,)))
+
+
 class TestSubroutineOp:
 
     op1 = generate_subroutine_op_example(

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -14,7 +14,7 @@
 """Tests for Subroutine and SubroutineOp"""
 # pylint: disable=unused-argument
 import inspect
-from collections import Counter
+from collections import Counter, defaultdict
 from functools import partial
 
 import numpy as np
@@ -52,10 +52,10 @@ class TestInitialization:
         assert len(q.queue) == 1
         qml.assert_equal(q.queue[0], qml.RX(0.5, 0))
 
-        with pytest.raises(
-            NotImplementedError, match="does not have a defined compute_resources function."
-        ):
-            S.compute_resources(0.5, wires=0)
+        resources = S.compute_resources(0.5, wires=0)
+        expected = defaultdict(int)
+        expected[qml.resource_rep(qml.RX)] = 1
+        assert resources == expected
 
     def test_wire_argnames(self):
         """Test that wire argnames can be specified."""
@@ -189,6 +189,36 @@ def test_operator_method():
     assert isinstance(op, SubroutineOp)
     assert op.output == 2
     qml.equal(op.decomposition()[0], qml.RX(0.5, 0))
+
+
+def test_fallback_creating_resources_AbstractArray():
+    """Test that the fallback for calculating resources works with AbstractArray's."""
+
+    @partial(Subroutine, static_argnames="rotation")
+    def f(params, wires, rotation):
+        for (
+            p,
+            w,
+        ) in zip(params["a"], wires):
+            qml.PauliRot(p, rotation, w)
+        qml.MultiControlledX(wires)
+
+    p = AbstractArray((3,), float)
+    w = AbstractArray((3,))
+
+    resources = f.compute_resources({"a": p}, w, "Z")
+    expected = defaultdict(int)
+    expected[qml.resource_rep(qml.PauliRot, pauli_word="Z")] = 3
+
+    r = qml.resource_rep(
+        qml.MultiControlledX,
+        num_control_wires=2,
+        num_zero_control_values=0,
+        num_work_wires=0,
+        work_wire_type="borrowed",
+    )
+    expected[r] = 1
+    assert resources == expected
 
 
 class TestSubroutineOp:
@@ -837,3 +867,25 @@ class TestGraphDecomposition:
 
         op = f.operator(0)
         qml.ops.functions.assert_valid(op, skip_pickle=True, skip_capture=True)
+
+    def test_compute_resources_fallback(self):
+        """Test that the compute_resources fallback allows integration with decomps by default."""
+
+        @partial(Subroutine, static_argnames="rotation")
+        def f(params, wires, rotation):
+            for (
+                p,
+                w,
+            ) in zip(params, wires):
+                qml.PauliRot(p, rotation, w)
+            qml.MultiControlledX(wires)
+
+        params = np.array([0.5, 1.2, 3.4])
+        wires = [0, 1, 2]
+        tape = qml.tape.QuantumScript([f.operator(params, wires, "X")])
+        [decomposed], _ = qml.decompose(tape, gate_set=qml.gate_sets.ALL_OPS)
+        print(decomposed.circuit)
+        qml.assert_equal(decomposed[0], qml.PauliRot(0.5, "X", 0))
+        qml.assert_equal(decomposed[1], qml.PauliRot(1.2, "X", 1))
+        qml.assert_equal(decomposed[2], qml.PauliRot(3.4, "X", 2))
+        qml.assert_equal(decomposed[3], qml.MultiControlledX(wires))

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -222,7 +222,7 @@ def test_fallback_creating_resources_AbstractArray():
 
 
 def test_fallback_resources_error():
-    """Test that is an error occurs when using the resources fallback, we an more informative error."""
+    """Test that if an error occurs when using the resources fallback, we get a more informative error."""
 
     @qml.templates.Subroutine
     def f(wires):


### PR DESCRIPTION
**Context:**

Right now, if `Subroutine` classes are going to be integrated with tape-based PL and graph-based decompositions, they need to provide a `compute_resources` function.  This just adds to the overhead of adding new subroutines and makes them less user friendly.

**Description of the Change:**

Creates a fallback calculating the resources from calling the implementation using empty numpy arrays for the parameters and basic integers for the wires.

**Benefits:**

Easier to get subroutines up and running.

**Possible Drawbacks:**

This fallback is incredibly inefficient, so I would still recommend it's not used much for code where efficiency matters.

**Related GitHub Issues:**

[sc-113864]