### PR TITLE
add subroutine support to CollectOpsandMeas

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -96,6 +96,7 @@
   [(#9097)](https://github.com/PennyLaneAI/pennylane/pull/9097)
   [(#9119)](https://github.com/PennyLaneAI/pennylane/pull/9119)
   [(#9172)](https://github.com/PennyLaneAI/pennylane/pull/9172)
+  [(#9177)](https://github.com/PennyLaneAI/pennylane/pull/9177)
 
   ```python
   from pennylane.templates import Subroutine

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -32,6 +32,7 @@ from pennylane.capture.primitives import (
     measure_prim,
     pauli_measure_prim,
     qnode_prim,
+    quantum_subroutine_prim,
     value_and_grad_prim,
     vjp_prim,
 )
@@ -44,9 +45,33 @@ from pennylane.ops.mid_measure import (
     measure,
     pauli_measure,
 )
-from pennylane.wires import DynamicWire
+from pennylane.wires import DynamicWire, Wires
 
 from .qscript import QuantumScript
+
+
+class CollectedSubroutine(Operator):
+    """Represents a single subroutine encountered by CollectOpsandMeas.
+    While it contains less information than the corresponding :class:`~.SubroutineOp`,
+    it can be useful for testing the captured plxpr.
+
+    The only properties held onto by this "Operator" are name (a string), wires, and
+    decomposition.
+
+    """
+
+    _primitive = None
+
+    def __repr__(self) -> str:
+        return f"<CollectedSubroutine: {self.name}>"
+
+    def __init__(self, name: str, decomp: list[Operator]):
+        self._decomp = decomp
+        super().__init__(wires=Wires.all_wires([op.wires for op in decomp]))
+        self._name = name
+
+    def decomposition(self):
+        return self._decomp
 
 
 class CollectOpsandMeas(FlattenedInterpreter):
@@ -241,6 +266,17 @@ def _allocate_primitive(self, *, num_wires, state, restored):
 def _deallocate_primitive(self, *wires):
     self.state["ops"].append(Deallocate(wires))
     return []
+
+
+# pylint: disable=unused-argument
+@CollectOpsandMeas.register_primitive(quantum_subroutine_prim)
+def _quantum_subroutine(self, *args, jaxpr, name, **kwargs):
+    child = CollectOpsandMeas()
+    out = child.eval(jaxpr.jaxpr, jaxpr.consts, *args)
+    name = name.split("_")[0]
+    with pause():
+        self.state["ops"].append(CollectedSubroutine(name, child.state["ops"]))
+    return out
 
 
 def plxpr_to_tape(plxpr: "jax.extend.core.Jaxpr", consts, *args, shots=None) -> QuantumScript:

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -45,33 +45,10 @@ from pennylane.ops.mid_measure import (
     measure,
     pauli_measure,
 )
-from pennylane.wires import DynamicWire, Wires
+from pennylane.templates.core import CollectedSubroutine
+from pennylane.wires import DynamicWire
 
 from .qscript import QuantumScript
-
-
-class CollectedSubroutine(Operator):
-    """Represents a single subroutine encountered by CollectOpsandMeas.
-    While it contains less information than the corresponding :class:`~.SubroutineOp`,
-    it can be useful for testing the captured plxpr.
-
-    The only properties held onto by this "Operator" are name (a string), wires, and
-    decomposition.
-
-    """
-
-    _primitive = None
-
-    def __repr__(self) -> str:
-        return f"<CollectedSubroutine: {self.name}>"
-
-    def __init__(self, name: str, decomp: list[Operator]):
-        self._decomp = decomp
-        super().__init__(wires=Wires.all_wires([op.wires for op in decomp]))
-        self._name = name
-
-    def decomposition(self):
-        return self._decomp
 
 
 class CollectOpsandMeas(FlattenedInterpreter):

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -753,4 +753,34 @@ class Subroutine:
         return op.output
 
 
-__all__ = ["Subroutine", "SubroutineOp", "AbstractArray", "subroutine_resource_rep"]
+class CollectedSubroutine(Operation):
+    """Represents a single subroutine encountered by CollectOpsandMeas.
+    While it contains less information than the corresponding :class:`~.SubroutineOp`,
+    it can be useful for testing the captured plxpr.
+
+    The only properties held onto by this "Operator" are name (a string), wires, and
+    decomposition.
+
+    """
+
+    _primitive = None
+
+    def __repr__(self) -> str:
+        return f"<CollectedSubroutine: {self.name}>"
+
+    def __init__(self, name: str, decomp: list[Operation]):
+        self._decomp = decomp
+        super().__init__(wires=Wires.all_wires([op.wires for op in decomp]))
+        self._name = name
+
+    def decomposition(self):
+        return self._decomp
+
+
+__all__ = [
+    "Subroutine",
+    "SubroutineOp",
+    "AbstractArray",
+    "subroutine_resource_rep",
+    "CollectedSubroutine",
+]

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -189,6 +189,7 @@ _ABSTRACT_OR_META_TYPES = {
     qml.ops.ControlledOp,
     qml.ops.qubit.BasisStateProjector,
     qml.ops.qubit.StateVectorProjector,
+    qml.templates.core.CollectedSubroutine,
     StatePrepBase,
     qml.resource.ResourcesOperation,
     qml.resource.ErrorOperation,

--- a/tests/tape/test_plxpr_conversion.py
+++ b/tests/tape/test_plxpr_conversion.py
@@ -70,10 +70,19 @@ class TestCollectOpsandMeas:
         ops = interpreter.state["ops"]
         for op in ops:
             assert op.name == "MyFunc"
+            assert repr(op) == "<CollectedSubroutine: MyFunc>"
+
+        assert ops[0].wires == qml.wires.Wires((0, 1))
+        assert ops[1].wires == qml.wires.Wires((2, 3))
+        assert ops[2].wires == qml.wires.Wires((3, 4))
 
         qml.assert_equal(ops[0].decomposition()[0], qml.PauliRot(0.5, "XY", (0, 1)))
-        qml.assert_equal(ops[1].decomposition()[0], qml.PauliRot(1.5, (2, 3), "YZ"))
-        qml.assert_equal(ops[2].decomposition()[0], qml.PauliRot(2.5, "XY", (3, 4)))
+        qml.assert_equal(
+            ops[1].decomposition()[0], qml.PauliRot(jax.numpy.array(1.5), "YZ", (2, 3))
+        )
+        qml.assert_equal(
+            ops[2].decomposition()[0], qml.PauliRot(jax.numpy.array(2.5), "XY", (3, 4))
+        )
 
     def test_for_loop(self):
         """Test collecting the operations in a for loop."""
@@ -616,21 +625,3 @@ class TestPlxprToTape:
         assert tape.operations[2].wires == tape.operations[1].wires
         assert isinstance(tape.operations[3], qml.allocation.Deallocate)
         assert tape.operations[3].wires == tape.operations[1].wires
-
-    def test_subroutine(self):
-        """Test that jaxpr's with subroutines can be converted to a tape."""
-
-        @qml.capture.subroutine
-        def some_func(x):
-            qml.RX(x, 0)
-
-        def c(x):
-            some_func(x)
-            some_func(x)
-
-        jaxpr = jax.make_jaxpr(c)(0.5)
-        tape = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, 0.5)
-        assert isinstance(tape, qml.tape.QuantumScript)
-        assert len(tape) == 2
-        qml.assert_equal(tape[0], qml.RX(0.5, 0))
-        qml.assert_equal(tape[1], qml.RX(0.5, 0))

--- a/tests/tape/test_plxpr_conversion.py
+++ b/tests/tape/test_plxpr_conversion.py
@@ -14,6 +14,8 @@
 """
 Tests for CollectOpsandMeas and plxpr_to_tape
 """
+from functools import partial
+
 import pytest
 
 import pennylane as qml
@@ -48,6 +50,30 @@ class TestCollectOpsandMeas:
         assert len(obj.state["ops"]) == 3
 
         qml.assert_equal(obj.state["measurements"][0], qml.expval(qml.Z(0)))
+
+    def test_subroutine(self):
+        """Test that CollectOpsandMeas collects a subroutine into a placeholder op."""
+
+        @partial(qml.templates.Subroutine, static_argnames="pauli_word")
+        def MyFunc(x, wires, pauli_word):
+            qml.PauliRot(x, pauli_word, wires)
+
+        def workflow(x):
+            MyFunc(x, (0, 1), "XY")
+            MyFunc(x + 1, (2, 3), "YZ")
+            MyFunc(x + 2, (3, 4), "XY")
+
+        interpreter = CollectOpsandMeas()
+        x = 0.5
+        interpreter(workflow)(x)
+
+        ops = interpreter.state["ops"]
+        for op in ops:
+            assert op.name == "MyFunc"
+
+        qml.assert_equal(ops[0].decomposition()[0], qml.PauliRot(0.5, "XY", (0, 1)))
+        qml.assert_equal(ops[1].decomposition()[0], qml.PauliRot(1.5, (2, 3), "YZ"))
+        qml.assert_equal(ops[2].decomposition()[0], qml.PauliRot(2.5, "XY", (3, 4)))
 
     def test_for_loop(self):
         """Test collecting the operations in a for loop."""

--- a/tests/templates/subroutines/qchem/test_basis_rotation.py
+++ b/tests/templates/subroutines/qchem/test_basis_rotation.py
@@ -162,7 +162,9 @@ class TestDecomposition:
             jax = pytest.importorskip("jax")
             wires = jax.numpy.arange(num_wires)
             jaxpr = jax.make_jaxpr(qml.BasisRotation)(wires, unitary_matrix)
-            queue = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, wires, unitary_matrix)
+            tape = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, wires, unitary_matrix)
+            assert tape[0].name == "BasisRotation"
+            queue = tape[0].decomposition()
         else:
             op = qml.BasisRotation.operator(wires=range(num_wires), unitary_matrix=unitary_matrix)
             queue = op.decomposition()
@@ -239,7 +241,9 @@ class TestDecomposition:
             jax = pytest.importorskip("jax")
             wires = jax.numpy.arange(num_wires)
             jaxpr = jax.make_jaxpr(qml.BasisRotation)(wires, ortho_matrix)
-            queue = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, wires, ortho_matrix)
+            tape = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, wires, ortho_matrix)
+            assert tape[0].name == "BasisRotation"
+            queue = tape[0].decomposition()
         else:
             op = qml.BasisRotation.operator(wires=range(num_wires), unitary_matrix=ortho_matrix)
             queue = op.decomposition()


### PR DESCRIPTION
**Context:**

I noticed that it might be hard to test the proper integration of Subroutines with program capture without an unwiedly amount of detail and work.

**Description of the Change:**

When CollectOpsandMeas encounters a `quantum_subroutine_prim`, it created a `CollectedSubroutine`, with a name and decomposition.  This will make it so that `CollectOpsandMeas` can be used for testing nested Subroutines and program capture more easily.  

**Benefits:**

Easier testing.

**Possible Drawbacks:**

`CollectedSubroutine` is *not* a `SubroutineOp`, because some pieces of information were wiped away when we captured it.  So we can't use `qml.assert_equal` to compare the two.  But we might want to create a helper to make it easier to comapre a `SubroutineOp` to it's corresponding `CollectedSubroutine`.

**Related GitHub Issues:**

[sc-113894]