### PR TITLE
fix: register `TargetMapper` labels for `pyzx==0.10.0` compatibility

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -147,6 +147,9 @@ The following classes have been ported over:
 
 <h3>Improvements 🛠</h3>
 
+* ZX-related transforms are now compatible with `pyzx` v0.10.0.
+  [(#9179)](https://github.com/PennyLaneAI/pennylane/pull/9179)
+
 * The :func:`~.transforms.unitary_to_rot` transform now recursively decomposes `QubitUnitary` operations. 
   This fixed a bug where two-qubit unitaries would decompose incorrectly to two single-qubit unitaries rather
   than their rotation decomposition.
@@ -766,9 +769,6 @@ The following classes have been ported over:
 
 
 <h3>Bug fixes 🐛</h3>
-
-* Fixed the incompatibility between `zx` submodule and the recently released `pyzx` v0.10.0.
-  [(#9179)](https://github.com/PennyLaneAI/pennylane/pull/9179)
 
 * Fixed a bug where the hashable parameters of a `CompressedResourceOp` in the graph-based
   decomposition system were sensitive to the insertion order of keyword arguments/hyperparameters.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -767,6 +767,9 @@ The following classes have been ported over:
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed the incompatibility between `zx` submodule and the recently released `pyzx` v0.10.0.
+  [(#9179)](https://github.com/PennyLaneAI/pennylane/pull/9179)
+
 * Fixed a bug where the hashable parameters of a `CompressedResourceOp` in the graph-based
   decomposition system were sensitive to the insertion order of keyword arguments/hyperparameters.
   [(#9137)](https://github.com/PennyLaneAI/pennylane/pull/9137)

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -380,6 +380,12 @@ def to_zx(tape, expand_measurements=False):
             q_mapper.set_next_row(i, 1)
             q_mapper.set_qubit(i, i)
 
+        # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit _labels
+        # set instead of _qubits.keys(); register every qubit so that output
+        # boundary vertices are created later.
+        if hasattr(q_mapper, "_labels"):
+            q_mapper._labels.update(range(len(mapped_tape.wires)))
+
         # Expand the tape to be compatible with PyZX and add rotations first for measurements
         kwargs = {"gate_set": gate_sets.PYZX}
         if qml.decomposition.enabled_graph():

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -386,8 +386,11 @@ def to_zx(tape, expand_measurements=False):
             inputs.append(vertex)
             q_mapper.set_prev_vertex(i, vertex)
             if _pyzx_010:
+                # add_label(i, 1) does all three things: set qubit, set rows, update labels
                 q_mapper.add_label(i, 1)
             else:  # pragma: no cover
+                # pyzx 0.9: `add_label(l)` has a different signature (no `row` param) and destructive semantics (set_all_rows).
+                # We must call `set_next_row(i, 1)` + `set_qubit(i, i)` separately.
                 q_mapper.set_next_row(i, 1)
                 q_mapper.set_qubit(i, i)
 

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -373,19 +373,21 @@ def to_zx(tape, expand_measurements=False):
         inputs = []
 
         # Create the qubits in the graph and the qubit mapper
+        # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit set
+        # populated only via add_label(label, row).  Use it so output boundary
+        # vertices are created later.
+        from packaging.version import Version  # pylint: disable=import-outside-toplevel
+
+        _pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
         for i in range(len(mapped_tape.wires)):
             vertex = graph.add_vertex(VertexType.BOUNDARY, i, 0)
             inputs.append(vertex)
             q_mapper.set_prev_vertex(i, vertex)
-            q_mapper.set_next_row(i, 1)
-            q_mapper.set_qubit(i, i)
-
-        # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit _labels
-        # set instead of _qubits.keys(); register every qubit so that output
-        # boundary vertices are created later.
-        # pylint: disable=protected-access
-        if hasattr(q_mapper, "_labels"):
-            q_mapper._labels.update(range(len(mapped_tape.wires)))
+            if _pyzx_010:
+                q_mapper.add_label(i, 1)
+            else:
+                q_mapper.set_next_row(i, 1)
+                q_mapper.set_qubit(i, i)
 
         # Expand the tape to be compatible with PyZX and add rotations first for measurements
         kwargs = {"gate_set": gate_sets.PYZX}

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -323,6 +323,14 @@ def to_zx(tape, expand_measurements=False):
     from pyzx.circuit.gates import TargetMapper
     from pyzx.graph import Graph
 
+    ######################################################################
+    # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit set
+    # populated only via add_label(label, row).  Use it so output boundary
+    # vertices are created later.
+    from packaging.version import Version
+
+    _pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
+
     # Dictionary of gates (PennyLane to PyZX circuit)
     # Please keep in mind to keep this in sync with the pennylane.decomposition.gate_sets.PYZX,
     # and to update both if the PyZX gate spec changes.
@@ -373,12 +381,6 @@ def to_zx(tape, expand_measurements=False):
         inputs = []
 
         # Create the qubits in the graph and the qubit mapper
-        # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit set
-        # populated only via add_label(label, row).  Use it so output boundary
-        # vertices are created later.
-        from packaging.version import Version  # pylint: disable=import-outside-toplevel
-
-        _pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
         for i in range(len(mapped_tape.wires)):
             vertex = graph.add_vertex(VertexType.BOUNDARY, i, 0)
             inputs.append(vertex)

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -385,7 +385,7 @@ def to_zx(tape, expand_measurements=False):
             q_mapper.set_prev_vertex(i, vertex)
             if _pyzx_010:
                 q_mapper.add_label(i, 1)
-            else:
+            else:  # pragma: no cover
                 q_mapper.set_next_row(i, 1)
                 q_mapper.set_qubit(i, i)
 

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -383,6 +383,7 @@ def to_zx(tape, expand_measurements=False):
         # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit _labels
         # set instead of _qubits.keys(); register every qubit so that output
         # boundary vertices are created later.
+        # pylint: disable=protected-access
         if hasattr(q_mapper, "_labels"):
             q_mapper._labels.update(range(len(mapped_tape.wires)))
 

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -320,14 +320,14 @@ def to_zx(tape, expand_measurements=False):
 
     # pylint: disable=import-outside-toplevel
     import pyzx
-    from pyzx.circuit.gates import TargetMapper
-    from pyzx.graph import Graph
 
     ######################################################################
     # pyzx >= 0.10.0: TargetMapper.labels() reads from an explicit set
     # populated only via add_label(label, row).  Use it so output boundary
     # vertices are created later.
     from packaging.version import Version
+    from pyzx.circuit.gates import TargetMapper
+    from pyzx.graph import Graph
 
     _pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ docs = [
     # TODO: Remove once galois becomes compatible with latest numpy
     "numpy>=2.0,<=2.2",
     "pygments-github-lexers",
-    "pyzx<0.10.0",
+    "pyzx",
     "docutils==0.20",
     "sphinx==8.1",
     "sphinx-automodapi==0.19",
@@ -122,7 +122,7 @@ docs = [
     "openfermionpyscf"
 ]
 external-libraries = [
-    "pyzx<0.10.0",
+    "pyzx",
     "stim",
     "quimb",
     "optax",

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -113,12 +113,12 @@ class TestPushHadamards:
 
         if Version(pyzx.__version__) >= Version("0.10"):
             pytest.skip("no errors for pyzx version 0.10 and above.")
-
-        with pytest.raises(
-            TypeError,
-            match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
-        ):
-            qml.transforms.zx.push_hadamards(qs)
+        else:
+            with pytest.raises(
+                TypeError,
+                match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
+            ):
+                qml.transforms.zx.push_hadamards(qs)
 
     @pytest.mark.parametrize(
         "measurements",

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -106,7 +106,7 @@ class TestPushHadamards:
         (qml.RX, qml.RY),
     )
     def test_rotation_gates_error(self, rot_gate):
-        """Test that an error is raised when the input circuit contains RX or RY rotation gates."""
+        """Test that an error is raised when the input circuit contains RX or RY rotation gates when using `pyzx<0.10`."""
         from packaging.version import Version  # pylint: disable=import-outside-toplevel
 
         qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -107,12 +107,13 @@ class TestPushHadamards:
     )
     def test_rotation_gates_error(self, rot_gate):
         """Test that an error is raised when the input circuit contains RX or RY rotation gates."""
-        qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])
-
         from packaging.version import Version  # pylint: disable=import-outside-toplevel
 
+        qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])
+
         if Version(pyzx.__version__) >= Version("0.10"):
-            pytest.skip("no errors for pyzx version 0.10 and above.")
+            # pyzx 0.10+ no longer raises for rotation gates
+            qml.transforms.zx.push_hadamards(qs)
         else:
             with pytest.raises(
                 TypeError,

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -23,6 +23,9 @@ import pennylane as qml
 from pennylane.tape import QuantumScript
 
 pyzx = pytest.importorskip("pyzx")
+from packaging.version import Version
+
+_pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
 
 
 def test_import_pyzx_error(monkeypatch):
@@ -105,21 +108,16 @@ class TestPushHadamards:
         "rot_gate",
         (qml.RX, qml.RY),
     )
+    @pytest.mark.skipif(_pyzx_010, reason="pyzx 0.10+ no longer raises for rotation gates")
     def test_rotation_gates_error(self, rot_gate):
         """Test that an error is raised when the input circuit contains RX or RY rotation gates when using `pyzx<0.10`."""
-        from packaging.version import Version  # pylint: disable=import-outside-toplevel
-
         qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])
 
-        if Version(pyzx.__version__) >= Version("0.10"):
-            # pyzx 0.10+ no longer raises for rotation gates
+        with pytest.raises(
+            TypeError,
+            match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
+        ):
             qml.transforms.zx.push_hadamards(qs)
-        else:
-            with pytest.raises(
-                TypeError,
-                match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
-            ):
-                qml.transforms.zx.push_hadamards(qs)
 
     @pytest.mark.parametrize(
         "measurements",

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -109,6 +109,11 @@ class TestPushHadamards:
         """Test that an error is raised when the input circuit contains RX or RY rotation gates."""
         qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])
 
+        from packaging.version import Version  # pylint: disable=import-outside-toplevel
+
+        if Version(pyzx.__version__) >= Version("0.10"):
+            pytest.skip("no errors for pyzx version 0.10 and above.")
+
         with pytest.raises(
             TypeError,
             match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -22,7 +22,7 @@ import pytest
 import pennylane as qml
 from pennylane.tape import QuantumScript
 
-pytest.importorskip("pyzx")
+pyzx = pytest.importorskip("pyzx")
 
 
 def test_import_pyzx_error(monkeypatch):

--- a/tests/transforms/zx/test_push_hadamards.py
+++ b/tests/transforms/zx/test_push_hadamards.py
@@ -18,12 +18,12 @@ import sys
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 import pennylane as qml
 from pennylane.tape import QuantumScript
 
 pyzx = pytest.importorskip("pyzx")
-from packaging.version import Version
 
 _pyzx_010 = Version(pyzx.__version__) >= Version("0.10")  # pylint: disable=protected-access
 
@@ -105,19 +105,32 @@ class TestPushHadamards:
         assert new_qs.operations == expected_ops
 
     @pytest.mark.parametrize(
-        "rot_gate",
-        (qml.RX, qml.RY),
+        "rot_gate, expected_names",
+        (
+            (qml.RX, ["Hadamard", "RZ", "Hadamard"]),
+            (qml.RY, ["S", "Hadamard", "RZ", "Hadamard", "Adjoint(S)"]),
+        ),
     )
-    @pytest.mark.skipif(_pyzx_010, reason="pyzx 0.10+ no longer raises for rotation gates")
-    def test_rotation_gates_error(self, rot_gate):
-        """Test that an error is raised when the input circuit contains RX or RY rotation gates when using `pyzx<0.10`."""
+    def test_rotation_gates(self, rot_gate, expected_names):
+        """Test push_hadamards behavior with RX/RY rotation gates.
+
+        pyzx < 0.10 does not support rotation gates in this pipeline and raises
+        a TypeError.  pyzx >= 0.10 decomposes them into Hadamard + RZ form while
+        preserving the unitary (up to global phase).
+        """
         qs = QuantumScript(ops=[rot_gate(0.5, wires=0)])
 
-        with pytest.raises(
-            TypeError,
-            match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
-        ):
-            qml.transforms.zx.push_hadamards(qs)
+        if _pyzx_010:
+            (new_qs,), _ = qml.transforms.zx.push_hadamards(qs)
+
+            assert [op.name for op in new_qs.operations] == expected_names
+            assert all(op.wires == qml.wires.Wires([0]) for op in new_qs.operations)
+        else:
+            with pytest.raises(
+                TypeError,
+                match=r"The input quantum circuit must be a phase-polynomial \+ Hadamard circuit.",
+            ):
+                qml.transforms.zx.push_hadamards(qs)
 
     @pytest.mark.parametrize(
         "measurements",


### PR DESCRIPTION
## Context

[PyZX PR #325](https://github.com/zxcalc/pyzx/pull/325) ("Fix and improve `circuit_to_graph`"), authored by Boldizsár Poór ([@boldar99](https://github.com/boldar99)) and merged on 2025-08-06, refactored the `TargetMapper` class in [`pyzx/circuit/gates.py`](https://github.com/zxcalc/pyzx/blob/fc3c6b3b9126c0563f85c1292d2b8446f1ee8e2d/pyzx/circuit/gates.py#L34). The key breaking change is in commit [`fc3c6b3`](https://github.com/zxcalc/pyzx/commit/fc3c6b3b9126c0563f85c1292d2b8446f1ee8e2d):

```python
# pyzx <= 0.9.0 — labels() derived from _qubits dict
def labels(self) -> Set[int]:
    return set(self._qubits.keys())

# pyzx >= 0.10.0 — labels() reads from an explicit _labels set
def labels(self) -> Set[int]:
    return self._labels
```

The `_labels` set is now only populated via `add_label()`. In the old code, any call to `set_qubit()` implicitly made a label visible through `_qubits.keys()`. After the refactor, `set_qubit()` still populates `_qubits` but *no longer* makes the label visible to `labels()` — only `add_label()` does that.

This change shipped in [PyZX v0.10.0](https://github.com/zxcalc/pyzx/releases/tag/v0.10.0) (released 2026-03-12).

## Backward Compatibility

0.9.0: [see the test log](https://github.com/PennyLaneAI/pennylane/actions/runs/23025418215/job/66872008066?pr=9179)
0.10.0: [log](https://github.com/PennyLaneAI/pennylane/actions/runs/23026342460/job/66875150837?pr=9179)


[sc-113935]
