### PR TITLE
Add the missing `sign_expand_data.json` to `MANIFEST.in` and `pyproject.toml`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include tests/*
 include example_config.toml
 include pennylane/qcut/_cut_kKaHyPar_sea20.ini
 include pennylane/logging/log_config.toml
+include pennylane/transforms/sign_expand/sign_expand_data.json

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -803,6 +803,11 @@ The following classes have been ported over:
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the data file `transforms/sign_expand/sign_expand_data.json` was not included in
+  the source distribution, causing errors when using `qml.transforms.sign_expand` in a production
+  environment.
+  [(#9197)](https://github.com/PennyLaneAI/pennylane/pull/9197)
+
 * Fixed a bug where `qml.math.givens_decomposition` modified the input in place when using `qjit`.
   [(#9155)](https://github.com/PennyLaneAI/pennylane/pull/9155)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ version = {attr = "pennylane._version.__version__"}
 [tool.setuptools_scm]
 
 [tool.setuptools.package-data]
-pennylane = ["devices/tests/pytest.ini", "drawer/plot.mplstyle"]
+pennylane = ["devices/tests/pytest.ini", "drawer/plot.mplstyle", "transforms/sign_expand/sign_expand_data.json"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Fix https://github.com/PennyLaneAI/pennylane/issues/9141

# Problem
`qp.transforms.sign_expand` raises a `FileNotFoundError` when PennyLane is installed from PyPI (wheel):
```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../site-packages/pennylane/transforms/sign_expand/sign_expand_data.json'
```
The JSON file exists in the repository but is not included in the built wheel.

### Root Cause

PennyLane's `pyproject.toml` sets `include-package-data = true`, which relies on `SOURCES.txt` (generated from `MANIFEST.in` and VCS tracking) to auto-include data files. However, `sign_expand_data.json` was never added to `MANIFEST.in` when the `sign_expand` transform was introduced. Without that entry, `setuptools`' auto-discovery does not pick it up—so it is silently excluded from both `sdist` and `wheel` builds.

> **Note:** Other runtime data files (`logging/log_config.toml`, `qcut/_cut_kKaHyPar_sea20.ini`) are unaffected because they were already declared in `MANIFEST.in`.

---

# Fix

This dual-location approach guarantees the file ships in both `sdist` and `wheel` distributions:

1. **`MANIFEST.in`:** Add `include pennylane/transforms/sign_expand/sign_expand_data.json` so the file is included in source distributions and feeds into `SOURCES.txt`.
2. **`pyproject.toml`:** Add `"transforms/sign_expand/sign_expand_data.json"` to `[tool.setuptools.package-data]` as an explicit declaration, ensuring inclusion in wheel builds regardless of VCS state or `SOURCES.txt` generation.
[sc-113270]