### PR TITLE
Update actions versions

### DIFF
--- a/.github/workflows/check_in_artifact.yml
+++ b/.github/workflows/check_in_artifact.yml
@@ -72,13 +72,13 @@ jobs:
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: ${{ inputs.main_branch_fetch_depth }}
           ref: main
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ inputs.artifact_name_pattern }}
           path: ${{ inputs.artifact_save_path }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PennyLane repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_branch }}
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -82,7 +82,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
     steps:
       - name: Checkout PennyLane repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_branch }}
      
@@ -105,7 +105,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout PennyLane repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_branch }}
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,12 +30,12 @@ jobs:
           ref: ${{ inputs.release_branch }}
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
           enable-cache: true  

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,7 @@ jobs:
     needs: [determine_runner, get_branch]
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: PennyLaneAI/sphinx-action@master
         with:
           docs-folder: "doc/"

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
           enable-cache: true        

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -734,7 +734,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
@@ -779,7 +779,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: test-report-*
           path: .github/test-reports

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -734,10 +734,10 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v6
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true  # upload errors should be caught early
@@ -779,7 +779,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v6
         with:
           pattern: test-report-*
           path: .github/test-reports

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -729,12 +729,12 @@ jobs:
     steps:
       # Checkout repo so Codecov action is able to resolve git HEAD reference
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
       - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
@@ -774,12 +774,12 @@ jobs:
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: test-report-*
           path: .github/test-reports

--- a/.github/workflows/module-validation.yml
+++ b/.github/workflows/module-validation.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
         with:
           python-version: "3.11"

--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
           enable-cache: true  

--- a/.github/workflows/rc_sync.yml
+++ b/.github/workflows/rc_sync.yml
@@ -28,13 +28,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out the PennyLane repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: main
 
       # Sets up Python environment
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -23,7 +23,7 @@ jobs:
       APT_PACKAGES_TO_INSTALL: "graphviz"
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 1
 
@@ -34,7 +34,7 @@ jobs:
 
     - name: Setup Python Environment
       id: setup_python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/sync-main-to-master.yml
+++ b/.github/workflows/sync-main-to-master.yml
@@ -11,7 +11,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
           token: ${{ secrets.PENNYLANE_MASTER_MAIN_WRITE }}

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -92,7 +92,7 @@ jobs:
           which pip
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
 

--- a/.github/workflows/tests-gpu.yml
+++ b/.github/workflows/tests-gpu.yml
@@ -56,13 +56,13 @@ jobs:
           echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" >> $GITHUB_ENV
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup Python
         id: setup_python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests-labs.yml
+++ b/.github/workflows/tests-labs.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Assess changed files
         id: changed-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
           enable-cache: true   

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           version: 0.9.17
           enable-cache: true   
+          cache-suffix: ${{ github.job }}-${{ matrix.python-version }}          
           
       - name: Update lock files
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -63,7 +63,7 @@ jobs:
           uv lock
 
       - name: Upload frozen requirements 
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frozen-lockfile
           path: uv.lock

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
@@ -113,7 +113,7 @@ jobs:
           cache-dependency-glob: 'pyproject.toml'
       
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '${{ inputs.python_version }}'
 
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload Durations file as artifact
         if: inputs.pytest_durations_file_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: durations-${{ inputs.job_name }}
           path: ${{ inputs.pytest_durations_file_path }}
@@ -210,7 +210,7 @@ jobs:
 
       - name: Upload Test Report Failures as artifact
         if: (failure() || cancelled()) && inputs.pytest_xml_file_path != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-report-${{ inputs.job_name }}
           path: ${{ env.TEST_REPORTS_DIR }}/${{ inputs.pytest_xml_file_path }}
@@ -220,7 +220,7 @@ jobs:
         run: bash <(sed -i 's/filename=\"/filename=\"pennylane\//g' coverage.xml)
 
       - name: Upload Coverage File
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.coverage_artifact_name }}
           path: coverage.xml

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -106,7 +106,7 @@ jobs:
           repository: PennyLaneAI/pennylane
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: ${{ inputs.uv_version }}
           enable-cache: true

--- a/.github/workflows/update-durations.yml
+++ b/.github/workflows/update-durations.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: durations-*
           path: ./
@@ -41,7 +41,7 @@ jobs:
           jq -s 'add' durations-jax-*/*.json > durations/jax_tests_durations.json
 
       - name: Upload combined durations artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: merged-durations
           path: ./durations

--- a/.github/workflows/update-durations.yml
+++ b/.github/workflows/update-durations.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: durations-*
           path: ./

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -15,13 +15,13 @@ jobs:
       branch_exists: ${{ steps.check_rc.outputs.branch_exists }}
     steps:
     - name: Checkout PennyLane repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: main
 
     # Sets up Python environment
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
         
@@ -47,7 +47,7 @@ jobs:
 
     - name: Checkout PennyLane repo
       if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
         ref: ${{ steps.check_rc.outputs.rc_branch }}
@@ -74,7 +74,7 @@ jobs:
       run: |
         uv build --wheel --out-dir dist
   
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       if: ${{ steps.check_rc.outputs.branch_exists == 'true' }}
       with:
         name: rc-nightly-wheels
@@ -88,7 +88,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v6
       if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
       with:
         name: rc-nightly-wheels

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -53,7 +53,7 @@ jobs:
         ref: ${{ steps.check_rc.outputs.rc_branch }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: 0.9.17
         enable-cache: true  

--- a/.github/workflows/upload-nightly-rc-release.yml
+++ b/.github/workflows/upload-nightly-rc-release.yml
@@ -88,7 +88,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v6
+    - uses: actions/download-artifact@v8
       if: ${{ needs.setup-rc.outputs.branch_exists == 'true' }}
       with:
         name: rc-nightly-wheels

--- a/.github/workflows/upload-nightly-release.yml
+++ b/.github/workflows/upload-nightly-release.yml
@@ -20,7 +20,7 @@ jobs:
         ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: 0.9.17
         enable-cache: true  

--- a/.github/workflows/upload-nightly-release.yml
+++ b/.github/workflows/upload-nightly-release.yml
@@ -54,7 +54,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v6
+    - uses: actions/download-artifact@v8
       with:
         name: nightly-wheels
         path: dist

--- a/.github/workflows/upload-nightly-release.yml
+++ b/.github/workflows/upload-nightly-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout PennyLane repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
 
@@ -41,7 +41,7 @@ jobs:
       run: |
         uv build --wheel --out-dir dist
   
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: nightly-wheels
         path: ./dist/*.whl
@@ -54,7 +54,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v6
       with:
         name: nightly-wheels
         path: dist

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
           enable-cache: true  

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -29,12 +29,12 @@ jobs:
       - tests
       - determine_runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
**Context:**
Github is deprecating node.js 20 in their older action plugins and is showing the warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

**Description of the Change:**
Change versions of:
- actions/checkout
- actions/download-artifact
- actions/setup-python
- actions/upload-artifact

**Benefits:**
The actions will no longer use a deprecated Node.js version.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
