### PR TITLE
feat: add documentation testing for `ops/qubit` and `ops/qutrit` modules

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -78,8 +78,6 @@ jobs:
           --ignore=pennylane/math
           --ignore=pennylane/compiler
           --ignore=pennylane/measurements
-          --ignore=pennylane/ops/qubit
-          --ignore=pennylane/ops/qutrit
           --ignore=pennylane/capture
           --ignore=pennylane/devices
           "

--- a/conftest.py
+++ b/conftest.py
@@ -54,7 +54,7 @@ def reset_pennylane_state(namespace):
     qml.decomposition.disable_graph()
     jax.config.update("jax_dynamic_shapes", False)
     # jax.config.update("jax_enable_x64", False)
-    base_numpy.set_printoptions(precision=8, linewidth=75)
+    base_numpy.set_printoptions(precision=8)
 
 
 pytest_collect_file = Sybil(

--- a/conftest.py
+++ b/conftest.py
@@ -54,6 +54,7 @@ def reset_pennylane_state(namespace):
     qml.decomposition.disable_graph()
     jax.config.update("jax_dynamic_shapes", False)
     # jax.config.update("jax_enable_x64", False)
+    base_numpy.set_printoptions(precision=8, linewidth=75)
 
 
 pytest_collect_file = Sybil(

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -752,8 +752,9 @@ The following classes have been ported over:
 * Specs can now return measurement information for QJIT'd workloads when passed ``level="device"``.
   [(#8988)](https://github.com/PennyLaneAI/pennylane/pull/8988)
 
-* Add documentation tests for the `decomposition` module.
+* Add documentation tests for various modules.
   [(#9004)](https://github.com/PennyLaneAI/pennylane/pull/9004)
+  [(#9206)](https://github.com/PennyLaneAI/pennylane/pull/9206)
 
 * Seeded a test `tests/measurements/test_classical_shadow.py::TestClassicalShadow::test_return_distribution` to fix stochastic failures by adding a `seed` parameter to the circuit helper functions and the test method.
   [(#8981)](https://github.com/PennyLaneAI/pennylane/pull/8981)

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -492,8 +492,8 @@ class Controlled(SymbolicOp):
     Sparse matrices are available if the base class defines either a sparse matrix
     or only a dense matrix.
 
-    >>> np.set_printoptions(precision=4) # easier to read the matrix
-    >>> qml.matrix(op)
+    >>> with np.set_printoptions(precision=4): # easier to read the matrix
+    ...     qml.matrix(op)
     array([[0.8156+0.j    , 0.    -0.5786j, 0.    +0.j    , 0.    +0.j    ],
            [0.    -0.5786j, 0.8156+0.j    , 0.    +0.j    , 0.    +0.j    ],
            [0.    +0.j    , 0.    +0.j    , 1.    +0.j    , 0.    +0.j    ],

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -492,13 +492,14 @@ class Controlled(SymbolicOp):
     Sparse matrices are available if the base class defines either a sparse matrix
     or only a dense matrix.
 
-    >>> with np.set_printoptions(precision=4): # easier to read the matrix
+    >>> with np.printoptions(precision=4): # easier to read the matrix
     ...     qml.matrix(op)
     array([[0.8156+0.j    , 0.    -0.5786j, 0.    +0.j    , 0.    +0.j    ],
            [0.    -0.5786j, 0.8156+0.j    , 0.    +0.j    , 0.    +0.j    ],
            [0.    +0.j    , 0.    +0.j    , 1.    +0.j    , 0.    +0.j    ],
            [0.    +0.j    , 0.    +0.j    , 0.    +0.j    , 1.    +0.j    ]])
-    >>> qml.eigvals(op)
+    >>> with np.printoptions(precision=4): # easier to read the matrix
+    ...     qml.eigvals(op)
     array([1.    +0.j    , 1.    +0.j    , 0.8156+0.5786j, 0.8156-0.5786j])
     >>> print(qml.generator(op, format='observable'))
     Projector(array([0]), wires=[0]) @ (-0.5 * X(1))

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -249,9 +249,10 @@ class Hermitian(Operator):
 
         >>> A = np.array([[-6, 2 + 1j], [2 - 1j, 0]])
         >>> _, evecs = np.linalg.eigh(A)
-        >>> qml.Hermitian.compute_diagonalizing_gates(evecs, wires=[0])
-        [QubitUnitary(array([[-0.94915323+0.j        ,  0.2815786 +0.1407893j ],
-               [ 0.31481445-0.j        ,  0.84894846+0.42447423j]]), wires=[0])]
+        >>> with np.printoptions(precision=4):
+        ...     print(qml.Hermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        [QubitUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j],
+               [ 0.3148-0.j    ,  0.8489+0.4245j]]), wires=[0])]
 
         """
         return [QubitUnitary(eigenvectors.conj().T, wires=wires)]

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -249,8 +249,9 @@ class Hermitian(Operator):
 
         >>> A = np.array([[-6, 2 + 1j], [2 - 1j, 0]])
         >>> _, evecs = np.linalg.eigh(A)
-        >>> with np.printoptions(precision=4):
-        ...     print(qml.Hermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        >>> with np.printoptions(precision=4): # easier to read the matrix
+        ...     # add 0 to normalize signed zeros before printing
+        ...     print(qml.Hermitian.compute_diagonalizing_gates(evecs+0, wires=[0]))
         [QubitUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j],
                [ 0.3148-0.j    ,  0.8489+0.4245j]]), wires=[0])]
 

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -249,10 +249,10 @@ class Hermitian(Operator):
 
         >>> A = np.array([[-6, 2 + 1j], [2 - 1j, 0]])
         >>> _, evecs = np.linalg.eigh(A)
+        >>> evecs = evecs + 0 # add 0 to normalize signed zeros before printing
         >>> with np.printoptions(precision=4): # easier to read the matrix
-        ...     # add 0 to normalize signed zeros before printing
-        ...     print(qml.Hermitian.compute_diagonalizing_gates(evecs+0, wires=[0]))
-        [QubitUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j],
+        ...     print(qml.Hermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        [QubitUnitary(array([[-0.9492-0.j    ,  0.2816+0.1408j],
                [ 0.3148-0.j    ,  0.8489+0.4245j]]), wires=[0])]
 
         """

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -143,7 +143,8 @@ class THermitian(Hermitian):
         >>> _, evecs = np.linalg.eigh(A)
         >>> from pprint import pprint
         >>> with np.printoptions(precision=4): # easier to read the matrix
-        ...     pprint(qml.THermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        ...     # add 0 to normalize signed zeros before printing
+        ...     pprint(qml.THermitian.compute_diagonalizing_gates(evecs+0, wires=[0]))
         [QutritUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j, -0.    +0.j    ],
                [ 0.3148-0.j    ,  0.8489+0.4245j,  0.    -0.j    ],
                [ 0.    -0.j    ,  0.    -0.j    ,  1.    -0.j    ]]), wires=[0])]

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -141,11 +141,11 @@ class THermitian(Hermitian):
 
         >>> A = np.array([[-6, 2 + 1j, 0], [2 - 1j, 0, 0], [0, 0, 1]])
         >>> _, evecs = np.linalg.eigh(A)
+        >>> evecs = evecs + 0 # add 0 to normalize signed zeros before printing
         >>> from pprint import pprint
         >>> with np.printoptions(precision=4): # easier to read the matrix
-        ...     # add 0 to normalize signed zeros before printing
-        ...     pprint(qml.THermitian.compute_diagonalizing_gates(evecs+0, wires=[0]))
-        [QutritUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j, -0.    +0.j    ],
+        ...     pprint(qml.THermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        [QutritUnitary(array([[-0.9492-0.j    ,  0.2816+0.1408j,  0.    -0.j    ],
                [ 0.3148-0.j    ,  0.8489+0.4245j,  0.    -0.j    ],
                [ 0.    -0.j    ,  0.    -0.j    ,  1.    -0.j    ]]), wires=[0])]
         """

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -142,13 +142,11 @@ class THermitian(Hermitian):
         >>> A = np.array([[-6, 2 + 1j, 0], [2 - 1j, 0, 0], [0, 0, 1]])
         >>> _, evecs = np.linalg.eigh(A)
         >>> from pprint import pprint
-        >>> pprint(qml.THermitian.compute_diagonalizing_gates(evecs, wires=[0]))
-        [QutritUnitary(array([[-0.94915323+0.j        ,  0.2815786 +0.1407893j ,
-                -0.        +0.j        ],
-            [ 0.31481445-0.j        ,  0.84894846+0.42447423j,
-                0.        -0.j        ],
-            [ 0.        -0.j        ,  0.        -0.j        ,
-                1.        -0.j        ]]), wires=[0])]
+        >>> with np.printoptions(precision=4): # easier to read the matrix
+        ...     pprint(qml.THermitian.compute_diagonalizing_gates(evecs, wires=[0]))
+        [QutritUnitary(array([[-0.9492+0.j    ,  0.2816+0.1408j, -0.    +0.j    ],
+               [ 0.3148-0.j    ,  0.8489+0.4245j,  0.    -0.j    ],
+               [ 0.    -0.j    ,  0.    -0.j    ,  1.    -0.j    ]]), wires=[0])]
         """
         return [QutritUnitary(eigenvectors.conj().T, wires=wires)]
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -696,7 +696,8 @@ class SumOfSlatersPrep(Operation):
     >>> where = np.where(prepared_state)
     >>> print(where)
     (array([ 0,  1,  2,  4,  8, 16, 32, 64]),)
-    >>> print(prepared_state[where])
+    >>> with np.printoptions(precision=4): # easier to read the matrix
+    ...     print(prepared_state[where])
     [ 0.3536+0.j     -0.    -0.3536j  0.    +0.3536j  0.3536+0.j
       0.3536+0.j     -0.    -0.3536j  0.3536+0.j      0.    +0.3536j]
 

--- a/pennylane/workflow/return_types_spec.rst
+++ b/pennylane/workflow/return_types_spec.rst
@@ -97,7 +97,7 @@ array([[1.        , 0.        ],
 >>> tape = qml.tape.QuantumScript((op,), [qml.expval(qml.Z(0))])
 >>> result = qml.device('default.qubit').execute(tape)
 >>> result
-array([1.    , 0.7071, 0.    ])
+array([1.    , 0.7071..., 0.    ])
 >>> result.shape
 (3,)
 


### PR DESCRIPTION
These modules have always been cleaned up but were being skipped due to a weird bug where CI would fail but locally it would pass.

After some investigation, it was because we were globally adjusting the print options of `numpy` in `controlled.py` which then affected subsequent modules.

[sc-100039]