### PR TITLE
BugFix: decomposition graph chooses incompatible symbolic rules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -5,7 +5,7 @@
 * Decomposition rules are re-written in a `qjit` compatible way so that they can be lowered to Catalyst/MLIR. Rules for the 
   following `SymbolicOps` have been re-written.
 
-  - :class:`qml.ops.op_math.Pow` [(#9199)](https://github.com/PennyLaneAI/pennylane/pull/9199)
+  - :class:`qml.ops.op_math.Pow` [(#9199)](https://github.com/PennyLaneAI/pennylane/pull/9199) [(#9213)](https://github.com/PennyLaneAI/pennylane/pull/9213)
 
 * A new angle solver has been added to find QSVT phase angles faster for large-degree polynomials.
   This can be accessed by setting `angle_solver = 'iterative-optax'` in `qml.qsvt` and

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -314,7 +314,13 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             self._graph.add_edge(self._start, op_node_idx, self._gate_set_weights[op])
             return op_node_idx
 
-        rules = [rule for rule in self._get_decompositions(op) if rule.is_applicable(**op.params)]
+        use_reconstructor = decomps_use_reconstructor(op.op_type, op.params)
+
+        rules = [
+            rule
+            for rule in self._get_decompositions(op, use_reconstructor)
+            if rule.is_applicable(**op.params)
+        ]
 
         # Treat ops that do not have a decomposition as supported if strict=False
         if not rules and not self._strict:
@@ -400,7 +406,9 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         self._graph.add_edge(d_node_idx, op_idx, 0)
         return d_node
 
-    def _get_decompositions(self, op: CompressedResourceOp) -> list[DecompositionRule]:
+    def _get_decompositions(
+        self, op: CompressedResourceOp, use_reconstructor: bool = False
+    ) -> list[DecompositionRule]:
         """Helper function to get a list of decomposition rules."""
 
         op_name = to_name(op)
@@ -421,19 +429,21 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             # inverted to obtain its adjoint. In this case, `self_adjoint` or `adjoint_rotation`
             # would've already been retrieved as a potential decomposition rule for this
             # operator, so there is no need to consider the general case.
-            decomps.extend(self._get_adjoint_decompositions(op))
+            decomps.extend(self._get_adjoint_decompositions(op, use_reconstructor))
 
         elif issubclass(op.op_type, qml.ops.Pow):
             # Similar to the adjoint case, the `_get_pow_decompositions` contains the general
             # approach we take to decompose powers of operators.
-            decomps.extend(self._get_pow_decompositions(op))
+            decomps.extend(self._get_pow_decompositions(op, use_reconstructor))
 
         elif op.op_type in (qml.ops.Controlled, qml.ops.ControlledOp):
-            decomps.extend(self._get_controlled_decompositions(op))
+            decomps.extend(self._get_controlled_decompositions(op, use_reconstructor))
 
         return decomps
 
-    def _get_adjoint_decompositions(self, op: CompressedResourceOp) -> list[DecompositionRule]:
+    def _get_adjoint_decompositions(
+        self, op: CompressedResourceOp, use_reconstructor: bool = False
+    ) -> list[DecompositionRule]:
         """Gets the decomposition rules for the adjoint of an operator."""
 
         base_class, base_params = (op.params["base_class"], op.params["base_params"])
@@ -444,38 +454,38 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         # General case: apply adjoint to each of the base op's decomposition rules.
         base = resource_rep(base_class, **base_params)
-        return [make_adjoint_decomp(base_decomp) for base_decomp in self._get_decompositions(base)]
+        return [
+            make_adjoint_decomp(base_decomp)
+            for base_decomp in self._get_decompositions(base, use_reconstructor)
+        ]
 
     @staticmethod
-    def _get_pow_decompositions(op: CompressedResourceOp) -> list[DecompositionRule]:
+    def _get_pow_decompositions(
+        op: CompressedResourceOp, use_reconstructor: bool = False
+    ) -> list[DecompositionRule]:
         """Gets the decomposition rules for the power of an operator."""
-
-        base_class, base_params = (op.params["base_class"], op.params["base_params"])
-        base_has_reconstructor = decomps_use_reconstructor(base_class, base_params)
 
         # Special case: power of zero
         if op.params["z"] == 0:
             return [null_decomp]
 
         if op.params["z"] == 1:
-            return [
-                qjit_compatible_decompose_to_base if base_has_reconstructor else decompose_to_base
-            ]
+            return [qjit_compatible_decompose_to_base if use_reconstructor else decompose_to_base]
 
         # Special case: power of a power
-        if issubclass(base_class, qml.ops.Pow):
-            return [qjit_compatible_merge_powers if base_has_reconstructor else merge_powers]
+        if issubclass(op.params["base_class"], qml.ops.Pow):
+            return [qjit_compatible_merge_powers if use_reconstructor else merge_powers]
 
         # Special case: power of an adjoint
-        if issubclass(base_class, qml.ops.Adjoint):
-            return [
-                qjit_compatible_flip_pow_adjoint if base_has_reconstructor else flip_pow_adjoint
-            ]
+        if issubclass(op.params["base_class"], qml.ops.Adjoint):
+            return [qjit_compatible_flip_pow_adjoint if use_reconstructor else flip_pow_adjoint]
 
         # General case: repeat the operator z times
-        return [qjit_compatible_repeat_pow_base if base_has_reconstructor else repeat_pow_base]
+        return [qjit_compatible_repeat_pow_base if use_reconstructor else repeat_pow_base]
 
-    def _get_controlled_decompositions(self, op: CompressedResourceOp) -> list[DecompositionRule]:
+    def _get_controlled_decompositions(
+        self, op: CompressedResourceOp, use_reconstructor: bool = False
+    ) -> list[DecompositionRule]:
         """Adds a controlled decomposition node to the graph."""
 
         base_class, base_params = op.params["base_class"], op.params["base_params"]
@@ -493,7 +503,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         # General case: apply control to the base op's decomposition rules.
         base = resource_rep(base_class, **base_params)
-        rules = [make_controlled_decomp(decomp) for decomp in self._get_decompositions(base)]
+        rules = [
+            make_controlled_decomp(decomp)
+            for decomp in self._get_decompositions(base, use_reconstructor)
+        ]
 
         # There's always the option of turning the controlled operator into a controlled
         # qubit unitary if the base operator has a matrix form.

--- a/pennylane/decomposition/reconstruct.py
+++ b/pennylane/decomposition/reconstruct.py
@@ -30,6 +30,9 @@ def decomps_use_reconstructor(op_type, op_params):
     # TODO: Adjoint to be implemented in a follow-up PR [sc-110066]
     if op_type in (qml.ops.Controlled, qml.ops.Adjoint):
         return False
+    if issubclass(op_type, qml.ops.Pow):
+        base_class, base_params = op_params["base_class"], op_params["base_params"]
+        return decomps_use_reconstructor(base_class, base_params)
     return has_reconstructor(op_type, op_params)
 
 

--- a/pennylane/decomposition/symbolic_decomposition.py
+++ b/pennylane/decomposition/symbolic_decomposition.py
@@ -163,6 +163,8 @@ def flip_pow_adjoint(*params, wires, base, z, **__):
     qml.adjoint(qml.pow(base_op, z))
 
 
+# TODO: to be enabled in a follow-up PR [sc-110066]
+# pragma: no cover
 @register_resources(_flip_pow_adjoint_resource)
 def qjit_compatible_flip_pow_adjoint(*params, wires, base_class, base_params, z, **__):
     """Decompose the power of an adjoint in a qjit compatible way."""

--- a/tests/decomposition/test_symbolic_decomposition.py
+++ b/tests/decomposition/test_symbolic_decomposition.py
@@ -38,7 +38,6 @@ from pennylane.decomposition.symbolic_decomposition import (
     pow_involutory,
     pow_involutory_no_reconstructor,
     pow_rotation,
-    qjit_compatible_flip_pow_adjoint,
     repeat_pow_base,
     self_adjoint,
     to_controlled_qubit_unitary,
@@ -217,7 +216,8 @@ class TestPowDecomposition:
         ("base_op", "rule"),
         [
             (CustomOpWithoutReconstructor, flip_pow_adjoint),
-            (CustomOpWithReconstructor, qjit_compatible_flip_pow_adjoint),
+            # TODO: to be enabled in a follow-up PR [sc-110066]
+            # (CustomOpWithReconstructor, qjit_compatible_flip_pow_adjoint),
         ],
     )
     def test_flip_pow_adjoint(self, base_op, rule):

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -446,6 +446,15 @@ class TestDecomposeGraphEnabled:
         ]
 
     @pytest.mark.integration
+    def test_controlled_pow(self):
+        """Tests that a controlled Pow is correctly decompose."""
+
+        op = qml.ctrl(qml.pow(qml.H(0), 1), control=1)
+        tape = qml.tape.QuantumScript([op])
+        [new_tape], _ = qml.decompose(tape, gate_set={qml.CH})
+        assert new_tape.operations == [qml.CH([1, 0])]
+
+    @pytest.mark.integration
     def test_adjoint_decomp(self):
         """Tests decomposing an adjoint operation."""
 

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -447,7 +447,7 @@ class TestDecomposeGraphEnabled:
 
     @pytest.mark.integration
     def test_controlled_pow(self):
-        """Tests that a controlled Pow is correctly decompose."""
+        """Tests that a controlled Pow is correctly decomposed."""
 
         op = qml.ctrl(qml.pow(qml.QubitUnitary([[0, 1], [1, 0]], wires=0), 1), control=1)
         tape = qml.tape.QuantumScript([op])

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -449,10 +449,10 @@ class TestDecomposeGraphEnabled:
     def test_controlled_pow(self):
         """Tests that a controlled Pow is correctly decompose."""
 
-        op = qml.ctrl(qml.pow(qml.H(0), 1), control=1)
+        op = qml.ctrl(qml.pow(qml.QubitUnitary([[0, 1], [1, 0]], wires=0), 1), control=1)
         tape = qml.tape.QuantumScript([op])
-        [new_tape], _ = qml.decompose(tape, gate_set={qml.CH})
-        assert new_tape.operations == [qml.CH([1, 0])]
+        [new_tape], _ = qml.decompose(tape, gate_set={qml.ControlledQubitUnitary})
+        assert new_tape.operations == [qml.ControlledQubitUnitary([[0, 1], [1, 0]], wires=[1, 0])]
 
     @pytest.mark.integration
     def test_adjoint_decomp(self):


### PR DESCRIPTION
**Context:**

In https://github.com/PennyLaneAI/pennylane/pull/9199, decomposition rules that make use of the reconstructor are used for `Pow`, but when this extended to controlled operators because one of the controlled decomposition rules is to apply `ctrl` to the decomposition rule of the base. When the base is a `Pow`, the controlled decomposition rule (which has not yet been updated) will try to call the updated power decomposition rule, which does not work.

**Description of the Change:**

In graph construction, decide whether to use the new decomposition rules at the top level.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
