### PR TITLE
fix: improve docs for `shadow_expval` measurement

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -830,7 +830,7 @@ The following classes have been ported over:
 
 <h3>Documentation 📝</h3>
 
-* Improve documentation for the :func:`~.shadow_expval` measurement.
+* Refined the documentation of :func:~.shadow_expval measurement for clarity and added instructions for achieving reproducible results with the seed keyword argument.
   [(#9216)](https://github.com/PennyLaneAI/pennylane/pull/9216)
 
 * The definition of the ``pipeline`` argument for :func:`~.transforms.compile` 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -844,7 +844,8 @@ The following classes have been ported over:
 
 <h3>Documentation 📝</h3>
 
-* Refined the documentation of :func:~.shadow_expval measurement for clarity and added instructions for achieving reproducible results with the seed keyword argument.
+* Refined the documentation of :func:~.shadow_expval measurement for clarity and added instructions 
+  for achieving reproducible results with the seed keyword argument.
   [(#9216)](https://github.com/PennyLaneAI/pennylane/pull/9216)
 
 * The definition of the ``pipeline`` argument for :func:`~.transforms.compile` 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -827,6 +827,9 @@ The following classes have been ported over:
 
 <h3>Documentation 📝</h3>
 
+* Improve documentation for the :func:`~.shadow_expval` measurement.
+  [(#9216)](https://github.com/PennyLaneAI/pennylane/pull/9216)
+
 * The definition of the ``pipeline`` argument for :func:`~.transforms.compile` 
   was clarified in its documentation.
   [(#9159)](https://github.com/PennyLaneAI/pennylane/pull/9159)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -373,11 +373,7 @@ class ClassicalShadowMP(MeasurementTransform):
             stacked_state = rotated_state[np.arange(shots), sampled_index]
             stacked_state = np.stack(
                 [
-                    np.take(
-                        stacked_state[i],
-                        sampled_index[i],
-                        axis=num_remaining_qubits - 1,
-                    )
+                    np.take(stacked_state[i], sampled_index[i], axis=num_remaining_qubits - 1)
                     for i in range(shots)
                 ]
             )

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -615,7 +615,7 @@ def shadow_expval(
             Provide a single observable or a sequence to estimate the expectation values of multiple
             observables from the same classical shadows data.
         k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
-            the simple mean of the group. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
+            the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
             obseravbles.
         seed (int | None):  Optional seed for the random Pauli measurement basis in the
             classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -597,9 +597,9 @@ def shadow_expval(
 
     The Classical Shadows protocol provide a way to estimate a large number of expectation values
     (even non-commuting ones) using a single set of random Pauli measurements.
-    See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
+    See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
 
-    Args:
+   Args:
         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
             Provide a single observable or a sequence to estimate the expectation values of multiple
             observables from the same classical shadows data.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -624,7 +624,7 @@ def shadow_expval(
             .. note::
 
                 The ``seed`` argument only controls the measurement basis choice.
-                The device's ``seed`` sepeartely controls the sampling outcomes.
+                The ``seed`` of a simulator device separately controls the sampling outcomes.
                 For fully reproducible results, you must seed both the device and the measurement.
 
                 .. code-block:: python

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -671,7 +671,7 @@ def shadow_expval(
 
         >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
 
-        We can estimate it's expectation value with the classical shadows protocol:
+        We can estimate its expectation value with the classical shadows protocol:
 
         .. code-block:: python
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -600,30 +600,30 @@ def shadow_expval(
     See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
 
     Args:
-         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
-             Provide a single observable or a sequence to estimate the expectation values of multiple
-             observables from the same classical shadows data.
-         k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means.
-             The default is ``k=1``, which simply computes the mean of all measurements.
-             ``k>1`` provides no expected advantage for Pauli measurements and Pauli observables.
-         seed (int | None): Optional seed for the random Pauli measurement basis in the
-             classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
-             in per shot. If ``None``, a random seed will be generated.
+        H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
+            Provide a single observable or a sequence to estimate the expectation values of multiple
+            observables from the same classical shadows data.
+        k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means.
+            The default is ``k=1``, which simply computes the mean of all measurements.
+            ``k>1`` provides no expected advantage for Pauli measurements and Pauli observables.
+        seed (int | None): Optional seed for the random Pauli measurement basis in the
+            classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
+            in per shot. If ``None``, a random seed will be generated.
 
-             .. note::
+            .. note::
 
-                 The ``seed`` argument only controls the measurement basis choice.
-                 The ``seed`` of a simulator device separately controls the sampling outcomes.
-                 For fully reproducible results, you must seed both the device and the measurement.
+                The ``seed`` argument only controls the measurement basis choice.
+                The ``seed`` of a simulator device separately controls the sampling outcomes.
+                For fully reproducible results, you must seed both the device and the measurement.
 
-                 .. code-block:: python
+                .. code-block:: python
 
-                     dev = qml.device("default.qubit", seed=42, shots=100)
+                    dev = qml.device("default.qubit", seed=42, shots=100)
 
-                     @qml.qnode(dev)
-                     def circuit():
-                         qml.H(0)
-                         return qml.shadow_expval(qml.Z(0), seed=99)
+                    @qml.qnode(dev)
+                    def circuit():
+                        qml.H(0)
+                        return qml.shadow_expval(qml.Z(0), seed=99)
 
      Returns:
          ShadowExpvalMP: Measurement process instance

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -612,8 +612,8 @@ def shadow_expval(
 
     Args:
         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
-            Provide a single observable or a list to estimate multiple expectation values from the
-            same shadows data in a single circuit execution.
+            Provide a single observable or a sequence to estimate the expectation values of multiple
+            observables from the same classical shadows data.
         k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
             the simple mean of the group. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
             obseravbles.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -625,77 +625,77 @@ def shadow_expval(
                         qml.H(0)
                         return qml.shadow_expval(qml.Z(0), seed=99)
 
-     Returns:
-         ShadowExpvalMP: Measurement process instance
+    Returns:
+        ShadowExpvalMP: Measurement process instance
 
-     .. seealso::
+    .. seealso::
 
-         This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
-         :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
+        This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
+        :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
 
-     **Example**
+    **Example**
 
-     With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
-     observables requires its own separate circuit execution. However, with ``shadow_expval``
-     we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
+    With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
+    observables requires its own separate circuit execution. However, with ``shadow_expval``
+    we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
 
-     Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
-     (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` state.
-     Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
+    Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
+    (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` state.
+    Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
 
-     .. code-block:: python
+    .. code-block:: python
 
-         device = qml.device("default.qubit", seed=42)
+        device = qml.device("default.qubit", seed=42)
 
-         @qml.set_shots(1_000)
-         @qml.qnode(device)
-         def circuit():
-             qml.H(0) # Create |+> state
-             return qml.shadow_expval((qml.X(0), qml.Y(0), qml.Z(0)), seed=99)
+        @qml.set_shots(1_000)
+        @qml.qnode(device)
+        def circuit():
+            qml.H(0) # Create |+> state
+            return qml.shadow_expval((qml.X(0), qml.Y(0), qml.Z(0)), seed=99)
 
-     >>> print(circuit())
-     [0.984 0.    0.03 ]
+    >>> print(circuit())
+    [0.984 0.    0.03 ]
 
-     This is very close to their expected values!
+    This is very close to their expected values!
 
-     .. details::
-         :title: Differentiability
+    .. details::
+        :title: Differentiability
 
-         Consider the following observable,
+        Consider the following observable,
 
-         >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+        >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
 
-         We can estimate its expectation value with the classical shadows protocol:
+        We can estimate its expectation value with the classical shadows protocol:
 
-         .. code-block:: python
+        .. code-block:: python
 
-             dev = qml.device("default.qubit", seed=42, wires=range(2))
+            dev = qml.device("default.qubit", seed=42, wires=range(2))
 
-             @qml.set_shots(shots=10_000)
-             @qml.qnode(dev)
-             def circuit(x, obs):
-                 qml.Hadamard(0)
-                 qml.CNOT((0,1))
-                 qml.RX(x, wires=0)
-                 return qml.shadow_expval(obs, seed=99)
+            @qml.set_shots(shots=10_000)
+            @qml.qnode(dev)
+            def circuit(x, obs):
+                qml.Hadamard(0)
+                qml.CNOT((0,1))
+                qml.RX(x, wires=0)
+                return qml.shadow_expval(obs, seed=99)
 
-             x = pnp.array(0.5, requires_grad=True)
+            x = pnp.array(0.5, requires_grad=True)
 
-         >>> print(circuit(x, H))
-         1.8891
-         >>> print(qml.grad(circuit)(x, H))
-         -0.4653...
+        >>> print(circuit(x, H))
+        1.8891
+        >>> print(qml.grad(circuit)(x, H))
+        -0.4653...
 
-         In ``shadow_expval``, we can also pass a list of observables to estimate them
-         all from the same shadow data.
-         Note that each qnode execution internally performs one quantum measurement, so be sure
-         to include all observables that you want to estimate from a single measurement in the same execution.
+        In ``shadow_expval``, we can also pass a list of observables to estimate them
+        all from the same shadow data.
+        Note that each qnode execution internally performs one quantum measurement, so be sure
+        to include all observables that you want to estimate from a single measurement in the same execution.
 
-         >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
-         >>> print(circuit(x, Hs))
-         [ 1.8783  0.0096 -0.0174  0.0138]
-         >>> print(qml.jacobian(circuit)(x, Hs))
-         [-0.4851 -0.0063 -0.0099  0.0006]
+        >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
+        >>> print(circuit(x, Hs))
+        [ 1.8783  0.0096 -0.0174  0.0138]
+        >>> print(qml.jacobian(circuit)(x, Hs))
+        [-0.4851 -0.0063 -0.0099  0.0006]
     """
     seed = seed or np.random.randint(2**30)
     return ShadowExpvalMP(H=H, seed=seed, k=k)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -603,7 +603,7 @@ def shadow_expval(
         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
             Provide a single observable or a sequence to estimate the expectation values of multiple
             observables from the same classical shadows data.
-        k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
+        k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means. The default is ``k=1``, which simply computes
             the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
             observables.
         seed (int | None): Optional seed for the random Pauli measurement basis in the

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -646,7 +646,7 @@ def shadow_expval(
     we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
 
     Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
-    (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` in a single circuit execution.
+    (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` state.
     Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
 
     .. code-block:: python

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -601,7 +601,7 @@ def shadow_expval(
 
     Classical shadows provide a way to estimate a large number of expectation values
     (even non-commuting ones) using a single set of random Pauli measurements.
-    See `2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
+    See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
 
     .. note::
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -643,7 +643,7 @@ def shadow_expval(
 
     With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
     observables requires its own separate circuit execution. However, with ``shadow_expval``
-    we can use shadow data from a single circuit execution to estimate expectation values.
+    we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
 
     Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
     (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` in a single circuit execution.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -595,107 +595,107 @@ def shadow_expval(
 ) -> ShadowExpvalMP:
     r"""Estimate expectation values using Classical Shadows with full differentiability support.
 
-    The Classical Shadows protocol provide a way to estimate a large number of expectation values
-    (even non-commuting ones) using a single set of random Pauli measurements.
-    See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
+     The Classical Shadows protocol provide a way to estimate a large number of expectation values
+     (even non-commuting ones) using a single set of random Pauli measurements.
+     See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
 
-   Args:
-        H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
-            Provide a single observable or a sequence to estimate the expectation values of multiple
-            observables from the same classical shadows data.
-        k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means. The default is ``k=1``, which simply computes
-            the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
-            observables.
-        seed (int | None): Optional seed for the random Pauli measurement basis in the
-            classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
-            in per shot. If ``None``, a random seed will be generated.
+    Args:
+         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
+             Provide a single observable or a sequence to estimate the expectation values of multiple
+             observables from the same classical shadows data.
+         k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means. The default is ``k=1``, which simply computes
+             the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
+             observables.
+         seed (int | None): Optional seed for the random Pauli measurement basis in the
+             classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
+             in per shot. If ``None``, a random seed will be generated.
 
-            .. note::
+             .. note::
 
-                The ``seed`` argument only controls the measurement basis choice.
-                The ``seed`` of a simulator device separately controls the sampling outcomes.
-                For fully reproducible results, you must seed both the device and the measurement.
+                 The ``seed`` argument only controls the measurement basis choice.
+                 The ``seed`` of a simulator device separately controls the sampling outcomes.
+                 For fully reproducible results, you must seed both the device and the measurement.
 
-                .. code-block:: python
+                 .. code-block:: python
 
-                    dev = qml.device("default.qubit", seed=42, shots=100)
+                     dev = qml.device("default.qubit", seed=42, shots=100)
 
-                    @qml.qnode(dev)
-                    def circuit():
-                        qml.H(0)
-                        return qml.shadow_expval(qml.Z(0), seed=99)
+                     @qml.qnode(dev)
+                     def circuit():
+                         qml.H(0)
+                         return qml.shadow_expval(qml.Z(0), seed=99)
 
-    Returns:
-        ShadowExpvalMP: Measurement process instance
+     Returns:
+         ShadowExpvalMP: Measurement process instance
 
-    .. seealso::
+     .. seealso::
 
-        This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
-        :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
+         This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
+         :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
 
-    **Example**
+     **Example**
 
-    With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
-    observables requires its own separate circuit execution. However, with ``shadow_expval``
-    we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
+     With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
+     observables requires its own separate circuit execution. However, with ``shadow_expval``
+     we can reuse the shadow data generated from the circuit executions to estimate all expectation values simultaneously.
 
-    Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
-    (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` state.
-    Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
+     Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
+     (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` state.
+     Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
 
-    .. code-block:: python
+     .. code-block:: python
 
-        device = qml.device("default.qubit", seed=42)
+         device = qml.device("default.qubit", seed=42)
 
-        @qml.set_shots(1_000)
-        @qml.qnode(device)
-        def circuit():
-            qml.H(0) # Create |+> state
-            return qml.shadow_expval((qml.X(0), qml.Y(0), qml.Z(0)), seed=99)
+         @qml.set_shots(1_000)
+         @qml.qnode(device)
+         def circuit():
+             qml.H(0) # Create |+> state
+             return qml.shadow_expval((qml.X(0), qml.Y(0), qml.Z(0)), seed=99)
 
-    >>> print(circuit())
-    [0.984 0.    0.03 ]
+     >>> print(circuit())
+     [0.984 0.    0.03 ]
 
-    This is very close to their expected values!
+     This is very close to their expected values!
 
-    .. details::
-        :title: Differentiability
+     .. details::
+         :title: Differentiability
 
-        Consider the following observable,
+         Consider the following observable,
 
-        >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+         >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
 
-        We can estimate its expectation value with the classical shadows protocol:
+         We can estimate its expectation value with the classical shadows protocol:
 
-        .. code-block:: python
+         .. code-block:: python
 
-            dev = qml.device("default.qubit", seed=42, wires=range(2))
+             dev = qml.device("default.qubit", seed=42, wires=range(2))
 
-            @qml.set_shots(shots=10_000)
-            @qml.qnode(dev)
-            def circuit(x, obs):
-                qml.Hadamard(0)
-                qml.CNOT((0,1))
-                qml.RX(x, wires=0)
-                return qml.shadow_expval(obs, seed=99)
+             @qml.set_shots(shots=10_000)
+             @qml.qnode(dev)
+             def circuit(x, obs):
+                 qml.Hadamard(0)
+                 qml.CNOT((0,1))
+                 qml.RX(x, wires=0)
+                 return qml.shadow_expval(obs, seed=99)
 
-            x = pnp.array(0.5, requires_grad=True)
+             x = pnp.array(0.5, requires_grad=True)
 
-        >>> print(circuit(x, H))
-        1.8891
-        >>> print(qml.grad(circuit)(x, H))
-        -0.4653...
+         >>> print(circuit(x, H))
+         1.8891
+         >>> print(qml.grad(circuit)(x, H))
+         -0.4653...
 
-        In ``shadow_expval``, we can also pass a list of observables to estimate them
-        all from the same shadow data.
-        Note that each qnode execution internally performs one quantum measurement, so be sure
-        to include all observables that you want to estimate from a single measurement in the same execution.
+         In ``shadow_expval``, we can also pass a list of observables to estimate them
+         all from the same shadow data.
+         Note that each qnode execution internally performs one quantum measurement, so be sure
+         to include all observables that you want to estimate from a single measurement in the same execution.
 
-        >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
-        >>> print(circuit(x, Hs))
-        [ 1.8783  0.0096 -0.0174  0.0138]
-        >>> print(qml.jacobian(circuit)(x, Hs))
-        [-0.4851 -0.0063 -0.0099  0.0006]
+         >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
+         >>> print(circuit(x, Hs))
+         [ 1.8783  0.0096 -0.0174  0.0138]
+         >>> print(qml.jacobian(circuit)(x, Hs))
+         [-0.4851 -0.0063 -0.0099  0.0006]
     """
     seed = seed or np.random.randint(2**30)
     return ShadowExpvalMP(H=H, seed=seed, k=k)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -613,7 +613,7 @@ def shadow_expval(
         k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
             the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
             observables.
-        seed (int | None):  Optional seed for the random Pauli measurement basis in the
+        seed (int | None): Optional seed for the random Pauli measurement basis in the
             classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
             in per shot. If ``None``, a random seed will be generated.
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -595,7 +595,7 @@ def shadow_expval(
 ) -> ShadowExpvalMP:
     r"""Estimate expectation values using Classical Shadows with full differentiability support.
 
-    Classical shadows provide a way to estimate a large number of expectation values
+    The Classical Shadows protocol provide a way to estimate a large number of expectation values
     (even non-commuting ones) using a single set of random Pauli measurements.
     See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -642,7 +642,7 @@ def shadow_expval(
     **Example**
 
     With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
-    observables requires it's own separate circuit execution. However, with ``shadow_expval``
+    observables requires its own separate circuit execution. However, with ``shadow_expval``
     we can use shadow data from a single circuit execution to estimate expectation values.
 
     Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -616,7 +616,7 @@ def shadow_expval(
             observables from the same classical shadows data.
         k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
             the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
-            obseravbles.
+            observables.
         seed (int | None):  Optional seed for the random Pauli measurement basis in the
             classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
             in per shot. If ``None``, a random seed will be generated.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -595,9 +595,9 @@ def shadow_expval(
 ) -> ShadowExpvalMP:
     r"""Estimate expectation values using Classical Shadows with full differentiability support.
 
-     The Classical Shadows protocol provide a way to estimate a large number of expectation values
-     (even non-commuting ones) using a single set of random Pauli measurements.
-     See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
+    The Classical Shadows protocol provide a way to estimate a large number of expectation values
+    (even non-commuting ones) using a single set of random Pauli measurements.
+    See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal and theoretical details.
 
     Args:
          H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -603,9 +603,9 @@ def shadow_expval(
          H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
              Provide a single observable or a sequence to estimate the expectation values of multiple
              observables from the same classical shadows data.
-         k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means. The default is ``k=1``, which simply computes
-             the mean of all measurements. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
-             observables.
+         k (int): Number of equal parts for which to split the shadow's measurements in order to compute the median of means.
+             The default is ``k=1``, which simply computes the mean of all measurements.
+             ``k>1`` provides no expected advantage for Pauli measurements and Pauli observables.
          seed (int | None): Optional seed for the random Pauli measurement basis in the
              classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
              in per shot. If ``None``, a random seed will be generated.

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -599,13 +599,6 @@ def shadow_expval(
     (even non-commuting ones) using a single set of random Pauli measurements.
     See `arXiv:2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
 
-    .. note::
-
-        This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
-        :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
-        To compute correct gradients using PennyLane's automatic differentiation system,
-        you must use this measurement.
-
     Args:
         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
             Provide a single observable or a sequence to estimate the expectation values of multiple
@@ -634,6 +627,11 @@ def shadow_expval(
 
     Returns:
         ShadowExpvalMP: Measurement process instance
+
+    .. seealso::
+
+        This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
+        :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
 
     **Example**
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -641,7 +641,7 @@ def shadow_expval(
 
     **Example**
 
-    With the standard :func:`~.pennylane.expval` measurement each group of non-commuting
+    With the standard :func:`~.pennylane.expval` measurement, each group of non-commuting
     observables requires it's own separate circuit execution. However, with ``shadow_expval``
     we can use shadow data from a single circuit execution to estimate expectation values.
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -696,9 +696,9 @@ def shadow_expval(
         We can compute the expectation value of the obseravble as well as its gradient in the usual way,
 
         >>> print(circuit(x, H))
-        1.8936
+        1.8891
         >>> print(qml.grad(circuit)(x, H))
-        -0.4536...
+        -0.4653...
 
         In ``shadow_expval``, we can also pass a list of observables to estimate them
         all from the same shadow data.
@@ -707,9 +707,9 @@ def shadow_expval(
 
         >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
         >>> print(circuit(x, Hs))
-        [ 1.917   0.0282 -0.0156 -0.0066]
+        [ 1.8783  0.0096 -0.0174  0.0138]
         >>> print(qml.jacobian(circuit)(x, Hs))
-        [-4.743e-01 -1.140e-02 -4.500e-03  3.000e-04]
+        [-0.4851 -0.0063 -0.0099  0.0006]
     """
     seed = seed or np.random.randint(2**30)
     return ShadowExpvalMP(H=H, seed=seed, k=k)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -14,8 +14,9 @@
 """
 This module contains the qml.classical_shadow measurement.
 """
+
 import copy
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from string import ascii_letters
 
 import numpy as np
@@ -129,13 +130,15 @@ class ClassicalShadowMP(MeasurementTransform):
                 rotations = [
                     rot
                     for wire_idx, wire in enumerate(wires)
-                    for rot in obs_list[recipes[t][wire_idx]].compute_diagonalizing_gates(
-                        wires=wire
-                    )
+                    for rot in obs_list[
+                        recipes[t][wire_idx]
+                    ].compute_diagonalizing_gates(wires=wire)
                 ]
 
                 device.reset()
-                device.apply(tape.operations, rotations=tape.diagonalizing_gates + rotations)
+                device.apply(
+                    tape.operations, rotations=tape.diagonalizing_gates + rotations
+                )
 
                 outcomes[t] = device.generate_samples()[0][mapped_wires]
         finally:
@@ -230,9 +233,7 @@ class ClassicalShadowMP(MeasurementTransform):
             stacked_dim = ascii_letters[num_remaining_qubits + 1]
 
             state_str = f"{stacked_dim}{ascii_letters[:num_remaining_qubits]}"
-            conj_state_str = (
-                f"{stacked_dim}{conj_state_first_qubit}{ascii_letters[1:num_remaining_qubits]}"
-            )
+            conj_state_str = f"{stacked_dim}{conj_state_first_qubit}{ascii_letters[1:num_remaining_qubits]}"
             target_str = f"{stacked_dim}a{conj_state_first_qubit}"
 
             first_qubit_state = np.einsum(
@@ -242,7 +243,9 @@ class ClassicalShadowMP(MeasurementTransform):
             )
 
             # sample the observables on the first qubit
-            probs = (np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1) / 2
+            probs = (
+                np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1
+            ) / 2
             samples = bit_rng.random(size=probs.shape) > probs
             outcomes[:, active_qubit] = samples
 
@@ -346,7 +349,9 @@ class ClassicalShadowMP(MeasurementTransform):
             )
 
             # sample the observables on the first qubit
-            probs = (np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1) / 2
+            probs = (
+                np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1
+            ) / 2
             samples = bit_rng.random(size=probs.shape) > probs
             outcomes[:, active_qubit] = samples
 
@@ -372,7 +377,11 @@ class ClassicalShadowMP(MeasurementTransform):
             stacked_state = rotated_state[np.arange(shots), sampled_index]
             stacked_state = np.stack(
                 [
-                    np.take(stacked_state[i], sampled_index[i], axis=num_remaining_qubits - 1)
+                    np.take(
+                        stacked_state[i],
+                        sampled_index[i],
+                        axis=num_remaining_qubits - 1,
+                    )
                     for i in range(shots)
                 ]
             )
@@ -404,7 +413,9 @@ class ClassicalShadowMP(MeasurementTransform):
     ) -> tuple:
         return (2, shots, n_wires), np.int8
 
-    def shape(self, shots: int | None = None, num_device_wires: int = 0) -> tuple[int, int, int]:
+    def shape(
+        self, shots: int | None = None, num_device_wires: int = 0
+    ) -> tuple[int, int, int]:
         # otherwise, the return type requires a device
         if shots is None:
             raise MeasurementShapeError(
@@ -452,7 +463,7 @@ class ShadowExpvalMP(MeasurementTransform):
 
     def __init__(
         self,
-        H: Operator | Sequence,
+        H: Operator | Sequence[Operator],
         seed: int | None = None,
         k: int = 1,
         id: str | None = None,
@@ -480,7 +491,9 @@ class ShadowExpvalMP(MeasurementTransform):
             ClassicalShadow,
         )
 
-        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process(tape, device)
+        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process(
+            tape, device
+        )
         shadow = ClassicalShadow(bits, recipes, wire_map=self.wires.tolist())
         return shadow.expval(self.H, self.k)
 
@@ -501,11 +514,13 @@ class ShadowExpvalMP(MeasurementTransform):
         Returns:
             float: The estimate of the expectation value.
         """
-        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process_state_with_shots(
-            state, wire_order, shots, rng=rng
-        )
+        bits, recipes = classical_shadow(
+            wires=self.wires, seed=self.seed
+        ).process_state_with_shots(state, wire_order, shots, rng=rng)
         # tach-ignore
-        from pennylane.shadows import ClassicalShadow  # pylint:disable=import-outside-toplevel
+        from pennylane.shadows import (
+            ClassicalShadow,  # pylint:disable=import-outside-toplevel
+        )
 
         shadow = ClassicalShadow(bits, recipes, wire_map=self.wires.tolist())
         return shadow.expval(self.H, self.k)
@@ -555,7 +570,7 @@ class ShadowExpvalMP(MeasurementTransform):
 
         This is the union of all the Wires objects of the measurement.
         """
-        if isinstance(self.H, Iterable):
+        if isinstance(self.H, Sequence):
             return Wires.all_wires([h.wires for h in self.H])
 
         return self.H.wires
@@ -563,10 +578,10 @@ class ShadowExpvalMP(MeasurementTransform):
     def queue(self, context=QueuingManager):
         """Append the measurement process to an annotated queue, making sure
         the observable is not queued"""
-        # A CompositeOp is also an Iterable, but we should consider it to be a single observable
+        # A CompositeOp is also an Sequence, but we should consider it to be a single observable
         Hs = (
             self.H
-            if isinstance(self.H, Iterable) and not isinstance(self.H, Operator)
+            if isinstance(self.H, Sequence) and not isinstance(self.H, Operator)
             else [self.H]
         )
         for H in Hs:
@@ -576,10 +591,10 @@ class ShadowExpvalMP(MeasurementTransform):
         return self
 
     def __copy__(self):
-        # A CompositeOp is also an Iterable, we do not want to copy each operand of the op.
+        # A CompositeOp is also an Sequence, we do not want to copy each operand of the op.
         H_copy = (
             [copy.copy(H) for H in self.H]
-            if isinstance(self.H, Iterable) and not isinstance(self.H, Operator)
+            if isinstance(self.H, Sequence) and not isinstance(self.H, Operator)
             else copy.copy(self.H)
         )
         return self.__class__(
@@ -589,64 +604,112 @@ class ShadowExpvalMP(MeasurementTransform):
         )
 
 
-def shadow_expval(H, k=1, seed=None) -> ShadowExpvalMP:
-    r"""Compute expectation values using classical shadows in a differentiable manner.
+def shadow_expval(
+    H: Operator | Sequence[Operator], k: int = 1, seed: int | None = None
+) -> ShadowExpvalMP:
+    r"""Estimate expectation values using Classical Shadows with full differentiability support.
 
-    The canonical way of computing expectation values is to simply average the expectation values for each local snapshot, :math:`\langle O \rangle = \sum_t \text{tr}(\rho^{(t)}O) / T`.
-    This corresponds to the case ``k=1``. In the original work, `2002.08953 <https://arxiv.org/abs/2002.08953>`_, it has been proposed to split the ``T`` measurements into ``k`` equal
-    parts to compute the median of means. For the case of Pauli measurements and Pauli observables, there is no advantage expected from setting ``k>1``.
+    Classical shadows provide a way to estimate a large number of expectation values
+    (even non-commuting ones) using a single set of random Pauli measurements.
+    See `2002.08953 <https://arxiv.org/abs/2002.08953>`_ for the original proposal.
+
+    .. note::
+
+        This measurement internally relies on the measurement :func:`~.pennylane.classical_shadow` and the class
+        :class:`~.pennylane.ClassicalShadow` for post-processing in order to compute expectation values.
+        To compute correct gradients using PennyLane's automatic differentiation system,
+        you must use this measurement.
 
     Args:
-        H (Union[Iterable[Operator], Operator]): Observable or
-            iterable of observables to compute the expectation value over.
-        k (int): Number of equal parts to split the shadow's measurements to compute the median of means. ``k=1`` (default) corresponds to simply taking the mean over all measurements.
-        seed (Union[None, int]):  Seed used to randomly sample Pauli measurements during the
-            classical shadows protocol. If None, a random seed will be generated. If a tape with
-            a ``shadow_expval`` measurement is copied, the seed will also be copied.
-            Different seeds are still generated for different constructed tapes.
+        H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
+            Provide a single observable or a list to estimate multiple expectation values from the 
+            same shadows data in a single circuit execution.
+        k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
+            the simple mean of the group. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
+            obseravbles.
+        seed (int | None):  Optional seed for the random Pauli measurement basis in the
+            classical shadows protocol. This controls which bases (X, Y or Z) each qubit is measured
+            in per shot. If ``None``, a random seed will be generated.
+
+            .. note::
+
+                The ``seed`` argument only controls the measurement basis choice.
+                The device's ``seed`` sepeartely controls the sampling outcomes.
+                For fully reproducible results, you must seed both the device and the measurement.
+
+                .. code-block:: python
+
+                    dev = qml.device("default.qubit", seed=42, shots=100)
+
+                    @qml.qnode(dev)
+                    def circuit():
+                        qml.H(0)
+                        return qml.shadow_expval(qml.Z(0), seed=99)
 
     Returns:
         ShadowExpvalMP: Measurement process instance
 
-    .. note::
-
-        This measurement uses the measurement :func:`~.pennylane.classical_shadow` and the class :class:`~.pennylane.ClassicalShadow` for post-processing
-        internally to compute expectation values. In order to compute correct gradients using PennyLane's automatic differentiation,
-        you need to use this measurement.
-
     **Example**
+
+    With the standard :func:`~.pennylane.expval` measurement each group of non-commuting
+    observables requires it's own separate circuit execution. However, with ``shadow_expval``
+    we can use shadow data from a single circuit execution to estimate expectation values.
+
+    Let's say we want to estimate the expectation values of all three (non-commuting) single qubit Paulis
+    (:class:`~.X`, :class:`~.Y`, :class:`~.Z`) on a :math:`| + \rangle` in a single circuit execution.
+    Theoretically, we would expect that :math:`\langle X \rangle = 1`, :math:`\langle Y \rangle = \langle Z \rangle = 0`.
 
     .. code-block:: python
 
-        H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+        device = qml.device("default.qubit", seed=42)
 
-        dev = qml.device("default.qubit", seed=42, wires=range(2))
+        @qml.set_shots(1_000)
+        @qml.qnode(device)
+        def circuit():
+            qml.H(0) # Create |+> state
+            return qml.shadow_expval((qml.X(0), qml.Y(0), qml.Z(0)), seed=99)
 
-        @qml.set_shots(shots=10_000)
-        @qml.qnode(dev)
-        def circuit(x, obs):
-            qml.Hadamard(0)
-            qml.CNOT((0,1))
-            qml.RX(x, wires=0)
-            return qml.shadow_expval(obs, seed=42)
+    >>> print(circuit())
+    [0.984 0.    0.03 ]
 
-        x = pnp.array(0.5, requires_grad=True)
+    This is very close to their expected values! 
 
-    We can compute the expectation value of H as well as its gradient in the usual way.
+    .. details::
+        :title: Differentiability
 
-    >>> print(circuit(x, H))
-    1.8936
-    >>> print(qml.grad(circuit)(x, H))
-    -0.4536...
+        .. code-block:: python
 
-    In ``shadow_expval``, we can pass a list of observables. Note that each qnode execution internally performs one quantum measurement, so be sure
-    to include all observables that you want to estimate from a single measurement in the same execution.
+            H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
 
-    >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
-    >>> print(circuit(x, Hs))
-    [ 1.917   0.0282 -0.0156 -0.0066]
-    >>> print(qml.jacobian(circuit)(x, Hs))
-    [-4.743e-01 -1.140e-02 -4.500e-03  3.000e-04]
+            dev = qml.device("default.qubit", seed=42, wires=range(2))
+
+            @qml.set_shots(shots=10_000)
+            @qml.qnode(dev)
+            def circuit(x, obs):
+                qml.Hadamard(0)
+                qml.CNOT((0,1))
+                qml.RX(x, wires=0)
+                return qml.shadow_expval(obs, seed=99)
+
+            x = pnp.array(0.5, requires_grad=True)
+
+        We can compute the expectation value of the obseravble as well as its gradient in the usual way,
+
+        >>> print(circuit(x, H))
+        1.8936
+        >>> print(qml.grad(circuit)(x, H))
+        -0.4536...
+
+        In ``shadow_expval``, we can also pass a list of observables to estimate them
+        all from the same shadow data.
+        Note that each qnode execution internally performs one quantum measurement, so be sure
+        to include all observables that you want to estimate from a single measurement in the same execution.
+
+        >>> Hs = [H, qml.X(0), qml.Y(0), qml.Z(0)]
+        >>> print(circuit(x, Hs))
+        [ 1.917   0.0282 -0.0156 -0.0066]
+        >>> print(qml.jacobian(circuit)(x, Hs))
+        [-4.743e-01 -1.140e-02 -4.500e-03  3.000e-04]
     """
     seed = seed or np.random.randint(2**30)
     return ShadowExpvalMP(H=H, seed=seed, k=k)

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -130,15 +130,13 @@ class ClassicalShadowMP(MeasurementTransform):
                 rotations = [
                     rot
                     for wire_idx, wire in enumerate(wires)
-                    for rot in obs_list[
-                        recipes[t][wire_idx]
-                    ].compute_diagonalizing_gates(wires=wire)
+                    for rot in obs_list[recipes[t][wire_idx]].compute_diagonalizing_gates(
+                        wires=wire
+                    )
                 ]
 
                 device.reset()
-                device.apply(
-                    tape.operations, rotations=tape.diagonalizing_gates + rotations
-                )
+                device.apply(tape.operations, rotations=tape.diagonalizing_gates + rotations)
 
                 outcomes[t] = device.generate_samples()[0][mapped_wires]
         finally:
@@ -233,7 +231,9 @@ class ClassicalShadowMP(MeasurementTransform):
             stacked_dim = ascii_letters[num_remaining_qubits + 1]
 
             state_str = f"{stacked_dim}{ascii_letters[:num_remaining_qubits]}"
-            conj_state_str = f"{stacked_dim}{conj_state_first_qubit}{ascii_letters[1:num_remaining_qubits]}"
+            conj_state_str = (
+                f"{stacked_dim}{conj_state_first_qubit}{ascii_letters[1:num_remaining_qubits]}"
+            )
             target_str = f"{stacked_dim}a{conj_state_first_qubit}"
 
             first_qubit_state = np.einsum(
@@ -243,9 +243,7 @@ class ClassicalShadowMP(MeasurementTransform):
             )
 
             # sample the observables on the first qubit
-            probs = (
-                np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1
-            ) / 2
+            probs = (np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1) / 2
             samples = bit_rng.random(size=probs.shape) > probs
             outcomes[:, active_qubit] = samples
 
@@ -349,9 +347,7 @@ class ClassicalShadowMP(MeasurementTransform):
             )
 
             # sample the observables on the first qubit
-            probs = (
-                np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1
-            ) / 2
+            probs = (np.einsum("abc,acb->a", first_qubit_state, obs[:, active_qubit]) + 1) / 2
             samples = bit_rng.random(size=probs.shape) > probs
             outcomes[:, active_qubit] = samples
 
@@ -413,9 +409,7 @@ class ClassicalShadowMP(MeasurementTransform):
     ) -> tuple:
         return (2, shots, n_wires), np.int8
 
-    def shape(
-        self, shots: int | None = None, num_device_wires: int = 0
-    ) -> tuple[int, int, int]:
+    def shape(self, shots: int | None = None, num_device_wires: int = 0) -> tuple[int, int, int]:
         # otherwise, the return type requires a device
         if shots is None:
             raise MeasurementShapeError(
@@ -491,9 +485,7 @@ class ShadowExpvalMP(MeasurementTransform):
             ClassicalShadow,
         )
 
-        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process(
-            tape, device
-        )
+        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process(tape, device)
         shadow = ClassicalShadow(bits, recipes, wire_map=self.wires.tolist())
         return shadow.expval(self.H, self.k)
 
@@ -514,13 +506,11 @@ class ShadowExpvalMP(MeasurementTransform):
         Returns:
             float: The estimate of the expectation value.
         """
-        bits, recipes = classical_shadow(
-            wires=self.wires, seed=self.seed
-        ).process_state_with_shots(state, wire_order, shots, rng=rng)
-        # tach-ignore
-        from pennylane.shadows import (
-            ClassicalShadow,  # pylint:disable=import-outside-toplevel
+        bits, recipes = classical_shadow(wires=self.wires, seed=self.seed).process_state_with_shots(
+            state, wire_order, shots, rng=rng
         )
+        # tach-ignore
+        from pennylane.shadows import ClassicalShadow  # pylint:disable=import-outside-toplevel
 
         shadow = ClassicalShadow(bits, recipes, wire_map=self.wires.tolist())
         return shadow.expval(self.H, self.k)
@@ -622,7 +612,7 @@ def shadow_expval(
 
     Args:
         H (Sequence[Operator] | Operator): Obserable(s) whose expectation values are to be estimated.
-            Provide a single observable or a list to estimate multiple expectation values from the 
+            Provide a single observable or a list to estimate multiple expectation values from the
             same shadows data in a single circuit execution.
         k (int): Number of groups for the median-of-means estimator. The default is ``k=1``, which simply computes
             the simple mean of the group. ``k>1`` provides no expected advantage for Pauli measurements and Pauli
@@ -672,14 +662,18 @@ def shadow_expval(
     >>> print(circuit())
     [0.984 0.    0.03 ]
 
-    This is very close to their expected values! 
+    This is very close to their expected values!
 
     .. details::
         :title: Differentiability
 
-        .. code-block:: python
+        Consider the following observable,
 
-            H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+        >>> H = qml.Hamiltonian([1., 1.], [qml.Z(0) @ qml.Z(1), qml.X(0) @ qml.X(1)])
+
+        We can estimate it's expectation value with the classical shadows protocol:
+
+        .. code-block:: python
 
             dev = qml.device("default.qubit", seed=42, wires=range(2))
 
@@ -692,8 +686,6 @@ def shadow_expval(
                 return qml.shadow_expval(obs, seed=99)
 
             x = pnp.array(0.5, requires_grad=True)
-
-        We can compute the expectation value of the obseravble as well as its gradient in the usual way,
 
         >>> print(circuit(x, H))
         1.8891


### PR DESCRIPTION
Goal of this PR is to explain what the `seed` kwarg is really doing here and how it differs from the device `seed` kwarg.

While I was at it, I completely refreshed the documentation. :heh:

[sc-114763]