### PR TITLE
deprecation: legacy template UI raises a `PennyLaneDeprecationWarning` favouring new `Subroutine` system

### DIFF
--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -870,15 +870,16 @@ class Subroutine:
             return self._capture_subroutine(*bound_args.args, **bound_args.kwargs)
         op = self.operator(*args, id=id, **kwargs)
 
-        if op.output is not None or queuing.QueuingManager.recording():
+        if op.output is not None:
             return op.output
 
-        warnings.warn(
-            f"Calling '{self.name}' in order to obtain an 'Operator' instance outside a queuing context is deprecated "
-            "and will be removed in a future release. Please use '{self.name}.operator(*args, **kwargs)' in order to "
-            "obtain the operator explicitly.",
-            PennyLaneDeprecationWarning,
-        )
+        if not queuing.QueuingManager.recording():
+            warnings.warn(
+                f"Calling '{self.name}' in order to obtain an 'Operator' instance outside a queuing context is deprecated "
+                "and will be removed in a future release. Please use '{self.name}.operator(*args, **kwargs)' in order to "
+                "obtain the operator explicitly.",
+                PennyLaneDeprecationWarning,
+            )
         return op
 
 

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -56,7 +56,7 @@ def test_legacy_ui():
     with qml.queuing.AnnotatedQueue() as q:
         S_op = S(3.14, 0)
 
-    assert S_op is None
+    assert isinstance(S_op, SubroutineOp)
     assert len(q.queue) == 1
     qml.assert_equal(q.queue[0], S_op_correct)
 
@@ -370,7 +370,7 @@ class TestSubroutineCall:
         with qml.queuing.AnnotatedQueue() as q:
             out = f(0, ["X"])
         op = q.queue[0]
-        assert out is None
+        assert isinstance(out, SubroutineOp)
         assert op.bound_args.arguments["pauli_words"] == ("X",)
 
     def test_fill_in_default_values(self):
@@ -382,8 +382,8 @@ class TestSubroutineCall:
 
         with qml.queuing.AnnotatedQueue() as q:
             out = f(0)
-        assert out is None
         op = q.queue[0]
+        assert isinstance(out, SubroutineOp)
         assert op.bound_args.arguments["metadata"] == "default_value"
 
     @pytest.mark.usefixtures("ignore_id_deprecation")


### PR DESCRIPTION
**Context:**

After merging in QFT as a subroutine (https://github.com/PennyLaneAI/pennylane/pull/9057/changes), it was determined to be too large of a breaking change for users due to the new required UI in order to generate an operator from the subroutine.

**Description of the Change:**

This PR adds temporary backwards compatibility and raises a deprecation warning when appropriate.

**Benefits:** Legacy UI is retained but a message indicating what to do is raised to the user.

**Possible Drawbacks:** Let's see ...
