### PR TITLE
Revert "Make QFT a Subroutine (#9057)"

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -88,7 +88,7 @@
   [(#8915)](https://github.com/PennyLaneAI/pennylane/pull/8915)
   [(#9045)](https://github.com/PennyLaneAI/pennylane/pull/9045)
 
-* Adds a new `qml.templates.core.Subroutine` class for adding a layer of abstraction for
+* Adds a new `qml.templates.Subroutine` class for adding a layer of abstraction for
   quantum functions. These objects can now return classical values or mid circuit measurements,
   and are compatible with Program Capture Catalyst. Any `Operator` with a single definition
   in terms of its implementation, a more complicated call signature, and that exists
@@ -109,7 +109,7 @@
   [(#9176)](https://github.com/PennyLaneAI/pennylane/pull/9176)
 
   ```python
-  from pennylane.templates.core import Subroutine
+  from pennylane.templates import Subroutine
 
   @Subroutine
   def MyTemplate(x, y, wires):
@@ -129,7 +129,6 @@
 
 The following classes have been ported over:
 - `qml.BasisRotation` [(#9026)](https://github.com/PennyLaneAI/pennylane/pull/9026)
-- `qml.QFT` [(#9057)](https://github.com/PennyLaneAI/pennylane/pull/9057)
 
 * Added a `qml.decomposition.local_decomps` context
   manager that allows one to add decomposition rules to an operator, only taking effect within the context.

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -124,6 +124,7 @@ operations = {
     "QubitSum",
     "OrbitalRotation",
     "FermionicSWAP",
+    "QFT",
     "ThermalRelaxationError",
     "ECR",
     "ParametrizedEvolution",

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -135,6 +135,7 @@ ALL_DQ_GATES_PLUS_MCM = ALL_DQ_GATES | GateSet({"MidMeasureMP"})
 ALL_DQ_GATES_PLUS_MCM.name = "All DefaultQubit Gates With MCM"
 
 _special_operator_support = {
+    "QFT": lambda op: len(op.wires) < 6,
     "GroverOperator": lambda op: len(op.wires) < 13,
     "FromBloq": lambda op: len(op.wires) < 4 and op.has_matrix,
     "IQP": lambda op: len(op.wires) < 6,

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -94,6 +94,7 @@ ops = {
     "Barrier": qml.Barrier(wires=[0, 1, 2]),
     "WireCut": qml.WireCut(wires=[0]),
     "Toffoli": qml.Toffoli(wires=[0, 1, 2]),
+    "QFT": qml.templates.QFT(wires=[0, 1, 2]),
     "IsingXX": qml.IsingXX(0, wires=[0, 1]),
     "IsingYY": qml.IsingYY(0, wires=[0, 1]),
     "IsingZZ": qml.IsingZZ(0, wires=[0, 1]),
@@ -124,6 +125,7 @@ all_ops = ops.keys()
 all_available_ops = qml.ops._qubit__ops__.copy()  # pylint: disable=protected-access
 all_available_ops.remove("CPhase")  # CPhase is an alias of ControlledPhaseShift
 all_available_ops.remove("SQISW")  # SQISW is an alias of SISWAP
+all_available_ops.add("QFT")  # QFT was recently moved to being a template, but let's keep it here
 
 symbolic_ops = {"Adjoint(S)", "Adjoint(T)", "Adjoint(SX)", "Adjoint(ISWAP)", "Adjoint(SISWAP)"}
 

--- a/pennylane/drawer/_add_obj.py
+++ b/pennylane/drawer/_add_obj.py
@@ -50,7 +50,7 @@ from pennylane.ops import (
 )
 from pennylane.pytrees import flatten
 from pennylane.tape import QuantumScript
-from pennylane.templates.core import SubroutineOp
+from pennylane.templates import SubroutineOp
 from pennylane.templates.subroutines import TemporaryAND
 
 

--- a/pennylane/drawer/drawable_layers.py
+++ b/pennylane/drawer/drawable_layers.py
@@ -26,7 +26,7 @@ from pennylane.ops import (
     PauliMeasure,
 )
 from pennylane.pytrees import flatten
-from pennylane.templates.core import SubroutineOp
+from pennylane.templates import SubroutineOp
 
 from .utils import default_wire_map, unwrap_controls
 

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -397,7 +397,7 @@ def tape_mpl(
     .. code-block:: python
 
         ops = [
-            qml.QFT.operator(wires=(0,1,2,3)),
+            qml.QFT(wires=(0,1,2,3)),
             qml.IsingXX(1.234, wires=(0,2)),
             qml.Toffoli(wires=(0,1,2)),
             qml.CSWAP(wires=(0,2,3)),

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -251,7 +251,7 @@ def tape_text(
     .. code-block:: python
 
         ops = [
-            qml.QFT.operator(wires=(0, 1, 2)),
+            qml.QFT(wires=(0, 1, 2)),
             qml.RX(1.234, wires=0),
             qml.RY(1.234, wires=1),
             qml.RZ(1.234, wires=2),

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -21,7 +21,7 @@ import numpy as np
 from pennylane.measurements import MeasurementProcess
 from pennylane.ops import Conditional, Controlled, MeasurementValue, MidMeasure, PauliMeasure
 from pennylane.pytrees import flatten
-from pennylane.templates.core import SubroutineOp
+from pennylane.templates import SubroutineOp
 
 
 def _get_subroutine_mvs(op: SubroutineOp) -> list[MeasurementValue]:

--- a/pennylane/estimator/resource_mapping.py
+++ b/pennylane/estimator/resource_mapping.py
@@ -101,7 +101,7 @@ def _register_subroutine(subroutine: qtemps.Subroutine):
 
 
 @_map_to_resource_op.register
-def _resources_for_subroutine(op: qtemps.core.SubroutineOp):
+def _resources_for_subroutine(op: qtemps.SubroutineOp):
     if op.subroutine in _Subroutine_map:
         return _Subroutine_map[op.subroutine](op)
     with QueuingManager.stop_recording():
@@ -295,8 +295,8 @@ def _(op: qtemps.SemiAdder):
     )
 
 
-@_register_subroutine(qtemps.QFT)
-def _handle_qft(op):
+@_map_to_resource_op.register
+def _(op: qtemps.QFT):
     return re_temps.QFT(num_wires=len(op.wires), wires=op.wires)
 
 

--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -49,47 +49,6 @@ except (ModuleNotFoundError, ImportError) as import_error:
     Bloq = object
 
 
-_Subroutine_call_graph_map: dict = {}
-"""A registry for the call graphs of SubroutineOps."""
-
-_Subroutine_to_bloq_map: dict = {}
-"""A registry for SubroutineOps we want to convert to Bloq."""
-
-
-def _register_subroutine_call_graph(subroutine: qtemps.core.Subroutine):
-    """Register a function for the call graph of a SubroutineOp using a decorator.
-
-    .. code-block::
-        @_register_subroutine_call_graph(MySubroutine)
-        def _call_graph(op: SubroutineOp):
-            ...
-
-    """
-
-    def subroutine_call_graph_decorator(f):
-        _Subroutine_call_graph_map[subroutine] = f
-        return f
-
-    return subroutine_call_graph_decorator
-
-
-def _register_subroutine_to_bloq(subroutine: qtemps.core.Subroutine):
-    """Register a function conversion of a SubroutineOp to Bloq using a decorator.
-
-    .. code-block::
-        @_register_subroutine_to_bloq(MySubroutine)
-        def _to_bloq(op: SubroutineOp):
-            ...
-
-    """
-
-    def subroutine_to_bloq_decorator(f):
-        _Subroutine_to_bloq_map[subroutine] = f
-        return f
-
-    return subroutine_to_bloq_decorator
-
-
 def _get_op_call_graph_estimator(op):
     """Return call graph for PennyLane Operator. The call graph depends on the results of calling
     estimate on said PennyLane Operator."""
@@ -123,15 +82,6 @@ def _get_op_call_graph(op):  # pylint: disable=unused-argument
 
 
 @_get_op_call_graph.register
-def _call_graph_for_subroutine(op: qtemps.core.SubroutineOp):
-    if op.subroutine in _Subroutine_call_graph_map:
-        return _Subroutine_call_graph_map[op.subroutine](op)
-    raise NotImplementedError(
-        f"Subroutine {op.subroutine} has no registered call graph."
-    )  # pragma: no cover
-
-
-@_get_op_call_graph.register
 def _(op: qtemps.subroutines.qpe.QuantumPhaseEstimation):
     """Call graph for Quantum Phase Estimation"""
 
@@ -144,7 +94,7 @@ def _(op: qtemps.subroutines.qpe.QuantumPhaseEstimation):
     ).controlled(CtrlSpec(cvs=[1]))
     gate_counts[controlled_unitary] = (2 ** len(op.estimation_wires)) - 1
     adjoint_qft = _map_to_bloq(
-        qtemps.QFT.operator(wires=op.estimation_wires), map_ops=False, call_graph="decomposition"
+        qtemps.QFT(wires=op.estimation_wires), map_ops=False, call_graph="decomposition"
     ).adjoint()
     gate_counts[adjoint_qft] = 1
 
@@ -375,8 +325,8 @@ def _(op: qtemps.subroutines.QROM):
     return gate_types
 
 
-@_register_subroutine_call_graph(qtemps.subroutines.QFT)
-def _qft_call_graph(op):
+@_get_op_call_graph.register
+def _(op: qtemps.subroutines.QFT):
     """Call graph for Quantum Fourier Transform"""
 
     # From PL Decomposition
@@ -475,7 +425,7 @@ def _(op: qtemps.subroutines.ModExp):
         num_aux_swap = num_aux_wires - 1
 
     qft = _map_to_bloq(
-        qtemps.QFT.operator(wires=range(num_aux_wires)), map_ops=False, call_graph="decomposition"
+        qtemps.QFT(wires=range(num_aux_wires)), map_ops=False, call_graph="decomposition"
     )
     qft_dag = qft.adjoint()
 
@@ -572,19 +522,6 @@ def _handle_custom_map(op, map_ops, custom_mapping, **kwargs):
     return None
 
 
-@_map_to_bloq.register
-def _to_bloq_for_subroutine(
-    op: qtemps.core.SubroutineOp, custom_mapping=None, map_ops=True, **kwargs
-):
-    if op.subroutine in _Subroutine_to_bloq_map:
-        return _Subroutine_to_bloq_map[op.subroutine](
-            op, custom_mapping=custom_mapping, map_ops=map_ops, **kwargs
-        )
-    raise NotImplementedError(
-        f"Subroutine {op.subroutine} has no registered conversion to Bloq."
-    )  # pragma: no cover
-
-
 # pylint: disable=import-outside-toplevel
 @_map_to_bloq.register
 def _(
@@ -607,8 +544,8 @@ def _(
 
 
 # pylint: disable=import-outside-toplevel
-@_register_subroutine_to_bloq(qtemps.subroutines.QFT)
-def _qft_to_bloq(op, custom_mapping=None, map_ops=True, **kwargs):
+@_map_to_bloq.register
+def _(op: qtemps.subroutines.QFT, custom_mapping=None, map_ops=True, **kwargs):
     """Mapping for QFT, which maps to ``qt.QFTTextBook`` by default"""
     from qualtran.bloqs.qft import QFTTextBook
 

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -198,7 +198,7 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         actual_gate_counts[op_rep] += 1
 
     if rule.exact_resources and not (
-        isinstance(op, qml.templates.core.SubroutineOp) and not op.subroutine.exact_resources
+        isinstance(op, qml.templates.SubroutineOp) and not op.subroutine.exact_resources
     ):
         non_zero_gate_counts = {k: v for k, v in gate_counts.items() if v > 0}
         assert non_zero_gate_counts == actual_gate_counts, (
@@ -407,7 +407,7 @@ def _check_pytree(op):
 
 
 def _check_capture(op):
-    if isinstance(op, qml.templates.core.SubroutineOp):
+    if isinstance(op, qml.templates.SubroutineOp):
         return
     try:
         import jax

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -43,7 +43,7 @@ from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
 from pennylane.pytrees import flatten
 from pennylane.tape import QuantumScript
-from pennylane.templates.core import SubroutineOp
+from pennylane.templates import SubroutineOp
 from pennylane.templates.subroutines import QSVT, ControlledSequence, PrepSelPrep, Select
 
 OPERANDS_MISMATCH_ERROR_MESSAGE = "op1 and op2 have different operands because "

--- a/pennylane/ops/op_math/change_op_basis.py
+++ b/pennylane/ops/op_math/change_op_basis.py
@@ -59,7 +59,7 @@ def _apply_op_or_func(op_or_func):
 def _convert_to_prod(op_or_func):
     if isinstance(op_or_func, Callable):
         try:
-            return prod.prod(op_or_func)()  # pylint: disable=no-member
+            return prod(op_or_func)()
         except TypeError as e:
             raise TypeError(
                 "change_op_basis requires that Callable inputs have no parameters. functools.partial can be used to achieve this."
@@ -95,7 +95,7 @@ def change_op_basis(
     **Example**
 
     Consider the following example involving a ``ChangeOpBasis``. The compute, uncompute pattern is composed of
-    a ``SWAP``, followed by a ``PhaseAdder``, and finally an inverse ``SWAP``.
+    a Quantum Fourier Transform (``QFT``), followed by a ``PhaseAdder``, and finally an inverse ``QFT``.
 
     .. code-block:: python
 
@@ -110,7 +110,7 @@ def change_op_basis(
             qml.H(0)
             qml.CNOT([1,2])
             qml.ctrl(
-                qml.change_op_basis(qml.SWAP([1,2]), qml.PhaseAdder(1, x_wires=[1,2])),
+                qml.change_op_basis(qml.QFT([1,2]), qml.PhaseAdder(1, x_wires=[1,2])),
                 control=0
             )
             return qml.state()
@@ -121,10 +121,9 @@ def change_op_basis(
     resulting in a much more resource-efficient decomposition:
 
     >>> print(qml.draw(circuit2)())
-    0: ──H───────╭●─────────────────┤  State
-    1: ─╭●─╭SWAP─├PhaseAdder─╭SWAP†─┤  State
-    2: ─╰X─╰SWAP─╰PhaseAdder─╰SWAP†─┤  State
-
+    0: ──H──────╭●────────────────┤  State
+    1: ─╭●─╭QFT─├PhaseAdder─╭QFT†─┤  State
+    2: ─╰X─╰QFT─╰PhaseAdder─╰QFT†─┤  State
 
     A ``Callable`` can also be provided as an argument to ``ChangeOpBasis``. This can be a function that applies a series
     of ``Operation`` s. Since ``ChangeOpBasis`` requires this ``Callable`` to have no input arguments, ``functools.partial``

--- a/pennylane/ops/op_math/decompositions/unitary_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/unitary_decompositions.py
@@ -259,7 +259,7 @@ def multi_qubit_decomposition(U, wires):
 
     .. code-block:: pycon
 
-        >>> matrix_target = qml.matrix(qml.QFT, wire_order=[0,1,2])([0,1,2])
+        >>> matrix_target = qml.matrix(qml.QFT([0,1,2]))
         >>> ops = qml.ops.multi_qubit_decomposition(matrix_target, [0,1,2])
         >>> matrix_decomposition = qml.matrix(qml.prod(*ops[::-1]), wire_order = [0,1,2])
         >>> print([op.name for op in ops])

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -34,7 +34,7 @@ from pennylane.decomposition import (
 )
 from pennylane.exceptions import WireError
 from pennylane.operation import Operation, Operator, StatePrepBase
-from pennylane.templates.state_preparations.mottonen import MottonenStatePreparation
+from pennylane.templates.state_preparations import MottonenStatePreparation
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/__init__.py
+++ b/pennylane/templates/__init__.py
@@ -15,6 +15,13 @@
 This module contains templates, which are pre-coded routines that can be used in a quantum node.
 """
 
+from .core import (
+    Subroutine,
+    SubroutineOp,
+    AbstractArray,
+    subroutine_resource_rep,
+    adjoint_subroutine_resource_rep,
+)
 from .embeddings import *
 from .layer import layer
 from .state_preparations import *

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -50,7 +50,7 @@ from pennylane.decomposition import (
 )
 from pennylane.decomposition.resources import auto_wrap
 from pennylane.operation import Operation, Operator
-from pennylane.ops.op_math.change_op_basis import ChangeOpBasis
+from pennylane.ops import ChangeOpBasis
 from pennylane.pytrees import flatten, unflatten
 from pennylane.wires import Wires
 
@@ -62,7 +62,7 @@ class AbstractArray:
     """An abstract representation of an array that contains the shape and dtype
     attributes necessary for resource calculations.
 
-    This class is used with :func:`~pennylane.templates.core.subroutine_resource_rep`
+    This class is used with :func:`~pennylane.templates.subroutine_resource_rep`
     for specifying abstract information about a :class:`~.Subroutine` for
     purposes of resource calculations used with graph decompositions.
 
@@ -196,7 +196,7 @@ def subroutine_resource_rep(subroutine: "Subroutine", *args, **kwargs) -> Compre
         def S_resources(params, wires, rotation):
             return {qml.resource_rep(rotation): params.shape[0]}
 
-        @partial(qml.templates.core.Subroutine, static_argnames="rotation", compute_resources=S_resources)
+        @partial(qml.templates.Subroutine, static_argnames="rotation", compute_resources=S_resources)
         def S(params, wires, rotation):
             for x in params:
                 rotation(x, wires)
@@ -206,7 +206,7 @@ def subroutine_resource_rep(subroutine: "Subroutine", *args, **kwargs) -> Compre
 
     .. code-block:: python
 
-        from pennylane.templates.core import AbstractArray, subroutine_resource_rep
+        from pennylane.templates import AbstractArray, subroutine_resource_rep
 
         class MyOp(qml.operation.Operation):
             pass
@@ -274,8 +274,8 @@ def _get_array_types():
     if has_jax:
         import jax  # pylint: disable=import-outside-toplevel
 
-        return (jax.numpy.ndarray, np.ndarray, AbstractArray)
-    return (np.ndarray, AbstractArray)
+        return (jax.numpy.ndarray, np.ndarray)
+    return (np.ndarray,)
 
 
 @lru_cache
@@ -487,7 +487,7 @@ class Subroutine:
     .. code-block:: python
 
         from functools import partial
-        from pennylane.templates.core import Subroutine
+        from pennylane.templates import Subroutine
 
         @Subroutine
         def MyTemplate(x, y, wires):
@@ -624,7 +624,7 @@ class Subroutine:
         def RXLayerResources(params, wires):
             return {qml.RX: qml.math.shape(params)[0]}
 
-        @partial(qml.templates.core.Subroutine, compute_resources=RXLayerResources)
+        @partial(qml.templates.Subroutine, compute_resources=RXLayerResources)
         def RXLayer(params, wires):
             for i in range(params.shape[0]):
                 qml.RX(params[i], wires[i])
@@ -632,7 +632,7 @@ class Subroutine:
     For example, we should be able to calculate the resources using the :class:`~.AbstractArray`
     class.
 
-    >>> from pennylane.templates.core import AbstractArray
+    >>> from pennylane.templates import AbstractArray
     >>> abstract_params = AbstractArray((10,), float)
     >>> abstract_wires = AbstractArray((10,))
     >>> RXLayer.compute_resources(abstract_params, abstract_wires)
@@ -643,7 +643,7 @@ class Subroutine:
 
     .. code-block:: python
 
-        from pennylane.templates.core import AbstractArray, subroutine_resource_rep
+        from pennylane.templates import AbstractArray, subroutine_resource_rep
 
         class MyOp(qml.operation.Operation):
             pass
@@ -697,7 +697,7 @@ class Subroutine:
 
     .. code-block:: python
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(x, wires):
             if x < 0:
                 qml.X(wires)
@@ -724,7 +724,7 @@ class Subroutine:
 
     .. code-block:: python
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         @qml.capture.run_autograph
         def UsingAutograph(x, wires):
             if x < 0:
@@ -732,7 +732,7 @@ class Subroutine:
             else:
                 qml.Y(wires)
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def UsingCond(x, wires):
             qml.cond(x  > 0, qml.X, qml.Y)(wires)
 
@@ -824,15 +824,11 @@ class Subroutine:
             if capture.enabled():
                 import jax  # pylint: disable=import-outside-toplevel
 
-                if (
-                    len(register) > 0
-                    and math.get_interface(register) != "jax"
-                    and not isinstance(register, AbstractArray)
-                ):
+                if len(register) > 0 and math.get_interface(register) != "jax":
                     # don't stack if already a jax array
                     bound_args.arguments[wire_argname] = jax.numpy.stack(register)
             else:
-                bound_args.arguments[wire_argname] = register
+                bound_args.arguments[wire_argname] = Wires(register)
         return bound_args
 
     @property

--- a/pennylane/templates/state_preparations/cosine_window.py
+++ b/pennylane/templates/state_preparations/cosine_window.py
@@ -19,10 +19,9 @@ import numpy as np
 import pennylane as qml
 from pennylane import capture, math, register_resources
 from pennylane.control_flow import for_loop
-from pennylane.decomposition import add_decomps, resource_rep
+from pennylane.decomposition import add_decomps, adjoint_resource_rep, resource_rep
 from pennylane.exceptions import WireError
 from pennylane.operation import StatePrepBase
-from pennylane.templates.core import AbstractArray, adjoint_subroutine_resource_rep
 from pennylane.wires import Wires
 
 
@@ -149,8 +148,8 @@ def _cosine_window_resources(num_wires):
     return {
         resource_rep(qml.Hadamard): 1,
         resource_rep(qml.RZ): 1,
+        adjoint_resource_rep(qml.QFT, {"num_wires": num_wires}): 1,
         resource_rep(qml.PhaseShift): num_wires,
-        adjoint_subroutine_resource_rep(qml.QFT, AbstractArray((num_wires,))): 1,
     }
 
 

--- a/pennylane/templates/subroutines/arithmetic/adder.py
+++ b/pennylane/templates/subroutines/arithmetic/adder.py
@@ -14,22 +14,14 @@
 """
 Contains the Adder template.
 """
-from functools import partial
-
 from pennylane.decomposition import (
     add_decomps,
+    change_op_basis_resource_rep,
     register_resources,
 )
 from pennylane.decomposition.resources import resource_rep
 from pennylane.operation import Operation
-from pennylane.ops import adjoint
 from pennylane.ops.op_math import change_op_basis
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
 
@@ -210,7 +202,7 @@ class Adder(Operation):
         **Example**
 
         >>> qml.Adder.compute_decomposition(k=2, x_wires=[0,1,2], mod=8, work_wires=[3])
-        [(Adjoint(<QFT(wires=(0, 1, 2))>)) @ PhaseAdder(wires=[0, 1, 2]) @ <QFT(wires=(0, 1, 2))>]
+        [(Adjoint(QFT(wires=[0, 1, 2]))) @ PhaseAdder(wires=[0, 1, 2]) @ QFT(wires=[0, 1, 2])]
         """
         if mod == 2 ** len(x_wires):
             qft_wires = x_wires
@@ -219,13 +211,7 @@ class Adder(Operation):
             qft_wires = work_wires[:1] + x_wires
             work_wire = work_wires[1:]
 
-        op_list = [
-            change_op_basis(
-                partial(QFT, qft_wires),
-                PhaseAdder(k, qft_wires, mod, work_wire),
-                partial(adjoint(QFT), qft_wires),
-            )
-        ]
+        op_list = [change_op_basis(QFT(qft_wires), PhaseAdder(k, qft_wires, mod, work_wire))]
 
         return op_list
 
@@ -233,11 +219,10 @@ class Adder(Operation):
 def _adder_decomposition_resources(num_x_wires, mod) -> dict:
     qft_wires = num_x_wires if mod == 2**num_x_wires else 1 + num_x_wires
     return {
-        change_op_basis_subroutine_resource_rep(
-            subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
+        change_op_basis_resource_rep(
+            resource_rep(QFT, num_wires=qft_wires),
             resource_rep(PhaseAdder, num_x_wires=qft_wires, mod=mod),
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
-        ): 1
+        ): 1,
     }
 
 
@@ -250,11 +235,7 @@ def _adder_decomposition(k, x_wires: WiresLike, mod, work_wires: WiresLike, **__
         qft_wires = work_wires[:1] + x_wires
         work_wire = work_wires[1:]
 
-    change_op_basis(
-        partial(QFT, qft_wires),
-        PhaseAdder(k, qft_wires, mod, work_wire),
-        partial(adjoint(QFT), qft_wires),
-    )
+    change_op_basis(QFT(qft_wires), PhaseAdder(k, qft_wires, mod, work_wire))
 
 
 add_decomps(Adder, _adder_decomposition)

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -14,24 +14,18 @@
 """
 Contains the Multiplier template.
 """
-from functools import partial
 
 import numpy as np
 
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
+    change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.operation import Operation
 from pennylane.ops import SWAP, Prod, adjoint, change_op_basis, prod
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
@@ -223,9 +217,9 @@ class Multiplier(Operation):
         >>> ops = qml.Multiplier.compute_decomposition(k=3, mod=8, x_wires=[0,1,2], work_wires=[3,4,5])
         >>> from pprint import pprint
         >>> pprint(ops)
-         [(Adjoint(<QFT(wires=(3, 4, 5))>)) @ (ControlledSequence(PhaseAdder(wires=[3, 4, 5]), control=[0, 1, 2])) @ <QFT(wires=(3, 4, 5))>,
-         SWAP(wires=[2, 5]) @ SWAP(wires=[1, 4]) @ SWAP(wires=[0, 3]),
-         (Adjoint(<QFT(wires=(3, 4, 5))>)) @ (Adjoint(ControlledSequence(PhaseAdder(wires=[3, 4, 5]), control=[0, 1, 2]))) @ <QFT(wires=(3, 4, 5))>]
+        [(Adjoint(QFT(wires=[3, 4, 5]))) @ (ControlledSequence(PhaseAdder(wires=[3, 4, 5]), control=[0, 1, 2])) @ QFT(wires=[3, 4, 5]),
+        SWAP(wires=[2, 5]) @ SWAP(wires=[1, 4]) @ SWAP(wires=[0, 3]),
+        (Adjoint(QFT(wires=[3, 4, 5]))) @ (Adjoint(ControlledSequence(PhaseAdder(wires=[3, 4, 5]), control=[0, 1, 2]))) @ QFT(wires=[3, 4, 5])]
 
         """
 
@@ -239,22 +233,20 @@ class Multiplier(Operation):
             wires_aux_swap = wires_aux
 
         op1 = change_op_basis(
-            partial(QFT, wires=wires_aux),
+            QFT(wires=wires_aux),
             ControlledSequence(PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires),
-            partial(adjoint(QFT), wires=wires_aux),
         )
 
         target_op = prod(*reversed([SWAP(wires) for wires in zip(x_wires, wires_aux_swap)]))
 
         inv_k = pow(k, -1, mod)
         op2 = change_op_basis(
-            partial(QFT, wires=wires_aux),
+            QFT(wires=wires_aux),
             adjoint(
                 ControlledSequence(
                     PhaseAdder(inv_k, wires_aux, mod, work_wire_aux), control=x_wires
                 )
             ),
-            partial(adjoint(QFT), wires=wires_aux),
         )
 
         return [op1, target_op, op2]
@@ -273,30 +265,26 @@ def _multiplier_decomposition_resources(
     }
     if num_x_wires > 1:
         return {
-            change_op_basis_subroutine_resource_rep(
-                subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
+            change_op_basis_resource_rep(
+                resource_rep(QFT, num_wires=num_wires_aux),
                 resource_rep(ControlledSequence, **cs_base_params),
-                adjoint_subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
             ): 1,
             resource_rep(Prod, resources={resource_rep(SWAP): num_x_wires}): 1,
-            change_op_basis_subroutine_resource_rep(
-                subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
+            change_op_basis_resource_rep(
+                resource_rep(QFT, num_wires=num_wires_aux),
                 adjoint_resource_rep(ControlledSequence, cs_base_params),
-                adjoint_subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
             ): 1,
         }
 
     return {
-        change_op_basis_subroutine_resource_rep(
-            subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
+        change_op_basis_resource_rep(
+            resource_rep(QFT, num_wires=num_wires_aux),
             resource_rep(ControlledSequence, **cs_base_params),
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
         ): 1,
         SWAP: 1,
-        change_op_basis_subroutine_resource_rep(
-            subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
+        change_op_basis_resource_rep(
+            resource_rep(QFT, num_wires=num_wires_aux),
             adjoint_resource_rep(ControlledSequence, cs_base_params),
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((num_wires_aux,))),
         ): 1,
     }
 
@@ -314,23 +302,19 @@ def _multiplier_decomposition(k, x_wires: WiresLike, mod, work_wires: WiresLike,
 
     inv_k = pow(k, -1, mod)
     change_op_basis(
-        partial(QFT, wires=wires_aux),
+        QFT(wires=wires_aux),
         ControlledSequence(PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires),
-        partial(adjoint(QFT), wires=wires_aux),
     )
-
     prod(
         *reversed(
             [SWAP(wires=[x_wire, aux_wire]) for x_wire, aux_wire in zip(x_wires, wires_aux_swap)]
         )
     )
-
     change_op_basis(
-        partial(QFT, wires=wires_aux),
+        QFT(wires=wires_aux),
         adjoint(
             ControlledSequence(PhaseAdder(inv_k, wires_aux, mod, work_wire_aux), control=x_wires)
         ),
-        partial(adjoint(QFT), wires=wires_aux),
     )
 
 

--- a/pennylane/templates/subroutines/arithmetic/out_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/out_adder.py
@@ -15,21 +15,15 @@
 Contains the OutAdder template.
 """
 from collections import defaultdict
-from functools import partial
 
 from pennylane.decomposition import (
     add_decomps,
+    change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.operation import Operation
-from pennylane.ops import Prod, adjoint, change_op_basis
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
+from pennylane.ops import Prod, change_op_basis
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
@@ -271,7 +265,8 @@ class OutAdder(Operation):
         >>> ops = qml.OutAdder.compute_decomposition(x_wires=[0,1], y_wires=[2,3], output_wires=[5,6], mod=4, work_wires=[4,7])
         >>> from pprint import pprint
         >>> pprint(ops)
-        [(Adjoint(<QFT(wires=(5, 6))>)) @ ((ControlledSequence(PhaseAdder(wires=[5, 6]), control=[2, 3])) @ (ControlledSequence(PhaseAdder(wires=[5, 6]), control=[0, 1]))) @ <QFT(wires=(5, 6))>]
+        [(Adjoint(QFT(wires=[5, 6]))) @ ((ControlledSequence(PhaseAdder(wires=[5, 6]), control=[2, 3])) @ (ControlledSequence(PhaseAdder(wires=[5, 6]), control=[0, 1]))) @ QFT(wires=[5, 6])]
+
         """
         if mod != 2 ** len(output_wires) and mod is not None:
             qft_new_output_wires = work_wires[:1] + output_wires
@@ -284,13 +279,7 @@ class OutAdder(Operation):
             PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=y_wires
         ) @ ControlledSequence(PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=x_wires)
 
-        op_list = [
-            change_op_basis(
-                partial(QFT, wires=qft_new_output_wires),
-                target_op,
-                partial(adjoint(QFT), wires=qft_new_output_wires),
-            )
-        ]
+        op_list = [change_op_basis(QFT(wires=qft_new_output_wires), target_op)]
 
         return op_list
 
@@ -316,10 +305,8 @@ def _out_adder_decomposition_resources(num_output_wires, num_x_wires, num_y_wire
     ] += 1
 
     return {
-        change_op_basis_subroutine_resource_rep(
-            subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
-            resource_rep(Prod, resources=target_resources),
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
+        change_op_basis_resource_rep(
+            resource_rep(QFT, num_wires=qft_wires), resource_rep(Prod, resources=target_resources)
         ): 1
     }
 
@@ -334,14 +321,13 @@ def _out_adder_decomposition(x_wires, y_wires, output_wires, mod, work_wires, **
         work_wire = ()
 
     change_op_basis(
-        partial(QFT, wires=qft_new_output_wires),
+        QFT(wires=qft_new_output_wires),
         (
             ControlledSequence(PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=y_wires)
             @ ControlledSequence(
                 PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=x_wires
             )
         ),
-        partial(adjoint(QFT), wires=qft_new_output_wires),
     )
 
 

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -14,21 +14,14 @@
 """
 Contains the OutMultiplier template.
 """
-from functools import partial
-
 from pennylane.decomposition import (
     add_decomps,
+    change_op_basis_resource_rep,
     register_resources,
 )
 from pennylane.decomposition.resources import resource_rep
 from pennylane.operation import Operation
-from pennylane.ops import adjoint, change_op_basis
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
+from pennylane.ops import change_op_basis
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
@@ -277,7 +270,7 @@ class OutMultiplier(Operation):
         **Example**
 
         >>> qml.OutMultiplier.compute_decomposition(x_wires=[0,1], y_wires=[2,3], output_wires=[5,6], mod=4, work_wires=[4,7])
-        [(Adjoint(<QFT(wires=(5, 6))>)) @ (ControlledSequence(ControlledSequence(PhaseAdder(wires=[5, 6]), control=[0, 1]), control=[2, 3])) @ <QFT(wires=(5, 6))>]
+        [(Adjoint(QFT(wires=[5, 6]))) @ (ControlledSequence(ControlledSequence(PhaseAdder(wires=[5, 6]), control=[0, 1]), control=[2, 3])) @ QFT(wires=[5, 6])]
         """
         if mod != 2 ** len(output_wires):
             qft_output_wires = work_wires[:1] + output_wires
@@ -288,15 +281,14 @@ class OutMultiplier(Operation):
 
         op_list = [
             change_op_basis(
-                partial(QFT, wires=qft_output_wires),
+                QFT(wires=qft_output_wires),
                 ControlledSequence(
                     ControlledSequence(
                         PhaseAdder(1, qft_output_wires, mod, work_wire), control=x_wires
                     ),
                     control=y_wires,
                 ),
-                partial(adjoint(QFT), wires=qft_output_wires),
-            ),
+            )
         ]
         return op_list
 
@@ -306,8 +298,8 @@ def _out_multiplier_decomposition_resources(
 ) -> dict:
     qft_wires = num_output_wires + 1 if mod != 2**num_output_wires else num_output_wires
     return {
-        change_op_basis_subroutine_resource_rep(
-            subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
+        change_op_basis_resource_rep(
+            resource_rep(QFT, num_wires=qft_wires),
             resource_rep(
                 ControlledSequence,
                 base_class=ControlledSequence,
@@ -318,7 +310,6 @@ def _out_multiplier_decomposition_resources(
                 },
                 num_control_wires=num_y_wires,
             ),
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((qft_wires,))),
         ): 1
     }
 
@@ -340,12 +331,11 @@ def _out_multiplier_decomposition(
         work_wire = ()
 
     change_op_basis(
-        partial(QFT, wires=qft_output_wires),
+        QFT(wires=qft_output_wires),
         ControlledSequence(
             ControlledSequence(PhaseAdder(1, qft_output_wires, mod, work_wire), control=x_wires),
             control=y_wires,
         ),
-        partial(adjoint(QFT), wires=qft_output_wires),
     )
 
 

--- a/pennylane/templates/subroutines/arithmetic/out_poly.py
+++ b/pennylane/templates/subroutines/arithmetic/out_poly.py
@@ -19,17 +19,13 @@ from collections import Counter
 from pennylane import math
 from pennylane.decomposition import (
     add_decomps,
+    adjoint_resource_rep,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.operation import Operation
 from pennylane.ops import adjoint, ctrl
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
 
@@ -436,7 +432,7 @@ class OutPoly(Operation):
             [work_wires[0]] + registers_wires[-1] if work_wires[0] else registers_wires[-1]
         )
 
-        list_ops.append(QFT.operator(wires=output_adder_mod))
+        list_ops.append(QFT(wires=output_adder_mod))
 
         wires_vars = [len(w) for w in registers_wires[:-1]]
 
@@ -478,7 +474,7 @@ def _out_poly_decomposition_resources(num_output_wires, num_work_wires, mod, coe
 
     resources = Counter(
         {
-            subroutine_resource_rep(QFT, AbstractArray((num_output_adder_mod,))): 1,
+            resource_rep(QFT, num_wires=num_output_adder_mod): 1,
         }
     )
 
@@ -504,7 +500,7 @@ def _out_poly_decomposition_resources(num_output_wires, num_work_wires, mod, coe
             )
             resources[ctrl_phase_rep] += 1
 
-    resources[adjoint_subroutine_resource_rep(QFT, AbstractArray((num_output_adder_mod,)))] = 1
+    resources[adjoint_resource_rep(QFT, {"num_wires": num_output_adder_mod})] = 1
 
     return dict(resources)
 
@@ -551,7 +547,7 @@ def _out_poly_decomposition(
                 control=controls,
             )
 
-    adjoint(QFT)(wires=output_adder_mod)
+    adjoint(QFT(wires=output_adder_mod))
 
 
 add_decomps(OutPoly, _out_poly_decomposition)

--- a/pennylane/templates/subroutines/arithmetic/phase_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/phase_adder.py
@@ -16,7 +16,6 @@ Contains the PhaseAdder template.
 """
 
 from collections import defaultdict
-from functools import partial
 
 import numpy as np
 
@@ -25,16 +24,11 @@ from pennylane.control_flow import for_loop
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
+    change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.operation import Operation
-from pennylane.templates.core import (
-    AbstractArray,
-    adjoint_subroutine_resource_rep,
-    change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
-)
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
 
@@ -252,9 +246,9 @@ class PhaseAdder(Operation):
 
             op_list.append(
                 ops.change_op_basis(
-                    partial(ops.adjoint(QFT), wires=x_wires),
+                    ops.adjoint(QFT)(wires=x_wires),
                     ops.ctrl(ops.X(work_wire), control=aux_k, control_values=1),
-                    partial(QFT, wires=x_wires),
+                    QFT(wires=x_wires),
                 )
             )
 
@@ -268,9 +262,7 @@ class PhaseAdder(Operation):
                         *[ops.adjoint(op) for op in _add_k_fourier(k, x_wires)],
                     ),
                     ops.CNOT(wires=[aux_k, work_wire[0]]),
-                    ops.prod(
-                        *_add_k_fourier(k, x_wires)[::-1], QFT.operator(wires=x_wires), ops.X(aux_k)
-                    ),
+                    ops.prod(*_add_k_fourier(k, x_wires)[::-1], QFT(wires=x_wires), ops.X(aux_k)),
                 )
             )
 
@@ -286,7 +278,7 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         int,
         {
             resource_rep(ops.X): 1,
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((num_x_wires,))): 1,
+            adjoint_resource_rep(QFT, {"num_wires": num_x_wires}): 1,
             adjoint_resource_rep(ops.PhaseShift): num_x_wires,
         },
     )
@@ -295,7 +287,7 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         int,
         {
             resource_rep(ops.PhaseShift): num_x_wires,
-            subroutine_resource_rep(QFT, AbstractArray((num_x_wires,))): 1,
+            resource_rep(QFT, num_wires=num_x_wires): 1,
             resource_rep(ops.X): 1,
         },
     )
@@ -303,17 +295,17 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
     return {
         ops.PhaseShift: num_x_wires,
         adjoint_resource_rep(ops.PhaseShift): num_x_wires,
-        change_op_basis_subroutine_resource_rep(
-            adjoint_subroutine_resource_rep(QFT, AbstractArray((num_x_wires,))),
+        change_op_basis_resource_rep(
+            adjoint_resource_rep(QFT, {"num_wires": num_x_wires}),
             resource_rep(ops.CNOT),
-            subroutine_resource_rep(QFT, AbstractArray((num_x_wires,))),
+            resource_rep(QFT, num_wires=num_x_wires),
         ): 1,
-        change_op_basis_subroutine_resource_rep(
+        ops.ControlledPhaseShift: num_x_wires,
+        change_op_basis_resource_rep(
             resource_rep(ops.Prod, resources=basis_op_resources1),
             resource_rep(ops.CNOT),
             resource_rep(ops.Prod, resources=basis_op_resources2),
         ): 1,
-        ops.ControlledPhaseShift: num_x_wires,
     }
 
 
@@ -336,9 +328,9 @@ def _phase_adder_decomposition(k, x_wires: WiresLike, mod, work_wire, **__):
     _add_k_fourier_loop(k)
     ops.adjoint(_add_k_fourier_loop)(mod)
     ops.change_op_basis(
-        partial(ops.adjoint(QFT), wires=x_wires),
+        ops.adjoint(QFT)(wires=x_wires),
         ops.CNOT(wires=[aux_k, work_wire[0]]),
-        partial(QFT, wires=x_wires),
+        QFT(wires=x_wires),
     )
     ops.ctrl(_add_k_fourier_loop, control=work_wire)(mod)
     ops.change_op_basis(
@@ -348,9 +340,7 @@ def _phase_adder_decomposition(k, x_wires: WiresLike, mod, work_wire, **__):
             *reversed(ops.adjoint(_add_k_fourier_loop)(k)),
         ),
         ops.CNOT(wires=[aux_k, work_wire[0]]),
-        ops.prod(
-            ops.prod(_add_k_fourier_loop)(k), QFT.operator(wires=x_wires), ops.X(aux_k), lazy=False
-        ),
+        ops.prod(ops.prod(_add_k_fourier_loop)(k), QFT(wires=x_wires), ops.X(aux_k), lazy=False),
     )
 
 

--- a/pennylane/templates/subroutines/qchem/basis_rotation.py
+++ b/pennylane/templates/subroutines/qchem/basis_rotation.py
@@ -21,7 +21,7 @@ import numpy as np
 from pennylane import capture, compiler, math
 from pennylane.control_flow import for_loop
 from pennylane.ops import PhaseShift, SingleExcitation, cond
-from pennylane.templates.core import Subroutine
+from pennylane.templates import Subroutine
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -23,27 +23,13 @@ import numpy as np
 from pennylane import math
 from pennylane.capture import enabled
 from pennylane.control_flow import for_loop
+from pennylane.decomposition import add_decomps, register_resources
+from pennylane.operation import Operation
 from pennylane.ops import SWAP, ControlledPhaseShift, Hadamard
-from pennylane.templates.core import Subroutine
-from pennylane.wires import WiresLike
+from pennylane.wires import Wires, WiresLike
 
 
-def qft_decomp_resources(wires: WiresLike):
-    """Calculate the resources for QFT."""
-    num_wires = len(wires)
-    return {
-        Hadamard: num_wires,
-        SWAP: num_wires // 2,
-        ControlledPhaseShift: num_wires * (num_wires - 1) // 2,
-    }
-
-
-@functools.partial(
-    Subroutine,
-    static_argnames=[],
-    compute_resources=qft_decomp_resources,
-)
-def QFT(wires: WiresLike):
+class QFT(Operation):
     r"""QFT(wires)
     Apply a quantum Fourier transform (QFT).
 
@@ -140,9 +126,98 @@ def QFT(wires: WiresLike):
         >>> qml.set_shots(scFT_add, 1)(7, 3, num_wires=4) # doctest: +SKIP
         array([[1, 1, 1, 0]])
     """
-    num_wires = len(wires)
-    shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
 
+    grad_method = None
+    resource_keys = {"num_wires"}
+
+    def __init__(self, wires: WiresLike, id=None):
+        wires = Wires(wires)
+        self.hyperparameters["num_wires"] = len(wires)
+        super().__init__(wires=wires, id=id)
+
+    def _flatten(self):
+        return tuple(), (self.wires, tuple())
+
+    @property
+    def num_params(self):
+        return 0
+
+    def decomposition(self):
+        return self.compute_decomposition(wires=self.wires)
+
+    @staticmethod
+    @functools.lru_cache
+    def compute_matrix(num_wires):  # pylint: disable=arguments-differ
+        return np.fft.ifft(np.eye(2**num_wires), norm="ortho")
+
+    @staticmethod
+    def compute_decomposition(wires: WiresLike):  # pylint: disable=arguments-differ
+        r"""Representation of the operator as a product of other operators (static method).
+
+        .. math:: O = O_1 O_2 \dots O_n.
+
+
+        .. seealso:: :meth:`~.QFT.decomposition`.
+
+        Args:
+            wires (Iterable, Wires): wires that the operator acts on
+
+        Returns:
+            list[Operator]: decomposition of the operator
+
+        **Example:**
+
+        >>> qml.QFT.compute_decomposition(wires=(0,1,2))
+        [H(0),
+         ControlledPhaseShift(1.5707963267948966, wires=Wires([1, 0])),
+         ControlledPhaseShift(0.7853981633974483, wires=Wires([2, 0])),
+         H(1),
+         ControlledPhaseShift(1.5707963267948966, wires=Wires([2, 1])),
+         H(2),
+         SWAP(wires=[0, 2])]
+
+        """
+        wires = Wires(wires)
+        num_wires = len(wires)
+
+        shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
+
+        shift_len = len(shifts)
+        decomp_ops = []
+        for i, wire in enumerate(wires):
+            decomp_ops.append(Hadamard(wire))
+
+            for shift, control_wire in zip(shifts[: shift_len - i], wires[i + 1 :]):
+                op = ControlledPhaseShift(shift, wires=[control_wire, wire])
+                decomp_ops.append(op)
+
+        first_half_wires = wires[: num_wires // 2]
+        last_half_wires = wires[-(num_wires // 2) :]
+
+        for wire1, wire2 in zip(first_half_wires, reversed(last_half_wires)):
+            swap = SWAP(wires=[wire1, wire2])
+            decomp_ops.append(swap)
+
+        return decomp_ops
+
+    @property
+    def resource_params(self) -> dict:
+        return {"num_wires": len(self.wires)}
+
+
+def _qft_decomposition_resources(num_wires):
+    return {
+        Hadamard: num_wires,
+        SWAP: num_wires // 2,
+        ControlledPhaseShift: num_wires * (num_wires - 1) // 2,
+    }
+
+
+# pylint: disable=no-value-for-parameter
+@register_resources(_qft_decomposition_resources)
+def _qft_decomposition(wires: WiresLike, num_wires, **__):
+
+    shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
     if enabled():
         shifts = math.array(shifts, like="jax")
         wires = math.array(wires, like="jax")
@@ -159,12 +234,15 @@ def QFT(wires: WiresLike):
             def cphaseshift_loop(j):
                 ControlledPhaseShift(shifts[j], wires=[wires[i + j + 1], wires[i]])
 
-            cphaseshift_loop()  # pylint: disable=no-value-for-parameter
+            cphaseshift_loop()
 
-    outer_loop()  # pylint: disable=no-value-for-parameter
+    outer_loop()
 
     @for_loop(num_wires // 2)
     def swaps(i):
         SWAP(wires=[wires[i], wires[num_wires - i - 1]])
 
-    swaps()  # pylint: disable=no-value-for-parameter
+    swaps()
+
+
+add_decomps(QFT, _qft_decomposition)

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -16,11 +16,11 @@ Contains the QuantumPhaseEstimation template.
 """
 # pylint: disable=arguments-differ
 import copy
-from collections import defaultdict
 
 from pennylane import math, ops
 from pennylane.decomposition import (
     add_decomps,
+    adjoint_resource_rep,
     controlled_resource_rep,
     register_resources,
     resource_rep,
@@ -30,7 +30,6 @@ from pennylane.operation import Operator
 from pennylane.ops import pow as qml_pow
 from pennylane.queuing import QueuingManager
 from pennylane.resource.error import ErrorOperation, SpectralNormError
-from pennylane.templates.core import AbstractArray, adjoint_subroutine_resource_rep
 from pennylane.wires import Wires
 
 from .qft import QFT
@@ -301,14 +300,16 @@ class QuantumPhaseEstimation(ErrorOperation):
         op_list = [ops.Hadamard(w) for w in estimation_wires]
         pow_ops = (pow(unitary, 2**i) for i in range(len(estimation_wires) - 1, -1, -1))
         op_list.extend(ops.ctrl(op, w) for op, w in zip(pow_ops, estimation_wires))
-        op_list.append(ops.adjoint(QFT)(wires=estimation_wires))
+        op_list.append(ops.adjoint(QFT(wires=estimation_wires)))
 
         return op_list
 
 
 def _qpe_decomp_resource(base_resource_rep, num_estimation_wires):
-    gate_count = defaultdict(int)
-    gate_count[ops.Hadamard] = num_estimation_wires
+    gate_count = {
+        ops.Hadamard: num_estimation_wires,
+        adjoint_resource_rep(QFT, {"num_wires": num_estimation_wires}): 1,
+    }
     for i in range(num_estimation_wires):
         gate_count[
             controlled_resource_rep(
@@ -321,9 +322,6 @@ def _qpe_decomp_resource(base_resource_rep, num_estimation_wires):
                 num_control_wires=1,
             )
         ] = 1
-    gate_count.update(
-        {adjoint_subroutine_resource_rep(QFT, AbstractArray((num_estimation_wires,))): 1}
-    )
     return gate_count
 
 
@@ -333,7 +331,7 @@ def _qpe_decomp(wires, unitary, estimation_wires, **_):  # pylint: disable=unuse
         ops.Hadamard(w)
     for i, w in enumerate(estimation_wires):
         ops.ctrl(qml_pow(unitary, 2 ** (len(estimation_wires) - 1 - i)), w)
-    ops.adjoint(QFT)(wires=estimation_wires)
+    ops.adjoint(QFT(wires=estimation_wires))
 
 
 add_decomps(QuantumPhaseEstimation, _qpe_decomp)

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -35,7 +35,7 @@ from pennylane.decomposition.reconstruct import get_decomp_kwargs
 from pennylane.exceptions import DecompositionUndefinedError
 from pennylane.operation import Operator
 from pennylane.ops import Conditional, GlobalPhase
-from pennylane.templates.core import SubroutineOp
+from pennylane.templates import SubroutineOp
 from pennylane.transforms.core import transform
 
 
@@ -101,7 +101,6 @@ def _get_plxpr_decompose():  # pylint: disable=too-many-statements
         ):  # pylint: disable=too-many-arguments
             self.max_expansion = max_expansion
             self._current_depth = 0
-            self.subroutine_cache = {}
 
             if not enabled_graph() and (fixed_decomps or alt_decomps):
                 raise TypeError(

--- a/pennylane/transforms/qmc.py
+++ b/pennylane/transforms/qmc.py
@@ -341,24 +341,25 @@ def quantum_monte_carlo(
         >>> from pprint import pprint
         >>> pprint(specs)
         CircuitSpecs(device_name='default.qubit',
-                 num_device_wires=12,
-                 shots=Shots(total_shots=None, shot_vector=()),
-                 level='device',
-                 resources=SpecsResources(gate_types={'Adjoint(CNOT)': 7812,
-                                                      'Adjoint(ControlledPhaseShift)': 15,
-                                                      'Adjoint(Hadamard)': 6,
-                                                      'Adjoint(RY)': 3150,
-                                                      'Adjoint(SWAP)': 3,
-                                                      'CNOT': 7874,
-                                                      'CZ': 126,
-                                                      'Hadamard': 258,
-                                                      'MultiControlledX': 126,
-                                                      'PauliX': 252,
-                                                      'RY': 3175},
-                                          gate_sizes={1: 6841, 2: 15830, 7: 126},
-                                          measurements={'probs(6 wires)': 1},
-                                          num_allocs=12,
-                                          depth=21502))
+                     num_device_wires=12,
+                     shots=Shots(total_shots=None, shot_vector=()),
+                     level='device',
+                     resources=SpecsResources(gate_types={'Adjoint(CNOT)': 7812,
+                                                          'Adjoint(QFT)': 1,
+                                                          'Adjoint(RY)': 3150,
+                                                          'CNOT': 7874,
+                                                          'CZ': 126,
+                                                          'Hadamard': 258,
+                                                          'MultiControlledX': 126,
+                                                          'PauliX': 252,
+                                                          'RY': 3175},
+                                              gate_sizes={1: 6835,
+                                                          2: 15812,
+                                                          6: 1,
+                                                          7: 126},
+                                              measurements={'probs(6 wires)': 1},
+                                              num_allocs=12,
+                                              depth=21502))
     """
     operations = tape.operations.copy()
     wires = Wires(wires)
@@ -389,6 +390,6 @@ def quantum_monte_carlo(
             for _ in range(n_reps):
                 updated_operations.extend(tape_q.operations)
 
-        updated_operations.append(adjoint(QFT, lazy=False)(wires=estimation_wires))
+        updated_operations.append(adjoint(QFT(wires=estimation_wires), lazy=False))
     updated_tape = tape.copy(operations=updated_operations)
     return [updated_tape], lambda x: x[0]

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -186,6 +186,8 @@ unmodified_templates_cases = [
     (qml.AQFT, (1, [0, 1, 2]), {}),
     (qml.AQFT, (2,), {"wires": [0, 1, 2, 3]}),
     (qml.AQFT, (), {"order": 2, "wires": [0, 2, 3, 1]}),
+    (qml.QFT, ([0, 1],), {}),
+    (qml.QFT, (), {"wires": [0, 1]}),
     (qml.ArbitraryUnitary, (jnp.ones(15), [2, 3]), {}),
     (qml.ArbitraryUnitary, (jnp.zeros(15),), {"wires": [3, 2]}),
     pytest.param(
@@ -1588,8 +1590,8 @@ unsupported_templates = [
     qml.QutritBasisStatePreparation,
     qml.SqueezingEmbedding,
     qml.TrotterizedQfunc,  # TODO: add support in follow up PR
-    qml.templates.core.SubroutineOp,
-    qml.templates.core.Subroutine,
+    qml.templates.SubroutineOp,
+    qml.templates.Subroutine,
 ]
 modified_templates = [
     t for t in all_templates if t not in unmodified_templates + unsupported_templates
@@ -1601,7 +1603,7 @@ def test_templates_are_modified(template):
     """Test that all templates that are not listed as unmodified in the test cases above
     actually have their _primitive_bind_call modified."""
     # Make sure the template actually is modified in its primitive binding function
-    if template == qml.templates.core.SubroutineOp:
+    if template == qml.templates.SubroutineOp:
         return
     assert template._primitive_bind_call.__code__ != original_op_bind_code
 

--- a/tests/capture/transforms/test_capture_decompose.py
+++ b/tests/capture/transforms/test_capture_decompose.py
@@ -142,7 +142,7 @@ class TestDecomposeInterpreter:
         """Test that decompose works when there is a subroutine in the circuit."""
         interpreter = DecomposeInterpreter(gate_set=qml.gate_sets.ROTATIONS_PLUS_CNOT)
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(x, wires):
             qml.IsingXX(x, wires)
 

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -14,14 +14,14 @@
 """
 Tests for capturing a qnode into jaxpr.
 """
+
+# pylint: disable=protected-access,wrong-import-position,ungrouped-imports
+
 import pytest
 
 import pennylane as qml
 from pennylane.exceptions import CaptureError, QuantumFunctionError
 from tests.capture.capture_utils import extract_ops_and_meas_prims
-
-# pylint: disable=protected-access,wrong-import-position,ungrouped-imports
-
 
 pytestmark = [pytest.mark.jax, pytest.mark.capture]
 
@@ -614,11 +614,12 @@ class TestDevicePreprocessing:
 
     def test_non_native_ops_execution(self, dev_name, seed):
         """Test that operators that aren't natively supported by a device can be executed by a qnode."""
-        dev = qml.device(dev_name, wires=[0, 1], seed=seed)
+        dev = qml.device(dev_name, wires=2, seed=seed)
 
         @qml.qnode(dev)
         def circuit():
-            qml.AQFT(10, [0, 1])
+            # QFT not supported on DQ or LQ
+            qml.QFT(wires=[0, 1])
             return qml.state()
 
         assert qml.math.allclose(circuit(), [0.5] * 4)

--- a/tests/decomposition/test_resources.py
+++ b/tests/decomposition/test_resources.py
@@ -116,8 +116,8 @@ class TestCompressedResourceOp:
     def test_initialization(self):
         """Tests creating a CompressedResourceOp object."""
 
-        op = CompressedResourceOp(qml.MultiControlledX, {"num_wires": 5})
-        assert op.op_type is qml.MultiControlledX
+        op = CompressedResourceOp(qml.QFT, {"num_wires": 5})
+        assert op.op_type is qml.QFT
         assert op.params == {"num_wires": 5}
 
         op = CompressedResourceOp(qml.RX)
@@ -139,13 +139,13 @@ class TestCompressedResourceOp:
         op = CompressedResourceOp(qml.RX, {})
         assert isinstance(hash(op), int)
 
-        op = CompressedResourceOp(qml.MultiControlledX, {"num_wires": 5})
+        op = CompressedResourceOp(qml.QFT, {"num_wires": 5})
         assert isinstance(hash(op), int)
 
         op = CompressedResourceOp(
             qml.ops.Controlled,
             {
-                "base_class": qml.MultiControlledX,
+                "base_class": qml.QFT,
                 "base_params": {"num_wires": 5},  # nested dictionary in params
                 "num_control_wires": 1,
                 "num_zero_control_values": 1,

--- a/tests/devices/default_qubit/test_default_qubit_preprocessing.py
+++ b/tests/devices/default_qubit/test_default_qubit_preprocessing.py
@@ -403,8 +403,8 @@ class TestPreprocessing:
             (qml.CRX(0.1, wires=[0, 1]), True),
             (qml.Snapshot(), True),
             (qml.Barrier(), False),
-            (qml.QFT.operator(wires=range(5)), False),
-            (qml.QFT.operator(wires=range(10)), False),
+            (qml.QFT(wires=range(5)), True),
+            (qml.QFT(wires=range(10)), False),
             (qml.GroverOperator(wires=range(10)), True),
             (qml.GroverOperator(wires=range(14)), False),
             (

--- a/tests/devices/default_tensor/test_default_tensor.py
+++ b/tests/devices/default_tensor/test_default_tensor.py
@@ -86,6 +86,7 @@ operations_list = {
     "SX": qml.SX(wires=[0]),
     "Adjoint(SX)": qml.adjoint(qml.SX(wires=[0])),
     "Toffoli": qml.Toffoli(wires=[0, 1, 2]),
+    "QFT": qml.templates.QFT(wires=[0, 1, 2]),
     "IsingXX": qml.IsingXX(1.234, wires=[0, 1]),
     "IsingYY": qml.IsingYY(1.234, wires=[0, 1]),
     "IsingZZ": qml.IsingZZ(1.234, wires=[0, 1]),

--- a/tests/devices/default_tensor/test_tensor_expval.py
+++ b/tests/devices/default_tensor/test_tensor_expval.py
@@ -376,7 +376,7 @@ def test_multi_qubit_gates(theta, phi, method):
         qml.Hadamard(wires=[4]),
         qml.CCZ(wires=[0, 1, 2]),
         qml.CSWAP(wires=[2, 3, 4]),
-        qml.QFT.operator(wires=[0, 1, 2]),
+        qml.QFT(wires=[0, 1, 2]),
         qml.CNOT(wires=[2, 4]),
         qml.Toffoli(wires=[0, 1, 2]),
         qml.DoubleExcitation(phi, wires=[0, 1, 3, 4]),

--- a/tests/devices/default_tensor/test_tensor_var.py
+++ b/tests/devices/default_tensor/test_tensor_var.py
@@ -383,7 +383,7 @@ def test_multi_qubit_gates(theta, phi, method):
         qml.Hadamard(wires=[4]),
         qml.CCZ(wires=[0, 1, 2]),
         qml.CSWAP(wires=[2, 3, 4]),
-        qml.QFT.operator(wires=[0, 1, 2]),
+        qml.QFT(wires=[0, 1, 2]),
         qml.CNOT(wires=[2, 4]),
         qml.Toffoli(wires=[0, 1, 2]),
         qml.DoubleExcitation(phi, wires=[0, 1, 3, 4]),

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -80,9 +80,7 @@ class TestPrivateHelpers:
     def decomposer(op):
         return op.decomposition()
 
-    @pytest.mark.parametrize(
-        "op", (qml.PauliX(0), qml.RX(1.2, wires=0), qml.MultiControlledX(wires=range(3)))
-    )
+    @pytest.mark.parametrize("op", (qml.PauliX(0), qml.RX(1.2, wires=0), qml.QFT(wires=range(3))))
     def test_operator_decomposition_gen_accepted_operator(self, op):
         """Test the _operator_decomposition_gen function on an operator that is accepted."""
 
@@ -516,7 +514,7 @@ class TestDecomposeTransformations:
         device_wires = qml.wires.Wires([0, 1, 2, 3])
 
         # Create a tape with an operation that needs decomposition
-        tape = qml.tape.QuantumScript([qml.QFT.operator(wires=[0, 1])], [qml.expval(qml.Z(0))])
+        tape = qml.tape.QuantumScript([qml.QFT(wires=[0, 1])], [qml.expval(qml.Z(0))])
 
         # Test with device_wires and target_gates
         batch, _ = decompose(

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -908,7 +908,7 @@ class TestMidCircuitMeasurements:
         * mcm output that is not used by anything
         """
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [2] + [qml.measure(w) for w in wires]
 
@@ -937,7 +937,7 @@ class TestMidCircuitMeasurements:
     def test_subroutine_with_multi_measure_measurement_value(self):
         """Test that the subroutine can output a measurement value with multiple measurements."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             m0 = qml.measure(wires[0])
             m1 = qml.measure(wires[1])

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -98,7 +98,7 @@ class TestDefaultBitMap:
     def test_subroutine(self):
         """Test that default_bit_map can handle subroutines that return measurement values."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [qml.measure(w) for w in wires]
 
@@ -446,7 +446,7 @@ class TestCwireConnections:
     def test_subroutine_with_output(self):
         """Test that cwire_connections can handle a subroutine with MCM outputs."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [2] + [qml.measure(w) for w in wires]
 

--- a/tests/drawer/test_tape_mpl.py
+++ b/tests/drawer/test_tape_mpl.py
@@ -620,7 +620,7 @@ general_op_data = [
     # State Prep
     qml.BasisState([0, 1, 0], wires=(0, 1, 2)),
     ### Templates
-    qml.QFT.operator(wires=range(3)),
+    qml.QFT(wires=range(3)),
     qml.Permute([4, 2, 0, 1, 3], wires=(0, 1, 2, 3, 4)),
     qml.GroverOperator(wires=(0, 1, 2, 3, 4, 5)),
     ### Continuous Variable

--- a/tests/drawer/test_tape_text.py
+++ b/tests/drawer/test_tape_text.py
@@ -125,7 +125,7 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments, too-many-posit
     def test_subroutine_mcm_grouping(self):
         """Unit test the _subroutine_mcm_grouping_symbols helper."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [2] + [qml.measure(w) for w in wires]
 
@@ -387,7 +387,7 @@ class TestHelperFunctions:  # pylint: disable=too-many-arguments, too-many-posit
     def test_add_subroutine_op_with_output(self):
         """Test that classical wires are drawn for subroutines with mcm outputs."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [2] + [qml.measure(w) for w in wires]
 

--- a/tests/estimator/test_estimator_mapping.py
+++ b/tests/estimator/test_estimator_mapping.py
@@ -48,14 +48,14 @@ class TestMapToResourceOp:
     def test_unknown_subroutine_decomposition(self):
         """Test that if an unknown subroutine is provided, it just uses the decomposition."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             qml.X(wires)
 
         r_op = _map_to_resource_op(f.operator(0))
         assert r_op == re_ops.X()
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def g(wires):
             qml.X(wires)
             qml.Y(wires)
@@ -128,7 +128,7 @@ class TestMapToResourceOp:
                 qml.SemiAdder(x_wires=[0, 1, 2], y_wires=[3, 4], work_wires=[5]),
                 re_temps.SemiAdder(max_register_size=3, wires=[0, 1, 2, 3, 4]),
             ),
-            (qtemps.QFT.operator(wires=[0, 1, 2]), re_temps.QFT(num_wires=3, wires=[0, 1, 2])),
+            (qtemps.QFT(wires=[0, 1, 2]), re_temps.QFT(num_wires=3, wires=[0, 1, 2])),
             (
                 qtemps.AQFT(order=3, wires=[0, 1, 2, 3, 4]),
                 re_temps.AQFT(order=3, num_wires=5, wires=[0, 1, 2, 3, 4]),
@@ -405,7 +405,7 @@ class TestMapToResourceOp:
             ),
             (
                 qops.ChangeOpBasis(
-                    compute_op=qtemps.QFT.operator(wires=[0, 1, 2]),
+                    compute_op=qtemps.QFT(wires=[0, 1, 2]),
                     target_op=qtemps.ControlledSequence(qops.S(wires=2), control=[0, 1]),
                     uncompute_op=qops.adjoint(qtemps.AQFT(order=3, wires=[0, 1, 2, 3, 4])),
                 ),

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -568,7 +568,7 @@ class TestToBloqDecomposition:
                 qml.ctrl(qml.RX(0.1, wires=0), control=[1]), True, call_graph="decomposition"
             ): 15,
             qml.to_bloq(
-                qml.adjoint(qml.QFT.operator(wires=range(1, 5))), False, call_graph="decomposition"
+                qml.adjoint(qml.QFT(wires=range(1, 5))), False, call_graph="decomposition"
             ): 1,
         }
 
@@ -626,7 +626,7 @@ class TestToBloqDecomposition:
                 {
                     (qml.Hadamard(0), True): 4,
                     (qml.ctrl(qml.RX(0.1, wires=0), control=[1]), True): 15,
-                    (qml.adjoint(qml.QFT.operator(wires=range(1, 5))), False): 1,
+                    (qml.adjoint(qml.QFT(wires=range(1, 5))), False): 1,
                 },
             ),
             (
@@ -650,7 +650,7 @@ class TestToBloqDecomposition:
             ),
             (qml.BasisState(np.array([1, 1]), wires=[0, 1]), {(qml.X(0), True): 2}),
             (
-                qml.QFT.operator(wires=range(5)),
+                qml.QFT(wires=range(5)),
                 # From ResourceQFT
                 {
                     (qml.H(0), True): 5,
@@ -854,8 +854,8 @@ class TestToBloqDecomposition:
                     work_wires=[5, 6, 7, 8, 9],
                 ),
                 {
-                    (qml.ctrl(qml.adjoint(qml.QFT.operator(range(4))), control=[4]), False): 1,
-                    (qml.ctrl(qml.QFT.operator(range(4)), control=[4]), False): 1,
+                    (qml.ctrl(qml.adjoint(qml.QFT(range(4))), control=[4]), False): 1,
+                    (qml.ctrl(qml.QFT(range(4)), control=[4]), False): 1,
                     (qml.Toffoli([0, 1, 2]), True): 6,
                 },
             ),
@@ -868,8 +868,8 @@ class TestToBloqDecomposition:
                     work_wires=[6, 7, 8, 9, 10],
                 ),
                 {
-                    (qml.ctrl(qml.QFT.operator(range(3)), control=[4]), False): 1,
-                    (qml.ctrl(qml.adjoint(qml.QFT.operator(range(3))), control=[4]), False): 1,
+                    (qml.ctrl(qml.QFT(range(3)), control=[4]), False): 1,
+                    (qml.ctrl(qml.adjoint(qml.QFT(range(3))), control=[4]), False): 1,
                     (qml.Toffoli([0, 1, 2]), True): 21,
                 },
             ),
@@ -926,11 +926,11 @@ class TestToBloqDecomposition:
                 },
             ),
             (
-                qml.Select(ops=[qml.X(2), qml.QFT.operator(wires=[2, 3, 4])], control=[0, 1]),
+                qml.Select(ops=[qml.X(2), qml.QFT(wires=[2, 3, 4])], control=[0, 1]),
                 {
                     (qml.X(wires=[2]), True): 2,
                     (qml.ctrl(qml.X(2), control=[0]), True): 1,
-                    (qml.ctrl(qml.QFT.operator(wires=[2, 3, 4]), control=[0]), True): 1,
+                    (qml.ctrl(qml.QFT(wires=[2, 3, 4]), control=[0]), True): 1,
                 },
             ),
             (
@@ -961,7 +961,7 @@ class TestToBloqDecomposition:
                 ),
                 "qpe_bloq",
             ),
-            (qml.QFT.operator(wires=range(4)), "qft_bloq"),
+            (qml.QFT(wires=range(4)), "qft_bloq"),
             (
                 qml.ModExp(
                     x_wires=[0, 1],
@@ -1041,7 +1041,7 @@ class TestToBloqDecomposition:
                 "qsvt_custom_mapping",
                 "qsvt_custom_bloq",
             ),
-            (qml.QFT.operator(wires=range(4)), "qft_custom_mapping", "qft_custom_bloq"),
+            (qml.QFT(wires=range(4)), "qft_custom_mapping", "qft_custom_bloq"),
             (
                 qml.ModExp(
                     x_wires=[0, 1],
@@ -1121,7 +1121,7 @@ class TestToBloqDecomposition:
                     )
                 },
                 "qft_custom_mapping": {
-                    qml.QFT.operator(wires=range(4)): TextbookQPE(
+                    qml.QFT(wires=range(4)): TextbookQPE(
                         unitary=qml.to_bloq(qml.RX(0.1, wires=0)),
                         ctrl_state_prep=LPResourceState(4),
                     )
@@ -1327,7 +1327,7 @@ class TestToBloqEstimator:
             ),
             (qml.BasisState(np.array([1, 1]), wires=[0, 1]), {(qml.X(0), True): 2}),
             (
-                qml.QFT.operator(wires=range(5)),
+                qml.QFT(wires=range(5)),
                 {
                     (qml.H(0), True): 5,
                     (qml.CNOT([0, 1]), True): 26,
@@ -1480,7 +1480,7 @@ class TestToBloqEstimator:
                 },
             ),
             (
-                qml.Select(ops=[qml.X(2), qml.QFT.operator(wires=[2, 3, 4])], control=[0, 1]),
+                qml.Select(ops=[qml.X(2), qml.QFT(wires=[2, 3, 4])], control=[0, 1]),
                 {
                     (qml.Toffoli([0, 1, 2]), True): 8,
                     (qml.CNOT([0, 1]), True): 14,
@@ -1603,7 +1603,7 @@ class TestToBloqEstimator:
                 },
             ),
             (
-                qml.Select(ops=[qml.X(2), qml.QFT.operator(wires=[2, 3, 4])], control=[0, 1]),
+                qml.Select(ops=[qml.X(2), qml.QFT(wires=[2, 3, 4])], control=[0, 1]),
                 {
                     (qml.Toffoli([0, 1, 2]), True): 8,
                     (qml.CNOT([0, 1]), True): 14,

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -30,7 +30,6 @@ from pennylane.operation import Channel, Operation, Operator, StatePrepBase
 from pennylane.ops.op_math import ChangeOpBasis
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 from pennylane.ops.op_math.pow import PowOperation
-from pennylane.templates.core import SubroutineOp
 from pennylane.templates.subroutines.time_evolution.trotter import TrotterizedQfunc
 
 
@@ -220,7 +219,6 @@ _CLASSES_TO_TEST = (
     - {i[1] for i in getmembers(qml.templates) if isclass(i[1]) and issubclass(i[1], Operator)}
     - {type(op) for (op, _) in _INSTANCES_TO_TEST}
     - {type(op) for (op, _) in _INSTANCES_TO_FAIL}
-    - {SubroutineOp}
 )
 """All operators, except those tested manually, abstract/meta classes, and templates."""
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -2897,7 +2897,7 @@ class TestBasisRotation:
 
         with pytest.raises(
             AssertionError,
-            match=re.escape("op1 has value (0, 1) and op2 has value (2, 3)"),
+            match=re.escape("op1 has value Wires([0, 1]) and op2 has value Wires([2, 3])"),
         ):
             assert_equal(op, other_op)
 
@@ -3166,11 +3166,11 @@ class TestCompareSubroutines:
     def test_different_subroutine_defs(self):
         """Test SubroutineOp are not equal if their Subroutines are not equal."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def Subroutine1(wires):
             qml.X(wires)
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def Subroutine2(wires):
             qml.Y(wires)
 
@@ -3184,7 +3184,7 @@ class TestCompareSubroutines:
     def test_different_static_args(self):
         """Test they are different if they have different static args."""
 
-        @partial(qml.templates.core.Subroutine, static_argnames=("a",))
+        @partial(qml.templates.Subroutine, static_argnames=("a",))
         def f(a, wires):
             pass
 
@@ -3198,20 +3198,20 @@ class TestCompareSubroutines:
     def test_different_wires(self):
         """Test they are different if their wires are different."""
 
-        @partial(qml.templates.core.Subroutine, wire_argnames=("reg1", "reg2"))
+        @partial(qml.templates.Subroutine, wire_argnames=("reg1", "reg2"))
         def f(reg1, reg2):
             pass
 
         op1 = qml.tape.make_qscript(f)((0,), (1,))[0]
         op2 = qml.tape.make_qscript(f)((1,), (0,))[0]
         assert not qml.equal(op1, op2)
-        with pytest.raises(AssertionError, match=r"has value \(1,\) for register reg1"):
+        with pytest.raises(AssertionError, match=r"has value Wires\(\[1\]\) for register reg1"):
             qml.assert_equal(op1, op2)
 
     def test_different_pytree_inputs(self):
         """Test that if the pytrees for an input are different, the ops are different."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(x, wires):
             pass
 
@@ -3225,7 +3225,7 @@ class TestCompareSubroutines:
     def test_different_data(self):
         """Test that if there is different data, they are different operators."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(x, wires):
             pass
 

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -861,5 +861,5 @@ class TestCommutingFunction:
     def test_non_commuting(self):
         """Test the function with an operator from the non-commuting list."""
 
-        res = qml.is_commuting(qml.PauliX(wires=0), qml.QFT.operator(wires=[1, 0]))
+        res = qml.is_commuting(qml.PauliX(wires=0), qml.QFT(wires=[1, 0]))
         assert res is False

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -798,7 +798,7 @@ class TestAdjointConstructorPreconstructedOp:
     """Test providing an already initialized operator to the transform."""
 
     @pytest.mark.parametrize(
-        "base", (qml.IsingXX(1.23, wires=("c", "d")), qml.QFT.operator(wires=(0, 1, 2)))
+        "base", (qml.IsingXX(1.23, wires=("c", "d")), qml.QFT(wires=(0, 1, 2)))
     )
     def test_single_op(self, base):
         """Test passing a single preconstructed op in a queuing context."""
@@ -856,7 +856,7 @@ class TestAdjointConstructorDifferentCallableTypes:
         assert len(tape) == 1
         assert out is tape[0]
         assert isinstance(out, Adjoint)
-        assert out.base.__class__ is qml.templates.core.SubroutineOp
+        assert out.base.__class__ is qml.QFT
         assert out.wires == qml.wires.Wires((0, 1, 2))
 
     def test_adjoint_on_function(self):

--- a/tests/ops/op_math/test_change_op_basis.py
+++ b/tests/ops/op_math/test_change_op_basis.py
@@ -29,7 +29,7 @@ from pennylane.exceptions import DeviceError
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.ops.op_math import ChangeOpBasis, change_op_basis
 from pennylane.queuing import AnnotatedQueue
-from pennylane.templates.core import Subroutine
+from pennylane.templates import Subroutine
 from pennylane.wires import Wires
 
 X, Y, Z = qml.PauliX, qml.PauliY, qml.PauliZ

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1440,7 +1440,7 @@ class TestTwoQubitDecompositionWarnings:
     "U, n_wires",
     [
         (qml.matrix(qml.CRX(0.123, [0, 2]) @ qml.CRY(0.456, [1, 3])), 4),
-        (qml.matrix(qml.QFT, wire_order=range(5))(range(5)), 5),
+        (qml.QFT.compute_matrix(5), 5),
         (qml.GroverOperator.compute_matrix(6, []), 6),
     ],
 )
@@ -1592,10 +1592,10 @@ class TestQubitUnitaryDecompositionGraph:
     @pytest.mark.parametrize(
         "U, n_wires",
         [
-            (qml.matrix(qml.QFT, wire_order=range(2))(range(2)), 2),
+            (qml.QFT.compute_matrix(2), 2),
             (qml.matrix(qml.CRX(0.123, [0, 2]) @ qml.CRY(0.456, [2, 0])), 2),
             (qml.matrix(qml.CRX(0.123, [0, 2]) @ qml.CRY(0.456, [1, 3])), 4),
-            (qml.matrix(qml.QFT, wire_order=range(5))(range(5)), 5),
+            (qml.QFT.compute_matrix(5), 5),
             (qml.GroverOperator.compute_matrix(6, []), 6),
         ],
     )

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -615,15 +615,26 @@ class TestMatrix:
     def test_prod_templates(self):
         """Test that we can compose templates and the generated matrix is correct."""
 
+        def get_qft_mat(num_wires):
+            omega = math.exp(np.pi * 1.0j / 2 ** (num_wires - 1))
+            mat = math.zeros((2**num_wires, 2**num_wires), dtype="complex128")
+
+            for m in range(2**num_wires):
+                for n in range(2**num_wires):
+                    mat[m, n] = omega ** (m * n)
+
+            return 1 / math.sqrt(2**num_wires) * mat
+
         wires = [0, 1, 2]
-        prod_op = Prod(qml.GroverOperator(wires=wires), qml.PauliX(wires=0))
+        prod_op = Prod(qml.QFT(wires=wires), qml.GroverOperator(wires=wires), qml.PauliX(wires=0))
         mat = prod_op.matrix()
 
         grov_mat = (1 / 4) * math.ones((8, 8), dtype="complex128") - math.eye(8, dtype="complex128")
+        qft_mat = get_qft_mat(3)
         x = math.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]])
         x_mat = math.kron(x, math.eye(4, dtype="complex128"))
 
-        true_mat = grov_mat @ x_mat
+        true_mat = qft_mat @ grov_mat @ x_mat
         assert np.allclose(mat, true_mat)
 
     def test_prod_qchem_ops(self):

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -474,6 +474,7 @@ class TestMatrix:
         assert np.allclose(mat, true_mat)
 
     templates_and_mats = (
+        (qml.QFT(wires=[0, 1, 2]), qml.QFT(wires=[0, 1, 2]).compute_matrix(3)),
         (
             qml.GroverOperator(wires=[0, 1, 2]),
             qml.GroverOperator(wires=[0, 1, 2]).compute_matrix(3, range(3)),

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -433,17 +433,30 @@ class TestMatrix:
 
         assert np.allclose(mat, true_mat)
 
+    @staticmethod
+    def get_qft_mat(num_wires):
+        """Helper function to generate the matrix of a qft protocol."""
+        omega = math.exp(np.pi * 1.0j / 2 ** (num_wires - 1))
+        mat = math.zeros((2**num_wires, 2**num_wires), dtype="complex128")
+
+        for m in range(2**num_wires):
+            for n in range(2**num_wires):
+                mat[m, n] = omega ** (m * n)
+
+        return 1 / math.sqrt(2**num_wires) * mat
+
     def test_sum_templates(self):
         """Test that we can sum templates and generated matrix is correct."""
         wires = [0, 1, 2]
-        sum_op = Sum(qml.GroverOperator(wires=wires), qml.PauliX(wires=0))
+        sum_op = Sum(qml.QFT(wires=wires), qml.GroverOperator(wires=wires), qml.PauliX(wires=0))
         mat = sum_op.matrix()
 
         grov_mat = (1 / 4) * math.ones((8, 8), dtype="complex128") - math.eye(8, dtype="complex128")
+        qft_mat = self.get_qft_mat(3)
         x = math.array([[0.0 + 0j, 1.0 + 0j], [1.0 + 0j, 0.0 + 0j]])
         x_mat = math.kron(x, math.eye(4, dtype="complex128"))
 
-        true_mat = grov_mat + x_mat
+        true_mat = grov_mat + qft_mat + x_mat
         assert np.allclose(mat, true_mat)
 
     def test_sum_qchem_ops(self):

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -461,7 +461,7 @@ class TestQubitUnitary:
         import jax
         from jax import numpy as jnp
 
-        matrix = jnp.array(qml.matrix(qml.MultiControlledX(wires=[0, 1, 2])))
+        matrix = jnp.array(qml.matrix(qml.QFT(wires=[0, 1, 2])))
 
         dev = qml.device("default.qubit", wires=3)
 
@@ -544,8 +544,8 @@ class TestQubitUnitary:
                 qml.matrix(qml.TrotterProduct(qml.X(0) @ qml.Z(1) - 0.3 * qml.Y(1), time=1))
             ),  # 2 cnots
             (qml.matrix(qml.CRY(1, wires=[0, 1]))),  # 2 cnots
-            (qml.matrix(qml.QFT, wire_order=[0, 1])(wires=[0, 1])),  # 3 cnots
-            (qml.matrix(qml.QFT, wire_order=[0, 1])(wires=[0, 1]) * np.exp(-12j)),  # 3 cnots
+            (qml.matrix(qml.QFT(wires=[0, 1]))),  # 3 cnots
+            (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.QFT(wires=[0, 1]))),  # 3 cnots
             (qml.matrix(qml.RZ(1, wires=0) @ qml.GroverOperator(wires=[0, 1]))),  # 1 cnot
             (qml.matrix(qml.GlobalPhase(12, wires=0) @ qml.GroverOperator(wires=[0, 1]))),  # 1 cnot
             (qml.matrix(qml.CRY(-1, wires=[0, 1]))),  # 2 cnots
@@ -574,7 +574,7 @@ class TestQubitUnitary:
 
         dev = qml.device("default.qubit")
 
-        matrix = qml.matrix(qml.QFT, wire_order=[0, 1])(wires=[0, 1])
+        matrix = qml.matrix(qml.QFT(wires=[0, 1]))
         ops_decompostion = qml.QubitUnitary.compute_decomposition(matrix, wires=[0, 1])
 
         @qml.qnode(dev)
@@ -599,7 +599,7 @@ class TestQubitUnitary:
         "U, wires",
         [
             (qml.matrix(qml.CRX(2, wires=[1, 0])), [0, 1]),
-            (qml.matrix(qml.QFT, wire_order=range(5))(range(5)), list(range(5))),
+            (qml.matrix(qml.QFT(wires=[0, 1, 2, 3, 4])), [0, 1, 2, 3, 4]),
             (qml.matrix(qml.CRX(1, [0, 2]) @ qml.CRY(2, [1, 3])), [0, 1, 2, 3]),
             (qml.matrix(qml.GroverOperator([0, 1, 2, 3, 4, 5])), [0, 1, 2, 3, 4, 5]),
         ],
@@ -618,11 +618,7 @@ class TestQubitUnitary:
         [
             (qml.matrix(qml.RY(1, 0) @ qml.RY(2, 1)), qml.matrix(qml.RX(2, 0) @ qml.RZ(4, 1)), 4),
             (qml.matrix(qml.RY(1, 0)), qml.matrix(qml.RX(2, 0)), 2),
-            (
-                qml.matrix(qml.GroverOperator([0, 1, 2])),
-                qml.matrix(qml.MultiControlledX([0, 1, 2])),
-                8,
-            ),
+            (qml.matrix(qml.GroverOperator([0, 1, 2])), qml.matrix(qml.QFT([0, 1, 2])), 8),
         ],
     )
     def test_compute_udv(self, a, b, size):

--- a/tests/tape/test_plxpr_conversion.py
+++ b/tests/tape/test_plxpr_conversion.py
@@ -20,7 +20,6 @@ import pytest
 
 import pennylane as qml
 from pennylane.ops.op_math.condition import Conditional
-from pennylane.templates.core import CollectedSubroutine
 
 pytestmark = [pytest.mark.jax, pytest.mark.capture]
 
@@ -29,22 +28,6 @@ jax = pytest.importorskip("jax")
 # pylint: disable=wrong-import-position
 from pennylane.ops.mid_measure import MidMeasure
 from pennylane.tape.plxpr_conversion import CollectOpsandMeas
-
-QFT_DECOMP = [
-    qml.H(0),
-    qml.ControlledPhaseShift(
-        qml.math.array(1.5707963267948966, like="jax"), wires=qml.wires.Wires([1, 0])
-    ),
-    qml.ControlledPhaseShift(
-        qml.math.array(0.7853981633974483, like="jax"), wires=qml.wires.Wires([2, 0])
-    ),
-    qml.H(1),
-    qml.ControlledPhaseShift(
-        qml.math.array(1.5707963267948966, like="jax"), wires=qml.wires.Wires([2, 1])
-    ),
-    qml.H(2),
-    qml.SWAP(wires=[0, 2]),
-]
 
 
 class TestCollectOpsandMeas:
@@ -63,8 +46,7 @@ class TestCollectOpsandMeas:
         obj(f)(1.2)
         qml.assert_equal(obj.state["ops"][0], qml.RX(1.2, 0))
         qml.assert_equal(obj.state["ops"][1], qml.CNOT((0, 1)))
-        assert isinstance(obj.state["ops"][2], CollectedSubroutine)
-        assert obj.state["ops"][2].name == "QFT"
+        qml.assert_equal(obj.state["ops"][2], qml.QFT((0, 1, 2)))
         assert len(obj.state["ops"]) == 3
 
         qml.assert_equal(obj.state["measurements"][0], qml.expval(qml.Z(0)))
@@ -72,7 +54,7 @@ class TestCollectOpsandMeas:
     def test_subroutine(self):
         """Test that CollectOpsandMeas collects a subroutine into a placeholder op."""
 
-        @partial(qml.templates.core.Subroutine, static_argnames="pauli_word")
+        @partial(qml.templates.Subroutine, static_argnames="pauli_word")
         def MyFunc(x, wires, pauli_word):
             qml.PauliRot(x, pauli_word, wires)
 
@@ -395,8 +377,7 @@ class TestCollectOpsandMeas:
         obj(f)(1.2)
         qml.assert_equal(obj.state["ops"][0], qml.RX(1.2, 0))
         qml.assert_equal(obj.state["ops"][1], qml.CNOT((0, 1)))
-        assert isinstance(obj.state["ops"][2], CollectedSubroutine)
-        assert obj.state["ops"][2].name == "QFT"
+        qml.assert_equal(obj.state["ops"][2], qml.QFT((0, 1, 2)))
         assert len(obj.state["ops"]) == 3
 
         qml.assert_equal(obj.state["measurements"][0], qml.expval(qml.Z(0)))
@@ -418,8 +399,7 @@ class TestPlxprToTape:
         tape = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, 1.2, shots=100)
         qml.assert_equal(tape[0], qml.RX(1.2, 0))
         qml.assert_equal(tape[1], qml.CNOT((0, 1)))
-        assert isinstance(tape[2], CollectedSubroutine)
-        assert tape[2].name == "QFT"
+        qml.assert_equal(tape[2], qml.QFT((0, 1, 2)))
         assert len(tape.operations) == 3
 
         qml.assert_equal(tape.measurements[0], qml.expval(qml.Z(0)))
@@ -440,8 +420,7 @@ class TestPlxprToTape:
         tape = qml.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, 1.2, shots=100)
         qml.assert_equal(tape[0], qml.RX(1.2, 0))
         qml.assert_equal(tape[1], qml.CNOT((0, 1)))
-        assert isinstance(tape[2], CollectedSubroutine)
-        assert tape[2].name == "QFT"
+        qml.assert_equal(tape[2], qml.QFT((0, 1, 2)))
         assert len(tape.operations) == 3
 
         qml.assert_equal(tape.measurements[0], qml.expval(qml.Z(0)))

--- a/tests/templates/state_preparations/test_cosine_window.py
+++ b/tests/templates/state_preparations/test_cosine_window.py
@@ -20,15 +20,8 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane.decomposition import resource_rep
 from pennylane.exceptions import WireError
-from pennylane.ops import Adjoint
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
-from pennylane.templates.core import (
-    AbstractArray,
-    CollectedSubroutine,
-    adjoint_subroutine_resource_rep,
-)
 from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.wires import Wires
 
@@ -39,7 +32,7 @@ def test_standard_validity():
 
     op = qml.CosineWindow(wires=[0, 1])
 
-    qml.ops.functions.assert_valid(op, skip_new_decomp=True)
+    qml.ops.functions.assert_valid(op)
 
 
 class TestDecomposition:
@@ -60,19 +53,22 @@ class TestDecomposition:
         for rule in qml.list_decomps(qml.CosineWindow):
             _test_decomposition_rule(op, rule)
 
+    @pytest.mark.parametrize(
+        "wires",
+        [
+            [0, 1],
+            [0, 1, 2],
+            [0, 1, 2, 3],
+            [0, 1, 2, 3, 4],
+        ],
+    )
     @pytest.mark.capture
-    def test_resources_capture(self):
+    def test_decomposition_new_capture(self, wires):
         """Tests the decomposition rule implemented with the new system."""
-        expected = {
-            resource_rep(qml.H): 1,
-            resource_rep(qml.RZ): 1,
-            adjoint_subroutine_resource_rep(qml.QFT, AbstractArray((2,))): 1,
-            resource_rep(qml.PhaseShift): 2,
-        }
+        op = qml.CosineWindow(wires=wires)
 
         for rule in qml.list_decomps(qml.CosineWindow):
-            actual = rule.compute_resources(num_wires=2)
-            assert actual.gate_counts == expected
+            _test_decomposition_rule(op, rule)
 
     @pytest.mark.integration
     @pytest.mark.capture
@@ -93,14 +89,10 @@ class TestDecomposition:
         jaxpr = jax.make_jaxpr(decomposed_f)()
         collector = CollectOpsandMeas()
         collector.eval(jaxpr.jaxpr, jaxpr.consts)
-        assert collector.state["ops"][0:2] == [
+        assert collector.state["ops"] == [
             qml.Hadamard(1),
             qml.RZ(3.141592653589793, wires=[1]),
-        ]
-        assert isinstance(collector.state["ops"][2], Adjoint)
-        assert isinstance(collector.state["ops"][2].base, CollectedSubroutine)
-        assert collector.state["ops"][2].base.name == "QFT"
-        assert collector.state["ops"][3:] == [
+            qml.adjoint(qml.QFT(wires=[0, 1])),
             qml.PhaseShift(jnp.array(-2.89760778e19), wires=[0]),
             qml.PhaseShift(jnp.array(1.44880389e19), wires=[1]),
         ]

--- a/tests/templates/subroutines/arithmetic/test_adder.py
+++ b/tests/templates/subroutines/arithmetic/test_adder.py
@@ -14,7 +14,6 @@
 """
 Tests for the Adder template.
 """
-from functools import partial
 
 import pytest
 
@@ -205,7 +204,7 @@ class TestAdder:
         )
 
         op_list = []
-        op_list.append(qml.QFT.operator(work_wires[:1] + x_wires))
+        op_list.append(qml.QFT(work_wires[:1] + x_wires))
         op_list.append(qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]))
         op_list.append(qml.adjoint(qml.QFT)(work_wires[:1] + x_wires))
 
@@ -224,21 +223,20 @@ class TestAdder:
 
         ctrl_op1 = qml.ops.Controlled(
             qml.change_op_basis(
-                partial(qml.QFT, work_wires[:1] + x_wires),
+                qml.QFT(work_wires[:1] + x_wires),
                 qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]),
-                partial(qml.adjoint(qml.QFT), work_wires[:1] + x_wires),
             ),
             control_wires,
             [1],
         )
 
         ctrl_op2 = qml.prod(
-            qml.adjoint(qml.QFT)(work_wires[:1] + x_wires),
+            qml.adjoint(qml.QFT(work_wires[:1] + x_wires)),
             qml.ctrl(
                 qml.PhaseAdder(k, work_wires[:1] + x_wires, mod, work_wires[1:]),
                 control=control_wires,
             ),
-            qml.QFT.operator(work_wires[:1] + x_wires),
+            qml.QFT(work_wires[:1] + x_wires),
         )
 
         mat1, mat2 = qml.matrix(ctrl_op1, wire_order), qml.matrix(ctrl_op2, wire_order)

--- a/tests/templates/subroutines/arithmetic/test_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_multiplier.py
@@ -14,7 +14,6 @@
 """
 Tests for the Multiplier template.
 """
-from functools import partial
 
 import numpy as np
 import pytest
@@ -104,7 +103,7 @@ class TestMultiplier:
         """Test that compute_decomposition and decomposition work as expected."""
         k, x_wires, mod, work_wires = 4, [0, 1, 2], 7, [3, 4, 5, 6, 7]
         multiplier_decomposition = qml.transforms.decompose(
-            qml.tape.QuantumScript([qml.Multiplier(k, x_wires, mod, work_wires)]), max_expansion=1
+            qml.tape.QuantumScript([qml.Multiplier(k, x_wires, mod, work_wires)]), max_expansion=2
         )[0][0].operations
 
         op_list = []
@@ -117,40 +116,26 @@ class TestMultiplier:
             wires_aux = work_wires[:3]
             wires_aux_swap = wires_aux
 
+        op_list.append(qml.QFT(wires=wires_aux))
         op_list.append(
-            qml.change_op_basis(
-                partial(qml.QFT, wires=wires_aux),
-                qml.ControlledSequence(
-                    qml.PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires
-                ),
-                partial(qml.adjoint(qml.QFT), wires_aux),
+            qml.ControlledSequence(
+                qml.PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires
             )
         )
+        op_list.append(qml.adjoint(qml.QFT(wires=wires_aux)))
 
+        for x_wire, aux_wire in zip(x_wires, wires_aux_swap):
+            op_list.append(qml.SWAP(wires=[x_wire, aux_wire]))
+        inv_k = pow(k, -1, mod)
+        op_list.append(qml.QFT(wires=wires_aux))
         op_list.append(
-            qml.prod(
-                *reversed(
-                    [
-                        qml.SWAP(wires=[x_wire, aux_wire])
-                        for x_wire, aux_wire in zip(x_wires, wires_aux_swap)
-                    ]
+            qml.adjoint(
+                qml.ControlledSequence(
+                    qml.PhaseAdder(inv_k, wires_aux, mod, work_wire_aux), control=x_wires
                 )
             )
         )
-
-        inv_k = pow(k, -1, mod)
-
-        op_list.append(
-            qml.change_op_basis(
-                partial(qml.QFT, wires=wires_aux),
-                qml.adjoint(
-                    qml.ControlledSequence(
-                        qml.PhaseAdder(inv_k, wires_aux, mod, work_wire_aux), control=x_wires
-                    )
-                ),
-                partial(qml.adjoint(qml.QFT), wires_aux),
-            )
-        )
+        op_list.append(qml.adjoint(qml.QFT(wires=wires_aux)))
 
         for op1, op2 in zip(multiplier_decomposition, op_list):
             qml.assert_equal(op1, op2)

--- a/tests/templates/subroutines/arithmetic/test_out_adder.py
+++ b/tests/templates/subroutines/arithmetic/test_out_adder.py
@@ -181,11 +181,15 @@ class TestOutAdder:
             7,
             [9, 10],
         )
-        _adder_decomposition = qml.OutAdder(
-            x_wires, y_wires, output_wires, mod, work_wires
-        ).compute_decomposition(x_wires, y_wires, output_wires, mod, work_wires)
+        _adder_decomposition = (
+            qml.OutAdder(x_wires, y_wires, output_wires, mod, work_wires)
+            .compute_decomposition(x_wires, y_wires, output_wires, mod, work_wires)[0]
+            .decomposition()
+        )
         adder_decomposition = [
-            *_adder_decomposition[0].decomposition(),
+            _adder_decomposition[0],
+            *_adder_decomposition[1].decomposition(),
+            _adder_decomposition[2],
         ]
 
         op_list = []
@@ -195,13 +199,15 @@ class TestOutAdder:
         else:
             qft_new_output_wires = output_wires
             work_wire = None
-        op_list.append(qml.QFT.operator(wires=qft_new_output_wires))
+        op_list.append(qml.QFT(wires=qft_new_output_wires))
+        op_list.append(
+            qml.ControlledSequence(
+                qml.PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=x_wires
+            )
+        )
         op_list.append(
             qml.ControlledSequence(
                 qml.PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=y_wires
-            )
-            @ qml.ControlledSequence(
-                qml.PhaseAdder(1, qft_new_output_wires, mod, work_wire), control=x_wires
             )
         )
         op_list.append(qml.adjoint(qml.QFT)(wires=qft_new_output_wires))

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -231,7 +231,7 @@ class TestOutMultiplier:
         else:
             qft_output_wires = output_wires
             work_wire = None
-        op_list.append(qml.QFT.operator(wires=qft_output_wires))
+        op_list.append(qml.QFT(wires=qft_output_wires))
         op_list.append(
             qml.ControlledSequence(
                 qml.ControlledSequence(

--- a/tests/templates/subroutines/arithmetic/test_out_poly.py
+++ b/tests/templates/subroutines/arithmetic/test_out_poly.py
@@ -177,10 +177,10 @@ class TestOutPoly:
             return x + y
 
         expected_decomposition = [
-            qml.QFT.operator(wires=[3]),
+            qml.QFT(wires=[3]),
             qml.ctrl(qml.PhaseAdder(1, x_wires=[3]), control=[2]),
             qml.ctrl(qml.PhaseAdder(1, x_wires=[3]), control=[1]),
-            qml.adjoint(qml.QFT)(wires=[3]),
+            qml.adjoint(qml.QFT(wires=[3])),
         ]
 
         ops = qml.OutPoly(
@@ -213,12 +213,12 @@ class TestOutPoly:
         pa2 = qml.PhaseAdder(k=2, mod=4, x_wires=[4, 5])
         pa1 = qml.PhaseAdder(k=1, mod=4, x_wires=[4, 5])
         expected = [
-            qml.QFT.operator(wires=[4, 5]),
+            qml.QFT(wires=[4, 5]),
             qml.ctrl(pa1, [3]),
             qml.ctrl(pa2, 2),
             qml.ctrl(pa1, 1),
             qml.ctrl(pa2, 0),
-            qml.adjoint(qml.QFT)(wires=[4, 5]),
+            qml.adjoint(qml.QFT(wires=[4, 5])),
         ]
         for op1, op2 in zip(decomp, expected):
             qml.assert_equal(op1, op2)

--- a/tests/templates/subroutines/arithmetic/test_phase_adder.py
+++ b/tests/templates/subroutines/arithmetic/test_phase_adder.py
@@ -14,7 +14,6 @@
 """
 Tests for the PhaseAdder template.
 """
-from functools import partial
 
 import pytest
 
@@ -238,13 +237,23 @@ class TestPhaseAdder:
         work_wire = [0]
 
         phase_adder_decomp = qml.PhaseAdder.compute_decomposition(k, x_wires, mod, work_wire)
+        cob_index = len(_add_k_fourier(k, x_wires)) + len(_add_k_fourier(mod, x_wires))
+        cob_decomp1 = phase_adder_decomp[cob_index].decomposition()
+        cob_decomp2 = phase_adder_decomp[-1].decomposition()
+
+        phase_adder_decomposition = [
+            *phase_adder_decomp[:cob_index],
+            *cob_decomp1,
+            *phase_adder_decomp[cob_index + 1 : -1],
+            *cob_decomp2,
+        ]
 
         op_list = []
         base_list_ops1 = [
             qml.adjoint(qml.QFT)(wires=x_wires),
             *[qml.adjoint(op) for op in _add_k_fourier(k, x_wires)],
         ]
-        base_list_ops2 = [*_add_k_fourier(k, x_wires)[::-1], qml.QFT.operator(wires=x_wires)]
+        base_list_ops2 = [*_add_k_fourier(k, x_wires)[::-1], qml.QFT(wires=x_wires)]
 
         if mod == 2 ** (len(x_wires)):
             op_list.extend(_add_k_fourier(k, x_wires))
@@ -252,26 +261,15 @@ class TestPhaseAdder:
             aux_k = x_wires[0]
             op_list.extend(_add_k_fourier(k, x_wires))
             op_list.extend(qml.adjoint(_add_k_fourier)(mod, x_wires))
-
-            op_list.append(
-                qml.change_op_basis(
-                    partial(qml.adjoint(qml.QFT), wires=x_wires),
-                    qml.ctrl(qml.PauliX(work_wire), control=aux_k, control_values=1),
-                    partial(qml.QFT, wires=x_wires),
-                )
-            )
-
+            op_list.append(qml.adjoint(qml.QFT)(wires=x_wires))
+            op_list.append(qml.ctrl(qml.PauliX(work_wire), control=aux_k, control_values=1))
+            op_list.append(qml.QFT(wires=x_wires))
             op_list.extend(qml.ctrl(op, control=work_wire) for op in _add_k_fourier(mod, x_wires))
+            op_list.append(qml.prod(qml.X(aux_k), *base_list_ops1))
+            op_list.append(qml.CNOT(wires=[aux_k, work_wire[0]]))
+            op_list.append(qml.prod(*base_list_ops2, qml.X(aux_k)))
 
-            op_list.append(
-                qml.change_op_basis(
-                    qml.prod(qml.X(aux_k), *base_list_ops1),
-                    qml.CNOT(wires=[aux_k, work_wire[0]]),
-                    qml.prod(*base_list_ops2, qml.X(aux_k)),
-                )
-            )
-
-        for op1, op2 in zip(phase_adder_decomp, op_list):
+        for op1, op2 in zip(phase_adder_decomposition, op_list):
             qml.assert_equal(op1, op2)
 
     @pytest.mark.parametrize("mod", [7, 8])

--- a/tests/templates/subroutines/qchem/test_basis_rotation.py
+++ b/tests/templates/subroutines/qchem/test_basis_rotation.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qml
-from pennylane.templates.core import AbstractArray
+from pennylane.templates import AbstractArray
 
 
 @pytest.mark.jax
@@ -69,8 +69,8 @@ class TestResources:
     def test_resources_real(self, matrix, wires):
         """Test that the resources can be calculated for AbstractArray with a real datatype."""
 
-        wires = qml.templates.core.AbstractArray((3,))
-        matrix = qml.templates.core.AbstractArray((4, 2), float)
+        wires = qml.templates.AbstractArray((3,))
+        matrix = qml.templates.AbstractArray((4, 2), float)
 
         resources = qml.BasisRotation.compute_resources(wires, matrix)
         assert resources == {qml.PhaseShift: 1, qml.SingleExcitation: 4 * 3 // 2}

--- a/tests/templates/subroutines/test_aqft.py
+++ b/tests/templates/subroutines/test_aqft.py
@@ -78,10 +78,10 @@ class TestAQFT:
 
     @pytest.mark.parametrize("wires", [3, 4, 5, 6, 7, 8, 9])
     def test_matrix_higher_order(self, wires):
-        """Test the matrix from AQFT for higher order."""
+        """Test if the matrix from AQFT and QFT are same for higher order"""
 
         m1 = qml.matrix(qml.AQFT(order=10, wires=range(wires)))
-        m2 = qml.matrix(qml.QFT, wire_order=range(wires))(wires=range(wires))
+        m2 = qml.matrix(qml.QFT(wires=range(wires)))
 
         assert np.allclose(m1, m2)
 

--- a/tests/templates/subroutines/test_qft.py
+++ b/tests/templates/subroutines/test_qft.py
@@ -25,17 +25,24 @@ from pennylane.capture import run_autograph
 @pytest.mark.jax
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
-    op = qml.QFT.operator(wires=(0, 1, 2))
-    qml.ops.functions.assert_valid(op, skip_pickle=True)
+    op = qml.QFT(wires=(0, 1, 2))
+    qml.ops.functions.assert_valid(op)
 
 
 class TestQFT:
     """Tests for the qft operations"""
 
-    @pytest.mark.parametrize("n_qubits", (3,))
-    def test_QFT_decomposition(self, n_qubits):
+    def test_QFT(self):
+        """Test if the QFT matrix is equal to a manually-calculated version for 3 qubits"""
+        op = qml.QFT(wires=range(3))
+        res = op.matrix()
+        exp = QFT
+        assert np.allclose(res, exp)
+
+    @pytest.mark.parametrize("n_qubits", range(2, 6))
+    def test_QFT_compute_decomposition(self, n_qubits):
         """Test if the QFT operation is correctly decomposed"""
-        decomp = qml.QFT.operator(wires=range(n_qubits)).decomposition()
+        decomp = qml.QFT.compute_decomposition(wires=range(n_qubits))
 
         dev = qml.device("default.qubit", wires=n_qubits)
 
@@ -46,7 +53,26 @@ class TestQFT:
             out_states.append(dev.execute(qs))
 
         reconstructed_unitary = np.array(out_states).T
-        expected_unitary = QFT
+        expected_unitary = qml.QFT(wires=range(n_qubits)).matrix()
+
+        assert np.allclose(reconstructed_unitary, expected_unitary)
+
+    @pytest.mark.parametrize("n_qubits", range(2, 6))
+    def test_QFT_decomposition(self, n_qubits):
+        """Test if the QFT operation is correctly decomposed"""
+        op = qml.QFT(wires=range(n_qubits))
+        decomp = op.decomposition()
+
+        dev = qml.device("default.qubit", wires=n_qubits)
+
+        out_states = []
+        for state in np.eye(2**n_qubits):
+            ops = [qml.StatePrep(state, wires=range(n_qubits))] + decomp
+            qs = qml.tape.QuantumScript(ops, [qml.state()])
+            out_states.append(dev.execute(qs))
+
+        reconstructed_unitary = np.array(out_states).T
+        expected_unitary = qml.QFT(wires=range(n_qubits)).matrix()
 
         assert np.allclose(reconstructed_unitary, expected_unitary)
 
@@ -67,6 +93,33 @@ class TestQFT:
 
         for i in range(1, n_qubits):
             assert np.allclose(0, circ(n_qubits)[i], tol)
+
+    def test_matrix(self, tol):
+        """Test that the matrix representation is correct."""
+
+        res_static = qml.QFT.compute_matrix(2)
+        res_dynamic = qml.QFT(wires=[0, 1]).matrix()
+        res_reordered = qml.QFT(wires=[0, 1]).matrix([1, 0])
+
+        expected = np.array(
+            [
+                [0.5 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j],
+                [0.5 + 0.0j, 0.0 + 0.5j, -0.5 + 0.0j, -0.0 - 0.5j],
+                [0.5 + 0.0j, -0.5 + 0.0j, 0.5 - 0.0j, -0.5 + 0.0j],
+                [0.5 + 0.0j, -0.0 - 0.5j, -0.5 + 0.0j, 0.0 + 0.5j],
+            ]
+        )
+
+        assert np.allclose(res_static, expected, atol=tol, rtol=0)
+        assert np.allclose(res_dynamic, expected, atol=tol, rtol=0)
+
+        expected_permuted = [
+            [0.5 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j, 0.5 + 0.0j],
+            [0.5 + 0.0j, 0.5 - 0.0j, -0.5 + 0.0j, -0.5 + 0.0j],
+            [0.5 + 0.0j, -0.5 + 0.0j, 0.0 + 0.5j, -0.0 - 0.5j],
+            [0.5 + 0.0j, -0.5 + 0.0j, -0.0 - 0.5j, 0.0 + 0.5j],
+        ]
+        assert np.allclose(res_reordered, expected_permuted, atol=tol, rtol=0)
 
     @pytest.mark.jax
     def test_jit(self):
@@ -93,9 +146,58 @@ class TestQFT:
 
 @pytest.mark.jax
 @pytest.mark.capture
-# pylint:disable=protected-access,too-few-public-methods
+# pylint:disable=protected-access
 class TestDynamicDecomposition:
     """Tests that dynamic decomposition via compute_qfunc_decomposition works correctly."""
+
+    @pytest.mark.usefixtures("enable_graph_decomposition")
+    def test_qft_plxpr(self):
+        """Test that the dynamic decomposition of QFT has the correct plxpr"""
+        import jax
+
+        from pennylane.capture.primitives import for_loop_prim
+        from pennylane.tape.plxpr_conversion import CollectOpsandMeas
+        from pennylane.transforms.decompose import DecomposeInterpreter
+
+        wires = [0, 1, 2, 3]
+        gate_set = None
+        max_expansion = 1
+
+        @DecomposeInterpreter(max_expansion=max_expansion, gate_set=gate_set)
+        def circuit(wires):
+            qml.QFT(wires=wires)
+            return qml.state()
+
+        jaxpr = jax.make_jaxpr(circuit)(wires=wires)
+
+        # Validate Jaxpr
+        jaxpr_eqns = jaxpr.eqns
+        outer_loop, swap_loop = (eqn for eqn in jaxpr_eqns if eqn.primitive == for_loop_prim)
+        assert outer_loop.primitive == for_loop_prim
+        assert swap_loop.primitive == for_loop_prim
+        outer_loop_eqn = outer_loop.params["jaxpr_body_fn"].eqns
+        swap_loop_eqn = swap_loop.params["jaxpr_body_fn"].eqns
+
+        hadamards = [eqn for eqn in outer_loop_eqn if eqn.primitive == qml.Hadamard._primitive]
+        assert len(hadamards) == 1
+
+        cphaseshift_loop = [eqn for eqn in outer_loop_eqn if eqn.primitive == for_loop_prim]
+        assert cphaseshift_loop[0].primitive == for_loop_prim
+        cphaseshift_eqns = cphaseshift_loop[0].params["jaxpr_body_fn"].eqns
+        assert cphaseshift_eqns[-1].primitive == qml.ControlledPhaseShift._primitive
+
+        assert swap_loop_eqn[-1].primitive == qml.SWAP._primitive
+
+        # Validate Ops
+        collector = CollectOpsandMeas()
+        collector.eval(jaxpr.jaxpr, jaxpr.consts, *wires)
+        ops_list = collector.state["ops"]
+        tape = qml.tape.QuantumScript([qml.QFT(wires=wires)])
+        [decomp_tape], _ = qml.transforms.decompose(
+            tape, max_expansion=max_expansion, gate_set=gate_set
+        )
+        for op1, op2 in zip(ops_list, decomp_tape.operations):
+            assert qml.equal(op1, op2, check_interface=False)
 
     @pytest.mark.parametrize("autograph", [True, False])
     @pytest.mark.parametrize("n_wires", [4, 5])
@@ -135,3 +237,30 @@ class TestDynamicDecomposition:
             result_comparison = circuit_comparison()
 
         assert qml.math.allclose(*result, result_comparison)
+
+    @pytest.mark.usefixtures("enable_graph_decomposition")
+    @pytest.mark.parametrize("wires", [[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]])
+    def test_qft_new_decomposition(self, wires):
+        """Test that QFT gives the correct decomposition in the graph-based system."""
+
+        import jax
+
+        from pennylane.tape.plxpr_conversion import CollectOpsandMeas
+        from pennylane.transforms.decompose import DecomposeInterpreter
+
+        @DecomposeInterpreter(gate_set={"GlobalPhase", "RX", "RZ", "CNOT"})
+        def circuit():
+            qml.QFT(wires=wires)
+
+        jaxpr = jax.make_jaxpr(circuit)()
+        collector = CollectOpsandMeas()
+        collector.eval(jaxpr.jaxpr, jaxpr.consts)
+
+        graph = qml.decomposition.DecompositionGraph(
+            operations=[qml.QFT(wires=wires)],
+            gate_set={"GlobalPhase", "RX", "RZ", "CNOT"},
+        )
+        solution = graph.solve()
+        expected_resources = solution.resource_estimate(qml.QFT(wires=wires))
+
+        assert len(collector.state["ops"]) == expected_resources.num_gates

--- a/tests/templates/subroutines/test_qpe.py
+++ b/tests/templates/subroutines/test_qpe.py
@@ -122,7 +122,7 @@ class TestDecomposition:
             qml.Hadamard(2)
             qml.ctrl(qml.pow(unitary, 2), control=[1])
             qml.ctrl(qml.pow(unitary, 1), control=[2])
-            qml.adjoint(qml.QFT)(wires=[1, 2])
+            qml.adjoint(qml.QFT(wires=[1, 2]))
         qscript2 = qml.tape.QuantumScript.from_queue(q)
         assert len(qscript) == len(qscript2)
         # qml.equal doesn't work for Adjoint or Pow op yet, so we stop before we get to it.
@@ -138,7 +138,7 @@ class TestDecomposition:
         assert qscript[3].control_wires == qscript2[3].control_wires
 
         assert isinstance(qscript[-1], qml.ops.op_math.Adjoint)  # pylint: disable=no-member
-        qml.assert_equal(qscript[-1].base, qml.QFT.operator(wires=(1, 2)))
+        qml.assert_equal(qscript[-1].base, qml.QFT(wires=(1, 2)))
 
         assert np.allclose(qscript[1].matrix(), qscript[1].matrix())
         assert np.allclose(qscript[3].matrix(), qscript[3].matrix())

--- a/tests/templates/subroutines/test_qsvt.py
+++ b/tests/templates/subroutines/test_qsvt.py
@@ -179,7 +179,7 @@ class TestQSVTBasics:
         """Test that the wire order is preserved."""
 
         op1 = qml.GroverOperator(wires=[0, 3])
-        op2 = qml.QFT.operator(wires=[2, 1])
+        op2 = qml.QFT(wires=[2, 1])
         qsvt_wires = qml.QSVT(op2, [op1]).wires
         assert qsvt_wires == op1.wires + op2.wires
 

--- a/tests/templates/subroutines/test_reflection.py
+++ b/tests/templates/subroutines/test_reflection.py
@@ -38,9 +38,9 @@ def test_standard_validity():
 @pytest.mark.parametrize(
     ("prod", "reflection_wires"),
     [
-        (qml.QFT.operator([0, 1, 4]), [0, 1, 2]),
-        (qml.QFT.operator([0, 1, 2]), [3]),
-        (qml.QFT.operator([0, 1, 2]), [0, 1, 2, 3]),
+        (qml.QFT([0, 1, 4]), [0, 1, 2]),
+        (qml.QFT([0, 1, 2]), [3]),
+        (qml.QFT([0, 1, 2]), [0, 1, 2, 3]),
     ],
 )
 def test_reflection_wires(prod, reflection_wires):
@@ -66,14 +66,14 @@ def test_reflection_wires(prod, reflection_wires):
             ],
         ),
         (
-            qml.Reflection(qml.QFT.operator(wires=[0, 1]), 0.5),
+            qml.Reflection(qml.QFT(wires=[0, 1]), 0.5),
             [
                 qml.GlobalPhase(np.pi),
-                qml.adjoint(qml.QFT.operator(wires=[0, 1])),
+                qml.adjoint(qml.QFT(wires=[0, 1])),
                 qml.PauliX(wires=[1]),
                 qml.ctrl(qml.PhaseShift(0.5, wires=[1]), control=0, control_values=[0]),
                 qml.PauliX(wires=[1]),
-                qml.QFT.operator(wires=[0, 1]),
+                qml.QFT(wires=[0, 1]),
             ],
         ),
     ],
@@ -88,7 +88,7 @@ def test_decomposition(op, expected):
     ("op"),
     [
         qml.Reflection(qml.Hadamard(wires=0), 0.5, reflection_wires=[0]),
-        qml.Reflection(qml.QFT.operator(wires=[0, 1]), 0.5),
+        qml.Reflection(qml.QFT(wires=[0, 1]), 0.5),
     ],
 )
 def test_decomposition_new(op):
@@ -100,7 +100,7 @@ def test_decomposition_new(op):
 def test_default_values():
     """Test that the default values are correct"""
 
-    U = qml.MultiControlledX(wires=[0, 1, 4])
+    U = qml.QFT(wires=[0, 1, 4])
     op = qml.Reflection(U)
 
     assert op.alpha == np.pi

--- a/tests/templates/subroutines/time_evolution/test_trotter.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter.py
@@ -1717,7 +1717,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]]),
                 qml.ControlledPhaseShift(time * arg2, wires=[wires[1], wires[0]]),
                 qml.CNOT([wires[0], wires[1]]),
-                qml.MultiControlledX(wires=wires[1:-1]),
+                qml.QFT(wires=wires[1:-1]),
             ]
 
             if reverse:
@@ -1731,7 +1731,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]]),
                 qml.ControlledPhaseShift((time / 2) * arg2, wires=[wires[1], wires[0]]),
                 qml.CNOT([wires[0], wires[1]]),
-                qml.MultiControlledX(wires=wires[1:-1]),
+                qml.QFT(wires=wires[1:-1]),
             ]
 
             if reverse:
@@ -1747,7 +1747,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]]),
                 qml.ControlledPhaseShift((p_4 * time / 2) * arg2, wires=[wires[1], wires[0]]),
                 qml.CNOT([wires[0], wires[1]]),
-                qml.MultiControlledX(wires=wires[1:-1]),
+                qml.QFT(wires=wires[1:-1]),
             ]
 
             expected_decomp1 = (
@@ -1763,7 +1763,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]]),
                 qml.ControlledPhaseShift((p4_comp * time / 2) * arg2, wires=[wires[1], wires[0]]),
                 qml.CNOT([wires[0], wires[1]]),
-                qml.MultiControlledX(wires=wires[1:-1]),
+                qml.QFT(wires=wires[1:-1]),
             ]
 
             expected_decomp2 = (
@@ -1801,7 +1801,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]])
 
             for _ in range(kwarg2):
-                qml.MultiControlledX(wires=wires[1:-1])
+                qml.QFT(wires=wires[1:-1])
 
         expected_t = time / n
         expected_decomp = self._generate_simple_decomp_trotterize(
@@ -1865,7 +1865,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]])
 
             for _ in range(kwarg2):
-                qml.MultiControlledX(wires=wires[1:-1])
+                qml.QFT(wires=wires[1:-1])
 
         expected_t = time / n
         expected_decomp = self._generate_simple_decomp_trotterize(
@@ -1933,7 +1933,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]])
 
             for _ in range(kwarg2):
-                qml.MultiControlledX(wires=wires[1:-1])
+                qml.QFT(wires=wires[1:-1])
 
         expected_t = time / n
         expected_decomp = self._generate_simple_decomp_trotterize(
@@ -1998,7 +1998,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]])
 
             for _ in range(kwarg2):
-                qml.MultiControlledX(wires=wires[1:-1])
+                qml.QFT(wires=wires[1:-1])
 
         @qml.qnode(qml.device("default.qubit", wires=wires), diff_method=method)
         def circ(time, alpha, beta, wires, **kwargs):
@@ -2034,9 +2034,9 @@ class TestTrotterizedQfuncIntegration:
         reference_time_grad, reference_arg1_grad, reference_arg2_grad = qml.grad(reference_circ)(
             time, arg1, arg2, wires
         )
-        assert allclose(measured_time_grad, reference_time_grad, atol=1e-05)
-        assert allclose(measured_arg1_grad, reference_arg1_grad, atol=1e-05)
-        assert allclose(measured_arg2_grad, reference_arg2_grad, atol=1e-05)
+        assert allclose(measured_time_grad, reference_time_grad)
+        assert allclose(measured_arg1_grad, reference_arg1_grad)
+        assert allclose(measured_arg2_grad, reference_arg2_grad)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("n", (1, 2, 3))
@@ -2067,7 +2067,7 @@ class TestTrotterizedQfuncIntegration:
                 qml.CNOT([wires[0], wires[1]])
 
             for _ in range(kwarg2):
-                qml.MultiControlledX(wires=wires[1:-1])
+                qml.QFT(wires=wires[1:-1])
 
         expected_t = time / n
         expected_decomp = self._generate_simple_decomp_trotterize(
@@ -2109,6 +2109,6 @@ class TestTrotterizedQfuncIntegration:
         reference_time_grad, reference_arg1_grad, reference_arg2_grad = jax.grad(
             reference_circ, argnums=[0, 1, 2]
         )(time, arg1, arg2, wires)
-        assert allclose(measured_time_grad, reference_time_grad, atol=1e-05)
-        assert allclose(measured_arg1_grad, reference_arg1_grad, atol=1e-05)
-        assert allclose(measured_arg2_grad, reference_arg2_grad, atol=1e-05)
+        assert allclose(measured_time_grad, reference_time_grad)
+        assert allclose(measured_arg1_grad, reference_arg1_grad)
+        assert allclose(measured_arg2_grad, reference_arg2_grad)

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -23,15 +23,12 @@ import pytest
 import pennylane as qml
 from pennylane.decomposition import resource_rep
 from pennylane.ops import CNOT, Adjoint, PauliX, PauliZ
+from pennylane.templates import AbstractArray, Subroutine, SubroutineOp, subroutine_resource_rep
 from pennylane.templates.core import (
-    AbstractArray,
     CollectedSubroutine,
-    Subroutine,
-    SubroutineOp,
     _make_signature_key,
     adjoint_subroutine_resource_rep,
     change_op_basis_subroutine_resource_rep,
-    subroutine_resource_rep,
 )
 
 
@@ -118,6 +115,7 @@ class TestInitialization:
 
         def compute_resources(x, wires, metadata):
             assert metadata == 2  # test filled in with default values.
+            assert isinstance(wires, qml.wires.Wires)
             return {qml.RX: len(wires)}
 
         @partial(Subroutine, compute_resources=compute_resources)
@@ -234,14 +232,14 @@ def test_fallback_creating_resources_AbstractArray():
 def test_fallback_resources_error():
     """Test that if an error occurs when using the resources fallback, we get a more informative error."""
 
-    @qml.templates.core.Subroutine
+    @qml.templates.Subroutine
     def f(wires):
         raise ValueError("AHHHH")
 
     with pytest.raises(
         ValueError, match="Fallback for computing resources for <Subroutine: f> failed."
     ):
-        f.compute_resources(qml.templates.core.AbstractArray((2,)))
+        f.compute_resources(qml.templates.AbstractArray((2,)))
 
 
 class TestSubroutineOp:
@@ -424,7 +422,7 @@ class TestSubroutineCapture:
 
         import jax
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             assert wires.shape == (1,)
             qml.X(wires[0])
@@ -455,7 +453,7 @@ class TestSubroutineCapture:
 
         import jax
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(wires):
             return [qml.measure(w) for w in wires]
 
@@ -602,7 +600,7 @@ class TestTapePLIntegration:
     def test_mcm_integration(self):
         """Test that subroutines can return the results of mid circuit measurements."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def MCMTester(wires):
             return [qml.measure(wires=w, reset=True) for w in wires]
 
@@ -621,7 +619,7 @@ class TestTapePLIntegration:
     def test_drawing(self):
         """Test that subroutines can be drawn."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def Tester(x, y, wires):
             qml.RX(x, wires[0])
             qml.RY(y, wires[1])
@@ -640,7 +638,7 @@ class TestTapePLIntegration:
     def test_specs(self):
         """Test that subroutines show up as gate types in specs."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def Tester(x, y, wires):
             qml.RX(x, wires[0])
             qml.RY(y, wires[1])
@@ -660,17 +658,17 @@ class TestGraphDecomposition:
     def test_creating_abstract_array(self):
         """Test basic checks for creating an AbstractArray."""
 
-        a = qml.templates.core.AbstractArray((2, 2, 3), np.float64)
+        a = qml.templates.AbstractArray((2, 2, 3), np.float64)
         assert a.shape == (2, 2, 3)
         assert a.dtype is np.dtype(np.float64)
 
-        b = qml.templates.core.AbstractArray(())
+        b = qml.templates.AbstractArray(())
         assert b.shape == ()
         assert b.dtype is np.dtype(np.int64)
 
         assert a != b
         assert hash(a)
-        assert b == qml.templates.core.AbstractArray(())
+        assert b == qml.templates.AbstractArray(())
 
     @pytest.mark.torch
     def test_torch_dtype_converted_to_numpy(self):
@@ -679,7 +677,7 @@ class TestGraphDecomposition:
         import torch
 
         x = torch.tensor(0.5, dtype=torch.float64)
-        a = qml.templates.core.AbstractArray((), x.dtype)
+        a = qml.templates.AbstractArray((), x.dtype)
         assert a.dtype is np.dtype(np.float64)
 
     def test_inbuilt_type_promotion_to_numpy(self):
@@ -691,7 +689,7 @@ class TestGraphDecomposition:
     def test_abstract_array_len(self):
         """Test that AbstractArray's have a length."""
 
-        a = qml.templates.core.AbstractArray((2, 3, 3))
+        a = qml.templates.AbstractArray((2, 3, 3))
         assert len(a) == 18
 
     def test_resource_keys(self):
@@ -993,7 +991,7 @@ class TestGraphDecomposition:
     def test_pytree_array_input_resource_params(self):
         """Test calculating the resource params when the dynamic input has a pytree structure."""
 
-        @qml.templates.core.Subroutine
+        @qml.templates.Subroutine
         def f(x, wires):
             pass
 
@@ -1017,7 +1015,7 @@ class TestGraphDecomposition:
         def RXLayerResources(params, wires):
             return {qml.RX: qml.math.shape(params)[0]}
 
-        @partial(qml.templates.core.Subroutine, compute_resources=RXLayerResources)
+        @partial(qml.templates.Subroutine, compute_resources=RXLayerResources)
         def RXLayer(params, wires):
             for i in range(params.shape[0]):
                 qml.RX(params[i], wires[i])
@@ -1035,7 +1033,7 @@ class TestGraphDecomposition:
         def RXLayerResources(params, wires):
             return {qml.RX: qml.math.shape(params)[0]}
 
-        @partial(qml.templates.core.Subroutine, compute_resources=RXLayerResources)
+        @partial(qml.templates.Subroutine, compute_resources=RXLayerResources)
         def RXLayer(params, wires):
             for i in range(params.shape[0]):
                 qml.RX(params[i], wires[i])
@@ -1059,7 +1057,7 @@ class TestGraphDecomposition:
         def RXLayerResources(params, wires):
             return {qml.RX: qml.math.shape(params)[0]}
 
-        @partial(qml.templates.core.Subroutine, compute_resources=RXLayerResources)
+        @partial(qml.templates.Subroutine, compute_resources=RXLayerResources)
         def RXLayer(params, wires):
             for i in range(params.shape[0]):
                 qml.RX(params[i], wires[i])
@@ -1067,7 +1065,7 @@ class TestGraphDecomposition:
         def RYLayerResources(params, wires):
             return {qml.RY: qml.math.shape(params)[0]}
 
-        @partial(qml.templates.core.Subroutine, compute_resources=RYLayerResources)
+        @partial(qml.templates.Subroutine, compute_resources=RYLayerResources)
         def RYLayer(params, wires):
             for i in range(params.shape[0]):
                 qml.RY(params[i], wires[i])

--- a/tests/transforms/test_decompose_transform.py
+++ b/tests/transforms/test_decompose_transform.py
@@ -309,9 +309,7 @@ def test_null_postprocessing():
 class TestPrivateHelpers:
     """Test the private helpers for preprocessing."""
 
-    @pytest.mark.parametrize(
-        "op", (qml.PauliX(0), qml.RX(1.2, wires=0), qml.MultiControlledX(wires=range(3)))
-    )
+    @pytest.mark.parametrize("op", (qml.PauliX(0), qml.RX(1.2, wires=0), qml.QFT(wires=range(3))))
     def test_operator_decomposition_gen_accepted_operator(self, op):
         """Test the _operator_decomposition_gen function on an operator that is accepted."""
 

--- a/tests/transforms/test_optimization/test_undo_swaps.py
+++ b/tests/transforms/test_optimization/test_undo_swaps.py
@@ -104,14 +104,14 @@ class TestUndoSwaps:
         def qfunc1():
             qml.RX(2, wires=0)
             qml.RY(-3, wires=1)
-            qml.MultiControlledX(wires=[0, 1, 2])
+            qml.QFT(wires=[0, 1, 2])
             qml.SWAP(wires=[1, 2])
             return qml.state()
 
         def qfunc2():
             qml.RX(2, wires=0)
             qml.RY(-3, wires=2)
-            qml.MultiControlledX(wires=[0, 2, 1])
+            qml.QFT(wires=[0, 2, 1])
             return qml.state()
 
         transformed_qfunc = undo_swaps(qfunc1)


### PR DESCRIPTION
**Context:** We are reverting the change to make `QFT` a `Subroutine` since there were some UI changes involved.

**Description of the Change:** Reverts https://github.com/PennyLaneAI/pennylane/pull/9057.

**Benefits:** No one has to change their code using `QFT`.

**Possible Drawbacks:** `QFT` is no longer Catalyst compatible.

**Related ShortCut Stories:** [sc-111133]
