### PR TITLE
feat: add `doctest` dependency group in `pyproject.toml`

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -102,6 +102,7 @@ jobs:
           pytest pennylane $IGNORE --ignore-glob='*tests*'
 
       - name: Test 'doc' folder
+        if: always()
         run: |
           WONT_FIX="
           --ignore=doc/code

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install PennyLane (editable)
         run: |
-          pip install --group docs --group dev -e . 
+          pip install --group doctest -e . 
 
       - name: Print Dependencies
         run: |

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -738,6 +738,9 @@ The following classes have been ported over:
 
 <h3>Internal changes ⚙️</h3>
 
+* Added the `doctest` group in `pyproject.toml` to easily maintain dependencies of the documentation tests workflow.
+  [(#9237)](https://github.com/PennyLaneAI/pennylane/pull/9237)
+
 * `BasisEmbedding` now captures as `BasisState` so it now works with Catalyst and
   program capture.
   [(#9183)](https://github.com/PennyLaneAI/pennylane/pull/9183)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ doctest = [
     "stim",
     "matplotlib",
     "torch",
+    "pyzx",
     "jax==0.7.1",
     "jaxlib==0.7.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ qcut = [
     "opt_einsum"
 ]
 doctest = [
-    # Test Infrastructure
+    # Tools needed for documentation testing
     "sybil",
     "pytest>=8.4.1",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,18 @@ qcut = [
     "kahypar==1.3.5",
     "opt_einsum"
 ]
+doctest = [
+    # Test Infrastructure
+    "sybil",
+    "pytest>=8.4.1",
+
+    # Used in docstrings of tested modules
+    "stim",
+    "matplotlib",
+    "torch",
+    "jax==0.7.1",
+    "jaxlib==0.7.1",
+]
 
 [[project.maintainers]]
 name = "Xanadu Quantum Technologies Inc."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ doctest = [
     "pytest>=8.4.1",
 
     # Used in docstrings of tested modules
-    "stim",
     "matplotlib",
     "torch",
     "pyzx",


### PR DESCRIPTION
**Context:**

@astralcai needed to add `stim` as a dependency in https://github.com/PennyLaneAI/pennylane/pull/9236 but it wasn't clear what group to add it in.

**Description of the Change:**

Create `doctest` group with a lean set of dependencies. This lets people do `pip install "pennylane[doctest]"` to install dependencies strictly related to documentation testing.

**Benefits:** Easily add any dependencies in the future.

**Possible Drawbacks:** None identified.

[sc-115250]