### PR TITLE
Bounty: Improve assert_equal error message for measurement processes

### DIFF
--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -677,7 +677,7 @@ def _equal_measurements(
     """Determine whether two MeasurementProcess objects are equal"""
 
     if op1.obs is not None and op2.obs is not None:
-        return equal(
+        obs_equal = equal(
             op1.obs,
             op2.obs,
             check_interface=check_interface,
@@ -685,6 +685,11 @@ def _equal_measurements(
             rtol=rtol,
             atol=atol,
         )
+        if isinstance(obs_equal, str):
+            return obs_equal
+        if not obs_equal:
+            return f"{op1} and {op2} are not equal because their observables are not equal."
+        return True
 
     if op1.mv is not None and op2.mv is not None:
         if isinstance(op1.mv, MeasurementValue) and isinstance(op2.mv, MeasurementValue):


### PR DESCRIPTION
## Summary

When comparing two measurement processes with different observables via , provide a more informative error message.

## Fix

Modified  in  to return a descriptive error string when observables don't match, instead of just returning .

## Before
```
>>> qml.assert_equal(qml.expval(qml.Z(0)), qml.expval(qml.X(0)))
AssertionError: expval(Z(0)) and expval(X(0)) are not equal for an unspecified reason.
```

## After
```
>>> qml.assert_equal(qml.expval(qml.Z(0)), qml.expval(qml.X(0)))
AssertionError: expval(Z(0)) and expval(X(0)) are not equal because their observables are not equal.
```

## Checklist

- [x] I have tested the change locally
- [x] Tests pass