### PR TITLE
fix: add guard against dynamic device wires with capture enabled

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -903,7 +903,7 @@ The following classes have been ported over:
 
 <h3>Bug fixes 🐛</h3>
 
-* Workflows with program capture that involve dynamic device wires will not raise a `NotImplementedError`
+* Workflows with program capture that involve dynamic device wires will now raise a `NotImplementedError`
   rather than providing incorrect results.
   [(#9248)](https://github.com/PennyLaneAI/pennylane/pull/9248)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -903,6 +903,10 @@ The following classes have been ported over:
 
 <h3>Bug fixes 🐛</h3>
 
+* Workflows with program capture that involve dynamic device wires will not raise a `NotImplementedError`
+  rather than providing incorrect results.
+  [(#9248)](https://github.com/PennyLaneAI/pennylane/pull/9248)
+
 * Fixed a bug in :mod:`~.estimator` where the ``ResourcesUndefinedError``
   was being returned as a class type rather than an instance,
   preventing the intended diagnostic message from being displayed.

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -89,6 +89,7 @@ except (ImportError, NameError) as e:  # pragma: no cover
     pass
 
 import pennylane as qml
+from pennylane import math
 from pennylane.capture import FlatFn, QmlPrimitive
 from pennylane.exceptions import CaptureError
 from pennylane.logging import debug_logger
@@ -206,7 +207,7 @@ def _(*args, qnode, device, execution_config, qfunc_jaxpr, n_consts, shots_len, 
         temp_all_args = []
         for a, d in zip(args, batch_dims, strict=True):
             if d is not None:
-                slices = [slice(None)] * qml.math.ndim(a)
+                slices = [slice(None)] * math.ndim(a)
                 slices[d] = 0
                 temp_all_args.append(a[tuple(slices)])
             else:
@@ -534,6 +535,11 @@ def _bind_qnode(qnode, *args, **kwargs):
     if qnode.device.wires is None:
         raise NotImplementedError(
             "devices must specify wires for integration with program capture."
+        )
+
+    if any(math.is_abstract(w) for w in qnode.device.wires):
+        raise NotImplementedError(
+            "Dynamic device wires are not currently supported with program capture."
         )
 
     # We compute ``abstracted_axes`` using the flattened arguments because trying to flatten

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -77,7 +77,7 @@ def test_error_if_dynamic_device_wires():
         def circuit():
             return qml.probs()
 
-        return circuit
+        return circuit()
 
     f_qjit = qml.qjit(f, capture=True)
     with pytest.raises(

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -65,14 +65,17 @@ def test_warning_about_execution_pipeline_unmaintained():
         c()
 
 
+@pytest.mark.catalyst
 @pytest.mark.external
 def test_error_if_dynamic_device_wires():
     """Test that a NotImplementedError is raised if the device has dynamic wires."""
 
+    pytest.importorskip("catalyst")
+
     def f(num_wires):
         @qml.qnode(qml.device("lightning.qubit", wires=num_wires))
         def circuit():
-            return qml.expval(qml.Z(0))
+            return qml.probs()
 
         return circuit
 

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -69,23 +69,17 @@ def test_error_if_dynamic_device_wires():
     """Test that a NotImplementedError is raised if the device has dynamic wires."""
 
     def f(num_wires):
-        dev = qml.device("default.qubit", wires=num_wires)
-
-        @qml.qnode(dev)
+        @qml.qnode(qml.device("lightning.qubit", wires=num_wires))
         def circuit():
-            return qml.sample()
+            return qml.expval(qml.Z(0))
 
         return circuit
 
+    f_qjit = qml.qjit(f, capture=True)
     with pytest.raises(
         NotImplementedError, match="Dynamic device wires are not currently supported"
     ):
-        jax.make_jaxpr(f)(3)
-
-    with pytest.raises(
-        NotImplementedError, match="Dynamic device wires are not currently supported"
-    ):
-        f(3)
+        f_qjit(3)
 
 
 def test_error_if_no_device_wires():

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -65,12 +65,9 @@ def test_warning_about_execution_pipeline_unmaintained():
         c()
 
 
-@pytest.mark.catalyst
-@pytest.mark.external
+@pytest.mark.capture
 def test_error_if_dynamic_device_wires():
     """Test that a NotImplementedError is raised if the device has dynamic wires."""
-
-    pytest.importorskip("catalyst")
 
     def f(num_wires):
         @qml.qnode(qml.device("lightning.qubit", wires=num_wires))
@@ -79,11 +76,10 @@ def test_error_if_dynamic_device_wires():
 
         return circuit()
 
-    f_qjit = qml.qjit(f, capture=True)
     with pytest.raises(
         NotImplementedError, match="Dynamic device wires are not currently supported"
     ):
-        f_qjit(3)
+        jax.make_jaxpr(f)(3)
 
 
 def test_error_if_no_device_wires():

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -65,6 +65,29 @@ def test_warning_about_execution_pipeline_unmaintained():
         c()
 
 
+def test_error_if_dynamic_device_wires():
+    """Test that a NotImplementedError is raised if the device has dynamic wires."""
+
+    def f(num_wires):
+        dev = qml.device("default.qubit", wires=num_wires)
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.sample()
+
+        return circuit
+
+    with pytest.raises(
+        NotImplementedError, match="Dynamic device wires are not currently supported"
+    ):
+        jax.make_jaxpr(f)(3)
+
+    with pytest.raises(
+        NotImplementedError, match="Dynamic device wires are not currently supported"
+    ):
+        f(3)
+
+
 def test_error_if_no_device_wires():
     """Test that a NotImplementedError is raised if the device does not provide wires."""
 

--- a/tests/capture/workflow/test_capture_qnode.py
+++ b/tests/capture/workflow/test_capture_qnode.py
@@ -65,6 +65,7 @@ def test_warning_about_execution_pipeline_unmaintained():
         c()
 
 
+@pytest.mark.external
 def test_error_if_dynamic_device_wires():
     """Test that a NotImplementedError is raised if the device has dynamic wires."""
 


### PR DESCRIPTION
**Context:**

```python
import pennylane as qml

def f(num_wires):
    @qml.qnode(qml.device('lightning.qubit', wires=num_wires))
    def c():
        return qml.probs()

    return c()

qf = qml.qjit(f)
print(qf(3)) # [1 0 0 0 0 0 0 0], correct output for 3 wires
qf_capture = qml.qjit(f, capture=True)
print(qf_capture(3)) # [1 0], wrong output for 3 wires, should be [1 0 0 0 0 0 0 0]

assert qf(3).shape == qf_capture(3).shape, "differnt shapes"
```

This should not happen - it's returning a wrong result. After [internal discussion
](https://xanaduhq.slack.com/archives/C06CNPQLK2T/p1775073230635969) we found that dynamic device wires aren't even supported so we should be erroring out. 

**Description of the Change:**

Add guard to prevent silent data corruption.

**Benefits:** Code behaves as expected.

**Possible Drawbacks:** None identified.

[sc-115491]
