### PR TITLE
fix: make prune() return self for fluent API usage

### DIFF
--- a/pennylane/fermi/fermionic.py
+++ b/pennylane/fermi/fermionic.py
@@ -621,8 +621,9 @@ class FermiSentence(dict):
         for fw, coeff in items:
             if abs(coeff) <= tol:
                 del self[fw]
+        return self
 
-    def simplify(self, tol=1e-8) -> None:
+    def simplify(self, tol=1e-8) -> "FermiSentence":
         """Remove any FermiWord with coefficients less than the threshold tolerance.
 
         This method mutates the ``FermiSentence`` in place, and does not return anything.

--- a/pennylane/pauli/pauli_arithmetic.py
+++ b/pennylane/pauli/pauli_arithmetic.py
@@ -1052,8 +1052,9 @@ class PauliSentence(dict):
         for pw, coeff in items:
             if not math.is_abstract(coeff) and abs(coeff) <= tol:
                 del self[pw]
+        return self
 
-    def simplify(self, tol=1e-8) -> None:
+    def simplify(self, tol=1e-8) -> "PauliSentence":
         """Remove any ``PauliWord`` with coefficients less than the threshold tolerance.
 
         This method mutates the ``PauliSentence`` in place, and does not return anything.


### PR DESCRIPTION
## Description

Previously, `FermiSentence.prune()` and `PauliSentence.prune()` returned `None`, which prevented chaining operations:

```python
fs_abs = fs.prune()
print(fs_abs)  # None (before fix)
```

Now `prune()` returns `self`, enabling fluent API usage:

```python
fs_abs = fs.prune()
print(fs_abs)  # FermiSentence (after fix)
```

This resolves the usability issue reported in issue #9093.

## Changes

- `pennylane/fermi/fermionic.py`: Added `return self` to `FermiSentence.prune()`
- `pennylane/pauli/pauli_arithmetic.py`: Added `return self` to `PauliSentence.prune()`

## Testing

```python
fs_abs = fs.prune()
assert fs_abs is fs  # Now works!
```

Closes #9093