### PR TITLE
Add `Toffoli` to `Elbow` decomposition with explicit work wires.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -175,6 +175,11 @@ The following classes have been ported over:
 
 <h3>Improvements 🛠</h3>
 
+* Added another decomposition to `MultiControlledX` with two control wires and at least one zeroed
+  work wire that has been passed explicitly. It decomposes into a pair of `TemporaryAND` and a
+  `CNOT`.
+  [(#9291)](https://github.com/PennyLaneAI/pennylane/pull/9291)
+
 * Replaced the O(n²) incremental ``@=`` operator chaining in ``qp.pauli.string_to_pauli_word`` and ``qp.pauli.binary_to_pauli`` with a single ``qp.prod(*tuple_of_ops)`` call, collecting operators via generator expressions. These operators are now much faster for large Pauli strings.
   [(#9271)](https://github.com/PennyLaneAI/pennylane/pull/9271)
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -29,6 +29,7 @@ import pennylane as qml
 from pennylane.allocation import allocate
 from pennylane.decomposition import (
     add_decomps,
+    adjoint_resource_rep,
     change_op_basis_resource_rep,
     register_condition,
     register_resources,
@@ -1804,7 +1805,7 @@ def _mcx_to_cnot_or_toffoli(wires, control_wires, control_values, **__):
 
 
 def _2cx_elbow_explicit_resources(**__):
-    return {change_op_basis_resource_rep(resource_rep(qml.Elbow), qml.CNOT): 1}
+    return {qml.Elbow: 1, qml.CNOT: 1, adjoint_resource_rep(qml.Elbow): 1}
 
 
 def _2cx_elbow_explicit_condition(num_control_wires, work_wire_type, num_work_wires, **__):
@@ -1814,8 +1815,10 @@ def _2cx_elbow_explicit_condition(num_control_wires, work_wire_type, num_work_wi
 @register_condition(_2cx_elbow_explicit_condition)
 @register_resources(_2cx_elbow_explicit_resources)
 def _2cx_elbow_explicit(wires: WiresLike, work_wires, control_values, **__):
-    elbow = qml.Elbow([wires[0], wires[1], work_wires[0]], control_values)
-    qml.change_op_basis(elbow, qml.CNOT([work_wires[0], wires[2]]))
+    elbow_wires = [wires[0], wires[1], work_wires[0]]
+    qml.Elbow(elbow_wires, control_values)
+    qml.CNOT([work_wires[0], wires[2]])
+    qml.adjoint(qml.Elbow)(elbow_wires, control_values)
 
 
 decompose_mcx_two_controls_elbows = flip_zero_control(_2cx_elbow_explicit)

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -1490,12 +1490,7 @@ add_decomps("Pow(Toffoli)", pow_involutory)
 
 
 def _toffoli_elbow_resources():
-    return {
-        change_op_basis_resource_rep(
-            qml.Elbow,
-            qml.CNOT,
-        ): 1,
-    }
+    return {change_op_basis_resource_rep(resource_rep(qml.Elbow), qml.CNOT): 1}
 
 
 @register_resources(_toffoli_elbow_resources, work_wires={"zeroed": 1})
@@ -1808,6 +1803,23 @@ def _mcx_to_cnot_or_toffoli(wires, control_wires, control_values, **__):
             qml.PauliX(w)
 
 
+def _2cx_elbow_explicit_resources(**__):
+    return {change_op_basis_resource_rep(resource_rep(qml.Elbow), qml.CNOT): 1}
+
+
+def _2cx_elbow_explicit_condition(num_control_wires, work_wire_type, num_work_wires, **__):
+    return num_work_wires >= 1 and num_control_wires == 2 and work_wire_type == "zeroed"
+
+
+@register_condition(_2cx_elbow_explicit_condition)
+@register_resources(_2cx_elbow_explicit_resources)
+def _2cx_elbow_explicit(wires: WiresLike, work_wires, control_values, **__):
+    elbow = qml.Elbow([wires[0], wires[1], work_wires[0]], control_values)
+    qml.change_op_basis(elbow, qml.CNOT([work_wires[0], wires[2]]))
+
+
+decompose_mcx_two_controls_elbows = flip_zero_control(_2cx_elbow_explicit)
+
 add_decomps(
     MultiControlledX,
     _mcx_to_cnot_or_toffoli,
@@ -1821,6 +1833,7 @@ add_decomps(
     decompose_mcx_one_borrowed_worker,
     decompose_mcx_one_zeroed_worker,
     decompose_mcx_with_no_worker,
+    decompose_mcx_two_controls_elbows,
 )
 add_decomps("Adjoint(MultiControlledX)", self_adjoint)
 add_decomps("Pow(MultiControlledX)", pow_involutory_no_reconstructor)

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -418,14 +418,21 @@ def _mcx_many_workers_condition(num_control_wires, num_work_wires, **__):
     return num_control_wires > 2 and num_work_wires >= num_control_wires - 2
 
 
-def _mcx_many_workers_resource(num_control_wires, work_wire_type, **__):
-
+def _mcx_many_workers_resource(num_control_wires, work_wire_type, num_work_wires, **__):
+    num_ww = num_control_wires - 2
     if work_wire_type == "borrowed":
-        return {ops.Toffoli: 4 * (num_control_wires - 2)}
+        return {ops.Toffoli: 4 * num_ww}
+    num_extra_ww = num_work_wires - num_ww
     return {
-        qml.TemporaryAND: num_control_wires - 2,
-        adjoint_resource_rep(qml.TemporaryAND): num_control_wires - 2,
-        ops.Toffoli: 1,
+        qml.TemporaryAND: num_ww,
+        adjoint_resource_rep(qml.TemporaryAND): num_ww,
+        resource_rep(
+            ops.MultiControlledX,
+            num_control_wires=2,
+            num_work_wires=num_extra_ww,
+            num_zero_control_values=0,
+            work_wire_type="zeroed",
+        ): 1,
     }
 
 
@@ -437,7 +444,9 @@ def _mcx_many_workers(wires, work_wires, work_wire_type, **__):
     https://arxiv.org/abs/quant-ph/9503016, which requires a suitably large register of
     work wires"""
     target_wire, control_wires = wires[-1], wires[:-1]
-    work_wires = work_wires[: len(control_wires) - 2]
+    num_work_wires = len(control_wires) - 2
+    extra_work_wires = work_wires[num_work_wires:]
+    work_wires = work_wires[:num_work_wires]
 
     if work_wire_type == "borrowed":
         up_gate = down_gate = ops.Toffoli
@@ -445,11 +454,11 @@ def _mcx_many_workers(wires, work_wires, work_wire_type, **__):
         down_gate = qml.TemporaryAND
         up_gate = ops.adjoint(qml.TemporaryAND)
 
-    @control_flow.for_loop(1, len(work_wires), 1)
+    @control_flow.for_loop(1, num_work_wires, 1)
     def loop_up(i):
         up_gate(wires=[control_wires[i], work_wires[i], work_wires[i - 1]])
 
-    @control_flow.for_loop(len(work_wires) - 1, 0, -1)
+    @control_flow.for_loop(num_work_wires - 1, 0, -1)
     def loop_down(i):
         down_gate(wires=[control_wires[i], work_wires[i], work_wires[i - 1]])
 
@@ -459,7 +468,12 @@ def _mcx_many_workers(wires, work_wires, work_wire_type, **__):
 
     down_gate(wires=[control_wires[-1], control_wires[-2], work_wires[-1]])
     loop_down()
-    ops.Toffoli(wires=[control_wires[0], work_wires[0], target_wire])
+
+    _wires = [control_wires[0], work_wires[0], target_wire]
+    if work_wire_type == "borrowed":
+        ops.Toffoli(_wires)
+    else:
+        ops.MultiControlledX(_wires, work_wires=extra_work_wires, work_wire_type="zeroed")
     loop_up()
     up_gate(wires=[control_wires[-1], control_wires[-2], work_wires[-1]])
 

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -483,7 +483,9 @@ decompose_mcx_many_workers_explicit = flip_zero_control(_mcx_many_workers)
 @register_condition(lambda num_work_wires, **_: not num_work_wires)
 @register_condition(lambda num_control_wires, **_: num_control_wires > 2)
 @register_resources(
-    lambda num_control_wires, **_: _mcx_many_workers_resource(num_control_wires, "zeroed"),
+    lambda num_control_wires, num_work_wires, **_: _mcx_many_workers_resource(
+        num_control_wires, "zeroed", num_work_wires
+    ),
     work_wires=lambda num_control_wires, **_: {"zeroed": num_control_wires - 2},
 )
 def _mcx_many_zeroed_workers(wires, **kwargs):
@@ -500,7 +502,9 @@ decompose_mcx_many_zeroed_workers = flip_zero_control(_mcx_many_zeroed_workers)
 @register_condition(lambda num_work_wires, **_: not num_work_wires)
 @register_condition(lambda num_control_wires, **_: num_control_wires > 2)
 @register_resources(
-    lambda num_control_wires, **_: _mcx_many_workers_resource(num_control_wires, "borrowed"),
+    lambda num_control_wires, num_work_wires, **_: _mcx_many_workers_resource(
+        num_control_wires, "borrowed", num_work_wires
+    ),
     work_wires=lambda num_control_wires, **_: {"borrowed": num_control_wires - 2},
 )
 def _mcx_many_borrowed_workers(wires, **kwargs):

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -422,13 +422,16 @@ def _mcx_many_workers_resource(num_control_wires, work_wire_type, num_work_wires
     num_ww = num_control_wires - 2
     if work_wire_type == "borrowed":
         return {ops.Toffoli: 4 * num_ww}
-    mcx_rep = resource_rep(
-        ops.MultiControlledX,
-        num_control_wires=2,
-        num_work_wires=num_work_wires - num_ww,  # Guaranteed to be >=0 due to condition function
-        num_zero_control_values=0,
-        work_wire_type="zeroed",
-    )
+    if num_work_wires == num_ww:
+        mcx_rep = resource_rep(qml.Toffoli)
+    else:
+        mcx_rep = resource_rep(
+            ops.MultiControlledX,
+            num_control_wires=2,
+            num_work_wires=num_work_wires - num_ww,  # Guaranteed to be >0 due to condition
+            num_zero_control_values=0,
+            work_wire_type="zeroed",
+        )
     return {qml.TemporaryAND: num_ww, adjoint_resource_rep(qml.TemporaryAND): num_ww, mcx_rep: 1}
 
 
@@ -466,7 +469,7 @@ def _mcx_many_workers(wires, work_wires, work_wire_type, **__):
     loop_down()
 
     _wires = [control_wires[0], work_wires[0], target_wire]
-    if work_wire_type == "borrowed":
+    if work_wire_type == "borrowed" or not extra_work_wires:
         ops.Toffoli(_wires)
     else:
         ops.MultiControlledX(_wires, work_wires=extra_work_wires, work_wire_type="zeroed")
@@ -483,8 +486,10 @@ decompose_mcx_many_workers_explicit = flip_zero_control(_mcx_many_workers)
 @register_condition(lambda num_work_wires, **_: not num_work_wires)
 @register_condition(lambda num_control_wires, **_: num_control_wires > 2)
 @register_resources(
-    lambda num_control_wires, num_work_wires, **_: _mcx_many_workers_resource(
-        num_control_wires, "zeroed", num_work_wires
+    lambda num_control_wires=None, **_: _mcx_many_workers_resource(
+        num_control_wires=num_control_wires,
+        work_wire_type="zeroed",
+        num_work_wires=num_control_wires - 2,
     ),
     work_wires=lambda num_control_wires, **_: {"zeroed": num_control_wires - 2},
 )
@@ -502,8 +507,10 @@ decompose_mcx_many_zeroed_workers = flip_zero_control(_mcx_many_zeroed_workers)
 @register_condition(lambda num_work_wires, **_: not num_work_wires)
 @register_condition(lambda num_control_wires, **_: num_control_wires > 2)
 @register_resources(
-    lambda num_control_wires, num_work_wires, **_: _mcx_many_workers_resource(
-        num_control_wires, "borrowed", num_work_wires
+    lambda num_control_wires=None, **_: _mcx_many_workers_resource(
+        num_control_wires=num_control_wires,
+        work_wire_type="borrowed",
+        num_work_wires=num_control_wires - 2,
     ),
     work_wires=lambda num_control_wires, **_: {"borrowed": num_control_wires - 2},
 )

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -419,20 +419,25 @@ def _mcx_many_workers_condition(num_control_wires, num_work_wires, **__):
 
 
 def _mcx_many_workers_resource(num_control_wires, work_wire_type, num_work_wires, **__):
-    num_ww = num_control_wires - 2
+    num_used_work_wires = num_control_wires - 2
     if work_wire_type == "borrowed":
-        return {ops.Toffoli: 4 * num_ww}
-    if num_work_wires == num_ww:
+        return {ops.Toffoli: 4 * num_used_work_wires}
+    if num_work_wires == num_used_work_wires:
         mcx_rep = resource_rep(qml.Toffoli)
     else:
         mcx_rep = resource_rep(
             ops.MultiControlledX,
             num_control_wires=2,
-            num_work_wires=num_work_wires - num_ww,  # Guaranteed to be >0 due to condition
+            num_work_wires=num_work_wires
+            - num_used_work_wires,  # Guaranteed to be >0 due to condition
             num_zero_control_values=0,
             work_wire_type="zeroed",
         )
-    return {qml.TemporaryAND: num_ww, adjoint_resource_rep(qml.TemporaryAND): num_ww, mcx_rep: 1}
+    return {
+        qml.TemporaryAND: num_used_work_wires,
+        adjoint_resource_rep(qml.TemporaryAND): num_used_work_wires,
+        mcx_rep: 1,
+    }
 
 
 # pylint: disable=no-value-for-parameter

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -422,18 +422,14 @@ def _mcx_many_workers_resource(num_control_wires, work_wire_type, num_work_wires
     num_ww = num_control_wires - 2
     if work_wire_type == "borrowed":
         return {ops.Toffoli: 4 * num_ww}
-    num_extra_ww = num_work_wires - num_ww
-    return {
-        qml.TemporaryAND: num_ww,
-        adjoint_resource_rep(qml.TemporaryAND): num_ww,
-        resource_rep(
-            ops.MultiControlledX,
-            num_control_wires=2,
-            num_work_wires=num_extra_ww,
-            num_zero_control_values=0,
-            work_wire_type="zeroed",
-        ): 1,
-    }
+    mcx_rep = resource_rep(
+        ops.MultiControlledX,
+        num_control_wires=2,
+        num_work_wires=num_work_wires - num_ww,  # Guaranteed to be >=0 due to condition function
+        num_zero_control_values=0,
+        work_wire_type="zeroed",
+    )
+    return {qml.TemporaryAND: num_ww, adjoint_resource_rep(qml.TemporaryAND): num_ww, mcx_rep: 1}
 
 
 # pylint: disable=no-value-for-parameter

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -683,20 +683,20 @@ class PCPhase(Operation):
 
     >>> op_13 = qml.PCPhase(1.23, dim=13, wires=[1, 2, 3, 4])
     >>> print(qml.draw(op_13.decomposition)())
-    1: ─╭●─────────╭●───────────╭GlobalPhase(-1.23)─┤  
-    2: ─╰Rϕ(-2.46)─├●───────────├GlobalPhase(-1.23)─┤  
-    3: ────────────├○───────────├GlobalPhase(-1.23)─┤  
+    1: ─╭●─────────╭●───────────╭GlobalPhase(-1.23)─┤
+    2: ─╰Rϕ(-2.46)─├●───────────├GlobalPhase(-1.23)─┤
+    3: ────────────├○───────────├GlobalPhase(-1.23)─┤
     4: ──X─────────╰Rϕ(2.46)──X─╰GlobalPhase(-1.23)─┤
 
     If ``dim`` is a power of two, a single (multi-controlled) ``PhaseShift`` gate is sufficient:
 
     >>> op_16 = qml.PCPhase(1.23, dim=16, wires=range(6))
     >>> print(qml.draw(op_16.decomposition, wire_order=range(6), show_all_wires=True)())
-    0: ────╭○───────────╭GlobalPhase(1.23)─┤  
-    1: ──X─╰Rϕ(2.46)──X─├GlobalPhase(1.23)─┤  
-    2: ─────────────────├GlobalPhase(1.23)─┤  
-    3: ─────────────────├GlobalPhase(1.23)─┤  
-    4: ─────────────────├GlobalPhase(1.23)─┤  
+    0: ────╭○───────────╭GlobalPhase(1.23)─┤
+    1: ──X─╰Rϕ(2.46)──X─├GlobalPhase(1.23)─┤
+    2: ─────────────────├GlobalPhase(1.23)─┤
+    3: ─────────────────├GlobalPhase(1.23)─┤
+    4: ─────────────────├GlobalPhase(1.23)─┤
     5: ─────────────────╰GlobalPhase(1.23)─┤
 
     """
@@ -830,9 +830,9 @@ class PCPhase(Operation):
 
         >>> op_13 = qml.PCPhase(1.23, dim=13, wires=[1, 2, 3, 4])
         >>> print(qml.draw(op_13.decomposition)())
-        1: ─╭●─────────╭●───────────╭GlobalPhase(-1.23)─┤  
-        2: ─╰Rϕ(-2.46)─├●───────────├GlobalPhase(-1.23)─┤  
-        3: ────────────├○───────────├GlobalPhase(-1.23)─┤  
+        1: ─╭●─────────╭●───────────╭GlobalPhase(-1.23)─┤
+        2: ─╰Rϕ(-2.46)─├●───────────├GlobalPhase(-1.23)─┤
+        3: ────────────├○───────────├GlobalPhase(-1.23)─┤
         4: ──X─────────╰Rϕ(2.46)──X─╰GlobalPhase(-1.23)─┤
 
         In the following we provide a detailed example for illustration purposes.
@@ -899,9 +899,9 @@ class PCPhase(Operation):
         which concludes the decomposition, now reading:
 
         >>> print(qml.draw(op_3.decomposition)())
-        0: ────╭○───────────╭○─────────╭GlobalPhase(1.23)─┤  
-        1: ──X─╰Rϕ(2.46)──X─├○─────────├GlobalPhase(1.23)─┤  
-        2: ─────────────────├●─────────├GlobalPhase(1.23)─┤  
+        0: ────╭○───────────╭○─────────╭GlobalPhase(1.23)─┤
+        1: ──X─╰Rϕ(2.46)──X─├○─────────├GlobalPhase(1.23)─┤
+        2: ─────────────────├●─────────├GlobalPhase(1.23)─┤
         3: ─────────────────╰Rϕ(-2.46)─╰GlobalPhase(1.23)─┤
 
         """

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -16,7 +16,6 @@ Tests for the controlled decompositions.
 """
 
 import itertools
-from collections import defaultdict
 
 import numpy as np
 import pytest
@@ -825,15 +824,9 @@ class TestMCXDecomposition:
             decompose_mcx_many_workers_explicit(wires=mcx.wires, **mcx.hyperparameters)
 
         # Verify that the resource estimate is correct.
-        resource = decompose_mcx_many_workers_explicit.compute_resources(**mcx.resource_params)
-        expected_gate_counts = {k: v for k, v in resource.gate_counts.items() if v > 0}
-        actual_gate_counts = defaultdict(int)
-        for _op in q.queue:
-            if isinstance(_op, qml.Projector):
-                continue
-            resource_rep = qml.resource_rep(type(_op), **_op.resource_params)
-            actual_gate_counts[resource_rep] += 1
-        assert actual_gate_counts == expected_gate_counts
+        _test_decomposition_rule(
+            mcx, decompose_mcx_many_workers_explicit, skip_decomp_matrix_check=True
+        )
 
         tape = qml.tape.QuantumScript.from_queue(q)
         matrix = _tape_to_matrix(tape, wire_order=control_wires + work_wires + [target_wire])
@@ -902,15 +895,9 @@ class TestMCXDecomposition:
             decompose_mcx_one_worker_explicit(wires=mcx.wires, **mcx.hyperparameters)
 
         # Verify that the resource estimate is correct.
-        resource = decompose_mcx_one_worker_explicit.compute_resources(**mcx.resource_params)
-        expected_gate_counts = {k: v for k, v in resource.gate_counts.items() if v > 0}
-        actual_gate_counts = defaultdict(int)
-        for _op in q.queue:
-            if isinstance(_op, qml.Projector):
-                continue
-            resource_rep = qml.resource_rep(type(_op), **_op.resource_params)
-            actual_gate_counts[resource_rep] += 1
-        assert actual_gate_counts == expected_gate_counts
+        _test_decomposition_rule(
+            mcx, decompose_mcx_one_worker_explicit, skip_decomp_matrix_check=True
+        )
 
         # Verify that the decomposition produces an equivalent matrix.
         tape = qml.tape.QuantumScript.from_queue(q)
@@ -946,15 +933,7 @@ class TestMCXDecomposition:
             _mcx_two_workers(mcx.wires, work_wires, work_wire_type)
 
         # Verify that the resource estimate is correct.
-        resource = _mcx_two_workers.compute_resources(**mcx.resource_params)
-        expected_gate_counts = {k: v for k, v in resource.gate_counts.items() if v > 0}
-        actual_gate_counts = defaultdict(int)
-        for _op in q.queue:
-            if isinstance(_op, qml.Projector):
-                continue
-            resource_rep = qml.resource_rep(type(_op), **_op.resource_params)
-            actual_gate_counts[resource_rep] += 1
-        assert actual_gate_counts == expected_gate_counts
+        _test_decomposition_rule(mcx, _mcx_two_workers, skip_decomp_matrix_check=True)
 
         # Verify that the decomposition produces an equivalent matrix.
         tape = qml.tape.QuantumScript.from_queue(q)
@@ -982,13 +961,7 @@ class TestMCXDecomposition:
             _decompose_mcx_with_no_worker(mcx.wires)
 
         # Verify that the resource estimate is correct.
-        resource = _decompose_mcx_with_no_worker.compute_resources(**mcx.resource_params)
-        expected_gate_counts = {k: v for k, v in resource.gate_counts.items() if v > 0}
-        actual_gate_counts = defaultdict(int)
-        for _op in q.queue:
-            resource_rep = qml.resource_rep(type(_op), **_op.resource_params)
-            actual_gate_counts[resource_rep] += 1
-        assert actual_gate_counts == expected_gate_counts
+        _test_decomposition_rule(mcx, _decompose_mcx_with_no_worker, skip_decomp_matrix_check=True)
 
         # Verify that the decomposition produces an equivalent matrix.
         tape = qml.tape.QuantumScript.from_queue(q)
@@ -1018,19 +991,40 @@ class TestMCXDecomposition:
         assert qml.math.allclose(matrix, expected_matrix)
 
     @pytest.mark.parametrize(
-        "test_mcx",
+        "params",
         [
-            qml.MultiControlledX(wires=[1, 0]),
-            qml.MultiControlledX(wires=[1, 0], control_values=[0]),
-            qml.MultiControlledX(wires=[2, 1, 0]),
-            qml.MultiControlledX(wires=[2, 1, 0], control_values=[0, 1]),
+            {"wires": [1, 0]},
+            {"wires": [1, 0], "control_values": [0]},
+            {"wires": [2, 1, 0]},
+            {"wires": [2, 1, 0], "control_values": [0, 1]},
+            {"wires": [1, 0], "work_wires": [2]},
+            {"wires": [1, 0], "control_values": [0], "work_wires": [2]},
+            {"wires": [2, 1, 0], "work_wires": [3, 4]},
+            {"wires": [2, 1, 0], "control_values": [0, 1], "work_wires": [3, 4]},
+            {"wires": [1, 0], "work_wires": [2], "work_wire_type": "zeroed"},
+            {"wires": [1, 0], "control_values": [0], "work_wires": [2], "work_wire_type": "zeroed"},
+            {"wires": [2, 1, 0], "work_wires": [3, 4], "work_wire_type": "zeroed"},
+            {
+                "wires": [2, 1, 0],
+                "control_values": [0, 1],
+                "work_wires": [3, 4],
+                "work_wire_type": "zeroed",
+            },
+            {"wires": [2, 3, 1, 0], "work_wires": [5, 4, 6], "work_wire_type": "zeroed"},
+            {
+                "wires": [2, 1, 0, 3],
+                "control_values": [0, 0, 1],
+                "work_wires": [5, 4, 6],
+                "work_wire_type": "zeroed",
+            },
         ],
     )
-    def test_mcx_decompositions(self, test_mcx):
+    def test_mcx_decompositions(self, params):
         """Tests that MCX can be resolved into CNOT and Toffoli properly."""
 
+        mcx = qml.MultiControlledX(**params)
         for rule in qml.list_decomps(qml.MultiControlledX):
-            _test_decomposition_rule(test_mcx, rule)
+            _test_decomposition_rule(mcx, rule)
 
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     @pytest.mark.parametrize("n_ctrl_wires", range(3, 10))


### PR DESCRIPTION
**Context:**
We have the decomposition of `Toffoli` into a pair of elbows and a `CNOT` when using implicit work wires via `allocate` (added [here](https://github.com/PennyLaneAI/pennylane/pull/8549))
We don't have it for `MultiControlledX([0, 1, 2], work_wires=[3], work_wire_type="zeroed")`.

**Description of the Change:**
Add the latter and adapt the many-workers decomposition of `MCX` to pass additional work wires to its central `Toffoli`, to make use of the new rule.

**Benefits:**
Expressivity of MCX decompositions.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116348]