### PR TITLE
BugFix: DecompositionGraph estimates work wires incorrectly

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1094,6 +1094,10 @@ The following classes have been ported over:
   produced for a specific wire configuration.
   [(#9270)](https://github.com/PennyLaneAI/pennylane/pull/9270)
 
+* Fixes a bug where the `DecompositionGraph` underestimates the minimum number of work wires required to solve for a particular operator
+  when it has decomposition rules with a lower work wire budget but is unrecheable from the provided gate set.
+  [(#9298)](https://github.com/PennyLaneAI/pennylane/pull/9298)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -97,7 +97,7 @@ class _OperatorNode:
     min_work_wires: int = 0
     """The minimum number of additional work wires required to decompose this operator."""
 
-    reacheable: bool = False
+    reachable: bool = False
     """Whether the operator node can be reached from the gate set."""
 
     def __hash__(self) -> int:
@@ -133,7 +133,7 @@ class _DecompositionNode:
     num_work_wire_not_available: int
     work_wire_dependent: bool = False
     min_work_wires: int = 0
-    reacheable: bool = True
+    reachable: bool = True
 
     def __post_init__(self):
         self.min_work_wires = self.min_work_wires or self.work_wire_spec.total
@@ -314,7 +314,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             return self._all_op_indices[op_node]
 
         if op in self._gate_set_weights:
-            op_node = replace(op_node, reacheable=True)
+            op_node = replace(op_node, reachable=True)
 
         op_node_idx = self._graph.add_node(op_node)
         self._all_op_indices[op_node] = op_node_idx
@@ -340,15 +340,15 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             self._graph.add_edge(self._start, op_node_idx, math.inf)
             return op_node_idx
 
-        op_reacheable = False
+        op_reachable = False
         work_wire_dependent = known_work_wire_dependent
         min_work_wires = -1  # use -1 to represent undetermined work wire requirement
         for decomposition in rules:
             d_node = self._add_decomp(decomposition, op_node, op_node_idx, num_used_work_wires)
-            if not d_node or not d_node.reacheable:
+            if not d_node or not d_node.reachable:
                 continue
-            # If a decomposition is reacheable, the operator is also reacheable
-            op_reacheable = True
+            # If a decomposition is reachable, the operator is also reachable
+            op_reachable = True
             # If any of the operator's decompositions depend on work wires, this operator
             # should also depend on work wires.
             if d_node.work_wire_dependent:
@@ -356,8 +356,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             if min_work_wires == -1 or d_node.min_work_wires < min_work_wires:
                 min_work_wires = d_node.min_work_wires
 
-        if op_reacheable:
-            op_node = replace(op_node, reacheable=True)
+        if op_reachable:
+            op_node = replace(op_node, reachable=True)
             self._replace_node(op_node_idx, op_node)
 
         # If we found that this operator depends on work wires, but it's currently recorded
@@ -416,8 +416,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             # decomposition is also dependent on work wires, even it itself does not use
             # any work wires.
             op_node = self._graph[op_node_idx]
-            if not op_node.reacheable:
-                d_node.reacheable = False
+            if not op_node.reachable:
+                d_node.reachable = False
             if op_node.work_wire_dependent:
                 d_node.work_wire_dependent = True
             max_op_min_work_wires = max(op_node.min_work_wires, max_op_min_work_wires)

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -97,6 +97,9 @@ class _OperatorNode:
     min_work_wires: int = 0
     """The minimum number of additional work wires required to decompose this operator."""
 
+    reacheable: bool = False
+    """Whether the operator node can be reached from the gate set."""
+
     def __hash__(self) -> int:
         # If the decomposition of an operator does not depend on the availability of work wires
         # at all, we don't need to have multiple nodes representing the same operator with
@@ -130,6 +133,7 @@ class _DecompositionNode:
     num_work_wire_not_available: int
     work_wire_dependent: bool = False
     min_work_wires: int = 0
+    reacheable: bool = True
 
     def __post_init__(self):
         self.min_work_wires = self.min_work_wires or self.work_wire_spec.total
@@ -309,6 +313,9 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         if op_node in self._all_op_indices:
             return self._all_op_indices[op_node]
 
+        if op in self._gate_set_weights:
+            op_node = replace(op_node, reacheable=True)
+
         op_node_idx = self._graph.add_node(op_node)
         self._all_op_indices[op_node] = op_node_idx
         self._op_to_op_nodes[op].add(op_node)
@@ -333,23 +340,32 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             self._graph.add_edge(self._start, op_node_idx, math.inf)
             return op_node_idx
 
+        op_reacheable = False
         work_wire_dependent = known_work_wire_dependent
         min_work_wires = -1  # use -1 to represent undetermined work wire requirement
         for decomposition in rules:
             d_node = self._add_decomp(decomposition, op_node, op_node_idx, num_used_work_wires)
+            if not d_node or not d_node.reacheable:
+                continue
+            # If a decomposition is reacheable, the operator is also reacheable
+            op_reacheable = True
             # If any of the operator's decompositions depend on work wires, this operator
             # should also depend on work wires.
-            if d_node and d_node.work_wire_dependent:
+            if d_node.work_wire_dependent:
                 work_wire_dependent = True
-            if d_node and (min_work_wires == -1 or d_node.min_work_wires < min_work_wires):
+            if min_work_wires == -1 or d_node.min_work_wires < min_work_wires:
                 min_work_wires = d_node.min_work_wires
+
+        if op_reacheable:
+            op_node = replace(op_node, reacheable=True)
+            self._replace_node(op_node_idx, op_node)
 
         # If we found that this operator depends on work wires, but it's currently recorded
         # as independent of work wires, we must replace every record of this operator node
         # with a new node with `work_wire_dependent` set to `True`.
         if not known_work_wire_dependent and work_wire_dependent:
-            new_op_node = replace(op_node, work_wire_dependent=True, min_work_wires=min_work_wires)
-            self._replace_node(op_node_idx, new_op_node)
+            op_node = replace(op_node, work_wire_dependent=True, min_work_wires=min_work_wires)
+            self._replace_node(op_node_idx, op_node)
             # Also record that this operator type depends on work wires, so in the future
             # when we encounter other instances of the same operator type, we correctly
             # identify it as work-wire dependent.
@@ -400,6 +416,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             # decomposition is also dependent on work wires, even it itself does not use
             # any work wires.
             op_node = self._graph[op_node_idx]
+            if not op_node.reacheable:
+                d_node.reacheable = False
             if op_node.work_wire_dependent:
                 d_node.work_wire_dependent = True
             max_op_min_work_wires = max(op_node.min_work_wires, max_op_min_work_wires)

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -568,6 +568,41 @@ class TestDecompositionGraph:
         solution = graph.solve(num_work_wires=None, minimize_work_wires=True)
         assert solution.decomposition(AnotherOp(0), num_work_wires=None) == _yet_another_decomp
 
+    def test_min_work_wires_unreacheable_rule(self, _):
+        """Tests that unrecheable rules are excluded when computing minimum work wires."""
+
+        class SimpleOp(Operation):  # pylint: disable=too-few-public-methods
+            """A simple operation that does not depend on work wires."""
+
+        @qml.register_resources({qml.X: 4})
+        def _simple_decomp(_):
+            raise NotImplementedError
+
+        @qml.register_resources({SimpleOp: 1, qml.CNOT: 4}, work_wires={"zeroed": 1})
+        def _custom_decomp(_):
+            raise NotImplementedError
+
+        # This decomposition rule isn't actually reacheable, therefore, the minimum number of
+        # work wires required to decompose `AnotherOp` should be 4, not 3
+        @qml.register_resources({CustomOp: 1, qml.H: 4}, work_wires={"zeroed": 2})
+        def _another_decomp(_):
+            raise NotImplementedError
+
+        @qml.register_resources({SimpleOp: 3, qml.CNOT: 4}, work_wires={"zeroed": 4})
+        def _yet_another_decomp(_):
+            raise NotImplementedError
+
+        graph = DecompositionGraph(
+            [AnotherOp(0)],
+            gate_set={qml.X, qml.CNOT},
+            alt_decomps={
+                SimpleOp: [_simple_decomp],
+                CustomOp: [_custom_decomp],
+                AnotherOp: [_another_decomp, _yet_another_decomp],
+            },
+        )
+        assert graph._min_work_wires == 4
+
 
 @pytest.mark.unit
 @patch(

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -582,7 +582,7 @@ class TestDecompositionGraph:
         def _custom_decomp(_):
             raise NotImplementedError
 
-        # This decomposition rule isn't actually reacheable, therefore, the minimum number of
+        # This decomposition rule isn't actually reacheable for the target gate set because it requires `qml.H`, therefore, the minimum number of
         # work wires required to decompose `AnotherOp` should be 4, not 3
         @qml.register_resources({CustomOp: 1, qml.H: 4}, work_wires={"zeroed": 2})
         def _another_decomp(_):


### PR DESCRIPTION
**Context:**

The graph first tries to figure out what the minimum required number of work wires is during construction time, and then use that as a constraint when solving the graph. The issue is that when we try to figure out how many work wires is minimally required, we look at all the available decomposition rules, without considering what the gate set is, so if there exist a decomposition rule that does not use work wires, the graph thinks that this operator is solvable without work wires, even when said decomposition rule may not be reachable from the provided gate set.

**Description of the Change:**

Track whether a decomposition rule is reachable during graph construction, and only update the minimum required work wires estimate for decomposition rules that are actually reachable.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Fixes https://github.com/PennyLaneAI/pennylane/issues/9294
[sc-116435]