### PR TITLE
Scaffold `qp.allocate` interface for Phase Gradient

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -173,6 +173,13 @@ The following classes have been ported over:
 * Added ``PauliSentence.prune`` and ``FermiSentence.prune`` that removes terms with coefficients below a provided threshold.
   [(#9278)](https://github.com/PennyLaneAI/pennylane/pull/9278)
 
+* Added a ``"phase-grad"`` allocation state to :func:`~.allocate` with required ``precision``
+  metadata, preserved through queuing, capture, and tape construction. This is a frontend
+  scaffold for phase-gradient allocation planning; concrete preparation and lowering are
+  deferred to follow-up changes. :func:`~.transforms.resolve_dynamic_wires` raises an explicit
+  error for unresolved ``"phase-grad"`` allocations.
+  [(#9300)](https://github.com/PennyLaneAI/pennylane/pull/9300)
+
 <h3>Improvements 🛠</h3>
 
 * Replaced the O(n²) incremental ``@=`` operator chaining in ``qp.pauli.string_to_pauli_word`` and ``qp.pauli.binary_to_pauli`` with a single ``qp.prod(*tuple_of_ops)`` call, collecting operators via generator expressions. These operators are now much faster for large Pauli strings.

--- a/pennylane/allocation.py
+++ b/pennylane/allocation.py
@@ -40,6 +40,11 @@ class AllocateState(StrEnum):
 
     ZERO = "zero"
     ANY = "any"
+    PHASE_GRAD = "phase-grad"
+
+    def is_phase_gradient(self) -> bool:
+        """Return True if this state represents a phase-gradient allocation request."""
+        return self is AllocateState.PHASE_GRAD
 
 
 if not has_jax:
@@ -51,14 +56,14 @@ else:
 
     @allocate_prim.def_impl
     def _allocate_primitive_impl(
-        *, num_wires, state: AllocateState = AllocateState.ZERO, restored=False
+        *, num_wires, state: AllocateState = AllocateState.ZERO, restored=False, precision=None
     ):
         raise NotImplementedError("jaxpr containing qubit allocation cannot be executed.")
 
     # pylint: disable=unused-argument
     @allocate_prim.def_abstract_eval
     def _allocate_primitive_abstract_eval(
-        *, num_wires, state: AllocateState = AllocateState.ZERO, restored=False
+        *, num_wires, state: AllocateState = AllocateState.ZERO, restored=False, precision=None
     ):
         return [jax.core.ShapedArray((), dtype=int) for _ in range(num_wires)]
 
@@ -82,16 +87,20 @@ class Allocate(Operator):
         wires (list[DynamicWire]): a list of dynamic wire values.
 
     Keyword Args:
-        state (Literal["any", "zero"]): the state that the wires need to start in.
+        state (Literal["any", "zero", "phase-grad"]): the state that the wires need to start in.
         restored (bool): Whether or not the qubit will be restored to the original state before being deallocated.
+        precision (float | None): For phase-gradient allocations, the target precision.
+            Must be ``None`` for ``"zero"`` and ``"any"`` states.
 
     ..see-also:: :func:`~.allocate`.
 
     """
 
-    def __init__(self, wires, state: AllocateState = AllocateState.ZERO, restored=False):
+    def __init__(
+        self, wires, state: AllocateState = AllocateState.ZERO, restored=False, precision=None
+    ):
         super().__init__(wires=wires)
-        self._hyperparameters = {"state": state, "restored": restored}
+        self._hyperparameters = {"state": state, "restored": restored, "precision": precision}
 
     @property
     def state(self) -> AllocateState:
@@ -103,13 +112,27 @@ class Allocate(Operator):
         """Whether the allocated wires will be restored to their original state before deallocation."""
         return self.hyperparameters["restored"]
 
+    @property
+    def precision(self) -> float | None:
+        """The target precision for phase-gradient allocations, or None."""
+        return self.hyperparameters["precision"]
+
+    @property
+    def is_phase_gradient(self) -> bool:
+        """Return True if this allocation requests a phase-gradient state."""
+        return self.state is AllocateState.PHASE_GRAD
+
     @classmethod
     def from_num_wires(
-        cls, num_wires: int, state: AllocateState = AllocateState.ZERO, restored=False
+        cls,
+        num_wires: int,
+        state: AllocateState = AllocateState.ZERO,
+        restored=False,
+        precision=None,
     ) -> "Allocate":
         """Initialize an ``Allocate`` op from a number of wires instead of already constructed dynamic wires."""
         wires = tuple(DynamicWire() for _ in range(num_wires))
-        return cls(wires=wires, state=state, restored=restored)
+        return cls(wires=wires, state=state, restored=restored, precision=precision)
 
 
 class Deallocate(Operator):
@@ -203,8 +226,9 @@ class DynamicRegister(Wires):
 
 def allocate(
     num_wires: int,
-    state: Literal["any", "zero"] | AllocateState = AllocateState.ZERO,
+    state: Literal["any", "zero", "phase-grad"] | AllocateState = AllocateState.ZERO,
     restored: bool = False,
+    precision: float | None = None,
 ) -> DynamicRegister:
     """Dynamically allocates new wires in-line,
     or as a context manager which also safely deallocates the new wires upon exiting the context.
@@ -214,9 +238,16 @@ def allocate(
             The number of wires to dynamically allocate.
 
     Keyword Args:
-        state (Literal["any", "zero"]):
-            Specifies whether to allocate ``num_wires`` in the all-zeros state (``"zero"``) or in
-            any arbitrary state (``"any"``). The default value is ``state="zero"``.
+        state (Literal["any", "zero", "phase-grad"]):
+            Specifies the requested initial state for the allocated wires.
+            ``"zero"`` allocates wires in the all-zeros state,
+            ``"any"`` allows any arbitrary initial state, and
+            ``"phase-grad"`` requests a phase-gradient state.
+            The default value is ``state="zero"``.
+
+            .. note::
+                ``"phase-grad"`` is experimental. Concrete preparation and lowering is
+                deferred to a follow-up change.
 
         restored (bool):
             Whether or not the dynamically allocated wires are returned to the same state they
@@ -224,6 +255,11 @@ def allocate(
             dynamically allocated wires to their original state before being deallocated.
             ``restored=False`` indicates that the user does not promise to restore the dynamically
             allocated wires before being deallocated. The default value is ``False``.
+
+        precision (float | None):
+            Target precision for ``"phase-grad"`` allocations. Required when
+            ``state="phase-grad"``; must be a positive float. Must be ``None``
+            for ``"zero"`` and ``"any"`` states. The default value is ``None``.
 
     Returns:
         DynamicRegister: an object, behaving similarly to ``Wires``, that represents the dynamically
@@ -365,15 +401,34 @@ def allocate(
         1: ──H──┤↗│  │0⟩──X─┤
     """
     state = AllocateState(state)
+
+    # Validate precision constraints
+    if precision is not None and not state.is_phase_gradient():
+        raise ValueError(
+            f"precision is only valid for state='phase-grad', got state='{state.value}'."
+        )
+    if state.is_phase_gradient() and precision is None:
+        raise ValueError(
+            "precision is required for state='phase-grad'. "
+            "Provide a positive float, e.g. precision=1e-6."
+        )
+    if precision is not None:
+        if not isinstance(precision, (int, float)):
+            raise TypeError(f"precision must be a positive number, got {type(precision).__name__}.")
+        if precision <= 0:
+            raise ValueError(f"precision must be positive, got {precision}.")
+
     if capture_enabled():
         if is_abstract(num_wires):
             raise NotImplementedError(
                 "Number of allocated wires must be static when capture is enabled."
             )
-        wires = allocate_prim.bind(num_wires=num_wires, state=state, restored=restored)
+        wires = allocate_prim.bind(
+            num_wires=num_wires, state=state, restored=restored, precision=precision
+        )
     else:
         wires = [DynamicWire() for _ in range(num_wires)]
     reg = DynamicRegister(wires)
     if not capture_enabled():
-        Allocate(reg, state=state, restored=restored)
+        Allocate(reg, state=state, restored=restored, precision=precision)
     return reg

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -230,12 +230,14 @@ def _qnode_primitive(
 
 
 @CollectOpsandMeas.register_primitive(allocate_prim)
-def _allocate_primitive(self, *, num_wires, state, restored):
+def _allocate_primitive(self, *, num_wires, state, restored, precision=None):
     wires = [DynamicWire() for _ in range(num_wires)]
     num_dynamic_wires = len(self.state["dynamic_wire_map"])
     int_wires = [np.iinfo(np.int32).max - i - num_dynamic_wires for i in range(num_wires)]
     self.state["dynamic_wire_map"].update(dict(zip(int_wires, wires, strict=True)))
-    self.state["ops"].append(Allocate(int_wires, state=state, restored=restored))
+    self.state["ops"].append(
+        Allocate(int_wires, state=state, restored=restored, precision=precision)
+    )
     return int_wires
 
 

--- a/pennylane/transforms/resolve_dynamic_wires.py
+++ b/pennylane/transforms/resolve_dynamic_wires.py
@@ -37,6 +37,12 @@ class _WireManager:
 
     def _retrieval_method(self, state: AllocateState):
         _retrieval_map = {AllocateState.ZERO: self._get_zeroed, AllocateState.ANY: self._get_any}
+        if state is AllocateState.PHASE_GRAD:
+            raise AllocationError(
+                "Phase-gradient allocation resolution is not yet implemented. "
+                "Concrete preparation and wire scheduling for 'phase-grad' state "
+                "will be added in a follow-up change."
+            )
         return _retrieval_map[state]
 
     @property
@@ -75,8 +81,15 @@ class _WireManager:
         self._loaned[w] = AllocateState.ZERO if restored else AllocateState.ANY
         return w, []
 
-    def get_wire(self, state: AllocateState, restored):
-        """Retrieve a concrete wire label from available registers."""
+    def get_wire(self, state: AllocateState, restored, **_kwargs):
+        """Retrieve a concrete wire label from available registers.
+
+        Extra keyword arguments (e.g. ``precision``) are accepted but not yet
+        used.  This is compatibility plumbing for non-wire allocation metadata
+        passed via ``**op.hyperparameters`` from ``_new_ops``.
+        TODO: Follow-up lowering for phase-gradient allocation should remove the
+        need for generic swallowed kwargs here.
+        """
         if not self._zeroed and not self._any_state:
             self._add_new_wire()
         return self._retrieval_method(state)(restored)

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -84,7 +84,11 @@ class TestAllocateOp:
 
         op = Allocate.from_num_wires(3, state=AllocateState.ANY, restored=True)
         assert len(op.wires) == 3
-        assert op.hyperparameters == {"state": AllocateState.ANY, "restored": True}
+        assert op.hyperparameters == {
+            "state": AllocateState.ANY,
+            "restored": True,
+            "precision": None,
+        }
         assert op.state == AllocateState.ANY
         assert op.restored
 
@@ -93,7 +97,11 @@ class TestAllocateOp:
         wires = [DynamicWire() for _ in range(5)]
         op = Allocate(wires, state=AllocateState.ANY, restored=True)
         assert op.wires == qml.wires.Wires(wires)
-        assert op.hyperparameters == {"state": AllocateState.ANY, "restored": True}
+        assert op.hyperparameters == {
+            "state": AllocateState.ANY,
+            "restored": True,
+            "precision": None,
+        }
         assert op.state == AllocateState.ANY
         assert op.restored
 
@@ -246,6 +254,7 @@ class TestCaptureIntegration:
             "num_wires": 2,
             "state": AllocateState.ZERO,
             "restored": True,
+            "precision": None,
         }
         assert len(jaxpr.eqns[0].outvars) == 2
         assert all(v.aval.shape == () for v in jaxpr.eqns[0].outvars)
@@ -281,6 +290,7 @@ class TestCaptureIntegration:
             "num_wires": 1,
             "state": AllocateState.ZERO,
             "restored": False,
+            "precision": None,
         }
         assert len(jaxpr.eqns[0].outvars) == 1
         assert all(v.aval.shape == () for v in jaxpr.eqns[0].outvars)
@@ -366,3 +376,166 @@ class TestDeviceIntegration:
         atol = 0.05 if mcm_method == "one-shot" else 1e-6
         assert qml.math.allclose(res1, 0, atol=atol)
         assert qml.math.allclose(res2, 0, atol=atol)
+
+
+# ---- Phase-gradient allocation scaffolding tests ----
+
+
+class TestAllocateStatePhaseGrad:
+    """Tests for the PHASE_GRAD member of AllocateState."""
+
+    def test_phase_grad_is_valid_state(self):
+        """Test that 'phase-grad' is a valid AllocateState."""
+        state = AllocateState("phase-grad")
+        assert state is AllocateState.PHASE_GRAD
+
+    def test_is_phase_gradient_true(self):
+        """Test is_phase_gradient returns True for PHASE_GRAD."""
+        assert AllocateState.PHASE_GRAD.is_phase_gradient()
+
+    def test_is_phase_gradient_false_for_zero(self):
+        """Test is_phase_gradient returns False for ZERO."""
+        assert not AllocateState.ZERO.is_phase_gradient()
+
+    def test_is_phase_gradient_false_for_any(self):
+        """Test is_phase_gradient returns False for ANY."""
+        assert not AllocateState.ANY.is_phase_gradient()
+
+
+class TestAllocatePhaseGrad:
+    """Tests for phase-gradient allocation via the allocate function and Allocate op."""
+
+    def test_allocate_phase_grad_returns_register(self):
+        """Test that allocate with state='phase-grad' returns a DynamicRegister."""
+        with qml.queuing.AnnotatedQueue() as q:
+            wires = allocate(3, state="phase-grad", precision=1e-6)
+        assert isinstance(wires, DynamicRegister)
+        assert len(wires) == 3
+
+        op = q.queue[0]
+        assert isinstance(op, Allocate)
+        assert op.state is AllocateState.PHASE_GRAD
+
+    def test_allocate_phase_grad_stores_precision(self):
+        """Test that precision is stored on the queued Allocate op."""
+        with qml.queuing.AnnotatedQueue() as q:
+            allocate(2, state="phase-grad", precision=1e-6)
+
+        op = q.queue[0]
+        assert op.state is AllocateState.PHASE_GRAD
+        assert op.precision == 1e-6
+        assert op.is_phase_gradient
+
+    def test_allocate_phase_grad_precision_required(self):
+        """Test that phase-grad without precision raises ValueError."""
+        with pytest.raises(ValueError, match="precision is required for state='phase-grad'"):
+            allocate(2, state="phase-grad")
+
+    def test_allocate_phase_grad_hyperparameters(self):
+        """Test full hyperparameters dict for phase-grad allocation."""
+        with qml.queuing.AnnotatedQueue() as q:
+            allocate(1, state="phase-grad", precision=0.001, restored=True)
+
+        op = q.queue[0]
+        assert op.hyperparameters == {
+            "state": AllocateState.PHASE_GRAD,
+            "restored": True,
+            "precision": 0.001,
+        }
+
+    def test_allocate_op_from_num_wires_phase_grad(self):
+        """Test Allocate.from_num_wires with phase-grad state."""
+        op = Allocate.from_num_wires(
+            4, state=AllocateState.PHASE_GRAD, precision=1e-4, restored=True
+        )
+        assert len(op.wires) == 4
+        assert op.state is AllocateState.PHASE_GRAD
+        assert op.precision == 1e-4
+        assert op.restored
+        assert op.is_phase_gradient
+
+    def test_zero_state_is_not_phase_gradient(self):
+        """Test Allocate.is_phase_gradient is False for zero state."""
+        op = Allocate.from_num_wires(1)
+        assert not op.is_phase_gradient
+
+    def test_any_state_is_not_phase_gradient(self):
+        """Test Allocate.is_phase_gradient is False for any state."""
+        op = Allocate.from_num_wires(1, state=AllocateState.ANY)
+        assert not op.is_phase_gradient
+
+    def test_zero_state_precision_is_none(self):
+        """Test that default zero state has precision=None."""
+        op = Allocate.from_num_wires(1)
+        assert op.precision is None
+
+
+class TestPhaseGradValidation:
+    """Tests for precision validation rules."""
+
+    def test_precision_required_for_phase_grad(self):
+        """Test that phase-grad without precision raises ValueError."""
+        with pytest.raises(ValueError, match="precision is required for state='phase-grad'"):
+            allocate(2, state="phase-grad")
+
+    def test_precision_rejected_for_zero_state(self):
+        """Test that precision raises ValueError for state='zero'."""
+        with pytest.raises(ValueError, match="precision is only valid for state='phase-grad'"):
+            allocate(2, state="zero", precision=1e-3)
+
+    def test_precision_rejected_for_any_state(self):
+        """Test that precision raises ValueError for state='any'."""
+        with pytest.raises(ValueError, match="precision is only valid for state='phase-grad'"):
+            allocate(2, state="any", precision=1e-3)
+
+    def test_non_positive_precision_rejected(self):
+        """Test that non-positive precision raises ValueError."""
+        with pytest.raises(ValueError, match="precision must be positive"):
+            allocate(2, state="phase-grad", precision=0.0)
+
+        with pytest.raises(ValueError, match="precision must be positive"):
+            allocate(2, state="phase-grad", precision=-1e-3)
+
+    def test_invalid_precision_type_rejected(self):
+        """Test that non-numeric precision raises TypeError."""
+        with pytest.raises(TypeError, match="precision must be a positive number"):
+            allocate(2, state="phase-grad", precision="high")
+
+
+@pytest.mark.jax
+@pytest.mark.capture
+class TestPhaseGradCaptureIntegration:
+    """Tests for phase-gradient params in captured JAXPR."""
+
+    def test_capture_phase_grad_state(self):
+        """Test that phase-grad state is captured in JAXPR params."""
+        import jax
+
+        def f():
+            w = allocate(2, state="phase-grad", precision=1e-6, restored=True)
+            deallocate(w)
+
+        jaxpr = jax.make_jaxpr(f)()
+        assert jaxpr.eqns[0].primitive == allocate_prim
+        assert jaxpr.eqns[0].params == {
+            "num_wires": 2,
+            "state": AllocateState.PHASE_GRAD,
+            "restored": True,
+            "precision": 1e-6,
+        }
+
+    def test_capture_phase_grad_different_precision(self):
+        """Test that different precision values are captured correctly."""
+        import jax
+
+        def f():
+            w = allocate(1, state="phase-grad", precision=0.01)
+            deallocate(w)
+
+        jaxpr = jax.make_jaxpr(f)()
+        assert jaxpr.eqns[0].params == {
+            "num_wires": 1,
+            "state": AllocateState.PHASE_GRAD,
+            "restored": False,
+            "precision": 0.01,
+        }

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -405,6 +405,43 @@ class TestAllocateStatePhaseGrad:
 class TestAllocatePhaseGrad:
     """Tests for phase-gradient allocation via the allocate function and Allocate op."""
 
+    def test_qml_allocate_phase_grad_in_qnode(self):
+        """Test that qml.allocate with phase-grad works inside a QNode at the user level."""
+
+        @qml.qnode(qml.device("default.qubit"))
+        def circuit():
+            qml.H(0)
+            with qml.allocate(2, state="phase-grad", precision=1e-6, restored=True) as wires:
+                qml.CNOT((0, wires[0]))
+                qml.CNOT((wires[0], wires[1]))
+            return qml.expval(qml.Z(0))
+
+        # At the user level, the tape should contain the Allocate op with phase-grad metadata
+        tape = qml.workflow.construct_tape(circuit)()
+        alloc_ops = [op for op in tape.operations if isinstance(op, Allocate)]
+        assert len(alloc_ops) == 1
+        assert alloc_ops[0].state is AllocateState.PHASE_GRAD
+        assert alloc_ops[0].precision == 1e-6
+        assert alloc_ops[0].is_phase_gradient
+
+    def test_qml_allocate_phase_grad_device_execution_raises(self):
+        """Test that device execution of a phase-grad allocation raises AllocationError.
+
+        Phase-gradient wire resolution is not yet implemented, so lowering to
+        device level should produce a clear error rather than silently miscompiling.
+        The inner AllocationError from resolve_dynamic_wires is wrapped by device
+        preprocessing into a higher-level message.
+        """
+
+        @qml.qnode(qml.device("default.qubit", wires=3))
+        def circuit():
+            with qml.allocate(1, state="phase-grad", precision=1e-6, restored=True) as wires:
+                qml.X(wires[0])
+            return qml.expval(qml.Z(0))
+
+        with pytest.raises(qml.exceptions.AllocationError):
+            circuit()
+
     def test_allocate_phase_grad_returns_register(self):
         """Test that allocate with state='phase-grad' returns a DynamicRegister."""
         with qml.queuing.AnnotatedQueue() as q:

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -402,11 +402,12 @@ class TestAllocateStatePhaseGrad:
         assert not AllocateState.ANY.is_phase_gradient()
 
 
+@pytest.mark.integration
 class TestAllocatePhaseGrad:
     """Tests for phase-gradient allocation via the allocate function and Allocate op."""
 
-    def test_qml_allocate_phase_grad_in_qnode(self):
-        """Test that qml.allocate with phase-grad works inside a QNode at the user level."""
+    def test_phase_grad_in_qnode_preserves_metadata(self):
+        """Test that phase-grad allocation inside a QNode preserves state and precision on the tape."""
 
         @qml.qnode(qml.device("default.qubit"))
         def circuit():
@@ -424,7 +425,7 @@ class TestAllocatePhaseGrad:
         assert alloc_ops[0].precision == 1e-6
         assert alloc_ops[0].is_phase_gradient
 
-    def test_qml_allocate_phase_grad_device_execution_raises(self):
+    def test_phase_grad_device_execution_raises(self):
         """Test that device execution of a phase-grad allocation raises AllocationError.
 
         Phase-gradient wire resolution is not yet implemented, so lowering to
@@ -442,7 +443,7 @@ class TestAllocatePhaseGrad:
         with pytest.raises(qml.exceptions.AllocationError):
             circuit()
 
-    def test_allocate_phase_grad_returns_register(self):
+    def test_phase_grad_returns_dynamic_register(self):
         """Test that allocate with state='phase-grad' returns a DynamicRegister."""
         with qml.queuing.AnnotatedQueue() as q:
             wires = allocate(3, state="phase-grad", precision=1e-6)
@@ -453,7 +454,7 @@ class TestAllocatePhaseGrad:
         assert isinstance(op, Allocate)
         assert op.state is AllocateState.PHASE_GRAD
 
-    def test_allocate_phase_grad_stores_precision(self):
+    def test_phase_grad_stores_precision_on_op(self):
         """Test that precision is stored on the queued Allocate op."""
         with qml.queuing.AnnotatedQueue() as q:
             allocate(2, state="phase-grad", precision=1e-6)
@@ -463,12 +464,12 @@ class TestAllocatePhaseGrad:
         assert op.precision == 1e-6
         assert op.is_phase_gradient
 
-    def test_allocate_phase_grad_precision_required(self):
+    def test_phase_grad_precision_required(self):
         """Test that phase-grad without precision raises ValueError."""
         with pytest.raises(ValueError, match="precision is required for state='phase-grad'"):
             allocate(2, state="phase-grad")
 
-    def test_allocate_phase_grad_hyperparameters(self):
+    def test_phase_grad_hyperparameters(self):
         """Test full hyperparameters dict for phase-grad allocation."""
         with qml.queuing.AnnotatedQueue() as q:
             allocate(1, state="phase-grad", precision=0.001, restored=True)
@@ -480,7 +481,7 @@ class TestAllocatePhaseGrad:
             "precision": 0.001,
         }
 
-    def test_allocate_op_from_num_wires_phase_grad(self):
+    def test_from_num_wires_phase_grad(self):
         """Test Allocate.from_num_wires with phase-grad state."""
         op = Allocate.from_num_wires(
             4, state=AllocateState.PHASE_GRAD, precision=1e-4, restored=True

--- a/tests/transforms/test_resolve_dynamic_wires.py
+++ b/tests/transforms/test_resolve_dynamic_wires.py
@@ -250,18 +250,19 @@ class TestReuse:
         qml.assert_equal(expected, new_tape)
 
 
-class TestPhaseGradResolution:
-    """Tests that phase-gradient allocations are explicitly not resolved yet."""
+def test_phase_grad_raises_allocation_error():
+    """Test that resolving a phase-grad allocation raises AllocationError.
 
-    def test_phase_grad_raises_allocation_error(self):
-        """Test that resolving a phase-grad allocation raises AllocationError."""
-        alloc = qml.allocation.Allocate.from_num_wires(
-            2, state=AllocateState.PHASE_GRAD, precision=1e-6
-        )
-        tape = qml.tape.QuantumScript([alloc])
+    Phase-gradient resolution is not yet implemented; this test serves as a
+    placeholder that will be expanded once the feature lands.
+    """
+    alloc = qml.allocation.Allocate.from_num_wires(
+        2, state=AllocateState.PHASE_GRAD, precision=1e-6
+    )
+    tape = qml.tape.QuantumScript([alloc])
 
-        with pytest.raises(
-            qml.exceptions.AllocationError,
-            match="Phase-gradient allocation resolution is not yet implemented",
-        ):
-            qml.transforms.resolve_dynamic_wires(tape, min_int=0)
+    with pytest.raises(
+        qml.exceptions.AllocationError,
+        match="Phase-gradient allocation resolution is not yet implemented",
+    ):
+        qml.transforms.resolve_dynamic_wires(tape, min_int=0)

--- a/tests/transforms/test_resolve_dynamic_wires.py
+++ b/tests/transforms/test_resolve_dynamic_wires.py
@@ -248,3 +248,20 @@ class TestReuse:
 
         expected = qml.tape.QuantumScript([qml.X(2), qml.Y(3)])
         qml.assert_equal(expected, new_tape)
+
+
+class TestPhaseGradResolution:
+    """Tests that phase-gradient allocations are explicitly not resolved yet."""
+
+    def test_phase_grad_raises_allocation_error(self):
+        """Test that resolving a phase-grad allocation raises AllocationError."""
+        alloc = qml.allocation.Allocate.from_num_wires(
+            2, state=AllocateState.PHASE_GRAD, precision=1e-6
+        )
+        tape = qml.tape.QuantumScript([alloc])
+
+        with pytest.raises(
+            qml.exceptions.AllocationError,
+            match="Phase-gradient allocation resolution is not yet implemented",
+        ):
+            qml.transforms.resolve_dynamic_wires(tape, min_int=0)


### PR DESCRIPTION
**Context:**
This PR adds the minimal frontend scaffold for phase-gradient allocation: a distinct `state="phase-grad"` allocation state plus required `precision` metadata preserved through queuing, capture, and tape construction. It intentionally does not yet implement phase-gradient preparation or lowering, and instead draws a clear error boundary for unresolved execution paths.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116441]