### PR TITLE
fix: update `SumOfSlaters` doc-string to no longer have stochastic signed zeros

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,6 +28,7 @@
   [(#8964)](https://github.com/PennyLaneAI/pennylane/pull/8964)
   [(#8997)](https://github.com/PennyLaneAI/pennylane/pull/8997)
   [(#9228)](https://github.com/PennyLaneAI/pennylane/pull/9228)
+  [(#9323)](https://github.com/PennyLaneAI/pennylane/pull/9323)
 
   Consider a sparse state on five qubits, specified by normalized coefficients and statevector
   indices pointing to the populated computational basis states:
@@ -941,9 +942,6 @@ The following classes have been ported over:
   [(#9188)](https://github.com/PennyLaneAI/pennylane/pull/9188)
 
 <h3>Documentation 📝</h3>
-
-* Fix the documentation example in `SumOfSlatersPrep` to prevent stochastic zeros from showing up.
-  [(#9323)](https://github.com/PennyLaneAI/pennylane/pull/9323)
 
 * The `qml` alias as in `import pennylane as qml` has been updated to `qp` in our source code and documentation.
   [(#9310)](https://github.com/PennyLaneAI/pennylane/pull/9310)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -942,6 +942,9 @@ The following classes have been ported over:
 
 <h3>Documentation 📝</h3>
 
+* Fix the documentation example in `SumOfSlatersPrep` to prevent stochastic zeros from showing up.
+  [(#9323)](https://github.com/PennyLaneAI/pennylane/pull/9323)
+
 * The `qml` alias as in `import pennylane as qml` has been updated to `qp` in our source code and documentation.
   [(#9310)](https://github.com/PennyLaneAI/pennylane/pull/9310)
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -703,8 +703,8 @@ class SumOfSlatersPrep(Operation):
     (array([ 0,  1,  2,  4,  8, 16, 32, 64]),)
     >>> # Adding 0.0 to the rounded result will prevent stochastic signed zeros
     >>> print(np.round(prepared_state[where], 4) + 0.0)
-    [ 0.3536+0.j     -0.    -0.3536j  0.    +0.3536j  0.3536+0.j
-      0.3536-0.j      0.    -0.3536j  0.3536-0.j     -0.    +0.3536j]
+    [0.3536+0.j     0.    -0.3536j 0.    +0.3536j 0.3536+0.j
+     0.3536+0.j     0.    -0.3536j 0.3536+0.j     0.    +0.3536j]
 
     That looks exactly right! Internally, the state preparation looks like this:
 
@@ -791,8 +791,8 @@ class SumOfSlatersPrep(Operation):
         (array([ 0,  1,  4, 13, 14, 17, 19, 22, 23, 25]),)
         >>> # Adding 0.0 to the rounded result will prevent stochastic signed zeros
         >>> print(np.round(prepared_state[where], 4) + 0.0)
-        [ 0.25-0.j    0.  +0.25j -0.25+0.j    0.5 -0.j    0.5 +0.j    0.25+0.j
-          0.  -0.25j  0.25+0.j   -0.25-0.j    0.25+0.j  ]
+        [ 0.25+0.j    0.  +0.25j -0.25+0.j    0.5 +0.j    0.5 +0.j    0.25+0.j
+          0.  -0.25j  0.25+0.j   -0.25+0.j    0.25+0.j  ]
 
 
         The reduced circuit looks like this:

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -701,7 +701,8 @@ class SumOfSlatersPrep(Operation):
     >>> where = np.where(prepared_state)
     >>> print(where)
     (array([ 0,  1,  2,  4,  8, 16, 32, 64]),)
-    >>> print(np.round(prepared_state[where], 4))
+    >>> # Adding 0.0 to the rounded result will prevent stochastic signed zeros
+    >>> print(np.round(prepared_state[where], 4) + 0.0)
     [ 0.3536+0.j     -0.    -0.3536j  0.    +0.3536j  0.3536+0.j
       0.3536-0.j      0.    -0.3536j  0.3536-0.j     -0.    +0.3536j]
 
@@ -788,7 +789,8 @@ class SumOfSlatersPrep(Operation):
         >>> where = np.where(np.abs(prepared_state)>1e-12)
         >>> print(where)
         (array([ 0,  1,  4, 13, 14, 17, 19, 22, 23, 25]),)
-        >>> print(np.round(prepared_state[where], 4))
+        >>> # Adding 0.0 to the rounded result will prevent stochastic signed zeros
+        >>> print(np.round(prepared_state[where], 4) + 0.0)
         [ 0.25-0.j    0.  +0.25j -0.25+0.j    0.5 -0.j    0.5 +0.j    0.25+0.j
           0.  -0.25j  0.25+0.j   -0.25-0.j    0.25+0.j  ]
 


### PR DESCRIPTION
**Context:**

This documentation kept failing every now and then because of stochastic signed zeros.

**Description of the Change:**

Use the fact that,

−0.0+0.0=0.0
0.0+0.0=0.0

to prevent this from happening.

**Benefits:**

Consistent doctesting.

**Possible Drawbacks:** Might be strange for users to read.

[sc-117011]
