### PR TITLE
Fix circuit drawing for state measurements with explicit device wires

### DIFF
--- a/pennylane/drawer/_add_obj.py
+++ b/pennylane/drawer/_add_obj.py
@@ -372,7 +372,8 @@ def _add_measurement(
     if m.mv is not None:
         return _add_cwire_measurement(m, layer_str, config)
 
-    layer_str = _add_grouping_symbols(m.wires, layer_str, config)
+    if type(m) not in (StateMP, DensityMatrixMP):
+        layer_str = _add_grouping_symbols(m.wires, layer_str, config)
 
     if m.obs is None:
         obs_label = None


### PR DESCRIPTION
Prevents grouping symbols (╭, ├, ╰) from being added around StateMP and DensityMatrixMP measurements. When a device has explicit wires, these measurements were incorrectly showing grouping symbols, causing the circuit drawing to differ from the case without explicit wires.

Fixes #7807