### PR TITLE
Register jax-jit compatible basis embedding decomp

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -314,6 +314,7 @@ The following classes have been ported over:
   decomposition for traced states without `qjit` to use powers of `X` rather than `RX`.
   [(#9069)](https://github.com/PennyLaneAI/pennylane/pull/9069)
   [(#9124)](https://github.com/PennyLaneAI/pennylane/pull/9124)
+  [(#9339)](https://github.com/PennyLaneAI/pennylane/pull/9339)
 
 * When inspecting a circuit with an integer ``level`` argument in `qp.draw` or `qp.specs`,
   markers in the compilation pipeline are no longer counted towards the level, making inspection more intuitive.

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -16,7 +16,11 @@ Contains the BasisEmbedding template.
 """
 
 from pennylane.decomposition import add_decomps
-from pennylane.ops.qubit.state_preparation import BasisState, _basis_state_decomp
+from pennylane.ops.qubit.state_preparation import (
+    BasisState,
+    _basis_state_decomp,
+    _jax_jit_basis_state_decomp,
+)
 
 
 class BasisEmbedding(BasisState):
@@ -79,4 +83,4 @@ class BasisEmbedding(BasisState):
 
 BasisEmbedding._primitive = BasisState._primitive  # pylint: disable=protected-access
 
-add_decomps(BasisEmbedding, _basis_state_decomp)
+add_decomps(BasisEmbedding, _basis_state_decomp, _jax_jit_basis_state_decomp)


### PR DESCRIPTION
**Context:**
As a follow up to https://github.com/PennyLaneAI/pennylane/pull/9124, the new `_jax_jit_basis_state_decomp` should be registered to `BasisEmbedding` as well since it is equivalent to a `BasisState`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-117397]
