### PR TITLE
fix transformed qnodes with dynamic numbers of shots

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1044,6 +1044,9 @@ The following classes have been ported over:
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug with program capture when a transform is applied to a qnode with a dynamic number of shots
+  and return `qml.sample`.
+
 * Fixed wire overlap validation in :class:`~.QROM` and :class:`~.Select` to support JAX-traced wires,
   enabling `qml.QROM` to be used with `qjit` when wires are passed as dynamic arguments.
   [(#9282)](https://github.com/PennyLaneAI/pennylane/pull/9282)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1046,6 +1046,7 @@ The following classes have been ported over:
 
 * Fixes a bug with program capture when a transform is applied to a qnode with a dynamic number of shots
   and return `qml.sample`.
+  [(#9342)](https://github.com/PennyLaneAI/pennylane/pull/9342)
 
 * Fixed wire overlap validation in :class:`~.QROM` and :class:`~.Select` to support JAX-traced wires,
   enabling `qml.QROM` to be used with `qjit` when wires are passed as dynamic arguments.

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -38,6 +38,7 @@ from pennylane.typing import ResultBatch
 def _create_transform_primitive():
     try:
         # pylint: disable=import-outside-toplevel
+        from pennylane.capture import register_custom_staging_rule
         from pennylane.capture.custom_primitives import QpPrimitive
     except ImportError:
         return None
@@ -56,6 +57,19 @@ def _create_transform_primitive():
     @transform_prim.def_abstract_eval
     def _abstract_eval(*_, inner_jaxpr, **__):
         return [out.aval for out in inner_jaxpr.outvars]
+
+    def setup_env(tracers, params):
+        args_tracers = tracers[slice(*params["args_slice"])]
+        args_vars = params["inner_jaxpr"].invars
+        env = dict(zip(args_vars, args_tracers), strict=True)
+
+        consts_tracers = tracers[slice(*params["consts_slice"])]
+        consts_vars = params["inner_jaxpr"].constvars
+        consts_env = dict(zip(consts_vars, consts_tracers, strict=True))
+        env.update(consts_env)
+        return env
+
+    register_custom_staging_rule(transform_prim, lambda params: params["inner_jaxpr"], setup_env)
 
     return transform_prim
 

--- a/tests/capture/test_capture_transforms.py
+++ b/tests/capture/test_capture_transforms.py
@@ -299,6 +299,59 @@ class TestCaptureTransforms:
         assert qfunc_jaxpr.eqns[1].primitive == qp.Z._primitive
         assert qfunc_jaxpr.eqns[2].primitive == qp.measurements.ExpectationMP._obs_primitive
 
+    @pytest.mark.usefixtures("enable_disable_dynamic_shapes")
+    def test_qnode_returns_dynamic_shape_consts(self):
+        """ "Test that a qnode that returns dynamic shapes can be transformed."""
+
+        def workflow(shots: int):
+            @qp.transform(pass_name="my_other_pass_name")
+            @qp.transform(pass_name="cancel-inverses")
+            @qp.qnode(qp.device("lightning.qubit", wires=1), shots=shots)
+            def aloha():
+                qp.Hadamard(wires=0)
+                return qp.sample()
+
+            return aloha()
+
+        jaxpr = jax.make_jaxpr(workflow)(3)
+
+        j = jaxpr.jaxpr
+        assert j.outvars[0].aval.shape[0] is j.invars[0]
+        assert j.outvars[0].aval.shape[1] == 1
+
+        j2 = j.eqns[0].params["inner_jaxpr"]
+        assert j2.outvars[0].aval.shape[0] is j2.constvars[0]
+        assert j2.outvars[0].aval.shape[1] == 1
+
+        j3 = j2.eqns[0].params["inner_jaxpr"]
+        assert j3.outvars[0].aval.shape[0] is j3.constvars[0]
+        assert j3.outvars[0].aval.shape[1] == 1
+
+    @pytest.mark.usefixtures("enable_disable_dynamic_shapes")
+    def test_qnode_return_dynamic_shapes_args(self):
+        """Test that a function that returns a dynamic shape that depends on an argument can be transformed."""
+
+        def workflow(shots: int):
+            @qp.transform(pass_name="my_other_pass_name")
+            def f(inner_shots):
+                @qp.qnode(qp.device("lightning.qubit", wires=1), shots=inner_shots)
+                def aloha():
+                    return qp.sample()
+
+                return aloha()
+
+            return f(shots)
+
+        jaxpr = jax.make_jaxpr(workflow)(3)
+
+        j = jaxpr.jaxpr
+        assert j.outvars[0].aval.shape[0] is j.invars[0]
+        assert j.outvars[0].aval.shape[1] == 1
+
+        j2 = j.eqns[0].params["inner_jaxpr"]
+        assert j2.outvars[0].aval.shape[0] is j2.invars[0]
+        assert j2.outvars[0].aval.shape[1] == 1
+
 
 class TestTapeTransformFallback:
     """Unit tests for falling back to tape transforms."""


### PR DESCRIPTION
**Context:**

Fixes handling of transformed qnodes that return dynamic shapes.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Replaces #9053 

Fixes https://github.com/PennyLaneAI/pennylane/issues/9054

[[sc-111318](https://app.shortcut.com/xanaduai/story/111318)]