### PR TITLE
Fix Trotter error estimate: variable shadowing in commutator parallel mode

### DIFF
--- a/pennylane/labs/trotter_error/product_formulas/error.py
+++ b/pennylane/labs/trotter_error/product_formulas/error.py
@@ -251,8 +251,8 @@ def perturbation_error(
 
             errors.append(
                 {
-                    order: (1j * timestep) ** order * expectation
-                    for order, expectation in expectations.items()
+                    order: (1j * timestep) ** order * exp
+                    for order, exp in expectations.items()
                 }
             )
 


### PR DESCRIPTION
Good day,

## Problem

In `perturbation_error` with `parallel_mode == 'commutator'`, there is a variable shadowing bug.

The code first accumulates expectation values per order:

```python
for expectation, order in applied_commutators:
    expectations[order] += expectation
```

Then builds the result dictionary:

```python
errors.append(
    {
        order: (1j * timestep) ** order * expectation
        for order, expectation in expectations.items()
    }
)
```

The dict comprehension loop variable `expectation` shadows the outer variable from the prior for-loop. As a result, **every order** is multiplied by the **last** expectation value seen in the outer loop, instead of the correct accumulated value for that specific order.

## Fix

Renamed the comprehension variable from `expectation` to `exp` to avoid the shadowing:

```python
errors.append(
    {
        order: (1j * timestep) ** order * exp
        for order, exp in expectations.items()
    }
)
```

This is a minimal one-line semantic fix (only the variable name in the comprehension was changed).

## Testing

The existing tests in `pennylane/labs/tests/trotter_error/product_formulas/test_error_trotter.py` cover this code path.

---

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly,
RoomWithRoof
