### PR TITLE
Update qml -> qp in top level tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,7 +28,6 @@
   [(#8964)](https://github.com/PennyLaneAI/pennylane/pull/8964)
   [(#8997)](https://github.com/PennyLaneAI/pennylane/pull/8997)
   [(#9228)](https://github.com/PennyLaneAI/pennylane/pull/9228)
-  [(#9228)](https://github.com/PennyLaneAI/pennylane/pull/9228)
   [(#9323)](https://github.com/PennyLaneAI/pennylane/pull/9323)
 
   Consider a sparse state on five qubits, specified by normalized coefficients and statevector

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -28,6 +28,7 @@
   [(#8964)](https://github.com/PennyLaneAI/pennylane/pull/8964)
   [(#8997)](https://github.com/PennyLaneAI/pennylane/pull/8997)
   [(#9228)](https://github.com/PennyLaneAI/pennylane/pull/9228)
+  [(#9228)](https://github.com/PennyLaneAI/pennylane/pull/9228)
   [(#9323)](https://github.com/PennyLaneAI/pennylane/pull/9323)
 
   Consider a sparse state on five qubits, specified by normalized coefficients and statevector
@@ -1015,6 +1016,7 @@ The following classes have been ported over:
   [(#9327)](https://github.com/PennyLaneAI/pennylane/pull/9327)
   [(#9330)](https://github.com/PennyLaneAI/pennylane/pull/9330)
   [(#9325)](https://github.com/PennyLaneAI/pennylane/pull/9325)
+  [(#9358)](https://github.com/PennyLaneAI/pennylane/pull/9358)
 
 * Documentation has been added to :func:`~.transforms.cancel_inverses` and
   :func:`~.transforms.merge_rotations` that details their usage within a ``qjit`` workflow.

--- a/tests/default_qubit_legacy.py
+++ b/tests/default_qubit_legacy.py
@@ -26,7 +26,7 @@ from string import ascii_letters
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import BasisState, Snapshot, StatePrep
 from pennylane._version import __version__
 from pennylane.devices._qubit_device import QubitDevice
@@ -84,7 +84,7 @@ class DefaultQubitLegacy(QubitDevice):
 
         This is the legacy implementation of DefaultQubit and is deprecated. It has been replaced by
         :class:`~pennylane.devices.DefaultQubit`, which can be accessed with the familiar constructor,
-        ``qml.device("default.qubit")``, and now supports backpropagation.
+        ``qp.device("default.qubit")``, and now supports backpropagation.
 
         This change will not alter device behaviour for most workflows, but may have implications for
         plugin developers and users who directly interact with device methods. Please consult
@@ -252,10 +252,10 @@ class DefaultQubitLegacy(QubitDevice):
             if getattr(obj, "has_matrix", False):
                 # pow operations dont work with backprop or adjoint without decomposition
                 # use class name string so we don't need to use isinstance check
-                return not (obj.__class__.__name__[:3] == "Pow" and qml.operation.is_trainable(obj))
+                return not (obj.__class__.__name__[:3] == "Pow" and qp.operation.is_trainable(obj))
             return obj.name in self.observables.union(self.operations)
 
-        return qml.BooleanFn(accepts_obj)
+        return qp.BooleanFn(accepts_obj)
 
     @functools.lru_cache
     def map_wires(self, wires):
@@ -315,10 +315,10 @@ class DefaultQubitLegacy(QubitDevice):
             elif isinstance(operation, Snapshot):
                 if self._debugger and self._debugger.active:
                     if not isinstance(
-                        operation.hyperparameters["measurement"], qml.measurements.StateMP
+                        operation.hyperparameters["measurement"], qp.measurements.StateMP
                     ):
                         raise NotImplementedError(
-                            f"{self.__class__.__name__} only supports `qml.state` measurements."
+                            f"{self.__class__.__name__} only supports `qp.state` measurements."
                         )
                     state_vector = np.array(self._flatten(self._state))
                     if operation.tag:
@@ -380,9 +380,9 @@ class DefaultQubitLegacy(QubitDevice):
 
         return self._apply_unitary(state, matrix, wires)
 
-    def _apply_global_phase(self, state, operation: qml.GlobalPhase):  # pylint: disable=no-self-use
+    def _apply_global_phase(self, state, operation: qp.GlobalPhase):  # pylint: disable=no-self-use
         """Applies a :class:`~.GlobalPhase` operation to the state."""
-        return qml.math.exp(-1j * operation.data[0]) * state
+        return qp.math.exp(-1j * operation.data[0]) * state
 
     def _apply_x(self, state, axes, **kwargs):
         """Applies a PauliX gate by rolling 1 unit along the axis specified in ``axes``.
@@ -650,8 +650,8 @@ class DefaultQubitLegacy(QubitDevice):
 
             # Compute  <psi| H |psi> via sum_i coeff_i * <psi| PauliWord |psi> using a sparse
             # representation of the Pauliword
-            res = qml.math.cast(qml.math.convert_like(0.0, observable.data), dtype=complex)
-            interface = qml.math.get_interface(self.state)
+            res = qp.math.cast(qp.math.convert_like(0.0, observable.data), dtype=complex)
+            interface = qp.math.get_interface(self.state)
 
             # Note: it is important that we use the Hamiltonian's data and not the coeffs
             # attribute. This is because the .data attribute may be 'unwrapped' as required by
@@ -659,30 +659,30 @@ class DefaultQubitLegacy(QubitDevice):
             # that the user provided.
             for op, coeff in zip(observable.ops, observable.data):
                 # extract a scipy.sparse.coo_matrix representation of this Pauli word
-                sparse_mat = qml.prod(op).sparse_matrix(wire_order=self.wires)
+                sparse_mat = qp.prod(op).sparse_matrix(wire_order=self.wires)
                 coo = coo_matrix(sparse_mat)
-                Hmat = qml.math.cast(qml.math.convert_like(coo.data, self.state), self.C_DTYPE)
+                Hmat = qp.math.cast(qp.math.convert_like(coo.data, self.state), self.C_DTYPE)
 
                 product = (
                     self._gather(self._conj(self.state), coo.row)
                     * Hmat
                     * self._gather(self.state, coo.col)
                 )
-                c = qml.math.convert_like(coeff, product)
+                c = qp.math.convert_like(coeff, product)
 
                 if interface == "tensorflow":
-                    c = qml.math.cast(c, "complex128")
+                    c = qp.math.cast(c, "complex128")
 
-                res = qml.math.convert_like(res, product) + qml.math.sum(c * product)
+                res = qp.math.convert_like(res, product) + qp.math.sum(c * product)
 
         else:
             # Coefficients and the state are not trainable, we can be more
             # efficient in how we compute the Hamiltonian sparse matrix.
             Hmat = observable.sparse_matrix(wire_order=self.wires)
 
-            state = qml.math.toarray(self.state)
+            state = qp.math.toarray(self.state)
             if is_state_batched:
-                res = qml.math.array(
+                res = qp.math.array(
                     [
                         csr_matrix.dot(
                             csr_matrix(self._conj(_state)),
@@ -698,7 +698,7 @@ class DefaultQubitLegacy(QubitDevice):
                 ).toarray()[0]
 
         if observable.name in ["Hamiltonian", "LinearCombination"]:
-            res = qml.math.squeeze(res)
+            res = qp.math.squeeze(res)
 
         return self._real(res)
 
@@ -823,8 +823,8 @@ class DefaultQubitLegacy(QubitDevice):
 
         # get computational basis state number
         basis_states = 2 ** (self.num_wires - 1 - np.array(device_wires))
-        basis_states = qml.math.convert_like(basis_states, state)
-        num = int(qml.math.dot(state, basis_states))
+        basis_states = qp.math.convert_like(basis_states, state)
+        num = int(qp.math.dot(state, basis_states))
 
         self._state = self._create_basis_state(num)
 
@@ -991,13 +991,13 @@ class DefaultQubitLegacy(QubitDevice):
         imag_state = self._imag(flat_state)
         return self.marginal_prob(real_state**2 + imag_state**2, wires)
 
-    def _get_diagonalizing_gates(self, circuit: qml.tape.QuantumScript) -> list[Operation]:
+    def _get_diagonalizing_gates(self, circuit: qp.tape.QuantumScript) -> list[Operation]:
         meas_filtered = [
             m
             for m in circuit.measurements
-            if m.obs is None or not isinstance(m.obs, qml.ops.LinearCombination)
+            if m.obs is None or not isinstance(m.obs, qp.ops.LinearCombination)
         ]
-        return super()._get_diagonalizing_gates(qml.tape.QuantumScript(measurements=meas_filtered))
+        return super()._get_diagonalizing_gates(qp.tape.QuantumScript(measurements=meas_filtered))
 
     def sample_basis_states(self, number_of_states, state_probability):
         """Sample from the computational basis states based on the state
@@ -1031,8 +1031,8 @@ class DefaultQubitLegacy(QubitDevice):
         basis_states = np.arange(number_of_states)
         # pylint:disable = import-outside-toplevel
         if (
-            qml.math.is_abstract(state_probability)
-            and qml.math.get_interface(state_probability) == "jax"
+            qp.math.is_abstract(state_probability)
+            and qp.math.get_interface(state_probability) == "jax"
         ):
             import jax
 
@@ -1046,7 +1046,7 @@ class DefaultQubitLegacy(QubitDevice):
                 )
             return jax.random.choice(key, basis_states, shape=(shots,), p=state_probability)
 
-        state_probs = qml.math.unwrap(state_probability)
+        state_probs = qp.math.unwrap(state_probability)
         if self._ndim(state_probability) == 2:
             # np.random.choice does not support broadcasting as needed here.
             return np.array([rng.choice(basis_states, shots, p=prob) for prob in state_probs])

--- a/tests/device_shots_to_analytic.py
+++ b/tests/device_shots_to_analytic.py
@@ -19,18 +19,18 @@ It can be used to eliminate flakiness in shot vector tests.
 import copy
 from types import MethodType
 
-import pennylane as qml
+import pennylane as qp
 
 
-def shots_to_analytic(dev: qml.devices.Device) -> qml.devices.Device:
+def shots_to_analytic(dev: qp.devices.Device) -> qp.devices.Device:
     """Make all executions analytic to prevent flakiness in tests.
 
     .. code-block:: python
 
-        @qml.qnode(shots_to_analytic(qml.device('default.qubit', shots=(1,1,1))))
+        @qp.qnode(shots_to_analytic(qp.device('default.qubit', shots=(1,1,1))))
         def f(x):
-            qml.RX(2*x, 0)
-            return qml.expval(qml.Z(0))
+            qp.RX(2*x, 0)
+            return qp.expval(qp.Z(0))
 
         f(0.5)
 
@@ -45,7 +45,7 @@ def shots_to_analytic(dev: qml.devices.Device) -> qml.devices.Device:
 
     # pylint: disable=unused-argument
     def new_execute(self, circuits, execution_config=None):
-        execution_config = execution_config or qml.devices.ExecutionConfig()
+        execution_config = execution_config or qp.devices.ExecutionConfig()
         results = []
         for c in circuits:
             if c.shots.has_partitioned_shots:

--- a/tests/dummy_debugger.py
+++ b/tests/dummy_debugger.py
@@ -15,7 +15,7 @@
 This file provides a dummy debugger for device tests.
 """
 
-import pennylane as qml
+import pennylane as qp
 
 
 # pylint: disable=too-few-public-methods
@@ -26,7 +26,7 @@ class Debugger:
         # Create a dummy object to act as the device
         # and add a dummy shots attribute to it
         self.device = type("", (), {})()
-        self.device.shots = qml.measurements.Shots(None)
+        self.device.shots = qp.measurements.Shots(None)
 
         self.active = True
         self.snapshots = {}

--- a/tests/gate_data.py
+++ b/tests/gate_data.py
@@ -1,6 +1,6 @@
 """Convenience gate representations for testing"""
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import math
 from pennylane import numpy as np
 
@@ -168,10 +168,10 @@ def Rotx(theta):
     Returns:
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_x \theta/2}`
     """
-    return qml.math.array(
+    return qp.math.array(
         [
-            [qml.math.cos(0.5 * theta), -1j * qml.math.sin(0.5 * theta)],
-            [-1j * qml.math.sin(0.5 * theta), qml.math.cos(0.5 * theta)],
+            [qp.math.cos(0.5 * theta), -1j * qp.math.sin(0.5 * theta)],
+            [-1j * qp.math.sin(0.5 * theta), qp.math.cos(0.5 * theta)],
         ],
         like=theta,
     )
@@ -186,10 +186,10 @@ def Roty(theta):
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_y \theta/2}`
     """
     return (
-        qml.math.array(
+        qp.math.array(
             [
-                [qml.math.cos(0.5 * theta), -qml.math.sin(0.5 * theta)],
-                [qml.math.sin(0.5 * theta), qml.math.cos(0.5 * theta)],
+                [qp.math.cos(0.5 * theta), -qp.math.sin(0.5 * theta)],
+                [qp.math.sin(0.5 * theta), qp.math.cos(0.5 * theta)],
             ],
             like=theta,
         )
@@ -205,8 +205,8 @@ def Rotz(theta):
     Returns:
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_z \theta/2}`
     """
-    return qml.math.array(
-        [[qml.math.exp(-0.5j * theta), 0.0], [0.0, qml.math.exp(0.5j * theta)]], like=theta
+    return qp.math.array(
+        [[qp.math.exp(-0.5j * theta), 0.0], [0.0, qp.math.exp(0.5j * theta)]], like=theta
     )
 
 

--- a/tests/gpu/test_gpu_torch.py
+++ b/tests/gpu/test_gpu_torch.py
@@ -18,7 +18,7 @@ Unit tests for PyTorch GPU support.
 # pylint: disable=protected-access
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 pytestmark_gpu = pytest.mark.gpu
 pytestmark_torch = pytest.mark.torch
@@ -34,15 +34,15 @@ class TestTorchGPUDevice:
     def test_device_to_cuda(self):
         """Checks device executes with cuda is input data is cuda"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         x = torch.tensor(0.1, requires_grad=True, device=torch.device("cuda"))
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(x, wires=0)
-            qml.expval(qml.PauliX(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(x, wires=0)
+            qp.expval(qp.PauliX(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         res = dev.execute(tape)
 
         assert res.is_cuda
@@ -53,17 +53,17 @@ class TestTorchGPUDevice:
     def test_mixed_devices(self):
         """Asserts works with both cuda and cpu input data"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         x = torch.tensor(0.1, requires_grad=True, device=torch.device("cuda"))
         y = torch.tensor(0.2, requires_grad=True, device=torch.device("cpu"))
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=0)
-            qml.expval(qml.PauliX(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=0)
+            qp.expval(qp.PauliX(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         res = dev.execute(tape)
 
         assert res.is_cuda
@@ -76,55 +76,55 @@ class TestTorchGPUDevice:
     def test_matrix_input(self):
         """Test goes to GPU for matrix valued inputs."""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         U = torch.eye(2, requires_grad=False, device=torch.device("cuda"))
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.QubitUnitary(U, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.QubitUnitary(U, wires=0)
+            qp.expval(qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         res = dev.execute(tape)
         assert res.is_cuda
 
     def test_resets(self):
         """Asserts reverts to cpu after execution on gpu"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         x = torch.tensor(0.1, requires_grad=True, device=torch.device("cuda"))
         y = torch.tensor(0.2, requires_grad=True, device=torch.device("cpu"))
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.RX(x, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q1:
+            qp.RX(x, wires=0)
+            qp.expval(qp.PauliZ(0))
 
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         res1 = dev.execute(tape1)
         assert res1.is_cuda
 
-        with qml.queuing.AnnotatedQueue() as q2:
-            qml.RY(y, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q2:
+            qp.RY(y, wires=0)
+            qp.expval(qp.PauliZ(0))
 
-        tape2 = qml.tape.QuantumScript.from_queue(q2)
+        tape2 = qp.tape.QuantumScript.from_queue(q2)
         res2 = dev.execute(tape2)
         assert not res2.is_cuda
 
     def test_integration(self):
         """Test cuda supported when device created in qnode creation."""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         x = torch.tensor(0.1, requires_grad=True, device=torch.device("cuda"))
         y = torch.tensor(0.2, requires_grad=True)
 
-        @qml.qnode(dev, interface="torch", diff_method="backprop")
+        @qp.qnode(dev, interface="torch", diff_method="backprop")
         def circ(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         res = circ(x, y)
         assert res.is_cuda
@@ -137,30 +137,30 @@ class TestTorchGPUDevice:
         """Test that the matrix conversion functionality of the QNode works with
         data on the host or the device.
         """
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
         p = torch.tensor(0.543, dtype=torch.float64, device=par_device)
-        U_in = qml.matrix(qml.RZ(0.9, 0))
+        U_in = qp.matrix(qp.RZ(0.9, 0))
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.QubitUnitary(U_in, wires=0)
-            qml.Hadamard(0)
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliY(0))
+            qp.QubitUnitary(U_in, wires=0)
+            qp.Hadamard(0)
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliY(0))
 
-        U = qml.matrix(circuit, wire_order=[0])(p)
+        U = qp.matrix(circuit, wire_order=[0])(p)
         assert U.device.type == par_device
 
     def test_amplitude_embedding(self):
         """Test that the padding capability of amplitude embedding works with
         GPUs."""
         n_wires = 2
-        dev = qml.device("default.qubit", wires=n_wires)
+        dev = qp.device("default.qubit", wires=n_wires)
 
-        @qml.qnode(dev, interface="torch")
+        @qp.qnode(dev, interface="torch")
         def circuit_cuda(inputs):
-            qml.AmplitudeEmbedding(inputs, wires=range(n_wires), pad_with=0, normalize=True)
-            return qml.expval(qml.PauliZ(0))
+            qp.AmplitudeEmbedding(inputs, wires=range(n_wires), pad_with=0, normalize=True)
+            return qp.expval(qp.PauliZ(0))
 
         inputs = torch.rand(n_wires)  # embedding shorter than 2 ** n_wires
         res1 = circuit_cuda(inputs)
@@ -177,18 +177,18 @@ def test_qnn_torchlayer():
     """Test if TorchLayer can be run on GPU"""
 
     n_qubits = 4
-    dev = qml.device("default.qubit", wires=n_qubits)
+    dev = qp.device("default.qubit", wires=n_qubits)
 
-    @qml.qnode(dev, interface="torch")
+    @qp.qnode(dev, interface="torch")
     def circuit(inputs, weights):
-        qml.templates.AngleEmbedding(inputs, wires=range(n_qubits))
-        qml.templates.BasicEntanglerLayers(weights, wires=range(n_qubits))
-        return [qml.expval(qml.PauliZ(wires=i)) for i in range(n_qubits)]
+        qp.templates.AngleEmbedding(inputs, wires=range(n_qubits))
+        qp.templates.BasicEntanglerLayers(weights, wires=range(n_qubits))
+        return [qp.expval(qp.PauliZ(wires=i)) for i in range(n_qubits)]
 
     n_layers = 1
     weight_shapes = {"weights": (n_layers, n_qubits)}
 
-    qlayer = qml.qnn.TorchLayer(circuit, weight_shapes)
+    qlayer = qp.qnn.TorchLayer(circuit, weight_shapes)
 
     x = torch.rand((5, n_qubits), dtype=torch.float64).to(torch.device("cuda"))
     res = qlayer(x)
@@ -209,13 +209,13 @@ class TestTorchMultiGPUDevice:
     def test_multi_gpu_outval(self):
         """Test that the output value of a multi-GPU QNode is on the correct device."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev, interface="torch")
+        @qp.qnode(dev, interface="torch")
         def circuit(params):
-            qml.RX(params[0], wires=0)
-            qml.RX(params[1], wires=1)
-            return qml.state()
+            qp.RX(params[0], wires=0)
+            qp.RX(params[1], wires=1)
+            return qp.state()
 
         params0 = torch.randn(2, dtype=torch.float64, device="cuda:0")
         res0 = circuit(params0)
@@ -231,7 +231,7 @@ class TestTorchMultiGPUDevice:
         x = torch.tensor([1, 2, 3], device="cuda:1")
         y = torch.tensor([4, 5], device="cuda:1")
 
-        res = qml.math.concatenate([x, y], axis=0)
+        res = qp.math.concatenate([x, y], axis=0)
         assert res.device == torch.device("cuda:1")
 
     def test_dist_tensors_concat(self):
@@ -241,4 +241,4 @@ class TestTorchMultiGPUDevice:
         y = torch.tensor([4, 5], device="cuda:1")
 
         with pytest.raises(RuntimeError, match="Expected all tensors to be on the same device"):
-            qml.math.concatenate([x, y], axis=0)
+            qp.math.concatenate([x, y], axis=0)

--- a/tests/param_shift_dev.py
+++ b/tests/param_shift_dev.py
@@ -18,17 +18,17 @@ This file provides a device that calculates derivatives via parameter shift.
 import dataclasses
 from typing import Optional
 
-import pennylane as qml
+import pennylane as qp
 
 
 # pylint: disable=unused-argument
-class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
+class ParamShiftDerivativesDevice(qp.devices.DefaultQubit):
     """This device provides derivatives via parameter shift."""
 
     name = "param_shift.qubit"
 
     def setup_execution_config(self, config=None, circuit=None):
-        config = config or qml.devices.ExecutionConfig()
+        config = config or qp.devices.ExecutionConfig()
         if config.gradient_method in {"device", "parameter-shift"}:
             config = dataclasses.replace(config, use_device_gradient=True)
             if config.use_device_jacobian_product is None:
@@ -39,7 +39,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
 
     def preprocess_transforms(self, execution_config=None):
         program = super().preprocess_transforms(execution_config)
-        program.add_transform(qml.transform(qml.gradients.param_shift.expand_transform))
+        program.add_transform(qp.transform(qp.gradients.param_shift.expand_transform))
         return program
 
     def supports_derivatives(self, execution_config=None, circuit=None):
@@ -49,7 +49,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
 
     def compute_derivatives(self, circuits, execution_config=None):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = (circuits,)
 
@@ -57,7 +57,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             self.tracker.update(derivative_batches=1, derivatives=len(circuits))
             self.tracker.record()
 
-        diff_batch, fn = qml.gradients.param_shift(circuits)
+        diff_batch, fn = qp.gradients.param_shift(circuits)
         diff_results = self.execute(diff_batch)
 
         jacs = fn(diff_results)
@@ -65,7 +65,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
 
     def execute_and_compute_derivatives(self, circuits, execution_config=None):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = (circuits,)
 
@@ -78,7 +78,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             )
             self.tracker.record()
 
-        diff_batch, fn = qml.gradients.param_shift(circuits)
+        diff_batch, fn = qp.gradients.param_shift(circuits)
         combined_batch = tuple(circuits) + tuple(diff_batch)
         all_results = self.execute(combined_batch)
         results = all_results[: len(circuits)]
@@ -86,10 +86,10 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
         return (results[0], jacs[0]) if is_single_circuit else (results, jacs)
 
     def compute_jvp(
-        self, circuits, tangents, execution_config: Optional[qml.devices.ExecutionConfig] = None
+        self, circuits, tangents, execution_config: Optional[qp.devices.ExecutionConfig] = None
     ):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = (circuits,)
             tangents = (tangents,)
@@ -98,15 +98,15 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             self.tracker.update(jvp_batches=1, jvps=len(circuits))
             self.tracker.record()
 
-        batch, fn = qml.gradients.batch_jvp(circuits, tangents, qml.gradients.param_shift)
+        batch, fn = qp.gradients.batch_jvp(circuits, tangents, qp.gradients.param_shift)
         results = self.execute(batch)
         return fn(results)[0] if is_single_circuit else fn(results)
 
     def execute_and_compute_jvp(
-        self, circuits, tangents, execution_config: Optional[qml.devices.ExecutionConfig] = None
+        self, circuits, tangents, execution_config: Optional[qp.devices.ExecutionConfig] = None
     ):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = [circuits]
             tangents = [tangents]
@@ -119,7 +119,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             )
             self.tracker.record()
 
-        batch, fn = qml.gradients.batch_jvp(circuits, tangents, qml.gradients.param_shift)
+        batch, fn = qp.gradients.batch_jvp(circuits, tangents, qp.gradients.param_shift)
         full_batch = tuple(circuits) + tuple(batch)
         all_results = self.execute(full_batch)
         results = all_results[: len(circuits)]
@@ -127,10 +127,10 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
         return (results[0], jvps[0]) if is_single_circuit else results, jvps
 
     def compute_vjp(
-        self, circuits, cotangents, execution_config: Optional[qml.devices.ExecutionConfig] = None
+        self, circuits, cotangents, execution_config: Optional[qp.devices.ExecutionConfig] = None
     ):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = [circuits]
             cotangents = [cotangents]
@@ -139,15 +139,15 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             self.tracker.update(vjp_batches=1, vjps=len(circuits))
             self.tracker.record()
 
-        batch, fn = qml.gradients.batch_vjp(circuits, cotangents, qml.gradients.param_shift)
+        batch, fn = qp.gradients.batch_vjp(circuits, cotangents, qp.gradients.param_shift)
         results = self.execute(batch)
         return fn(results)[0] if is_single_circuit else fn(results)
 
     def execute_and_compute_vjp(
-        self, circuits, cotangents, execution_config: Optional[qml.devices.ExecutionConfig] = None
+        self, circuits, cotangents, execution_config: Optional[qp.devices.ExecutionConfig] = None
     ):
         is_single_circuit = False
-        if isinstance(circuits, qml.tape.QuantumScript):
+        if isinstance(circuits, qp.tape.QuantumScript):
             is_single_circuit = True
             circuits = [circuits]
             cotangents = [cotangents]
@@ -160,7 +160,7 @@ class ParamShiftDerivativesDevice(qml.devices.DefaultQubit):
             )
             self.tracker.record()
 
-        batch, fn = qml.gradients.batch_vjp(circuits, cotangents, qml.gradients.param_shift)
+        batch, fn = qp.gradients.batch_vjp(circuits, cotangents, qp.gradients.param_shift)
         full_batch = tuple(circuits) + tuple(batch)
         all_results = self.execute(full_batch)
         results = all_results[: len(circuits)]

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -25,7 +25,7 @@ import re
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 
 @pytest.mark.slow
@@ -35,7 +35,7 @@ def test_about():
     """
     f = io.StringIO()
     with contextlib.redirect_stdout(f):
-        qml.about()
+        qp.about()
     out = f.getvalue().strip()
 
     assert "Version:" in out
@@ -43,7 +43,7 @@ def test_about():
     # 0.43.0-rc0 -> 0.43.0rc0
     # 0.43.0-dev0 -> 0.43.0.dev0
     is_rc_version = "rc" in pl_version_match
-    assert qml.version().replace("-", "" if is_rc_version else ".") in pl_version_match
+    assert qp.version().replace("-", "" if is_rc_version else ".") in pl_version_match
     assert "Numpy version" in out
     assert "Scipy version" in out
     assert "default.qubit" in out

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -19,7 +19,7 @@ import uuid
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import allocate, deallocate
 from pennylane.allocation import (
     Allocate,
@@ -77,7 +77,7 @@ class TestAllocateOp:
     def test_valid_operation(self):
         """Test that Allocate is a valid Operator."""
         op = Allocate.from_num_wires(3)
-        qml.ops.functions.assert_valid(op)
+        qp.ops.functions.assert_valid(op)
 
     def test_allocate_from_num_wires(self):
         """Test that the op can be instantiated with from_num_wires"""
@@ -92,7 +92,7 @@ class TestAllocateOp:
         """Test that the op can also be initialized with already created dynamic wires."""
         wires = [DynamicWire() for _ in range(5)]
         op = Allocate(wires, state=AllocateState.ANY, restored=True)
-        assert op.wires == qml.wires.Wires(wires)
+        assert op.wires == qp.wires.Wires(wires)
         assert op.hyperparameters == {"state": AllocateState.ANY, "restored": True}
         assert op.state == AllocateState.ANY
         assert op.restored
@@ -116,16 +116,16 @@ def test_dynamic_register_not_hashable():
     with pytest.raises(TypeError, match="unhashable type"):
         hash(reg)
 
-    with pytest.raises(qml.exceptions.WireError, match="Wires must be hashable"):
-        qml.wires.Wires((0, reg))
+    with pytest.raises(qp.exceptions.WireError, match="Wires must be hashable"):
+        qp.wires.Wires((0, reg))
 
 
 def test_Deallocate_validity():
     """Test that Deallocate is a valid operation."""
     wires = [DynamicWire(), DynamicWire()]
     op = Deallocate(wires)
-    assert op.wires == qml.wires.Wires(wires)
-    qml.ops.functions.assert_valid(op)
+    assert op.wires == qp.wires.Wires(wires)
+    qp.ops.functions.assert_valid(op)
 
 
 def test_error_bad_state():
@@ -137,24 +137,24 @@ def test_error_bad_state():
 
 def test_allocate_function():
     """Test that allocate returns dynamic wires and queues an Allocate op."""
-    with qml.queuing.AnnotatedQueue() as q:
+    with qp.queuing.AnnotatedQueue() as q:
         wires = allocate(4)
     assert isinstance(wires, DynamicRegister)
     assert len(wires) == 4
-    assert isinstance(wires[:3], qml.wires.Wires)
+    assert isinstance(wires[:3], qp.wires.Wires)
     assert all(isinstance(w, DynamicWire) for w in wires)
 
     assert len(q) == 1
     op = q.queue[0]
     assert isinstance(op, Allocate)
-    assert op.wires == qml.wires.Wires(wires)
+    assert op.wires == qp.wires.Wires(wires)
     assert op.state == AllocateState.ZERO
 
 
 def test_allocate_kwargs():
     """Test that the kwargs to allocate get passed to the op."""
 
-    with qml.queuing.AnnotatedQueue() as q:
+    with qp.queuing.AnnotatedQueue() as q:
         allocate(3, state="any", restored=True)
 
     op = q.queue[0]
@@ -167,9 +167,9 @@ class TestDeallocate:
     def test_single_dynamic_wire(self):
         """Test that deallocate can accept a single dynamic wire."""
         wire = DynamicWire()
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             op = deallocate(wire)
-        assert op.wires == qml.wires.Wires((wire,))
+        assert op.wires == qp.wires.Wires((wire,))
 
         assert len(q.queue) == 1
         assert op is q.queue[0]
@@ -184,9 +184,9 @@ class TestDeallocate:
         """Test multiple dynamic wires can be deallocated."""
 
         wires = [DynamicWire(), DynamicWire()]
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             op = deallocate(wires)
-        assert op.wires == qml.wires.Wires(wires)
+        assert op.wires == qp.wires.Wires(wires)
 
         assert len(q.queue) == 1
         assert op is q.queue[0]
@@ -203,18 +203,18 @@ def test_dynamic_register_repr():
 def test_allocate_context_manager():
     """Test that allocate when used as context manager allocates and deallocates qubits."""
 
-    with qml.queuing.AnnotatedQueue() as q:
+    with qp.queuing.AnnotatedQueue() as q:
         with allocate(3, state="any", restored=True) as wires:
             assert len(wires) == 3
             assert all(isinstance(w, DynamicWire) for w in wires)
             assert len(set(wires)) == 3
 
-            qml.I(wires)
+            qp.I(wires)
 
     assert len(q.queue) == 3
-    qml.assert_equal(q.queue[0], Allocate(wires, state=AllocateState.ANY, restored=True))
-    qml.assert_equal(q.queue[1], qml.I(wires))
-    qml.assert_equal(q.queue[2], Deallocate(wires))
+    qp.assert_equal(q.queue[0], Allocate(wires, state=AllocateState.ANY, restored=True))
+    qp.assert_equal(q.queue[1], qp.I(wires))
+    qp.assert_equal(q.queue[2], Deallocate(wires))
 
 
 @pytest.mark.jax
@@ -230,12 +230,12 @@ class TestCaptureIntegration:
         def f():
             if use_context:
                 with allocate(2, state="zero", restored=True) as wires:
-                    qml.H(wires[0])
-                    qml.Z(wires[1])
+                    qp.H(wires[0])
+                    qp.Z(wires[1])
             else:
                 w, w2 = allocate(2, state="zero", restored=True)
-                qml.H(w)
-                qml.Z(w2)
+                qp.H(w)
+                qp.Z(w2)
                 deallocate((w, w2))
 
         jaxpr = jax.make_jaxpr(f)()
@@ -269,7 +269,7 @@ class TestCaptureIntegration:
 
         def f():
             [w] = allocate(1)
-            qml.X(w)
+            qp.X(w)
             deallocate(w)
 
         jaxpr = jax.make_jaxpr(f)()
@@ -300,7 +300,7 @@ class TestCaptureIntegration:
 
         with pytest.raises(NotImplementedError):
             with allocate(2) as wires:
-                qml.X(wires)
+                qp.X(wires)
 
         with pytest.raises(NotImplementedError):
             deallocate(2)
@@ -308,7 +308,7 @@ class TestCaptureIntegration:
     def test_no_dynamic_allocation_size(self):
         """Test that allocation size must be static with capture."""
 
-        @qml.qnode(qml.device("default.qubit", wires=2))
+        @qp.qnode(qp.device("default.qubit", wires=2))
         def c(n: int):
             allocate(n)
 
@@ -327,21 +327,21 @@ class TestDeviceIntegration:
     def test_reuse_without_mcms(self, dev_name, device_wires, seed):
         """Test that a dynamic allocations that do not require mcms can be executed."""
 
-        @qml.qnode(qml.device(dev_name, wires=device_wires, seed=seed))
+        @qp.qnode(qp.device(dev_name, wires=device_wires, seed=seed))
         def c():
             with allocate(1, restored=True) as wires:
-                qml.H(wires)
-                qml.CNOT((wires[0], 0))
-                qml.H(wires)
+                qp.H(wires)
+                qp.CNOT((wires[0], 0))
+                qp.H(wires)
 
             with allocate(1) as wires:
-                qml.H(wires)
-                qml.CNOT((wires[0], 1))
-            return qml.expval(qml.Z(0)), qml.expval(qml.Z(1))
+                qp.H(wires)
+                qp.CNOT((wires[0], 1))
+            return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
 
         res1, res2 = c()
-        assert qml.math.allclose(res1, 0)
-        assert qml.math.allclose(res2, 0)
+        assert qp.math.allclose(res1, 0)
+        assert qp.math.allclose(res2, 0)
 
     @pytest.mark.parametrize("dev_name", ("default.qubit",))
     @pytest.mark.parametrize("device_wires", (None, (0, 1, 2, 3)))
@@ -349,20 +349,20 @@ class TestDeviceIntegration:
     def test_reuse_with_mcms(self, dev_name, device_wires, mcm_method, seed):
         """Test that a simple dynamic allocation can be executed."""
 
-        @qml.set_shots(5000 if mcm_method == "one-shot" else None)
-        @qml.qnode(qml.device(dev_name, wires=device_wires, seed=seed), mcm_method=mcm_method)
+        @qp.set_shots(5000 if mcm_method == "one-shot" else None)
+        @qp.qnode(qp.device(dev_name, wires=device_wires, seed=seed), mcm_method=mcm_method)
         def c():
             with allocate(1, restored=False) as wires:
-                qml.H(wires)
-                qml.CNOT((wires[0], 0))
-                qml.H(wires)
+                qp.H(wires)
+                qp.CNOT((wires[0], 0))
+                qp.H(wires)
 
             with allocate(1) as wires:
-                qml.H(wires)
-                qml.CNOT((wires[0], 1))
-            return qml.expval(qml.Z(0)), qml.expval(qml.Z(1))
+                qp.H(wires)
+                qp.CNOT((wires[0], 1))
+            return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
 
         res1, res2 = c()
         atol = 0.05 if mcm_method == "one-shot" else 1e-6
-        assert qml.math.allclose(res1, 0, atol=atol)
-        assert qml.math.allclose(res2, 0, atol=atol)
+        assert qp.math.allclose(res1, 0, atol=atol)
+        assert qp.math.allclose(res2, 0, atol=atol)

--- a/tests/test_autograd_grad.py
+++ b/tests/test_autograd_grad.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for qml.grad and qml.jacobian
+Unit tests for qp.grad and qp.jacobian
 """
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 
 def test_informative_error_on_bad_shape():
@@ -27,4 +27,4 @@ def test_informative_error_on_bad_shape():
         return (2 * x,)
 
     with pytest.raises(ValueError, match="autograd can only differentiate with"):
-        qml.jacobian(f)(qml.numpy.array(2.0))
+        qp.jacobian(f)(qp.numpy.array(2.0))

--- a/tests/test_boolean_fn.py
+++ b/tests/test_boolean_fn.py
@@ -17,7 +17,7 @@ Unit tests for BooleanFn utility class.
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 
 class TestBooleanFn:
@@ -32,20 +32,20 @@ class TestBooleanFn:
     )
     def test_basic_functionality(self, fn, arg, expected):
         """Test initialization and calling of BooleanFn."""
-        crit = qml.BooleanFn(fn)
+        crit = qp.BooleanFn(fn)
         assert crit(arg) == expected
 
     def test_not(self):
         """Test that logical negation works."""
-        crit = qml.BooleanFn(lambda x: x < 4)
+        crit = qp.BooleanFn(lambda x: x < 4)
         ncrit = ~crit
         assert crit(-2) and not ncrit(-2)
         assert not crit(10) and ncrit(10)
 
     def test_and(self):
         """Test that logical conjunction works."""
-        crit_0 = qml.BooleanFn(lambda x: x > 4)
-        crit_1 = qml.BooleanFn(lambda x: x < 9)
+        crit_0 = qp.BooleanFn(lambda x: x > 4)
+        crit_1 = qp.BooleanFn(lambda x: x < 9)
         crit = crit_0 & crit_1
         assert not crit(-2)
         assert crit(6)
@@ -53,8 +53,8 @@ class TestBooleanFn:
 
     def test_or(self):
         """Test that logical or works."""
-        crit_0 = qml.BooleanFn(lambda x: x < 4)
-        crit_1 = qml.BooleanFn(lambda x: x > 9)
+        crit_0 = qp.BooleanFn(lambda x: x < 4)
+        crit_1 = qp.BooleanFn(lambda x: x > 9)
         crit = crit_0 | crit_1
         assert crit(-2)
         assert not crit(6)
@@ -66,6 +66,6 @@ class TestBooleanFn:
         def greater_than_five(x):
             return x > 5
 
-        func = qml.BooleanFn(greater_than_five)
+        func = qp.BooleanFn(greater_than_five)
 
         assert repr(func) == "BooleanFn(greater_than_five)"

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -18,24 +18,24 @@ Sanity checks for classical automatic gradient formulas (without QNodes).
 import autograd
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as np
 
 
 def test_grad_no_ints():
     """Test that grad raises a `ValueError` if the trainable parameter is an int."""
 
-    x = qml.numpy.array(2)
+    x = qp.numpy.array(2)
 
     def f(x):
         return x**2
 
     with pytest.raises(ValueError, match="Autograd does not support differentiation of ints."):
-        qml.grad(f)(x)
+        qp.grad(f)(x)
 
-    y = qml.numpy.array([2, 2])
+    y = qp.numpy.array([2, 2])
     with pytest.raises(ValueError, match="Autograd does not support differentiation of ints."):
-        qml.jacobian(f)(y)
+        qp.jacobian(f)(y)
 
 
 class TestGradientUnivar:
@@ -44,7 +44,7 @@ class TestGradientUnivar:
     def test_sin(self, tol):
         """Tests with sin function."""
         x_vals = np.linspace(-10, 10, 16, endpoint=False)
-        g = qml.grad(np.sin, 0)
+        g = qp.grad(np.sin, 0)
         auto_grad = [g(x) for x in x_vals]
         correct_grad = np.cos(x_vals)
 
@@ -54,7 +54,7 @@ class TestGradientUnivar:
         """Tests exp function."""
         x_vals = np.linspace(-10, 10, 16, endpoint=False)
         func = lambda x: np.exp(x / 10.0) / 10.0
-        g = qml.grad(func, 0)
+        g = qp.grad(func, 0)
         auto_grad = [g(x) for x in x_vals]
         correct_grad = np.exp(x_vals / 10.0) / 100.0
 
@@ -64,7 +64,7 @@ class TestGradientUnivar:
         """Tests a polynomial function."""
         x_vals = np.linspace(-10, 10, 16, endpoint=False)
         func = lambda x: 2 * x**2 + 3 * x + 4
-        g = qml.grad(func, 0)
+        g = qp.grad(func, 0)
         auto_grad = [g(x) for x in x_vals]
         correct_grad = 4 * x_vals + 3
 
@@ -80,7 +80,7 @@ class TestGradientMultiVar:
         grad_multi_var = lambda x: np.array([np.cos(x[0]), -np.sin(x[1])])
 
         x_vec = [1.5, -2.5]
-        g = qml.grad(multi_var, 0)
+        g = qp.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
@@ -96,7 +96,7 @@ class TestGradientMultiVar:
             ]
         )
         x_vec = np.random.uniform(-5, 5, size=2)
-        g = qml.grad(multi_var, 0)
+        g = qp.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
@@ -107,7 +107,7 @@ class TestGradientMultiVar:
         multi_var = lambda x: np.sum([x_**2 for x_ in x])
         grad_multi_var = lambda x: np.array([2 * x_ for x_ in x])
         x_vec = np.random.uniform(-5, 5, size=2)
-        g = qml.grad(multi_var, 0)
+        g = qp.grad(multi_var, 0)
         auto_grad = g(x_vec)
         correct_grad = grad_multi_var(x_vec)
 
@@ -125,20 +125,20 @@ class TestGradientMultiargs:
         f = lambda x, y: np.sin(x) + np.cos(y)
 
         # gradient wrt first argument
-        gx = qml.grad(f, 0)
+        gx = qp.grad(f, 0)
 
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
         assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
-        gy = qml.grad(f, 1)
+        gy = qp.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
         assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
-        gxy = qml.grad(f, [0, 1])
+        gxy = qp.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
         assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
@@ -154,19 +154,19 @@ class TestGradientMultiargs:
         f = lambda x, y: np.exp(x / 3) * np.tanh(y)
 
         # gradient wrt first argument
-        gx = qml.grad(f, 0)
+        gx = qp.grad(f, 0)
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
         assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
-        gy = qml.grad(f, 1)
+        gy = qp.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
         assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
-        gxy = qml.grad(f, [0, 1])
+        gxy = qp.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
         assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
@@ -179,19 +179,19 @@ class TestGradientMultiargs:
         f = lambda x, y: np.sum([x_**2 for x_ in [x, y]])
 
         # gradient wrt first argument
-        gx = qml.grad(f, 0)
+        gx = qp.grad(f, 0)
         auto_gradx = gx(x, y)
         correct_gradx = gradf(x, y)[0]
         assert np.allclose(auto_gradx, correct_gradx, atol=tol, rtol=0)
 
         # gradient wrt second argument
-        gy = qml.grad(f, 1)
+        gy = qp.grad(f, 1)
         auto_grady = gy(x, y)
         correct_grady = gradf(x, y)[1]
         assert np.allclose(auto_grady, correct_grady, atol=tol, rtol=0)
 
         # gradient wrt both arguments
-        gxy = qml.grad(f, [0, 1])
+        gxy = qp.grad(f, [0, 1])
         auto_gradxy = gxy(x, y)
         correct_gradxy = gradf(x, y)
         assert np.allclose(auto_gradxy, correct_gradxy, atol=tol, rtol=0)
@@ -208,7 +208,7 @@ class TestGradientMultivarMultidim:
         gradf = lambda x: ([[np.cos(x[0, 0])], [-np.sin(x[[1]])]])
         f = lambda x: np.sin(x[0, 0]) + np.cos(x[1, 0])
 
-        g = qml.grad(f, 0)
+        g = qp.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
         assert np.allclose(auto_grad[0], correct_grad[0], atol=tol, rtol=0)
@@ -227,7 +227,7 @@ class TestGradientMultivarMultidim:
         )
         f = lambda x: np.exp(x[0, 0] / 3) * np.tanh(x[1, 0])
 
-        g = qml.grad(f, 0)
+        g = qp.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
         assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
@@ -240,7 +240,7 @@ class TestGradientMultivarMultidim:
         gradf = lambda x: np.array([[2 * x_[0]] for x_ in x])
         f = lambda x: np.sum([x_[0] ** 2 for x_ in x])
 
-        g = qml.grad(f, 0)
+        g = qp.grad(f, 0)
         auto_grad = g(x_vec_multidim)
         correct_grad = gradf(x_vec_multidim)
         assert np.allclose(auto_grad, correct_grad, atol=tol, rtol=0)
@@ -255,7 +255,7 @@ class TestGrad:
         def cost(x):
             return np.sin(x)
 
-        grad_fn = qml.grad(cost, argnums=[0])
+        grad_fn = qp.grad(cost, argnums=[0])
         arr1 = np.array([0.0, 1.0, 2.0], requires_grad=True)
 
         with pytest.raises(TypeError, match="only applies to real scalar-output functions"):
@@ -268,7 +268,7 @@ class TestGrad:
         def cost(x):
             return np.sum(np.sin(x) * x[0] ** 3)
 
-        grad_fn = qml.grad(cost)
+        grad_fn = qp.grad(cost)
         params = np.array([0.5, 1.0, 2.0], requires_grad=True)
         res = grad_fn(params)
         expected = autograd.grad(cost)(params)
@@ -281,7 +281,7 @@ class TestGrad:
         def cost(x):
             return np.sum(np.sin(x) * x[0] ** 3)
 
-        grad_fn = qml.grad(cost)
+        grad_fn = qp.grad(cost)
         params = np.array([-0.654, 1.0, 2.0], requires_grad=True)
 
         assert grad_fn.forward is None
@@ -301,13 +301,13 @@ class TestGrad:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_no_argnum_grad(self, mocker, tol):
-        """Test the qml.grad function for inferred argnums"""
+        """Test the qp.grad function for inferred argnums"""
         cost_fn = lambda x, y: np.sin(x) * np.cos(y) + x * y**2
 
         x = np.array(0.5, requires_grad=True)
         y = np.array(0.2, requires_grad=True)
 
-        grad_fn = qml.grad(cost_fn)
+        grad_fn = qp.grad(cost_fn)
         spy = mocker.spy(grad_fn, "_grad_with_forward")
 
         res = grad_fn(x, y)
@@ -329,25 +329,25 @@ class TestJacobian:
     """Tests for the jacobian function"""
 
     def test_single_argnums_jacobian(self, tol):
-        """Test the qml.jacobian function for a single argnums"""
+        """Test the qp.jacobian function for a single argnums"""
         cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
 
         x = np.array(0.5, requires_grad=True)
         y = np.array(0.2, requires_grad=True)
 
-        jac_fn = qml.jacobian(cost_fn, argnums=0)
+        jac_fn = qp.jacobian(cost_fn, argnums=0)
         res = jac_fn(x, y)
         expected = np.array([np.cos(x) * np.cos(y), y**2])
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     def test_multiple_argnums_jacobian(self, tol):
-        """Test the qml.jacobian function for multiple argnumss"""
+        """Test the qp.jacobian function for multiple argnumss"""
         cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
 
         x = np.array(0.5, requires_grad=True)
         y = np.array(0.2, requires_grad=True)
 
-        jac_fn = qml.jacobian(cost_fn, argnums=[0, 1])
+        jac_fn = qp.jacobian(cost_fn, argnums=[0, 1])
         res = jac_fn(x, y)
         expected = (
             np.array([np.cos(x) * np.cos(y), y**2]),
@@ -356,13 +356,13 @@ class TestJacobian:
         assert all(np.allclose(_r, _e, atol=tol, rtol=0) for _r, _e in zip(res, expected))
 
     def test_no_argnums_jacobian(self, tol):
-        """Test the qml.jacobian function for inferred argnumss"""
+        """Test the qp.jacobian function for inferred argnumss"""
         cost_fn = lambda x, y: np.array([np.sin(x) * np.cos(y), x * y**2])
 
         x = np.array(0.5, requires_grad=True)
         y = np.array(0.2, requires_grad=True)
 
-        jac_fn = qml.jacobian(cost_fn)
+        jac_fn = qp.jacobian(cost_fn)
         res = jac_fn(x, y)
         expected = (
             np.array([np.cos(x) * np.cos(y), y**2]),

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -22,7 +22,7 @@ import mcm_utils
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as np
 from pennylane.exceptions import CompileError
 from pennylane.transforms.dynamic_one_shot import fill_in_value
@@ -50,96 +50,96 @@ def catalyst_incompatible_version():
 def test_catalyst_incompatible():
     """Test qjit with an incompatible Catalyst version that's lower than required."""
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit():
-        qml.PauliX(0)
-        return qml.state()
+        qp.PauliX(0)
+        return qp.state()
 
     with pytest.raises(
         CompileError,
         match="PennyLane-Catalyst 0.[0-9]+.0 or greater is required, but installed 0.0.1",
     ):
-        qml.qjit(circuit)()
+        qp.qjit(circuit)()
 
 
 class TestCatalyst:
-    """Test ``qml.qjit`` with Catalyst"""
+    """Test ``qp.qjit`` with Catalyst"""
 
     def test_compiler(self):
         """Test compiler active and available methods"""
 
-        assert not qml.compiler.active()
-        assert not qml.compiler.available("SomeRandomCompiler")
+        assert not qp.compiler.active()
+        assert not qp.compiler.available("SomeRandomCompiler")
 
-        assert qml.compiler.available("catalyst")
-        assert qml.compiler.available_compilers() == ["catalyst", "cuda_quantum"]
+        assert qp.compiler.available("catalyst")
+        assert qp.compiler.available_compilers() == ["catalyst", "cuda_quantum"]
 
     def test_active_compiler(self):
-        """Test `qml.compiler.active_compiler` inside a simple circuit"""
-        dev = qml.device("lightning.qubit", wires=2)
+        """Test `qp.compiler.active_compiler` inside a simple circuit"""
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(phi, theta):
-            if qml.compiler.active_compiler() == "catalyst":
-                qml.RX(phi, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PhaseShift(theta, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            if qp.compiler.active_compiler() == "catalyst":
+                qp.RX(phi, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PhaseShift(theta, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(jnp.pi, jnp.pi / 2), 1.0)
-        assert jnp.allclose(qml.qjit(circuit)(jnp.pi, jnp.pi / 2), -1.0)
+        assert jnp.allclose(qp.qjit(circuit)(jnp.pi, jnp.pi / 2), -1.0)
 
     def test_active(self):
-        """Test `qml.compiler.active` inside a simple circuit"""
-        dev = qml.device("lightning.qubit", wires=2)
+        """Test `qp.compiler.active` inside a simple circuit"""
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(phi, theta):
-            if qml.compiler.active():
-                qml.RX(phi, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PhaseShift(theta, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            if qp.compiler.active():
+                qp.RX(phi, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PhaseShift(theta, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(jnp.pi, jnp.pi / 2), 1.0)
-        assert jnp.allclose(qml.qjit(circuit)(jnp.pi, jnp.pi / 2), -1.0)
+        assert jnp.allclose(qp.qjit(circuit)(jnp.pi, jnp.pi / 2), -1.0)
 
     @pytest.mark.parametrize("jax_enable_x64", [False, True])
     def test_jax_enable_x64(self, jax_enable_x64):
-        """Test whether `qml.compiler.active` changes `jax_enable_x64`."""
+        """Test whether `qp.compiler.active` changes `jax_enable_x64`."""
         jax.config.update("jax_enable_x64", jax_enable_x64)
         assert jax.config.jax_enable_x64 is jax_enable_x64
-        qml.compiler.active()
+        qp.compiler.active()
         assert jax.config.jax_enable_x64 is jax_enable_x64
 
     def test_qjit_circuit(self):
         """Test JIT compilation of a circuit with 2-qubit"""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(theta):
-            qml.Hadamard(wires=0)
-            qml.RX(theta, wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=0)
+            qp.RX(theta, wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
         assert jnp.allclose(circuit(0.5), 0.0)
 
     def test_qjit_aot(self):
         """Test AOT compilation of a circuit with 2-qubit"""
 
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(x: complex, z: ShapedArray(shape=(3,), dtype=jnp.float64)):
             theta = jnp.abs(x)
-            qml.RY(theta, wires=0)
-            qml.Rot(z[0], z[1], z[2], wires=0)
-            return qml.state()
+            qp.RY(theta, wires=0)
+            qp.Rot(z[0], z[1], z[2], wires=0)
+            return qp.state()
 
         # Check that the compilation happens at definition
         assert circuit.compiled_function
@@ -159,19 +159,19 @@ class TestCatalyst:
     )
     def test_variable_capture_multiple_devices(self, _in, _out):
         """Test variable capture using multiple backend devices."""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
+        @qp.qjit
         def workflow(n: int):
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def f(x: float):
-                qml.RX(n * x, wires=n)
-                return qml.expval(qml.PauliZ(wires=n))
+                qp.RX(n * x, wires=n)
+                return qp.expval(qp.PauliZ(wires=n))
 
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def g(x: float):
-                qml.RX(x, wires=1)
-                return qml.expval(qml.PauliZ(wires=1))
+                qp.RX(x, wires=1)
+                return qp.expval(qp.PauliZ(wires=1))
 
             return jnp.array_equal(f(jnp.pi), g(jnp.pi))
 
@@ -180,7 +180,7 @@ class TestCatalyst:
     def test_args_workflow(self):
         """Test arguments with workflows."""
 
-        @qml.qjit
+        @qp.qjit
         def workflow1(params1, params2):
             """A classical workflow"""
             res1 = params1["a"][0][0] + params2[1]
@@ -196,18 +196,18 @@ class TestCatalyst:
 
     def test_return_value_dict(self):
         """Test pytree return values."""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit1(params):
-            qml.RX(params[0], wires=0)
-            qml.RX(params[1], wires=1)
+            qp.RX(params[0], wires=0)
+            qp.RX(params[1], wires=1)
             return {
-                "w0": qml.expval(qml.PauliZ(0)),
-                "w1": qml.expval(qml.PauliZ(1)),
+                "w0": qp.expval(qp.PauliZ(0)),
+                "w1": qp.expval(qp.PauliZ(1)),
             }
 
-        jitted_fn = qml.qjit(circuit1)
+        jitted_fn = qp.qjit(circuit1)
 
         params = [0.2, 0.6]
         expected = {"w0": 0.98006658, "w1": 0.82533561}
@@ -218,31 +218,31 @@ class TestCatalyst:
 
     def test_qjit_python_if(self):
         """Test JIT compilation with the autograph support"""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit(autograph=True)
-        @qml.qnode(dev)
+        @qp.qjit(autograph=True)
+        @qp.qnode(dev)
         def circuit(x: int):
             if x < 5:
-                qml.Hadamard(wires=0)
+                qp.Hadamard(wires=0)
             else:
-                qml.T(wires=0)
+                qp.T(wires=0)
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(3), 0.0)
         assert jnp.allclose(circuit(5), 1.0)
 
     def test_compilation_opt(self):
         """Test user-configurable compilation options"""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit(target="mlir", keep_intermediate=True)
-        @qml.qnode(dev)
+        @qp.qjit(target="mlir", keep_intermediate=True)
+        @qp.qnode(dev)
         def circuit(x: float):
-            qml.RX(x, wires=0)
-            qml.RX(x**2, wires=1)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RX(x**2, wires=1)
+            return qp.expval(qp.PauliZ(0))
 
         mlir_str = str(circuit.mlir)
         result_header = "func.func public @circuit(%arg0: tensor<f64>) -> tensor<f64>"
@@ -251,62 +251,62 @@ class TestCatalyst:
 
     def test_qjit_adjoint(self):
         """Test JIT compilation with adjoint support"""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
-        @qml.qnode(device=dev)
+        @qp.qjit
+        @qp.qnode(device=dev)
         def workflow_cl(theta, wires):
             def func():
-                qml.RX(theta, wires=wires)
+                qp.RX(theta, wires=wires)
 
-            qml.adjoint(func)()
-            return qml.probs()
+            qp.adjoint(func)()
+            return qp.probs()
 
-        @qml.qnode(device=dev)
+        @qp.qnode(device=dev)
         def workflow_pl(theta, wires):
             def func():
-                qml.RX(theta, wires=wires)
+                qp.RX(theta, wires=wires)
 
-            qml.adjoint(func)()
-            return qml.probs()
+            qp.adjoint(func)()
+            return qp.probs()
 
         assert jnp.allclose(workflow_cl(0.1, [1]), workflow_pl(0.1, [1]))
 
     def test_qjit_adjoint_lazy(self):
         """Test that the lazy kwarg is supported."""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qnode(device=dev)
+        @qp.qnode(device=dev)
         def workflow_pl(theta, wires):
-            qml.Hadamard(wires)
-            qml.adjoint(qml.RX(theta, wires=wires), lazy=False)
-            return qml.probs()
+            qp.Hadamard(wires)
+            qp.adjoint(qp.RX(theta, wires=wires), lazy=False)
+            return qp.probs()
 
-        workflow_cl = qml.qjit(workflow_pl)
+        workflow_cl = qp.qjit(workflow_pl)
 
         assert jnp.allclose(workflow_cl(0.1, [1]), workflow_pl(0.1, [1]))
 
     def test_control(self):
         """Test that control works with qjit."""
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def workflow(theta, w, cw):
-            qml.Hadamard(wires=[0])
-            qml.Hadamard(wires=[1])
+            qp.Hadamard(wires=[0])
+            qp.Hadamard(wires=[1])
 
             def func(arg):
-                qml.RX(theta, wires=arg)
+                qp.RX(theta, wires=arg)
 
             def cond_fn():
-                qml.RY(theta, wires=w)
+                qp.RY(theta, wires=w)
 
-            qml.ctrl(func, control=[cw])(w)
-            qml.ctrl(qml.cond(theta > 0.0, cond_fn), control=[cw])()
-            qml.ctrl(qml.RZ, control=[cw])(theta, wires=w)
-            qml.ctrl(qml.RY(theta, wires=w), control=[cw])
-            return qml.probs()
+            qp.ctrl(func, control=[cw])(w)
+            qp.ctrl(qp.cond(theta > 0.0, cond_fn), control=[cw])()
+            qp.ctrl(qp.RZ, control=[cw])(theta, wires=w)
+            qp.ctrl(qp.RY(theta, wires=w), control=[cw])
+            return qp.probs()
 
         assert jnp.allclose(
             workflow(jnp.pi / 4, 1, 0), jnp.array([0.25, 0.25, 0.03661165, 0.46338835])
@@ -314,7 +314,7 @@ class TestCatalyst:
 
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_ctrl_work_wire_type_preserved_in_qjit(self, work_wire_type):
-        """Test that ``work_wire_type`` passed to ``qml.ctrl`` is propagated through the Catalyst
+        """Test that ``work_wire_type`` passed to ``qp.ctrl`` is propagated through the Catalyst
         compiler"""
         x_wires = [1, 2, 3]
         output = [4, 5, 6]
@@ -322,10 +322,10 @@ class TestCatalyst:
         control_wire = [0]
         work_wires_ctrl = [9]
 
-        @qml.qjit
+        @qp.qjit
         def func():
-            return qml.ctrl(
-                qml.SemiAdder(
+            return qp.ctrl(
+                qp.SemiAdder(
                     x_wires=x_wires,
                     y_wires=output,
                     work_wires=work_wires_add,
@@ -338,41 +338,41 @@ class TestCatalyst:
         op = func()
         assert op.hyperparameters["work_wire_type"] == work_wire_type
         assert op.work_wire_type == work_wire_type
-        assert op.control_wires == qml.wires.Wires(control_wire)
-        assert op.work_wires == qml.wires.Wires(work_wires_ctrl)
+        assert op.control_wires == qp.wires.Wires(control_wire)
+        assert op.work_wires == qp.wires.Wires(work_wires_ctrl)
 
 
 class TestCatalystControlFlow:
-    """Test ``qml.qjit`` with Catalyst's control-flow operations"""
+    """Test ``qp.qjit`` with Catalyst's control-flow operations"""
 
     def test_while_loop_defined_outside_qjit(self):
         """Test that the while loop can be defined outside the qjit."""
 
-        @qml.while_loop(lambda n: n < 4)
+        @qp.while_loop(lambda n: n < 4)
         def w(n):
             return n + 1
 
-        res = qml.qjit(w)(0)
-        assert qml.math.allclose(res, 4)
+        res = qp.qjit(w)(0)
+        assert qp.math.allclose(res, 4)
 
     def test_for_loop_defined_outside_qjit(self):
         """Test that a for_loop can be defined outside the qjit."""
 
-        @qml.for_loop(5)
+        @qp.for_loop(5)
         def f(i, x):
             return x + i
 
-        res = qml.qjit(f)(0)
-        assert qml.math.allclose(res, 10)
+        res = qp.qjit(f)(0)
+        assert qp.math.allclose(res, 10)
 
     def test_for_loop_dynamic_shapes(self):
         """Test that dynamic shapes work with default args."""
 
-        @qml.qjit
+        @qp.qjit
         def f(sz):
             x = jnp.ones([sz], dtype=float)
 
-            @qml.for_loop(0, 3, 1)
+            @qp.for_loop(0, 3, 1)
             def loop(_, a):
                 return a + x
 
@@ -381,17 +381,17 @@ class TestCatalystControlFlow:
 
         result = f(3)
         expected = 4 * jnp.ones(3)
-        assert qml.math.allclose(result, expected)
+        assert qp.math.allclose(result, expected)
 
     def test_while_loop_dynamic_shapes(self):
         """Test that while loops work with default args."""
 
-        @qml.qjit
-        @qml.qnode(qml.device("lightning.qubit", wires=4))
+        @qp.qjit
+        @qp.qnode(qp.device("lightning.qubit", wires=4))
         def f(sz):
             x = jnp.ones([sz], dtype=float)
 
-            @qml.while_loop(lambda i, _: i < 3)
+            @qp.while_loop(lambda i, _: i < 3)
             def loop(i, a):
                 return i + 1, a + x
 
@@ -400,35 +400,35 @@ class TestCatalystControlFlow:
 
         result = f(3)
         expected = 3 * jnp.ones(3)
-        assert qml.math.allclose(result, expected)
+        assert qp.math.allclose(result, expected)
 
     def test_alternating_while_loop(self):
         """Test simple while loop."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(n):
-            @qml.while_loop(lambda v: v[0] < v[1])
+            @qp.while_loop(lambda v: v[0] < v[1])
             def loop(v):
-                qml.PauliX(wires=0)
+                qp.PauliX(wires=0)
                 return v[0] + 1, v[1]
 
             loop((0, n))
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1), -1.0)
 
     def test_nested_while_loops(self):
         """Test nested while loops."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(n, m):
-            @qml.while_loop(lambda i, _: i < n)
+            @qp.while_loop(lambda i, _: i < n)
             def outer(i, sm):
-                @qml.while_loop(lambda j: j < m)
+                @qp.while_loop(lambda j: j < m)
                 def inner(j):
                     return j + 1
 
@@ -441,19 +441,19 @@ class TestCatalystControlFlow:
 
     def test_dynamic_wires_for_loops(self):
         """Test for loops with iteration index-dependant wires."""
-        dev = qml.device("lightning.qubit", wires=6)
+        dev = qp.device("lightning.qubit", wires=6)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(n: int):
-            qml.Hadamard(wires=0)
+            qp.Hadamard(wires=0)
 
-            @qml.for_loop(0, n - 1, 1)
+            @qp.for_loop(0, n - 1, 1)
             def loop_fn(i):
-                qml.CNOT(wires=[i, i + 1])
+                qp.CNOT(wires=[i, i + 1])
 
             loop_fn()
-            return qml.state()
+            return qp.state()
 
         expected = np.zeros(2**6)
         expected[[0, 2**6 - 1]] = 1 / np.sqrt(2)
@@ -462,24 +462,24 @@ class TestCatalystControlFlow:
 
     def test_nested_for_loops(self):
         """Test nested for loops."""
-        dev = qml.device("lightning.qubit", wires=4)
+        dev = qp.device("lightning.qubit", wires=4)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(n):
             # Input state: equal superposition
-            @qml.for_loop(0, n, 1)
+            @qp.for_loop(0, n, 1)
             def init(i):
-                qml.Hadamard(wires=i)
+                qp.Hadamard(wires=i)
 
             # QFT
-            @qml.for_loop(0, n, 1)
+            @qp.for_loop(0, n, 1)
             def qft(i):
-                qml.Hadamard(wires=i)
+                qp.Hadamard(wires=i)
 
-                @qml.for_loop(i + 1, n, 1)
+                @qp.for_loop(i + 1, n, 1)
                 def inner(j):
-                    qml.ControlledPhaseShift(np.pi / 2 ** (n - j + 1), [i, j])
+                    qp.ControlledPhaseShift(np.pi / 2 ** (n - j + 1), [i, j])
 
                 inner()
 
@@ -487,113 +487,113 @@ class TestCatalystControlFlow:
             qft()
 
             # Expected output: |100...>
-            return qml.state()
+            return qp.state()
 
         assert jnp.allclose(circuit(4), jnp.eye(2**4)[0])
 
     def test_cond(self):
         """Test condition with simple true_fn"""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(x: float):
             def ansatz_true():
-                qml.RX(x, wires=0)
-                qml.Hadamard(wires=0)
+                qp.RX(x, wires=0)
+                qp.Hadamard(wires=0)
 
-            qml.cond(x > 1.4, ansatz_true)()
+            qp.cond(x > 1.4, ansatz_true)()
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1.4), 1.0)
         assert jnp.allclose(circuit(1.6), 0.0)
 
     def test_cond_with_else(self):
         """Test condition with simple true_fn and false_fn"""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(x: float):
             def ansatz_true():
-                qml.RX(x, wires=0)
-                qml.Hadamard(wires=0)
+                qp.RX(x, wires=0)
+                qp.Hadamard(wires=0)
 
             def ansatz_false():
-                qml.RY(x, wires=0)
+                qp.RY(x, wires=0)
 
-            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+            qp.cond(x > 1.4, ansatz_true, ansatz_false)()
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1.4), 0.16996714)
         assert jnp.allclose(circuit(1.6), 0.0)
 
     def test_cond_with_elif(self):
         """Test condition with a simple elif branch"""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(x):
             def true_fn():
-                qml.RX(x, wires=0)
+                qp.RX(x, wires=0)
 
             def elif_fn():
-                qml.RY(x, wires=0)
+                qp.RY(x, wires=0)
 
             def false_fn():
-                qml.RX(x**2, wires=0)
+                qp.RX(x**2, wires=0)
 
-            qml.cond(x > 2.7, true_fn, false_fn, ((x > 1.4, elif_fn),))()
+            qp.cond(x > 2.7, true_fn, false_fn, ((x > 1.4, elif_fn),))()
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1.2), 0.13042371)
         assert jnp.allclose(circuit(jnp.pi), -1.0)
 
     def test_cond_with_elifs(self):
         """Test condition with multiple elif branches"""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.qnode(dev)
         def circuit(x):
             def true_fn():
-                qml.RX(x, wires=0)
+                qp.RX(x, wires=0)
 
             def elif1_fn():
-                qml.RY(x, wires=0)
+                qp.RY(x, wires=0)
 
             def elif2_fn():
-                qml.RZ(x, wires=0)
+                qp.RZ(x, wires=0)
 
             def false_fn():
-                qml.RX(x**2, wires=0)
+                qp.RX(x**2, wires=0)
 
-            qml.cond(x > 2.7, true_fn, false_fn, ((x > 2.4, elif1_fn), (x > 1.4, elif2_fn)))()
+            qp.cond(x > 2.7, true_fn, false_fn, ((x > 2.4, elif1_fn), (x > 1.4, elif2_fn)))()
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1.5), 1.0)
         assert jnp.allclose(circuit(jnp.pi), -1.0)
 
     def test_cond_with_elif_interpreted(self):
         """Test condition with an elif branch in interpreted mode"""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
             def true_fn():
-                qml.RX(x, wires=0)
+                qp.RX(x, wires=0)
 
             def elif_fn():
-                qml.RX(x**2, wires=0)
+                qp.RX(x**2, wires=0)
 
-            qml.cond(x > 2.7, true_fn, None, ((x > 1.4, elif_fn),))()
+            qp.cond(x > 2.7, true_fn, None, ((x > 1.4, elif_fn),))()
 
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(1.2), 1.0)
         assert jnp.allclose(circuit(jnp.pi), -1.0)
@@ -601,9 +601,9 @@ class TestCatalystControlFlow:
     def test_cond_with_decorator_syntax(self):
         """Test condition using the decorator syntax"""
 
-        @qml.qjit
+        @qp.qjit
         def f(x):
-            @qml.cond(x > 0)
+            @qp.cond(x > 0)
             def conditional():
                 return (x + 1) ** 2
 
@@ -623,19 +623,19 @@ class TestCatalystControlFlow:
 
 
 class TestCatalystGrad:
-    """Test ``qml.qjit`` with Catalyst's grad operations"""
+    """Test ``qp.qjit`` with Catalyst's grad operations"""
 
     @pytest.mark.parametrize("argnums", (None, 0))
-    @pytest.mark.parametrize("g_fn", (qml.grad, qml.jacobian))
+    @pytest.mark.parametrize("g_fn", (qp.grad, qp.jacobian))
     def test_lazy_dispatch_grad(self, g_fn, argnums):
         """Test that grad is lazily dispatched to the catalyst version at runtime."""
 
         def f(x):
             return x**2
 
-        g = qml.qjit(g_fn(f, argnums=argnums))(0.5)
-        assert qml.math.allclose(g, 1.0)
-        assert qml.math.get_interface(g) == "jax"
+        g = qp.qjit(g_fn(f, argnums=argnums))(0.5)
+        assert qp.math.allclose(g, 1.0)
+        assert qp.math.get_interface(g) == "jax"
 
     @pytest.mark.parametrize("argnums", (None, 0))
     def test_lazy_dispatch_value_and_grad(self, argnums):
@@ -644,66 +644,66 @@ class TestCatalystGrad:
         def f(x):
             return x**2
 
-        r, g = qml.qjit(qml.value_and_grad(f, argnums=argnums))(0.5)
-        assert qml.math.allclose(r, 0.25)
-        assert qml.math.allclose(g, 1.0)
-        assert qml.math.get_interface(g) == "jax"
+        r, g = qp.qjit(qp.value_and_grad(f, argnums=argnums))(0.5)
+        assert qp.math.allclose(r, 0.25)
+        assert qp.math.allclose(g, 1.0)
+        assert qp.math.get_interface(g) == "jax"
 
     def test_grad_classical_preprocessing(self):
         """Test the grad transformation with classical preprocessing."""
 
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
+        @qp.qjit
         def workflow(x):
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def circuit(x):
-                qml.RX(jnp.pi * x, wires=0)
-                return qml.expval(qml.PauliY(0))
+                qp.RX(jnp.pi * x, wires=0)
+                return qp.expval(qp.PauliY(0))
 
-            g = qml.grad(circuit)
+            g = qp.grad(circuit)
             return g(x)
 
         assert jnp.allclose(workflow(2.0), -jnp.pi)
 
     def test_grad_with_postprocessing(self):
         """Test the grad transformation with classical preprocessing and postprocessing."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
+        @qp.qjit
         def workflow(theta):
-            @qml.qnode(dev, diff_method="adjoint")
+            @qp.qnode(dev, diff_method="adjoint")
             def circuit(theta):
-                qml.RX(jnp.exp(theta**2) / jnp.cos(theta / 4), wires=0)
-                return qml.expval(qml.PauliZ(wires=0))
+                qp.RX(jnp.exp(theta**2) / jnp.cos(theta / 4), wires=0)
+                return qp.expval(qp.PauliZ(wires=0))
 
             def loss(theta):
                 return jnp.pi / jnp.tanh(circuit(theta))
 
-            return qml.grad(loss, method="auto")(theta)
+            return qp.grad(loss, method="auto")(theta)
 
         assert jnp.allclose(workflow(1.0), 5.04324559)
 
     def test_grad_with_multiple_qnodes(self):
         """Test the grad transformation with multiple QNodes with their own differentiation methods."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
+        @qp.qjit
         def workflow(theta):
-            @qml.qnode(dev, diff_method="parameter-shift")
+            @qp.qnode(dev, diff_method="parameter-shift")
             def circuit_A(params):
-                qml.RX(jnp.exp(params[0] ** 2) / jnp.cos(params[1] / 4), wires=0)
-                return qml.probs()
+                qp.RX(jnp.exp(params[0] ** 2) / jnp.cos(params[1] / 4), wires=0)
+                return qp.probs()
 
-            @qml.qnode(dev, diff_method="adjoint")
+            @qp.qnode(dev, diff_method="adjoint")
             def circuit_B(params):
-                qml.RX(jnp.exp(params[1] ** 2) / jnp.cos(params[0] / 4), wires=0)
-                return qml.expval(qml.PauliZ(wires=0))
+                qp.RX(jnp.exp(params[1] ** 2) / jnp.cos(params[0] / 4), wires=0)
+                return qp.expval(qp.PauliZ(wires=0))
 
             def loss(params):
                 return jnp.prod(circuit_A(params)) + circuit_B(params)
 
-            return qml.grad(loss)(theta)
+            return qp.grad(loss)(theta)
 
         result = workflow(jnp.array([1.0, 2.0]))
         reference = jnp.array([0.57367285, 44.4911605])
@@ -716,77 +716,77 @@ class TestCatalystGrad:
         def square(x: float):
             return x**2
 
-        @qml.qjit
+        @qp.qjit
         def dsquare(x: float):
-            return qml.grad(square)(x)
+            return qp.grad(square)(x)
 
         assert jnp.allclose(dsquare(2.3), 4.6)
 
     def test_jacobian_diff_method(self):
         """Test the Jacobian transformation with the device diff_method."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qnode(dev, diff_method="parameter-shift")
+        @qp.qnode(dev, diff_method="parameter-shift")
         def func(p):
-            qml.RY(p, wires=0)
-            return qml.probs(wires=0)
+            qp.RY(p, wires=0)
+            return qp.probs(wires=0)
 
-        @qml.qjit
+        @qp.qjit
         def workflow(p: float):
-            return qml.jacobian(func, method="auto")(p)
+            return qp.jacobian(func, method="auto")(p)
 
         result = workflow(0.5)
-        reference = qml.jacobian(func, argnums=0)(0.5)
+        reference = qp.jacobian(func, argnums=0)(0.5)
 
         assert jnp.allclose(result, reference)
 
     def test_jacobian_auto(self):
         """Test the Jacobian transformation with 'auto'."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
         def workflow(x):
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def circuit(x):
-                qml.RX(jnp.pi * x[0], wires=0)
-                qml.RY(x[1], wires=0)
-                return qml.probs()
+                qp.RX(jnp.pi * x[0], wires=0)
+                qp.RY(x[1], wires=0)
+                return qp.probs()
 
-            g = qml.jacobian(circuit)
+            g = qp.jacobian(circuit)
             return g(x)
 
         reference = workflow(np.array([2.0, 1.0]))
-        result = qml.qjit(workflow)(jnp.array([2.0, 1.0]))
+        result = qp.qjit(workflow)(jnp.array([2.0, 1.0]))
 
         assert jnp.allclose(result, reference)
 
     def test_jacobian_fd(self):
         """Test the Jacobian transformation with 'fd'."""
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
         def workflow(x):
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def circuit(x):
-                qml.RX(np.pi * x[0], wires=0)
-                qml.RY(x[1], wires=0)
-                return qml.probs()
+                qp.RX(np.pi * x[0], wires=0)
+                qp.RY(x[1], wires=0)
+                return qp.probs()
 
-            g = qml.jacobian(circuit, method="fd", h=0.3)
+            g = qp.jacobian(circuit, method="fd", h=0.3)
             return g(x)
 
-        result = qml.qjit(workflow)(np.array([2.0, 1.0]))
+        result = qp.qjit(workflow)(np.array([2.0, 1.0]))
         reference = np.array([[-0.37120096, -0.45467246], [0.37120096, 0.45467246]])
         assert jnp.allclose(result, reference)
 
     def test_jvp(self):
         """Test that the correct JVP is returned with QJIT."""
 
-        @qml.qjit
+        @qp.qjit
         def jvp(params, tangent):
             def f(x):
                 y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
                 return jnp.stack(y)
 
-            return qml.jvp(f, [params], [tangent])
+            return qp.jvp(f, [params], [tangent])
 
         x = jnp.array([0.1, 0.2])
         tangent = jnp.array([0.3, 0.6])
@@ -801,17 +801,17 @@ class TestCatalystGrad:
         def f(x, y):
             return y * x**2
 
-        @qml.qjit
+        @qp.qjit
         def w(x, y):
-            return qml.jvp(f, [x, y], [1.0], argnums=[1])
+            return qp.jvp(f, [x, y], [1.0], argnums=[1])
 
         x = jnp.array(0.5)
         y = jnp.array(3.0)
 
         res, dres = w(x, y)
 
-        assert qml.math.allclose(res, f(x, y))
-        assert qml.math.allclose(dres, x**2)
+        assert qp.math.allclose(res, f(x, y))
+        assert qp.math.allclose(dres, x**2)
 
     def test_vjp_argnums(self):
         """Test that res."""
@@ -819,17 +819,17 @@ class TestCatalystGrad:
         def f(x, y):
             return y * x**2
 
-        @qml.qjit
+        @qp.qjit
         def w(x, y):
-            return qml.vjp(f, [x, y], [1.0], argnums=[1])
+            return qp.vjp(f, [x, y], [1.0], argnums=[1])
 
         x = jnp.array(0.5)
         y = jnp.array(3.0)
 
         res, dres = w(x, y)
 
-        assert qml.math.allclose(res, f(x, y))
-        assert qml.math.allclose(dres, x**2)
+        assert qp.math.allclose(res, f(x, y))
+        assert qp.math.allclose(dres, x**2)
 
     def test_jvp_without_qjit(self):
         """Test that an error is raised when using JVP without QJIT."""
@@ -839,7 +839,7 @@ class TestCatalystGrad:
                 y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
                 return jnp.stack(y)
 
-            return qml.jvp(f, [params], [tangent])
+            return qp.jvp(f, [params], [tangent])
 
         x = jnp.array([0.1, 0.2])
         tangent = jnp.array([0.3, 0.6])
@@ -852,13 +852,13 @@ class TestCatalystGrad:
     def test_vjp(self):
         """Test that the correct VJP is returned with QJIT."""
 
-        @qml.qjit
+        @qp.qjit
         def vjp(params, cotangent):
             def f(x):
                 y = [jnp.sin(x[0]), x[1] ** 2, x[0] * x[1]]
                 return jnp.stack(y)
 
-            return qml.vjp(f, [params], [cotangent])
+            return qp.vjp(f, [params], [cotangent])
 
         x = jnp.array([0.1, 0.2])
         dy = jnp.array([-0.5, 0.1, 0.3])
@@ -870,21 +870,21 @@ class TestCatalystGrad:
 
 
 class TestCatalystSample:
-    """Test qml.sample with Catalyst."""
+    """Test qp.sample with Catalyst."""
 
     def test_sample_measure(self):
-        """Test that qml.sample can be used with catalyst.measure."""
+        """Test that qp.sample can be used with catalyst.measure."""
 
-        dev = qml.device("lightning.qubit", wires=1)
+        dev = qp.device("lightning.qubit", wires=1)
 
-        @qml.qjit
-        @qml.set_shots(1)
-        @qml.qnode(dev)
+        @qp.qjit
+        @qp.set_shots(1)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RY(x, wires=0)
+            qp.RY(x, wires=0)
             m = catalyst.measure(0)
-            qml.PauliX(0)
-            return qml.sample(m)
+            qp.PauliX(0)
+            return qp.sample(m)
 
         assert circuit(0.0) == 0
         assert circuit(jnp.pi) == 1
@@ -896,76 +896,76 @@ class TestCatalystMCMs:
     @pytest.mark.parametrize(
         "measure_f",
         [
-            qml.counts,
-            qml.expval,
-            qml.probs,
+            qp.counts,
+            qp.expval,
+            qp.probs,
         ],
     )
-    @pytest.mark.parametrize("meas_obj", [qml.PauliZ(0), [0], "mcm"])
+    @pytest.mark.parametrize("meas_obj", [qp.PauliZ(0), [0], "mcm"])
     def test_dynamic_one_shot_simple(self, measure_f, meas_obj, seed):
         """Tests that Catalyst yields the same results as PennyLane's DefaultQubit for a simple
         circuit with a mid-circuit measurement."""
 
-        if measure_f in (qml.counts, qml.probs, qml.sample) and isinstance(meas_obj, qml.PauliZ):
+        if measure_f in (qp.counts, qp.probs, qp.sample) and isinstance(meas_obj, qp.PauliZ):
             pytest.skip("Can't use observables with counts, probs or sample")
 
-        if measure_f in (qml.var, qml.expval) and (isinstance(meas_obj, list)):
+        if measure_f in (qp.var, qp.expval) and (isinstance(meas_obj, list)):
             pytest.skip("Can't use wires/mcm lists with var or expval")
 
-        if measure_f == qml.var and (not isinstance(meas_obj, list) and not meas_obj == "mcm"):
+        if measure_f == qp.var and (not isinstance(meas_obj, list) and not meas_obj == "mcm"):
             pytest.xfail("isa<UnrealizedConversionCastOp>")
 
         shots = 8000
 
-        dq = qml.device("default.qubit", seed=seed)
+        dq = qp.device("default.qubit", seed=seed)
 
-        @qml.defer_measurements
-        @qml.set_shots(shots)
-        @qml.qnode(dq)
+        @qp.defer_measurements
+        @qp.set_shots(shots)
+        @qp.qnode(dq)
         def ref_func(x, y):
-            qml.RX(x, wires=0)
-            m0 = qml.measure(0)
-            qml.cond(m0, qml.RY)(y, wires=1)
+            qp.RX(x, wires=0)
+            m0 = qp.measure(0)
+            qp.cond(m0, qp.RY)(y, wires=1)
 
             meas_key = "wires" if isinstance(meas_obj, list) else "op"
             meas_value = m0 if isinstance(meas_obj, str) else meas_obj
             kwargs = {meas_key: meas_value}
-            if measure_f is qml.counts:
+            if measure_f is qp.counts:
                 kwargs["all_outcomes"] = True
             return measure_f(**kwargs)
 
-        dev = qml.device("lightning.qubit", wires=2)
+        dev = qp.device("lightning.qubit", wires=2)
 
-        @qml.qjit
-        @qml.set_shots(shots)
-        @qml.qnode(dev, mcm_method="one-shot")
+        @qp.qjit
+        @qp.set_shots(shots)
+        @qp.qnode(dev, mcm_method="one-shot")
         def func(x, y):
-            qml.RX(x, wires=0)
+            qp.RX(x, wires=0)
             m0 = catalyst.measure(0)
 
             @catalyst.cond(m0 == 1)
             def ansatz():
-                qml.RY(y, wires=1)
+                qp.RY(y, wires=1)
 
             ansatz()
 
             meas_key = "wires" if isinstance(meas_obj, list) else "op"
             meas_value = m0 if isinstance(meas_obj, str) else meas_obj
             kwargs = {meas_key: meas_value}
-            if measure_f is qml.counts:
+            if measure_f is qp.counts:
                 kwargs["all_outcomes"] = True
             return measure_f(**kwargs)
 
         params = jnp.pi / 4 * jnp.ones(2)
         results0 = ref_func(*params)
         results1 = func(*params)
-        if measure_f is qml.counts:
+        if measure_f is qp.counts:
 
             def fname(x):
                 return format(x, f"0{len(meas_obj)}b") if isinstance(meas_obj, list) else x
 
             results1 = {fname(int(state)): count for state, count in zip(*results1)}
-        if measure_f is qml.sample:
+        if measure_f is qp.sample:
             results0 = results0[results0 != fill_in_value]
             results1 = results1[results1 != fill_in_value]
         mcm_utils.validate_measurements(measure_f, shots, results1, results0)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -20,7 +20,7 @@ import os
 import pytest
 import tomlkit as toml
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import Configuration
 
 config_filename = "default_config.toml"
@@ -222,7 +222,7 @@ class TestPennyLaneInit:
 
     def test_device_load(self, default_config):
         """Test loading a device with a configuration."""
-        dev = qml.device("default.gaussian", wires=2, config=default_config)
+        dev = qp.device("default.gaussian", wires=2, config=default_config)
 
         assert dev.hbar == 2
         assert not dev.shots

--- a/tests/test_grad.py
+++ b/tests/test_grad.py
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Unit tests for qml.grad
+Unit tests for qp.grad
 """
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 
-@pytest.mark.parametrize("grad_fn", (qml.grad, qml.jacobian))
+@pytest.mark.parametrize("grad_fn", (qp.grad, qp.jacobian))
 def test_kwarg_errors_without_qjit(grad_fn):
     """Test that errors are raised with method and h when qjit is not active."""
 
     def f(x):
         return x**2
 
-    x = qml.numpy.array(0.5)
+    x = qp.numpy.array(0.5)
 
     with pytest.raises(ValueError, match="method = 'fd' unsupported without QJIT."):
         grad_fn(f, method="fd")(x)
@@ -42,7 +42,7 @@ def test_grad_name():
     def f(x):
         return x**2
 
-    assert qml.grad(f).__name__ == "<grad: f>"
+    assert qp.grad(f).__name__ == "<grad: f>"
 
     class A:
 
@@ -52,7 +52,7 @@ def test_grad_name():
         def __call__(self, x):
             return x**2
 
-    assert qml.grad(A()).__name__ == "<grad: A>"
+    assert qp.grad(A()).__name__ == "<grad: A>"
 
 
 def test_jacobian_name():
@@ -61,7 +61,7 @@ def test_jacobian_name():
     def f(x):
         return x**2
 
-    assert qml.jacobian(f).__name__ == "<jacobian: f>"
+    assert qp.jacobian(f).__name__ == "<jacobian: f>"
 
     class A:
 
@@ -71,7 +71,7 @@ def test_jacobian_name():
         def __call__(self, x):
             return x**2
 
-    assert qml.jacobian(A()).__name__ == "<jacobian: A>"
+    assert qp.jacobian(A()).__name__ == "<jacobian: A>"
 
 
 def test_value_and_grad_name():
@@ -80,7 +80,7 @@ def test_value_and_grad_name():
     def f(x):
         return x**2
 
-    assert qml.value_and_grad(f).__name__ == "<value_and_grad: f>"
+    assert qp.value_and_grad(f).__name__ == "<value_and_grad: f>"
 
     class A:
 
@@ -90,7 +90,7 @@ def test_value_and_grad_name():
         def __call__(self, x):
             return x**2
 
-    assert qml.value_and_grad(A()).__name__ == "<value_and_grad: A>"
+    assert qp.value_and_grad(A()).__name__ == "<value_and_grad: A>"
 
 
 def test_vjp_without_qjit():
@@ -98,16 +98,16 @@ def test_vjp_without_qjit():
 
     def vjp(params, cotangent):
         def f(x):
-            y = [qml.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
-            return qml.math.stack(y)
+            y = [qp.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
+            return qp.math.stack(y)
 
-        return qml.vjp(f, [params], [cotangent])
+        return qp.vjp(f, [params], [cotangent])
 
-    x = qml.numpy.array([0.1, 0.2])
-    dy = qml.numpy.array([-0.5, 0.1, 0.3])
+    x = qp.numpy.array([0.1, 0.2])
+    dy = qp.numpy.array([-0.5, 0.1, 0.3])
 
     with pytest.raises(
-        qml.exceptions.CompileError,
+        qp.exceptions.CompileError,
         match="PennyLane does not support the VJP function without QJIT.",
     ):
         vjp(x, dy)
@@ -118,16 +118,16 @@ def test_jvp_without_qjit():
 
     def jvp(params, dparams):
         def f(x):
-            y = [qml.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
-            return qml.math.stack(y)
+            y = [qp.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
+            return qp.math.stack(y)
 
-        return qml.jvp(f, [params], [dparams])
+        return qp.jvp(f, [params], [dparams])
 
-    x = qml.numpy.array([0.1, 0.2])
-    dy = qml.numpy.array([-0.5, 0.1])
+    x = qp.numpy.array([0.1, 0.2])
+    dy = qp.numpy.array([-0.5, 0.1])
 
     with pytest.raises(
-        qml.exceptions.CompileError,
+        qp.exceptions.CompileError,
         match="PennyLane does not support the JVP function without QJIT.",
     ):
         jvp(x, dy)
@@ -138,15 +138,15 @@ def test_value_and_grad_without_qjit():
 
     def value_and_grad(params):
         def f(x):
-            y = [qml.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
-            return qml.math.stack(y)
+            y = [qp.math.sin(x[0]), x[1] ** 2, x[0] * x[1]]
+            return qp.math.stack(y)
 
-        return qml.value_and_grad(f)(params)
+        return qp.value_and_grad(f)(params)
 
-    x = qml.numpy.array([0.1, 0.2])
+    x = qp.numpy.array([0.1, 0.2])
 
     with pytest.raises(
-        qml.exceptions.CompileError,
+        qp.exceptions.CompileError,
         match="PennyLane does not support the value_and_grad function without QJIT.",
     ):
         value_and_grad(x)

--- a/tests/test_observable.py
+++ b/tests/test_observable.py
@@ -18,18 +18,18 @@ Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
 # pylint: disable=protected-access,cell-var-from-loop
 
 
-import pennylane as qml
+import pennylane as qp
 
 
 def test_pass_positional_wires_to_observable():
     """Tests whether the ability to pass wires as positional argument is retained"""
-    dev = qml.device("default.qubit", wires=1)
+    dev = qp.device("default.qubit", wires=1)
 
-    obs = qml.Identity(0)
+    obs = qp.Identity(0)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit():
-        return qml.expval(obs)
+        return qp.expval(obs)
 
-    tape = qml.workflow.construct_tape(circuit)()
+    tape = qp.workflow.construct_tape(circuit)()
     assert obs in tape.observables

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 from gate_data import CNOT, I, Toffoli, X
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import (
@@ -79,19 +79,19 @@ class TestOperatorConstruction:
 
     def test_operation_outside_context(self):
         """Test that an operation can be instantiated outside a QNode context"""
-        op = qml.ops.CNOT(wires=[0, 1])
-        assert isinstance(op, qml.operation.Operation)
+        op = qp.ops.CNOT(wires=[0, 1])
+        assert isinstance(op, qp.operation.Operation)
 
-        op = qml.ops.RX(0.5, wires=0)
-        assert isinstance(op, qml.operation.Operation)
+        op = qp.ops.RX(0.5, wires=0)
+        assert isinstance(op, qp.operation.Operation)
 
-        op = qml.ops.Hadamard(wires=0)
-        assert isinstance(op, qml.operation.Operation)
+        op = qp.ops.Hadamard(wires=0)
+        assert isinstance(op, qp.operation.Operation)
 
     def test_incorrect_num_wires(self):
         """Test that an exception is raised if called with wrong number of wires"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
             num_wires = 1
@@ -102,18 +102,18 @@ class TestOperatorConstruction:
     def test_non_unique_wires(self):
         """Test that an exception is raised if called with identical wires"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
             num_wires = 1
 
-        with pytest.raises(qml.wires.WireError, match="Wires must be unique"):
+        with pytest.raises(qp.wires.WireError, match="Wires must be unique"):
             DummyOp(0.5, wires=[1, 1])
 
     def test_num_wires_default_any_wires(self):
         """Test that num_wires is None by default."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
         assert DummyOp.num_wires is None
@@ -122,7 +122,7 @@ class TestOperatorConstruction:
     def test_incorrect_num_params(self):
         """Test that an exception is raised if called with wrong number of parameters"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares num_params as an instance property"""
 
             num_wires = 1
@@ -138,7 +138,7 @@ class TestOperatorConstruction:
         op = DummyOp(0.5, wires=0)
         assert op.num_params == 1
 
-        class DummyOp2(qml.operation.Operator):
+        class DummyOp2(qp.operation.Operator):
             r"""Dummy custom operator that declares num_params as a class property"""
 
             num_params = 4
@@ -152,7 +152,7 @@ class TestOperatorConstruction:
         assert op2.num_params == 4
         assert DummyOp2.num_params == 4
 
-        class DummyOp3(qml.operation.Operator):
+        class DummyOp3(qp.operation.Operator):
             r"""Dummy custom operator that does not declare num_params at all"""
 
             num_wires = 1
@@ -165,7 +165,7 @@ class TestOperatorConstruction:
     def test_incorrect_ndim_params(self):
         """Test that an exception is raised if called with wrongly-shaped parameters"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as an instance property"""
 
             num_wires = 1
@@ -179,7 +179,7 @@ class TestOperatorConstruction:
         op = DummyOp(0.5, wires=0)
         assert op.ndim_params == (0,)
 
-        class DummyOp2(qml.operation.Operator):
+        class DummyOp2(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (1, 2)
@@ -194,7 +194,7 @@ class TestOperatorConstruction:
         assert op2.ndim_params == (1, 2)
         assert DummyOp2.ndim_params == (1, 2)
 
-        class DummyOp3(qml.operation.Operator):
+        class DummyOp3(qp.operation.Operator):
             r"""Dummy custom operator that does not declare ndim_params at all"""
 
             num_wires = 1
@@ -206,7 +206,7 @@ class TestOperatorConstruction:
         # because it will simply set `ndim_params` to the ndims of the provided arguments
         assert op3.ndim_params == (0, 2)
 
-        class DummyOp4(qml.operation.Operator):
+        class DummyOp4(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -220,7 +220,7 @@ class TestOperatorConstruction:
     def test_default_pauli_rep(self):
         """Test that the default _pauli_rep attribute is None"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
             num_wires = 1
@@ -231,7 +231,7 @@ class TestOperatorConstruction:
     def test_list_or_tuple_params_casted_into_numpy_array(self):
         """Test that list parameters are casted into numpy arrays."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
             num_wires = 1
@@ -246,7 +246,7 @@ class TestOperatorConstruction:
     def test_wires_by_final_argument(self):
         """Test that wires can be passed as the final positional argument."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
@@ -257,7 +257,7 @@ class TestOperatorConstruction:
     def test_no_wires(self):
         """Test an error is raised if no wires are passed."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
@@ -267,15 +267,15 @@ class TestOperatorConstruction:
     def test_no_wires_for_op_with_any_wires(self):
         """Test that an operator that allows any number of wires can have zero wires."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             pass
 
-        assert DummyOp(wires=()).wires == qml.wires.Wires(())
+        assert DummyOp(wires=()).wires == qp.wires.Wires(())
 
     def test_name_setter(self):
         """Tests that we can set the name of an operator"""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator"""
 
             num_wires = 1
@@ -287,10 +287,10 @@ class TestOperatorConstruction:
     def test_default_hyperparams(self):
         """Tests that the hyperparams attribute is defined for all operations."""
 
-        class MyOp(qml.operation.Operation):
+        class MyOp(qp.operation.Operation):
             num_wires = 1
 
-        class MyOpOverwriteInit(qml.operation.Operation):
+        class MyOpOverwriteInit(qp.operation.Operation):
             num_wires = 1
 
             def __init__(self, wires):  # pylint:disable=super-init-not-called
@@ -305,7 +305,7 @@ class TestOperatorConstruction:
     def test_custom_hyperparams(self):
         """Tests that an operation can add custom hyperparams."""
 
-        class MyOp(qml.operation.Operation):
+        class MyOp(qp.operation.Operation):
             num_wires = 1
 
             def __init__(self, wires, basis_state=None):  # pylint:disable=super-init-not-called
@@ -316,9 +316,9 @@ class TestOperatorConstruction:
 
     def test_eq_correctness(self):
         """Test that using `==` on operators behaves the same as
-        `qml.equal`."""
+        `qp.equal`."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             num_wires = 1
 
         op1 = DummyOp(0)
@@ -330,7 +330,7 @@ class TestOperatorConstruction:
     def test_hash_correctness(self):
         """Test that the hash of two equivalent operators is the same."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             num_wires = 1
 
         op1 = DummyOp(0)
@@ -362,7 +362,7 @@ class TestPytreeMethods:
     def test_pytree_defaults(self):
         """Test the default behavior for the flatten and unflatten methods."""
 
-        class CustomOp(qml.operation.Operator):
+        class CustomOp(qp.operation.Operator):
             """A dummy operation with hyperparameters."""
 
             def __init__(self, x1, x2, wires, info):
@@ -376,14 +376,14 @@ class TestPytreeMethods:
         data, metadata = op._flatten()
         assert data == (1.2, 2.3)
         assert len(metadata) == 2
-        assert metadata[0] == qml.wires.Wires((0, 1))
+        assert metadata[0] == qp.wires.Wires((0, 1))
         assert metadata[1] == (("info", "value"),)
 
         # check metadata is hashable
         _ = {metadata: 0}
 
         new_op = CustomOp._unflatten(*op._flatten())
-        qml.assert_equal(op, new_op)
+        qp.assert_equal(op, new_op)
         assert new_op.i_got_initialized
 
 
@@ -408,7 +408,7 @@ class TestBroadcasting:
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -424,7 +424,7 @@ class TestBroadcasting:
         r"""Test that initialization of an operator with broadcasted parameters
         works and sets the ``batch_size`` correctly with Autograd parameters."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -442,7 +442,7 @@ class TestBroadcasting:
         works and sets the ``batch_size`` correctly with JAX parameters."""
         import jax
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -460,7 +460,7 @@ class TestBroadcasting:
         works and sets the ``batch_size`` correctly with TensorFlow parameters."""
         import tensorflow as tf
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -478,7 +478,7 @@ class TestBroadcasting:
         works and sets the ``batch_size`` correctly with Torch parameters."""
         import torch
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             ndim_params = (0, 2)
@@ -497,7 +497,7 @@ class TestBroadcasting:
         import tensorflow as tf
 
         def fun(x):
-            _ = qml.RX(x, 0).batch_size
+            _ = qp.RX(x, 0).batch_size
 
         # No kwargs
         fun0 = tf.function(fun)
@@ -517,7 +517,7 @@ class TestHasReprProperties:
     def test_has_matrix_true(self):
         """Test has_matrix property detects overriding of `compute_matrix` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
             @staticmethod
@@ -530,7 +530,7 @@ class TestHasReprProperties:
     def test_has_matrix_true_overridden_matrix(self):
         """Test has_matrix is true if `matrix` is overridden instead of `compute_matrix`."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             def matrix(self, _=None):
                 return np.eye(2)
 
@@ -540,7 +540,7 @@ class TestHasReprProperties:
     def test_has_matrix_false(self):
         """Test has_matrix property defaults to false if `compute_matrix` not overwritten."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
         assert MyOp.has_matrix is False
@@ -550,16 +550,16 @@ class TestHasReprProperties:
         """Test has_matrix with a concrete operation (StronglyEntanglingLayers)
         that does not have a matrix defined."""
 
-        rng = qml.numpy.random.default_rng(seed=seed)
-        shape = qml.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
+        rng = qp.numpy.random.default_rng(seed=seed)
+        shape = qp.StronglyEntanglingLayers.shape(n_layers=2, n_wires=2)
         params = rng.random(shape)
-        op = qml.StronglyEntanglingLayers(params, wires=range(2))
+        op = qp.StronglyEntanglingLayers(params, wires=range(2))
         assert op.has_matrix is False
 
     def test_has_adjoint_true(self):
         """Test has_adjoint property detects overriding of `adjoint` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
             adjoint = lambda self: self
 
@@ -569,7 +569,7 @@ class TestHasReprProperties:
     def test_has_adjoint_false(self):
         """Test has_adjoint property defaults to false if `adjoint` not overwritten."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
         assert MyOp.has_adjoint is False
@@ -578,13 +578,13 @@ class TestHasReprProperties:
     def test_has_decomposition_true_compute_decomposition(self):
         """Test has_decomposition property detects overriding of `compute_decomposition` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
             @staticmethod
             def compute_decomposition(x, wires=None):  # pylint:disable=arguments-differ
-                return [qml.RX(x, wires=wires)]
+                return [qp.RX(x, wires=wires)]
 
         assert MyOp.has_decomposition is True
         assert MyOp(0.2, wires=1).has_decomposition is True
@@ -592,12 +592,12 @@ class TestHasReprProperties:
     def test_has_decomposition_true_decomposition(self):
         """Test has_decomposition property detects overriding of `decomposition` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
             def decomposition(self):
-                return [qml.RX(self.parameters[0], wires=self.wires)]
+                return [qp.RX(self.parameters[0], wires=self.wires)]
 
         assert MyOp.has_decomposition is True
         assert MyOp(0.2, wires=1).has_decomposition is True
@@ -605,16 +605,16 @@ class TestHasReprProperties:
     def test_has_decomposition_graph_decomp(self):
         """Test that an operator provides a decomposition if it has a register graph decomp."""
 
-        class SomeRandomName(qml.operation.Operator):
+        class SomeRandomName(qp.operation.Operator):
             pass
 
-        with qml.decomposition.local_decomps():
+        with qp.decomposition.local_decomps():
 
-            @qml.register_resources({qml.X: 1})
+            @qp.register_resources({qp.X: 1})
             def decomp(x, wires):
-                qml.RX(x, wires)
+                qp.RX(x, wires)
 
-            qml.add_decomps(SomeRandomName, decomp)
+            qp.add_decomps(SomeRandomName, decomp)
 
             assert SomeRandomName(0.5, wires=0).has_decomposition
 
@@ -622,23 +622,23 @@ class TestHasReprProperties:
         """Test that operators with multiple decompositions and conditions have
         correct has_decomposition properties."""
 
-        class MNBV(qml.operation.Operator):
+        class MNBV(qp.operation.Operator):
             @property
             def resource_params(self):
                 return {"num_wires": len(self.wires)}
 
-        @qml.register_condition(lambda num_wires: num_wires == 1)
-        @qml.register_resources({qml.RX: 1})
+        @qp.register_condition(lambda num_wires: num_wires == 1)
+        @qp.register_resources({qp.RX: 1})
         def decomp1(x, wires):
-            qml.RX(x, wires)
+            qp.RX(x, wires)
 
-        @qml.register_condition(lambda num_wires: num_wires == 2)
-        @qml.register_resources({qml.CRX: 1})
+        @qp.register_condition(lambda num_wires: num_wires == 2)
+        @qp.register_resources({qp.CRX: 1})
         def decomp2(x, wires):
-            qml.CRX(x, wires)
+            qp.CRX(x, wires)
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(MNBV, decomp1, decomp2)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(MNBV, decomp1, decomp2)
 
             assert MNBV(0.5, wires=0).has_decomposition
             assert MNBV(0.5, wires=(0, 1)).has_decomposition
@@ -648,7 +648,7 @@ class TestHasReprProperties:
         """Test has_decomposition property defaults to false if neither
         `decomposition` nor `compute_decomposition` are overwritten."""
 
-        class TREWQ(qml.operation.Operator):
+        class TREWQ(qp.operation.Operator):
             num_wires = 1
 
         assert TREWQ(wires=0).has_decomposition is False
@@ -657,7 +657,7 @@ class TestHasReprProperties:
         """Test has_diagonalizing_gates property detects
         overriding of `compute_diagonalizing_gates` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
@@ -672,12 +672,12 @@ class TestHasReprProperties:
         """Test has_diagonalizing_gates property detects
         overriding of `diagonalizing_gates` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
             num_params = 1
 
             def diagonalizing_gates(self):
-                return [qml.RX(self.parameters[0], wires=self.wires)]
+                return [qp.RX(self.parameters[0], wires=self.wires)]
 
         assert MyOp.has_diagonalizing_gates is True
         assert MyOp(0.2, wires=1).has_diagonalizing_gates is True
@@ -686,7 +686,7 @@ class TestHasReprProperties:
         """Test has_diagonalizing_gates property defaults to false if neither
         `diagonalizing_gates` nor `compute_diagonalizing_gates` are overwritten."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
         assert MyOp.has_diagonalizing_gates is False
@@ -695,7 +695,7 @@ class TestHasReprProperties:
     def test_has_generator_true(self):
         """Test `has_generator` property detects overriding of `generator` method."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
             @staticmethod
@@ -709,13 +709,13 @@ class TestHasReprProperties:
         """Test has_generator with a concrete operation (RZ)
         that does have a generator defined."""
 
-        op = qml.RZ(0.3, 0)
+        op = qp.RZ(0.3, 0)
         assert op.has_generator is True
 
     def test_has_generator_false(self):
         """Test `has_generator` property defaults to false if `generator` not overwritten."""
 
-        class MyOp(qml.operation.Operator):
+        class MyOp(qp.operation.Operator):
             num_wires = 1
 
         assert MyOp.has_generator is False
@@ -725,7 +725,7 @@ class TestHasReprProperties:
         """Test has_generator with a concrete operation (Rot)
         that does not have a generator defined."""
 
-        op = qml.Rot(0.3, 0.2, 0.1, 0)
+        op = qp.Rot(0.3, 0.2, 0.1, 0)
         assert op.has_generator is False
 
 
@@ -735,7 +735,7 @@ class TestModificationMethods:
     def test_simplify_method(self):
         """Test that simplify method returns the same instance."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             num_wires = 1
@@ -747,16 +747,16 @@ class TestModificationMethods:
     def test_map_wires(self):
         """Test the map_wires method."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             num_wires = 3
 
         op = DummyOp(wires=[0, 1, 2])
-        op._pauli_rep = qml.pauli.PauliSentence(  # pylint:disable=attribute-defined-outside-init
+        op._pauli_rep = qp.pauli.PauliSentence(  # pylint:disable=attribute-defined-outside-init
             {
-                qml.pauli.PauliWord({0: "X", 1: "Y", 2: "Z"}): 1.1,
-                qml.pauli.PauliWord({0: "Z", 1: "X", 2: "Y"}): 2.2,
+                qp.pauli.PauliWord({0: "X", 1: "Y", 2: "Z"}): 1.1,
+                qp.pauli.PauliWord({0: "Z", 1: "X", 2: "Y"}): 2.2,
             }
         )
         wire_map = {0: 10, 1: 11, 2: 12}
@@ -765,10 +765,10 @@ class TestModificationMethods:
         assert op.wires == Wires([0, 1, 2])
         assert mapped_op.wires == Wires([10, 11, 12])
         assert mapped_op.pauli_rep is not op.pauli_rep
-        assert mapped_op.pauli_rep == qml.pauli.PauliSentence(
+        assert mapped_op.pauli_rep == qp.pauli.PauliSentence(
             {
-                qml.pauli.PauliWord({10: "X", 11: "Y", 12: "Z"}): 1.1,
-                qml.pauli.PauliWord({10: "Z", 11: "X", 12: "Y"}): 2.2,
+                qp.pauli.PauliWord({10: "X", 11: "Y", 12: "Z"}): 1.1,
+                qp.pauli.PauliWord({10: "Z", 11: "X", 12: "Y"}): 2.2,
             }
         )
 
@@ -776,7 +776,7 @@ class TestModificationMethods:
         """Test that the map_wires method doesn't change wires that are not present in the wire
         map."""
 
-        class DummyOp(qml.operation.Operator):
+        class DummyOp(qp.operation.Operator):
             r"""Dummy custom operator that declares ndim_params as a class property"""
 
             num_wires = 3
@@ -796,7 +796,7 @@ class TestOperationConstruction:
         """Test that an operation with a gradient recipe that depends on
         its instantiated parameter values works correctly"""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -816,7 +816,7 @@ class TestOperationConstruction:
         if ``parameter_frequencies`` are present.
         """
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -834,13 +834,13 @@ class TestOperationConstruction:
         if a generator is present to determine parameter_frequencies from.
         """
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
 
             def generator(self):
-                return -0.2 * qml.PauliX(wires=self.wires)
+                return -0.2 * qp.PauliX(wires=self.wires)
 
         x = 0.654
         op = DummyOp(x, wires=0)
@@ -851,7 +851,7 @@ class TestOperationConstruction:
         if no information is present to deduce an analytic gradient method.
         """
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -865,7 +865,7 @@ class TestOperationConstruction:
         if a grad_recipe is present.
         """
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -880,7 +880,7 @@ class TestOperationConstruction:
         if an operation does not have a parameter.
         """
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -892,14 +892,14 @@ class TestOperationConstruction:
         """Test that an operation with default parameter frequencies
         and a single parameter works correctly."""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
             grad_method = "A"
 
             def generator(self):
-                return -0.2 * qml.PauliX(wires=self.wires)
+                return -0.2 * qp.PauliX(wires=self.wires)
 
         x = 0.654
         op = DummyOp(x, wires=0)
@@ -909,7 +909,7 @@ class TestOperationConstruction:
         """Test that an operation with default parameter frequencies and multiple
         parameters raises an error when calling parameter_frequencies."""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_params = 3
@@ -919,7 +919,7 @@ class TestOperationConstruction:
         x = [0.654, 2.31, 0.1]
         op = DummyOp(*x, wires=0)
         with pytest.raises(
-            qml.exceptions.OperatorPropertyUndefined, match="DummyOp does not have parameter"
+            qp.exceptions.OperatorPropertyUndefined, match="DummyOp does not have parameter"
         ):
             _ = op.parameter_frequencies
 
@@ -928,7 +928,7 @@ class TestOperationConstruction:
         """Test that an operation with parameter frequencies that depend on
         its instantiated parameter values works correctly"""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_params = num_param
@@ -949,17 +949,17 @@ class TestOperationConstruction:
     def test_frequencies_sparse_generator(self):
         """Test that the parameter frequencies are correctly deduced from a generator
         that is a ``SparseHamiltonian``."""
-        DummyOp = copy.copy(qml.DoubleExcitationPlus)
-        DummyOp.parameter_frequencies = qml.operation.Operation.parameter_frequencies
+        DummyOp = copy.copy(qp.DoubleExcitationPlus)
+        DummyOp.parameter_frequencies = qp.operation.Operation.parameter_frequencies
 
         op = DummyOp(0.7, [0, 1, 2, 3])
-        assert isinstance(op.generator(), qml.SparseHamiltonian)
+        assert isinstance(op.generator(), qp.SparseHamiltonian)
         assert op.parameter_frequencies == [(1.0,)]
 
     def test_no_wires_passed(self):
         """Test exception raised if no wires are passed"""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -973,7 +973,7 @@ class TestOperationConstruction:
     def test_id(self):
         """Test that the id attribute of an operator can be set."""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -985,19 +985,19 @@ class TestOperationConstruction:
     def test_control_wires(self):
         """Test that control_wires defaults to an empty Wires object."""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
             grad_method = None
 
         op = DummyOp(1.0, wires=0)
-        assert op.control_wires == qml.wires.Wires([])
+        assert op.control_wires == qp.wires.Wires([])
 
     def test_is_hermitian(self):
         """Test that is_hermitian defaults to False for an Operator"""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operation"""
 
             num_wires = 1
@@ -1013,62 +1013,62 @@ class TestObservableConstruction:
     def test_construction_with_wires_pos_arg(self):
         """Test that the wires can be given as a positional argument"""
 
-        class DummyObserv(qml.operation.Operator):
+        class DummyObserv(qp.operation.Operator):
             r"""Dummy custom observable"""
 
             num_wires = 1
             grad_method = None
 
         ob = DummyObserv([1])
-        assert ob.wires == qml.wires.Wires(1)
+        assert ob.wires == qp.wires.Wires(1)
 
     def test_tensor_n_multiple_modes(self):
         """Checks that the TensorN operator was constructed correctly when
         multiple modes were specified."""
-        cv_obs = qml.TensorN(wires=[0, 1])
+        cv_obs = qp.TensorN(wires=[0, 1])
 
-        assert isinstance(cv_obs, qml.TensorN)
+        assert isinstance(cv_obs, qp.TensorN)
         assert cv_obs.wires == Wires([0, 1])
         assert cv_obs.ev_order is None
 
     def test_tensor_n_single_mode_wires_explicit(self):
         """Checks that instantiating a TensorN when passing a single mode as a
         keyword argument returns a NumberOperator."""
-        cv_obs = qml.TensorN(wires=[0])
+        cv_obs = qp.TensorN(wires=[0])
 
-        assert isinstance(cv_obs, qml.NumberOperator)
+        assert isinstance(cv_obs, qp.NumberOperator)
         assert cv_obs.wires == Wires([0])
         assert cv_obs.ev_order == 2
 
     def test_tensor_n_single_mode_wires_implicit(self):
         """Checks that instantiating TensorN when passing a single mode as a
         positional argument returns a NumberOperator."""
-        cv_obs = qml.TensorN(1)
+        cv_obs = qp.TensorN(1)
 
-        assert isinstance(cv_obs, qml.NumberOperator)
+        assert isinstance(cv_obs, qp.NumberOperator)
         assert cv_obs.wires == Wires([1])
         assert cv_obs.ev_order == 2
 
     def test_repr(self):
         """Test the string representation of an observable with and without a return type."""
 
-        m = qml.expval(qml.PauliZ(wires=["a"]) @ qml.PauliZ(wires=["b"]))
+        m = qp.expval(qp.PauliZ(wires=["a"]) @ qp.PauliZ(wires=["b"]))
         expected = "expval(Z('a') @ Z('b'))"
         assert str(m) == expected
 
-        m = qml.probs(wires=["a"])
+        m = qp.probs(wires=["a"])
         expected = "probs(wires=['a'])"
         assert str(m) == expected
 
-        m = qml.probs(op=qml.PauliZ(wires=["a"]))
+        m = qp.probs(op=qp.PauliZ(wires=["a"]))
         expected = "probs(Z('a'))"
         assert str(m) == expected
 
-        m = qml.PauliZ(wires=["a"]) @ qml.PauliZ(wires=["b"])
+        m = qp.PauliZ(wires=["a"]) @ qp.PauliZ(wires=["b"])
         expected = "Z('a') @ Z('b')"
         assert str(m) == expected
 
-        m = qml.PauliZ(wires=["a"])
+        m = qp.PauliZ(wires=["a"])
         expected = "Z('a')"
         assert str(m) == expected
 
@@ -1076,7 +1076,7 @@ class TestObservableConstruction:
     def test_id(self):
         """Test that the id attribute of an observable can be set."""
 
-        class DummyObserv(qml.operation.Operator):
+        class DummyObserv(qp.operation.Operator):
             r"""Dummy custom observable"""
 
             num_wires = 1
@@ -1088,7 +1088,7 @@ class TestObservableConstruction:
     def test_raises_if_no_wire_is_given(self):
         """Test that an error is raised if no wire is passed at initialization."""
 
-        class DummyObservable(qml.operation.Operator):
+        class DummyObservable(qp.operation.Operator):
             num_wires = 1
 
         with pytest.raises(Exception, match="Must specify the wires *"):
@@ -1097,7 +1097,7 @@ class TestObservableConstruction:
     def test_is_hermitian(self):
         """Test that the id attribute of an observable can be set."""
 
-        class DummyObserv(qml.operation.Operator):
+        class DummyObserv(qp.operation.Operator):
             r"""Dummy custom observable"""
 
             num_wires = 1
@@ -1114,7 +1114,7 @@ class TestOperatorIntegration:
         """Test that when raising an Operator to a power that is not a number raises
         a ValueError."""
 
-        class DummyOp(qml.operation.Operation):
+        class DummyOp(qp.operation.Operation):
             r"""Dummy custom operator"""
 
             num_wires = 1
@@ -1124,20 +1124,20 @@ class TestOperatorIntegration:
 
     def test_sum_with_operator(self):
         """Test the __sum__ dunder method with two operators."""
-        sum_op = qml.PauliX(0) + qml.RX(1, 0)
-        final_op = qml.sum(qml.PauliX(0), qml.RX(1, 0))
-        qml.assert_equal(sum_op, final_op)
+        sum_op = qp.PauliX(0) + qp.RX(1, 0)
+        final_op = qp.sum(qp.PauliX(0), qp.RX(1, 0))
+        qp.assert_equal(sum_op, final_op)
 
     def test_sum_with_scalar(self):
         """Test the __sum__ dunder method with a scalar value."""
-        sum_op = 5 + qml.PauliX(0) + 0
-        final_op = qml.sum(qml.PauliX(0), qml.s_prod(5, qml.Identity(0)))
-        qml.assert_equal(sum_op, final_op)
+        sum_op = 5 + qp.PauliX(0) + 0
+        final_op = qp.sum(qp.PauliX(0), qp.s_prod(5, qp.Identity(0)))
+        qp.assert_equal(sum_op, final_op)
 
     def test_sum_scalar_tensor(self):
         """Test the __sum__ dunder method with a scalar tensor."""
         scalar = pnp.array(5)
-        sum_op = qml.RX(1.23, 0) + scalar
+        sum_op = qp.RX(1.23, 0) + scalar
         assert sum_op[1].scalar is scalar
 
     @pytest.mark.torch
@@ -1146,7 +1146,7 @@ class TestOperatorIntegration:
         import torch
 
         scalar = torch.tensor(5)
-        sum_op = qml.RX(1.23, 0) + scalar
+        sum_op = qp.RX(1.23, 0) + scalar
         assert isinstance(sum_op, Sum)
         assert sum_op[1].scalar is scalar
 
@@ -1156,7 +1156,7 @@ class TestOperatorIntegration:
         import tensorflow as tf
 
         scalar = tf.constant(5)
-        sum_op = qml.RX(1.23, 0) + scalar
+        sum_op = qp.RX(1.23, 0) + scalar
         assert isinstance(sum_op, Sum)
         assert sum_op[1].scalar is scalar
 
@@ -1166,52 +1166,52 @@ class TestOperatorIntegration:
         from jax import numpy as jnp
 
         scalar = jnp.array(5)
-        sum_op = qml.RX(1.23, 0) + scalar
+        sum_op = qp.RX(1.23, 0) + scalar
         assert isinstance(sum_op, Sum)
         assert sum_op[1].scalar is scalar
 
     def test_sum_multi_wire_operator_with_scalar(self):
         """Test the __sum__ dunder method with a multi-wire operator and a scalar value."""
-        sum_op = 5 + qml.CNOT(wires=[0, 1])
-        final_op = qml.sum(
-            qml.CNOT(wires=[0, 1]),
-            qml.s_prod(5, qml.Identity([0, 1])),
+        sum_op = 5 + qp.CNOT(wires=[0, 1])
+        final_op = qp.sum(
+            qp.CNOT(wires=[0, 1]),
+            qp.s_prod(5, qp.Identity([0, 1])),
         )
-        qml.assert_equal(sum_op, final_op)
+        qp.assert_equal(sum_op, final_op)
 
     def test_sub_rsub_and_neg_dunder_methods(self):
         """Test the __sub__, __rsub__ and __neg__ dunder methods."""
-        sum_op = qml.PauliX(0) - 5
-        sum_op_2 = -(5 - qml.PauliX(0))
+        sum_op = qp.PauliX(0) - 5
+        sum_op_2 = -(5 - qp.PauliX(0))
         assert np.allclose(a=sum_op.matrix(), b=np.array([[-5, 1], [1, -5]]), rtol=0)
         assert np.allclose(a=sum_op.matrix(), b=sum_op_2.matrix(), rtol=0)
-        neg_op = -qml.PauliX(0)
+        neg_op = -qp.PauliX(0)
         assert np.allclose(a=neg_op.matrix(), b=np.array([[0, -1], [-1, 0]]), rtol=0)
 
     def test_sub_obs_from_op(self):
         """Test that __sub__ returns an SProd to be consistent with other Operator dunders."""
-        op = qml.S(0) - qml.PauliX(1)
+        op = qp.S(0) - qp.PauliX(1)
         assert isinstance(op, Sum)
         assert isinstance(op[1], SProd)
-        qml.assert_equal(op[0], qml.S(0))
-        qml.assert_equal(op[1], SProd(-1, qml.PauliX(1)))
+        qp.assert_equal(op[0], qp.S(0))
+        qp.assert_equal(op[1], SProd(-1, qp.PauliX(1)))
 
     def test_mul_with_scalar(self):
         """Test the __mul__ dunder method with a scalar value."""
-        sprod_op = 4 * qml.RX(1, 0)
-        sprod_op2 = qml.RX(1, 0) * 4
-        final_op = qml.s_prod(scalar=4, operator=qml.RX(1, 0))
-        qml.assert_equal(final_op, sprod_op2)
-        qml.assert_equal(sprod_op, final_op)
+        sprod_op = 4 * qp.RX(1, 0)
+        sprod_op2 = qp.RX(1, 0) * 4
+        final_op = qp.s_prod(scalar=4, operator=qp.RX(1, 0))
+        qp.assert_equal(final_op, sprod_op2)
+        qp.assert_equal(sprod_op, final_op)
 
     def test_mul_scalar_tensor(self):
         """Test the __mul__ dunder method with a scalar tensor."""
         scalar = pnp.array(5)
-        prod_op = qml.RX(1.23, 0) * scalar
+        prod_op = qp.RX(1.23, 0) * scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
-        prod_op2 = scalar * qml.RX(1.23, 0)
+        prod_op2 = scalar * qp.RX(1.23, 0)
         assert isinstance(prod_op2, SProd)
         assert prod_op.scalar is scalar
 
@@ -1219,21 +1219,21 @@ class TestOperatorIntegration:
         """Test that the __mul__ dunder works with a batched scalar."""
 
         scalar = np.array([0.5, 0.6, 0.7])
-        prod_op = scalar * qml.S(0)
+        prod_op = scalar * qp.S(0)
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
         assert prod_op.batch_size == 3
 
-        prod_op = qml.S(0) * scalar
+        prod_op = qp.S(0) * scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
         assert prod_op.batch_size == 3
 
     def test_divide_with_scalar(self):
         """Test the __truediv__ dunder method with a scalar value."""
-        sprod_op = qml.RX(1, 0) / 4
-        final_op = qml.s_prod(scalar=1 / 4, operator=qml.RX(1, 0))
-        assert isinstance(sprod_op, qml.ops.SProd)
+        sprod_op = qp.RX(1, 0) / 4
+        final_op = qp.s_prod(scalar=1 / 4, operator=qp.RX(1, 0))
+        assert isinstance(sprod_op, qp.ops.SProd)
         assert sprod_op.name == final_op.name
         assert sprod_op.wires == final_op.wires
         assert sprod_op.data == final_op.data
@@ -1242,13 +1242,13 @@ class TestOperatorIntegration:
     def test_divide_with_scalar_tensor(self):
         """Test the __truediv__ dunder method with a scalar tensor."""
         scalar = pnp.array(5)
-        prod_op = qml.RX(1.23, 0) / scalar
+        prod_op = qp.RX(1.23, 0) / scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar == 1 / scalar
 
     def test_divide_not_supported(self):
         """Test that the division of an operator with an unknown object is not supported."""
-        obs = qml.PauliX(0)
+        obs = qp.PauliX(0)
 
         with pytest.raises(TypeError, match="unsupported operand type"):
             _ = obs / object()
@@ -1270,7 +1270,7 @@ class TestOperatorIntegration:
             def __rmatmul__(self, other):
                 return True
 
-        op = qml.PauliX(0)
+        op = qp.PauliX(0)
         dummy = Dummy()
         assert op + dummy is True
         assert op - dummy is True
@@ -1283,11 +1283,11 @@ class TestOperatorIntegration:
         import torch
 
         scalar = torch.tensor(5)
-        prod_op = qml.RX(1.23, 0) * scalar
+        prod_op = qp.RX(1.23, 0) * scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
-        prod_op = scalar * qml.RX(1.23, 0)
+        prod_op = scalar * qp.RX(1.23, 0)
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
@@ -1297,11 +1297,11 @@ class TestOperatorIntegration:
         import tensorflow as tf
 
         scalar = tf.constant(5)
-        prod_op = qml.RX(1.23, 0) * scalar
+        prod_op = qp.RX(1.23, 0) * scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
-        prod_op = scalar * qml.RX(1.23, 0)
+        prod_op = scalar * qp.RX(1.23, 0)
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
@@ -1311,18 +1311,18 @@ class TestOperatorIntegration:
         from jax import numpy as jnp
 
         scalar = jnp.array(5)
-        prod_op = qml.RX(1.23, 0) * scalar
+        prod_op = qp.RX(1.23, 0) * scalar
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
-        prod_op = scalar * qml.RX(1.23, 0)
+        prod_op = scalar * qp.RX(1.23, 0)
         assert isinstance(prod_op, SProd)
         assert prod_op.scalar is scalar
 
     def test_mul_with_operator(self):
         """Test the __matmul__ dunder method with an operator."""
-        prod_op = qml.RX(1, 0) @ qml.PauliX(0)
-        final_op = qml.prod(qml.RX(1, 0), qml.PauliX(0))
+        prod_op = qp.RX(1, 0) @ qp.PauliX(0)
+        final_op = qp.prod(qp.RX(1, 0), qp.PauliX(0))
         assert isinstance(prod_op, Prod)
         assert prod_op.name == final_op.name
         assert prod_op.wires == final_op.wires
@@ -1332,18 +1332,18 @@ class TestOperatorIntegration:
     def test_mul_with_not_supported_object_raises_error(self):
         """Test that the __mul__ dunder method raises an error when using a non-supported object."""
         with pytest.raises(TypeError, match="can't multiply sequence by non-int of type 'PauliX'"):
-            _ = "dummy" * qml.PauliX(0)
+            _ = "dummy" * qp.PauliX(0)
 
     def test_matmul_with_not_supported_object_raises_error(self):
         """Test that the __matmul__ dunder method raises an error when using a non-supported object."""
         with pytest.raises(TypeError, match="unsupported operand type"):
-            _ = qml.PauliX(0) @ "dummy"
+            _ = qp.PauliX(0) @ "dummy"
 
     def test_label_for_operations_with_id(self):
         """Test that the label is correctly generated for an operation with an id"""
 
         with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-            op = qml.RX(1.344, wires=0, id="test_with_id")
+            op = qp.RX(1.344, wires=0, id="test_with_id")
         with pytest.warns(
             PennyLaneDeprecationWarning,
             match="Using 'id' to add a custom label to your operator is deprecated",
@@ -1355,7 +1355,7 @@ class TestOperatorIntegration:
         ):
             assert '"test_with_id"' in op.label(decimals=2)
 
-        op = qml.RX(1.344, wires=0)
+        op = qp.RX(1.344, wires=0)
         assert '"test_with_id"' not in op.label()
         assert '"test_with_id"' not in op.label(decimals=2)
 
@@ -1384,37 +1384,37 @@ class TestDefaultRepresentations:
             pass
 
         op = Operator_with_no_decomp(wires=0)
-        with pytest.raises(qml.operation.DecompositionUndefinedError):
+        with pytest.raises(qp.operation.DecompositionUndefinedError):
             Operator_with_no_decomp.compute_decomposition(wires=[1])
-        with pytest.raises(qml.operation.DecompositionUndefinedError):
+        with pytest.raises(qp.operation.DecompositionUndefinedError):
             op.decomposition()
 
     def test_decomposition_graph_fallback(self):
         """Test that the first registered decomp can be used if compute_decomposition is not overridden."""
 
-        class OpWithACustomName98786(qml.operation.Operator):
+        class OpWithACustomName98786(qp.operation.Operator):
             pass
 
-        @qml.register_resources({qml.RX: 1})
+        @qp.register_resources({qp.RX: 1})
         def decomp1(x, wires):
-            qml.RX(x, wires)
+            qp.RX(x, wires)
 
-        @qml.register_resources({qml.RZ: 1})
+        @qp.register_resources({qp.RZ: 1})
         def decomp2(x, wires):
-            qml.RZ(x, wires)
+            qp.RZ(x, wires)
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(OpWithACustomName98786, decomp1, decomp2)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(OpWithACustomName98786, decomp1, decomp2)
 
             [out] = OpWithACustomName98786(0.5, wires=0).decomposition()
-            qml.assert_equal(out, qml.RX(0.5, wires=0))
+            qp.assert_equal(out, qp.RX(0.5, wires=0))
 
             op = OpWithACustomName98786(0.5, wires=0)
-            with qml.queuing.AnnotatedQueue() as q:
+            with qp.queuing.AnnotatedQueue() as q:
                 op.decomposition()
 
             assert len(q.queue) == 1
-            qml.assert_equal(q.queue[0], qml.RX(0.5, wires=0))
+            qp.assert_equal(q.queue[0], qp.RX(0.5, wires=0))
 
     def test_graph_decomposition_fallback_conditions(self):
         """Test the graph decomposition fallback is sensitive to conditions."""
@@ -1423,73 +1423,73 @@ class TestDefaultRepresentations:
         """Test that operators with multiple decompositions and conditions have
         correct has_decomposition properties."""
 
-        class BVCX(qml.operation.Operator):
+        class BVCX(qp.operation.Operator):
             @property
             def resource_params(self):
                 return {"num_wires": len(self.wires)}
 
-        @qml.register_condition(lambda num_wires: num_wires == 1)
-        @qml.register_resources({qml.RX: 1})
+        @qp.register_condition(lambda num_wires: num_wires == 1)
+        @qp.register_resources({qp.RX: 1})
         def decomp1(x, wires):
-            qml.RX(x, wires)
+            qp.RX(x, wires)
 
-        @qml.register_condition(lambda num_wires: num_wires == 2)
-        @qml.register_resources({qml.CRX: 1})
+        @qp.register_condition(lambda num_wires: num_wires == 2)
+        @qp.register_resources({qp.CRX: 1})
         def decomp2(x, wires):
-            qml.CRX(x, wires)
+            qp.CRX(x, wires)
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(BVCX, decomp1, decomp2)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(BVCX, decomp1, decomp2)
 
             [op1] = BVCX(0.5, wires=0).decomposition()
-            qml.assert_equal(op1, qml.RX(0.5, wires=0))
+            qp.assert_equal(op1, qp.RX(0.5, wires=0))
             [op2] = BVCX(0.5, wires=(0, 1)).decomposition()
-            qml.assert_equal(op2, qml.CRX(0.5, wires=(0, 1)))
+            qp.assert_equal(op2, qp.CRX(0.5, wires=(0, 1)))
 
-            with pytest.raises(qml.exceptions.DecompositionUndefinedError):
+            with pytest.raises(qp.exceptions.DecompositionUndefinedError):
                 BVCX(0.5, wires=(0, 1, 2)).decomposition()
 
     def test_matrix_undefined(self):
         """Tests that custom error is raised in the default matrix representation."""
-        with pytest.raises(qml.operation.MatrixUndefinedError):
+        with pytest.raises(qp.operation.MatrixUndefinedError):
             MyOp.compute_matrix()
-        with pytest.raises(qml.operation.MatrixUndefinedError):
+        with pytest.raises(qp.operation.MatrixUndefinedError):
             op.matrix()
 
     def test_terms_undefined(self):
         """Tests that custom error is raised in the default terms representation."""
-        with pytest.raises(qml.operation.TermsUndefinedError):
+        with pytest.raises(qp.operation.TermsUndefinedError):
             op.terms()
 
     def test_sparse_matrix_undefined(self):
         """Tests that custom error is raised in the default sparse matrix representation."""
-        with pytest.raises(qml.operation.SparseMatrixUndefinedError):
+        with pytest.raises(qp.operation.SparseMatrixUndefinedError):
             MyOp.compute_sparse_matrix()
-        with pytest.raises(qml.operation.SparseMatrixUndefinedError):
+        with pytest.raises(qp.operation.SparseMatrixUndefinedError):
             op.sparse_matrix()
 
     def test_eigvals_undefined(self):
         """Tests that custom error is raised in the default eigenvalue representation."""
-        with pytest.raises(qml.operation.EigvalsUndefinedError):
+        with pytest.raises(qp.operation.EigvalsUndefinedError):
             MyOp.compute_eigvals()
-        with pytest.raises(qml.operation.EigvalsUndefinedError):
+        with pytest.raises(qp.operation.EigvalsUndefinedError):
             op.eigvals()
 
     def test_diaggates_undefined(self):
         """Tests that custom error is raised in the default diagonalizing gates representation."""
-        with pytest.raises(qml.operation.DiagGatesUndefinedError):
+        with pytest.raises(qp.operation.DiagGatesUndefinedError):
             MyOp.compute_diagonalizing_gates(wires=[1])
-        with pytest.raises(qml.operation.DiagGatesUndefinedError):
+        with pytest.raises(qp.operation.DiagGatesUndefinedError):
             op.diagonalizing_gates()
 
     def test_adjoint_undefined(self):
         """Tests that custom error is raised in the default adjoint representation."""
-        with pytest.raises(qml.operation.AdjointUndefinedError):
+        with pytest.raises(qp.operation.AdjointUndefinedError):
             op.adjoint()
 
     def test_generator_undefined(self):
         """Tests that custom error is raised in the default generator representation."""
-        with pytest.raises(qml.operation.GeneratorUndefinedError):
+        with pytest.raises(qp.operation.GeneratorUndefinedError):
             gate.generator()
 
     def test_pow_zero(self):
@@ -1504,7 +1504,7 @@ class TestDefaultRepresentations:
 
     def test_pow_undefined(self):
         """Tests that custom error is raised in the default pow decomposition."""
-        with pytest.raises(qml.operation.PowUndefinedError):
+        with pytest.raises(qp.operation.PowUndefinedError):
             gate.pow(1.234)
 
 
@@ -1541,7 +1541,7 @@ class TestChannel:
     def test_instance_made_correctly(self):
         """Test that instance of channel class is initialized correctly"""
 
-        class DummyOp(qml.operation.Channel):
+        class DummyOp(qp.operation.Channel):
             r"""Dummy custom channel"""
 
             num_wires = 1
@@ -1564,14 +1564,14 @@ class TestOperationDerivative:
     def test_no_generator_raise(self):
         """Tests if the function raises an exception if the input operation has no generator"""
 
-        class CustomOp(qml.operation.Operation):
+        class CustomOp(qp.operation.Operation):
             num_wires = 1
             num_params = 1
 
         op = CustomOp(0.5, wires=0)
 
         with pytest.raises(
-            qml.operation.GeneratorUndefinedError,
+            qp.operation.GeneratorUndefinedError,
             match="Operation CustomOp does not have a generator",
         ):
             operation_derivative(op)
@@ -1580,9 +1580,9 @@ class TestOperationDerivative:
         """Test if the function raises a ValueError if the input operation is composed of multiple
         parameters"""
 
-        class RotWithGen(qml.Rot):
+        class RotWithGen(qp.Rot):
             def generator(self):
-                return qml.Hermitian(np.zeros((2, 2)), wires=self.wires)
+                return qp.Hermitian(np.zeros((2, 2)), wires=self.wires)
 
         op = RotWithGen(0.1, 0.2, 0.3, wires=0)
 
@@ -1592,7 +1592,7 @@ class TestOperationDerivative:
     def test_rx(self):
         """Test if the function correctly returns the derivative of RX"""
         p = 0.3
-        op = qml.RX(p, wires=0)
+        op = qp.RX(p, wires=0)
 
         derivative = operation_derivative(op)
 
@@ -1605,7 +1605,7 @@ class TestOperationDerivative:
     def test_phase(self):
         """Test if the function correctly returns the derivative of PhaseShift"""
         p = 0.3
-        op = qml.PhaseShift(p, wires=0)
+        op = qp.PhaseShift(p, wires=0)
 
         derivative = operation_derivative(op)
         expected_derivative = np.array([[0, 0], [0, 1j * np.exp(1j * p)]])
@@ -1614,7 +1614,7 @@ class TestOperationDerivative:
     def test_cry(self):
         """Test if the function correctly returns the derivative of CRY"""
         p = 0.3
-        op = qml.CRY(p, wires=[0, 1])
+        op = qp.CRY(p, wires=[0, 1])
 
         derivative = operation_derivative(op)
         expected_derivative = 0.5 * np.array(
@@ -1633,7 +1633,7 @@ class TestOperationDerivative:
         without any other context, the operation derivative should make no
         assumption about the wire ordering."""
         p = 0.3
-        op = qml.CRY(p, wires=[1, 0])
+        op = qp.CRY(p, wires=[1, 0])
 
         derivative = operation_derivative(op)
         expected_derivative = 0.5 * np.array(
@@ -1653,7 +1653,7 @@ class TestCVOperation:
     def test_wires_not_found(self):
         """Make sure that `heisenberg_expand` method receives enough wires to actually expand"""
 
-        class DummyOp(qml.operation.CVOperation):
+        class DummyOp(qp.operation.CVOperation):
             num_wires = 1
 
         op = DummyOp(wires=1)
@@ -1664,7 +1664,7 @@ class TestCVOperation:
     def test_input_validation(self):
         """Make sure that size of input for `heisenberg_expand` method is validated"""
 
-        class DummyOp(qml.operation.CVOperation):
+        class DummyOp(qp.operation.CVOperation):
             num_wires = 1
 
         op = DummyOp(wires=1)
@@ -1676,7 +1676,7 @@ class TestCVOperation:
     def test_wrong_input_shape(self):
         """Ensure that `heisenberg_expand` raises exception if it receives an array with order > 2"""
 
-        class DummyOp(qml.operation.CVOperation):
+        class DummyOp(qp.operation.CVOperation):
             num_wires = 1
 
         op = DummyOp(wires=1)
@@ -1719,29 +1719,29 @@ class TestStatePrepBase:
 
 
 class TestCriteria:
-    doubleExcitation = qml.DoubleExcitation(0.1, wires=[0, 1, 2, 3])
-    rx = qml.RX(qml.numpy.array(0.3, requires_grad=True), wires=1)
-    stiff_rx = qml.RX(0.3, wires=1)
-    cnot = qml.CNOT(wires=[1, 0])
-    rot = qml.Rot(*qml.numpy.array([0.1, -0.7, 0.2], requires_grad=True), wires=0)
-    stiff_rot = qml.Rot(0.1, -0.7, 0.2, wires=0)
-    exp = qml.expval(qml.PauliZ(0))
+    doubleExcitation = qp.DoubleExcitation(0.1, wires=[0, 1, 2, 3])
+    rx = qp.RX(qp.numpy.array(0.3, requires_grad=True), wires=1)
+    stiff_rx = qp.RX(0.3, wires=1)
+    cnot = qp.CNOT(wires=[1, 0])
+    rot = qp.Rot(*qp.numpy.array([0.1, -0.7, 0.2], requires_grad=True), wires=0)
+    stiff_rot = qp.Rot(0.1, -0.7, 0.2, wires=0)
+    exp = qp.expval(qp.PauliZ(0))
 
     def test_is_trainable(self):
         """Test is_trainable criterion."""
-        assert qml.operation.is_trainable(self.rx)
-        assert not qml.operation.is_trainable(self.stiff_rx)
-        assert qml.operation.is_trainable(self.rot)
-        assert not qml.operation.is_trainable(self.stiff_rot)
-        assert not qml.operation.is_trainable(self.cnot)
+        assert qp.operation.is_trainable(self.rx)
+        assert not qp.operation.is_trainable(self.stiff_rx)
+        assert qp.operation.is_trainable(self.rot)
+        assert not qp.operation.is_trainable(self.stiff_rot)
+        assert not qp.operation.is_trainable(self.cnot)
 
 
 pairs_of_ops = [
-    (qml.S(0), qml.T(0)),
-    (qml.S(0), qml.PauliX(0)),
-    (qml.PauliX(0), qml.S(0)),
-    (qml.PauliX(0), qml.PauliY(0)),
-    (qml.PauliZ(0), qml.prod(qml.PauliX(0), qml.PauliY(1))),
+    (qp.S(0), qp.T(0)),
+    (qp.S(0), qp.PauliX(0)),
+    (qp.PauliX(0), qp.S(0)),
+    (qp.PauliX(0), qp.PauliY(0)),
+    (qp.PauliZ(0), qp.prod(qp.PauliX(0), qp.PauliY(1))),
 ]
 
 
@@ -1756,60 +1756,60 @@ class TestNewOpMath:
             """Tests adding two operators, observable or not."""
             op = op0 + op1
             assert isinstance(op, Sum)
-            qml.assert_equal(op[0], op0)
-            qml.assert_equal(op[1], op1)
+            qp.assert_equal(op[0], op0)
+            qp.assert_equal(op[1], op1)
 
         @pytest.mark.parametrize("op0,op1", pairs_of_ops)
         def test_sub_operators(self, op0, op1):
             """Tests subtracting two operators."""
             op = op0 - op1
             assert isinstance(op, Sum)
-            qml.assert_equal(op[0], op0)
+            qp.assert_equal(op[0], op0)
             assert isinstance(op[1], SProd)
             assert op[1].scalar == -1
-            qml.assert_equal(op[1].base, op1)
+            qp.assert_equal(op[1].base, op1)
 
         def test_sub_with_unknown_not_supported(self):
             """Test subtracting an unexpected type from an Operator."""
             with pytest.raises(TypeError, match="unsupported operand type"):
-                _ = qml.S(0) - "foo"
+                _ = qp.S(0) - "foo"
 
         def test_op_with_scalar(self):
             """Tests adding/subtracting ops with scalars."""
-            x0 = qml.PauliX(0)
+            x0 = qp.PauliX(0)
             for op in [x0 + 1, 1 + x0]:
                 assert isinstance(op, Sum)
-                qml.assert_equal(op[0], x0)
+                qp.assert_equal(op[0], x0)
                 assert isinstance(op[1], SProd)
                 assert op[1].scalar == 1
-                qml.assert_equal(op[1].base, qml.Identity(0))
+                qp.assert_equal(op[1].base, qp.Identity(0))
 
-            x1 = qml.PauliX(1)
+            x1 = qp.PauliX(1)
             op = x1 - 1.1
             assert isinstance(op, Sum)
-            qml.assert_equal(op[0], x1)
+            qp.assert_equal(op[0], x1)
             assert isinstance(op[1], SProd)
             assert op[1].scalar == -1.1
-            qml.assert_equal(op[1].base, qml.Identity(1))
+            qp.assert_equal(op[1].base, qp.Identity(1))
 
             op = 1.1 - x1  # will use radd
             assert isinstance(op, Sum)
             assert isinstance(op[0], SProd)
             assert op[0].scalar == -1
-            qml.assert_equal(op[0].base, x1)
+            qp.assert_equal(op[0].base, x1)
             assert isinstance(op[1], SProd)
             assert op[1].scalar == 1.1
-            qml.assert_equal(op[1].base, qml.Identity(1))
+            qp.assert_equal(op[1].base, qp.Identity(1))
 
         def test_adding_many_does_auto_simplify(self):
             """Tests that adding more than two operators creates nested Sums."""
-            op0, op1, op2 = qml.S(0), qml.T(0), qml.PauliZ(0)
+            op0, op1, op2 = qp.S(0), qp.T(0), qp.PauliZ(0)
             op = op0 + op1 + op2
             assert isinstance(op, Sum)
             assert len(op) == 3
-            qml.assert_equal(op[0], op0)
-            qml.assert_equal(op[1], op1)
-            qml.assert_equal(op[2], op2)
+            qp.assert_equal(op[0], op0)
+            qp.assert_equal(op[1], op1)
+            qp.assert_equal(op[2], op2)
 
     class TestMul:
         """Test the __mul__/__rmul__ dunders."""
@@ -1817,28 +1817,28 @@ class TestNewOpMath:
         @pytest.mark.parametrize("scalar", [0, 1, 1.1, 1 + 2j, [3, 4j]])
         def test_mul(self, scalar):
             """Tests multiplying an operator by a scalar coefficient works as expected."""
-            base = qml.PauliX(0)
+            base = qp.PauliX(0)
             for op in [scalar * base, base * scalar]:
                 assert isinstance(op, SProd)
-                assert qml.math.allequal(op.scalar, scalar)
-                qml.assert_equal(op.base, base)
+                assert qp.math.allequal(op.scalar, scalar)
+                qp.assert_equal(op.base, base)
 
-        @pytest.mark.parametrize("scalar", [1, 1.1, 1 + 2j, qml.numpy.array([3, 4j])])
+        @pytest.mark.parametrize("scalar", [1, 1.1, 1 + 2j, qp.numpy.array([3, 4j])])
         def test_div(self, scalar):
             """Tests diviing an operator by a scalar coefficient works as expected."""
-            base = qml.PauliX(0)
+            base = qp.PauliX(0)
             op = base / scalar
             assert isinstance(op, SProd)
-            assert qml.math.allequal(op.scalar, 1 / scalar)
-            qml.assert_equal(op.base, base)
+            assert qp.math.allequal(op.scalar, 1 / scalar)
+            qp.assert_equal(op.base, base)
 
         def test_mul_does_auto_simplify(self):
             """Tests that multiplying an SProd with a scalar creates nested SProds."""
-            op = 2 * qml.PauliX(0)
+            op = 2 * qp.PauliX(0)
             nested = 0.5 * op
             assert isinstance(nested, SProd)
             assert nested.scalar == 1.0
-            qml.assert_equal(nested.base, qml.X(0))
+            qp.assert_equal(nested.base, qp.X(0))
 
     class TestMatMul:
         """Test the __matmul__/__rmatmul__ dunders."""
@@ -1848,64 +1848,64 @@ class TestNewOpMath:
             """Tests matrix-multiplication of two operators, observable or not."""
             op = op0 @ op1
             assert isinstance(op, Prod)
-            qml.assert_equal(op[0], op0)
+            qp.assert_equal(op[0], op0)
             if isinstance(op1, Prod):
-                qml.assert_equal(op[1], op1[0])
-                qml.assert_equal(op[2], op1[1])
+                qp.assert_equal(op[1], op1[0])
+                qp.assert_equal(op[2], op1[1])
             else:
-                qml.assert_equal(op[1], op1)
+                qp.assert_equal(op[1], op1)
 
         def test_mul_does_auto_simplify(self):
             """Tests that matrix-multiplying a Prod with another operator creates nested Prods."""
-            op0, op1, op2 = qml.PauliX(0), qml.PauliY(1), qml.PauliZ(2)
+            op0, op1, op2 = qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)
             op = op0 @ op1 @ op2
             assert isinstance(op, Prod)
             assert len(op) == 3
-            qml.assert_equal(op[0], op0)
-            qml.assert_equal(op[1], op1)
-            qml.assert_equal(op[2], op2)
+            qp.assert_equal(op[0], op0)
+            qp.assert_equal(op[1], op1)
+            qp.assert_equal(op[2], op2)
 
 
 class TestHamiltonianLinearCombinationAlias:
-    """Unit tests for using qml.Hamiltonian as an alias for LinearCombination"""
+    """Unit tests for using qp.Hamiltonian as an alias for LinearCombination"""
 
     def test_hamiltonian_linear_combination_alias_enabled(self):
-        """Test that qml.Hamiltonian is an alias for LinearCombination with new operator
+        """Test that qp.Hamiltonian is an alias for LinearCombination with new operator
         arithmetic enabled"""
-        op = qml.Hamiltonian([1.0], [qml.X(0)])
+        op = qp.Hamiltonian([1.0], [qp.X(0)])
 
-        assert isinstance(op, qml.ops.LinearCombination)
-        assert isinstance(op, qml.Hamiltonian)
+        assert isinstance(op, qp.ops.LinearCombination)
+        assert isinstance(op, qp.Hamiltonian)
 
 
 @pytest.mark.parametrize(
     "op",
     [
-        qml.CZ(wires=[1, 0]),
-        qml.CCZ(wires=[2, 0, 1]),
-        qml.SWAP(wires=[1, 0]),
-        qml.IsingXX(1.23, wires=[1, 0]),
-        qml.Identity(wires=[3, 1, 2, 0]),
-        qml.ISWAP(wires=[1, 0]),
-        qml.SISWAP(wires=[1, 0]),
-        qml.SQISW(wires=[1, 0]),
-        qml.MultiRZ(1.23, wires=[2, 0, 1, 3]),
-        qml.IsingXY(1.23, wires=[1, 0]),
-        qml.IsingYY(1.23, wires=[1, 0]),
-        qml.IsingZZ(1.23, wires=[1, 0]),
-        qml.PSWAP(1.23, wires=[1, 0]),
+        qp.CZ(wires=[1, 0]),
+        qp.CCZ(wires=[2, 0, 1]),
+        qp.SWAP(wires=[1, 0]),
+        qp.IsingXX(1.23, wires=[1, 0]),
+        qp.Identity(wires=[3, 1, 2, 0]),
+        qp.ISWAP(wires=[1, 0]),
+        qp.SISWAP(wires=[1, 0]),
+        qp.SQISW(wires=[1, 0]),
+        qp.MultiRZ(1.23, wires=[2, 0, 1, 3]),
+        qp.IsingXY(1.23, wires=[1, 0]),
+        qp.IsingYY(1.23, wires=[1, 0]),
+        qp.IsingZZ(1.23, wires=[1, 0]),
+        qp.PSWAP(1.23, wires=[1, 0]),
     ],
 )
 def test_symmetric_matrix_early_return(op, mocker):
     """Test that operators that are symmetric over all wires are not reordered
     when the wire order only contains the same wires as the operator."""
 
-    spy = mocker.spy(qml.operation, "expand_matrix")
+    spy = mocker.spy(qp.operation, "expand_matrix")
     actual = op.matrix(wire_order=list(range(len(op.wires))))
 
     spy.assert_not_called()
     expected = op.matrix()
-    manually_expanded = qml.math.expand_matrix(
+    manually_expanded = qp.math.expand_matrix(
         expected, wires=op.wires, wire_order=list(range(len(op.wires)))
     )
 
@@ -1918,7 +1918,7 @@ def test_docstring_example_of_operator_class(tol):
     Operator class docstring, as well as in the 'adding_operators'
     page in the developer guide."""
 
-    class FlipAndRotate(qml.operation.Operation):
+    class FlipAndRotate(qp.operation.Operation):
         grad_method = "A"
 
         # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -1928,7 +1928,7 @@ def test_docstring_example_of_operator_class(tol):
 
             self._hyperparameters = {"do_flip": do_flip}
 
-            all_wires = qml.wires.Wires(wire_rot) + qml.wires.Wires(wire_flip)
+            all_wires = qp.wires.Wires(wire_rot) + qp.wires.Wires(wire_flip)
             super().__init__(angle, wires=all_wires, id=id)
 
         @property
@@ -1943,8 +1943,8 @@ def test_docstring_example_of_operator_class(tol):
         def compute_decomposition(angle, wires, do_flip):  # pylint: disable=arguments-differ
             op_list = []
             if do_flip:
-                op_list.append(qml.PauliX(wires=wires[1]))
-            op_list.append(qml.RX(angle, wires=wires[0]))
+                op_list.append(qp.PauliX(wires=wires[1]))
+            op_list.append(qp.RX(angle, wires=wires[0]))
             return op_list
 
         def adjoint(self):
@@ -1955,12 +1955,12 @@ def test_docstring_example_of_operator_class(tol):
                 do_flip=self.hyperparameters["do_flip"],
             )
 
-    dev = qml.device("default.qubit", wires=["q1", "q2", "q3"])
+    dev = qp.device("default.qubit", wires=["q1", "q2", "q3"])
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(angle):
         FlipAndRotate(angle, wire_rot="q1", wire_flip="q1")
-        return qml.expval(qml.PauliZ("q1"))
+        return qp.expval(qp.PauliZ("q1"))
 
     a = np.array(3.14)
     res = circuit(a)
@@ -1974,7 +1974,7 @@ def test_custom_operator_is_jax_pytree():
 
     import jax
 
-    class CustomOperator(qml.operation.Operator):
+    class CustomOperator(qp.operation.Operator):
         pass
 
     op = CustomOperator(1.2, wires=0)
@@ -1982,7 +1982,7 @@ def test_custom_operator_is_jax_pytree():
     assert data == [1.2]
 
     new_op = jax.tree_util.tree_unflatten(structure, [2.3])
-    qml.assert_equal(new_op, CustomOperator(2.3, wires=0))
+    qp.assert_equal(new_op, CustomOperator(2.3, wires=0))
 
 
 # pylint: disable=unused-import,no-name-in-module
@@ -1993,7 +1993,7 @@ def test_get_attr():
     with pytest.raises(
         AttributeError, match=f"module 'pennylane.operation' has no attribute '{attr_name}'"
     ):
-        _ = qml.operation.non_existent_attr  # error is raised if non-existent attribute accessed
+        _ = qp.operation.non_existent_attr  # error is raised if non-existent attribute accessed
 
     with pytest.raises(ImportError, match=f"cannot import name '{attr_name}'"):
         from pennylane.operation import (
@@ -2003,5 +2003,5 @@ def test_get_attr():
     from pennylane.operation import StatePrep
 
     assert (
-        StatePrep is qml.operation.StatePrepBase
+        StatePrep is qp.operation.StatePrepBase
     )  # StatePrep imported from operation.py is an alias for StatePrepBase

--- a/tests/test_qaoa.py
+++ b/tests/test_qaoa.py
@@ -25,7 +25,7 @@ from networkx import Graph
 from scipy.linalg import expm
 from scipy.sparse import csc_matrix, kron
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import qaoa
 from pennylane.qaoa.cycle import (
     _inner_net_flow_constraint_hamiltonian,
@@ -88,11 +88,11 @@ def lollipop_graph_rx(mesh_nodes: int, path_nodes: int, to_directed: bool = Fals
     return g
 
 
-def matrix(hamiltonian: qml.Hamiltonian, n_wires: int) -> csc_matrix:
+def matrix(hamiltonian: qp.Hamiltonian, n_wires: int) -> csc_matrix:
     r"""Calculates the matrix representation of an input Hamiltonian in the standard basis.
 
     Args:
-        hamiltonian (qml.Hamiltonian): the input Hamiltonian
+        hamiltonian (qp.Hamiltonian): the input Hamiltonian
         n_wires (int): the total number of wires
 
     Returns:
@@ -102,7 +102,7 @@ def matrix(hamiltonian: qml.Hamiltonian, n_wires: int) -> csc_matrix:
 
     for op in hamiltonian.ops:
 
-        if isinstance(op, qml.ops.Prod):
+        if isinstance(op, qp.ops.Prod):
             op_matrix = op.sparse_matrix(wire_order=list(range(n_wires)))
         else:
             op_wires = np.array(op.wires.tolist())
@@ -130,99 +130,99 @@ def make_xy_mixer_test_cases():
     return [
         (
             g2,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(1),
-                    qml.PauliY(0) @ qml.PauliY(1),
-                    qml.PauliX(1) @ qml.PauliX(2),
-                    qml.PauliY(1) @ qml.PauliY(2),
-                    qml.PauliX(2) @ qml.PauliX(3),
-                    qml.PauliY(2) @ qml.PauliY(3),
+                    qp.PauliX(0) @ qp.PauliX(1),
+                    qp.PauliY(0) @ qp.PauliY(1),
+                    qp.PauliX(1) @ qp.PauliX(2),
+                    qp.PauliY(1) @ qp.PauliY(2),
+                    qp.PauliX(2) @ qp.PauliX(3),
+                    qp.PauliY(2) @ qp.PauliY(3),
                 ],
             ),
         ),
         (
             line_graph,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(1),
-                    qml.PauliY(0) @ qml.PauliY(1),
-                    qml.PauliX(1) @ qml.PauliX(2),
-                    qml.PauliY(1) @ qml.PauliY(2),
+                    qp.PauliX(0) @ qp.PauliX(1),
+                    qp.PauliY(0) @ qp.PauliY(1),
+                    qp.PauliX(1) @ qp.PauliX(2),
+                    qp.PauliY(1) @ qp.PauliY(2),
                 ],
             ),
         ),
         (
             non_consecutive_graph,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(4),
-                    qml.PauliY(0) @ qml.PauliY(4),
-                    qml.PauliX(0) @ qml.PauliX(2),
-                    qml.PauliY(0) @ qml.PauliY(2),
-                    qml.PauliX(4) @ qml.PauliX(3),
-                    qml.PauliY(4) @ qml.PauliY(3),
-                    qml.PauliX(2) @ qml.PauliX(1),
-                    qml.PauliY(2) @ qml.PauliY(1),
+                    qp.PauliX(0) @ qp.PauliX(4),
+                    qp.PauliY(0) @ qp.PauliY(4),
+                    qp.PauliX(0) @ qp.PauliX(2),
+                    qp.PauliY(0) @ qp.PauliY(2),
+                    qp.PauliX(4) @ qp.PauliX(3),
+                    qp.PauliY(4) @ qp.PauliY(3),
+                    qp.PauliX(2) @ qp.PauliX(1),
+                    qp.PauliY(2) @ qp.PauliY(1),
                 ],
             ),
         ),
         (
             g2_rx,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(1),
-                    qml.PauliY(0) @ qml.PauliY(1),
-                    qml.PauliX(1) @ qml.PauliX(2),
-                    qml.PauliY(1) @ qml.PauliY(2),
-                    qml.PauliX(2) @ qml.PauliX(3),
-                    qml.PauliY(2) @ qml.PauliY(3),
+                    qp.PauliX(0) @ qp.PauliX(1),
+                    qp.PauliY(0) @ qp.PauliY(1),
+                    qp.PauliX(1) @ qp.PauliX(2),
+                    qp.PauliY(1) @ qp.PauliY(2),
+                    qp.PauliX(2) @ qp.PauliX(3),
+                    qp.PauliY(2) @ qp.PauliY(3),
                 ],
             ),
         ),
         (
             graph_rx,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(1),
-                    qml.PauliY(0) @ qml.PauliY(1),
-                    qml.PauliX(1) @ qml.PauliX(2),
-                    qml.PauliY(1) @ qml.PauliY(2),
+                    qp.PauliX(0) @ qp.PauliX(1),
+                    qp.PauliY(0) @ qp.PauliY(1),
+                    qp.PauliX(1) @ qp.PauliX(2),
+                    qp.PauliY(1) @ qp.PauliY(2),
                 ],
             ),
         ),
         (
             non_consecutive_graph_rx,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(4),
-                    qml.PauliY(0) @ qml.PauliY(4),
-                    qml.PauliX(0) @ qml.PauliX(2),
-                    qml.PauliY(0) @ qml.PauliY(2),
-                    qml.PauliX(4) @ qml.PauliX(3),
-                    qml.PauliY(4) @ qml.PauliY(3),
-                    qml.PauliX(2) @ qml.PauliX(1),
-                    qml.PauliY(2) @ qml.PauliY(1),
+                    qp.PauliX(0) @ qp.PauliX(4),
+                    qp.PauliY(0) @ qp.PauliY(4),
+                    qp.PauliX(0) @ qp.PauliX(2),
+                    qp.PauliY(0) @ qp.PauliY(2),
+                    qp.PauliX(4) @ qp.PauliX(3),
+                    qp.PauliY(4) @ qp.PauliY(3),
+                    qp.PauliX(2) @ qp.PauliX(1),
+                    qp.PauliY(2) @ qp.PauliY(1),
                 ],
             ),
         ),
         (
             Graph((np.array([0, 1]), np.array([1, 2]), np.array([2, 0]))),
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.5, 0.5, 0.5, 0.5],
                 [
-                    qml.PauliX(0) @ qml.PauliX(1),
-                    qml.PauliY(0) @ qml.PauliY(1),
-                    qml.PauliX(0) @ qml.PauliX(2),
-                    qml.PauliY(0) @ qml.PauliY(2),
-                    qml.PauliX(1) @ qml.PauliX(2),
-                    qml.PauliY(1) @ qml.PauliY(2),
+                    qp.PauliX(0) @ qp.PauliX(1),
+                    qp.PauliY(0) @ qp.PauliY(1),
+                    qp.PauliX(0) @ qp.PauliX(2),
+                    qp.PauliY(0) @ qp.PauliY(2),
+                    qp.PauliX(1) @ qp.PauliX(2),
+                    qp.PauliY(1) @ qp.PauliY(2),
                 ],
             ),
         ),
@@ -234,89 +234,89 @@ def make_bit_flip_mixer_test_cases():
         (
             Graph([(0, 1)]),
             1,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, -0.5, 0.5, -0.5],
                 [
-                    qml.PauliX(0),
-                    qml.PauliX(0) @ qml.PauliZ(1),
-                    qml.PauliX(1),
-                    qml.PauliX(1) @ qml.PauliZ(0),
+                    qp.PauliX(0),
+                    qp.PauliX(0) @ qp.PauliZ(1),
+                    qp.PauliX(1),
+                    qp.PauliX(1) @ qp.PauliZ(0),
                 ],
             ),
         ),
         (
             g1,
             0,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.25, 0.25, 0.25, 0.25, 0.5, 0.5],
                 [
-                    qml.PauliX(0),
-                    qml.PauliX(0) @ qml.PauliZ(1),
-                    qml.PauliX(1),
-                    qml.PauliX(1) @ qml.PauliZ(2),
-                    qml.PauliX(1) @ qml.PauliZ(0),
-                    qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-                    qml.PauliX(2),
-                    qml.PauliX(2) @ qml.PauliZ(1),
+                    qp.PauliX(0),
+                    qp.PauliX(0) @ qp.PauliZ(1),
+                    qp.PauliX(1),
+                    qp.PauliX(1) @ qp.PauliZ(2),
+                    qp.PauliX(1) @ qp.PauliZ(0),
+                    qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+                    qp.PauliX(2),
+                    qp.PauliX(2) @ qp.PauliZ(1),
                 ],
             ),
         ),
         (
             g1_rx,
             0,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.5, 0.5, 0.25, 0.25, 0.25, 0.25, 0.5, 0.5],
                 [
-                    qml.PauliX(0),
-                    qml.PauliX(0) @ qml.PauliZ(1),
-                    qml.PauliX(1),
-                    qml.PauliX(1) @ qml.PauliZ(2),
-                    qml.PauliX(1) @ qml.PauliZ(0),
-                    qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-                    qml.PauliX(2),
-                    qml.PauliX(2) @ qml.PauliZ(1),
+                    qp.PauliX(0),
+                    qp.PauliX(0) @ qp.PauliZ(1),
+                    qp.PauliX(1),
+                    qp.PauliX(1) @ qp.PauliZ(2),
+                    qp.PauliX(1) @ qp.PauliZ(0),
+                    qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+                    qp.PauliX(2),
+                    qp.PauliX(2) @ qp.PauliZ(1),
                 ],
             ),
         ),
         (
             Graph([("b", 1), (1, 0.3), (0.3, "b")]),
             1,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.25, -0.25, -0.25, 0.25, 0.25, -0.25, -0.25, 0.25, 0.25, -0.25, -0.25, 0.25],
                 [
-                    qml.PauliX("b"),
-                    qml.PauliX("b") @ qml.PauliZ(0.3),
-                    qml.PauliX("b") @ qml.PauliZ(1),
-                    qml.PauliX("b") @ qml.PauliZ(1) @ qml.PauliZ(0.3),
-                    qml.PauliX(1),
-                    qml.PauliX(1) @ qml.PauliZ(0.3),
-                    qml.PauliX(1) @ qml.PauliZ("b"),
-                    qml.PauliX(1) @ qml.PauliZ("b") @ qml.PauliZ(0.3),
-                    qml.PauliX(0.3),
-                    qml.PauliX(0.3) @ qml.PauliZ("b"),
-                    qml.PauliX(0.3) @ qml.PauliZ(1),
-                    qml.PauliX(0.3) @ qml.PauliZ(1) @ qml.PauliZ("b"),
+                    qp.PauliX("b"),
+                    qp.PauliX("b") @ qp.PauliZ(0.3),
+                    qp.PauliX("b") @ qp.PauliZ(1),
+                    qp.PauliX("b") @ qp.PauliZ(1) @ qp.PauliZ(0.3),
+                    qp.PauliX(1),
+                    qp.PauliX(1) @ qp.PauliZ(0.3),
+                    qp.PauliX(1) @ qp.PauliZ("b"),
+                    qp.PauliX(1) @ qp.PauliZ("b") @ qp.PauliZ(0.3),
+                    qp.PauliX(0.3),
+                    qp.PauliX(0.3) @ qp.PauliZ("b"),
+                    qp.PauliX(0.3) @ qp.PauliZ(1),
+                    qp.PauliX(0.3) @ qp.PauliZ(1) @ qp.PauliZ("b"),
                 ],
             ),
         ),
         (
             b_rx,
             1,
-            qml.Hamiltonian(
+            qp.Hamiltonian(
                 [0.25, -0.25, -0.25, 0.25, 0.25, -0.25, -0.25, 0.25, 0.25, -0.25, -0.25, 0.25],
                 [
-                    qml.PauliX("b"),
-                    qml.PauliX("b") @ qml.PauliZ(0.3),
-                    qml.PauliX("b") @ qml.PauliZ(1),
-                    qml.PauliX("b") @ qml.PauliZ(1) @ qml.PauliZ(0.3),
-                    qml.PauliX(1),
-                    qml.PauliX(1) @ qml.PauliZ(0.3),
-                    qml.PauliX(1) @ qml.PauliZ("b"),
-                    qml.PauliX(1) @ qml.PauliZ("b") @ qml.PauliZ(0.3),
-                    qml.PauliX(0.3),
-                    qml.PauliX(0.3) @ qml.PauliZ(1),
-                    qml.PauliX(0.3) @ qml.PauliZ("b"),
-                    qml.PauliX(0.3) @ qml.PauliZ("b") @ qml.PauliZ(1),
+                    qp.PauliX("b"),
+                    qp.PauliX("b") @ qp.PauliZ(0.3),
+                    qp.PauliX("b") @ qp.PauliZ(1),
+                    qp.PauliX("b") @ qp.PauliZ(1) @ qp.PauliZ(0.3),
+                    qp.PauliX(1),
+                    qp.PauliX(1) @ qp.PauliZ(0.3),
+                    qp.PauliX(1) @ qp.PauliZ("b"),
+                    qp.PauliX(1) @ qp.PauliZ("b") @ qp.PauliZ(0.3),
+                    qp.PauliX(0.3),
+                    qp.PauliX(0.3) @ qp.PauliZ(1),
+                    qp.PauliX(0.3) @ qp.PauliZ("b"),
+                    qp.PauliX(0.3) @ qp.PauliZ("b") @ qp.PauliZ(1),
                 ],
             ),
         ),
@@ -331,9 +331,9 @@ class TestMixerHamiltonians:
 
         wires = range(4)
         mixer_hamiltonian = qaoa.x_mixer(wires)
-        expected_hamiltonian = qml.Hamiltonian(
+        expected_hamiltonian = qp.Hamiltonian(
             [1, 1, 1, 1],
-            [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2), qml.PauliX(3)],
+            [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2), qp.PauliX(3)],
         )
         assert mixer_hamiltonian == expected_hamiltonian
 
@@ -344,7 +344,7 @@ class TestMixerHamiltonians:
         mixer_hamiltonian = qaoa.x_mixer(wires)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, mixer_hamiltonian.ops[0]) for o in mixer_hamiltonian.ops[1:])
+        assert all(qp.is_commuting(o, mixer_hamiltonian.ops[0]) for o in mixer_hamiltonian.ops[1:])
         # check that the 1-group grouping information was set
         assert mixer_hamiltonian.grouping_indices is not None
         assert mixer_hamiltonian.grouping_indices == ((0, 1, 2, 3),)
@@ -407,19 +407,19 @@ def make_max_cut_test_cases():
     ]
 
     cost_terms = [
-        [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1) @ qml.PauliZ(2), qml.Identity(0)],
-        [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1) @ qml.PauliZ(2), qml.Identity(0)],
+        [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliZ(1) @ qp.PauliZ(2), qp.Identity(0)],
+        [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliZ(1) @ qp.PauliZ(2), qp.Identity(0)],
         [
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.Identity(0),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.Identity(0),
         ],
-        [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1) @ qml.PauliZ(2), qml.Identity(0)],
-        [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliZ(1) @ qml.PauliZ(2), qml.Identity(0)],
+        [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliZ(1) @ qp.PauliZ(2), qp.Identity(0)],
+        [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliZ(1) @ qp.PauliZ(2), qp.Identity(0)],
     ]
 
-    cost_hamiltonians = [qml.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
+    cost_hamiltonians = [qp.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
 
     mixer_coeffs = [
         [1, 1, 1],
@@ -430,14 +430,14 @@ def make_max_cut_test_cases():
     ]
 
     mixer_terms = [
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
     ]
 
-    mixer_hamiltonians = [qml.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
+    mixer_hamiltonians = [qp.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
 
     return list(zip(GRAPHS, cost_hamiltonians, mixer_hamiltonians))
 
@@ -463,27 +463,27 @@ def make_max_independent_test_cases():
     ]
 
     cost_terms = [
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
         [
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliZ(2),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliZ(2),
         ],
-        # [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
+        # [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
         [
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliZ(2),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliZ(2),
         ],
     ]
 
-    cost_hamiltonians = [qml.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
+    cost_hamiltonians = [qp.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
 
     mixer_coeffs = [
         [0.5, 0.5, 0.25, 0.25, 0.25, 0.25, 0.5, 0.5],
@@ -495,44 +495,44 @@ def make_max_independent_test_cases():
 
     mixer_terms = [
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(1),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(1),
         ],
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(1),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(1),
         ],
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(2),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(0) @ qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(0),
-            qml.PauliX(2) @ qml.PauliZ(1),
-            qml.PauliX(2) @ qml.PauliZ(1) @ qml.PauliZ(0),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(2),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(0) @ qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(0),
+            qp.PauliX(2) @ qp.PauliZ(1),
+            qp.PauliX(2) @ qp.PauliZ(1) @ qp.PauliZ(0),
         ],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
     ]
 
-    mixer_hamiltonians = [qml.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
+    mixer_hamiltonians = [qp.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
 
     return list(zip(GRAPHS, CONSTRAINED, cost_hamiltonians, mixer_hamiltonians))
 
@@ -549,26 +549,26 @@ def make_min_vertex_cover_test_cases():
     ]
 
     cost_terms = [
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
         [
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliZ(2),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliZ(2),
         ],
         [
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliZ(2),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliZ(2),
         ],
     ]
 
-    cost_hamiltonians = [qml.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
+    cost_hamiltonians = [qp.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
 
     mixer_coeffs = [
         [0.5, -0.5, 0.25, -0.25, -0.25, 0.25, 0.5, -0.5],
@@ -580,44 +580,44 @@ def make_min_vertex_cover_test_cases():
 
     mixer_terms = [
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(1),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(1),
         ],
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(1),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(1),
         ],
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(2),
-            qml.PauliX(0) @ qml.PauliZ(1),
-            qml.PauliX(0) @ qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliX(1),
-            qml.PauliX(1) @ qml.PauliZ(2),
-            qml.PauliX(1) @ qml.PauliZ(0),
-            qml.PauliX(1) @ qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(0),
-            qml.PauliX(2) @ qml.PauliZ(1),
-            qml.PauliX(2) @ qml.PauliZ(1) @ qml.PauliZ(0),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(2),
+            qp.PauliX(0) @ qp.PauliZ(1),
+            qp.PauliX(0) @ qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliX(1),
+            qp.PauliX(1) @ qp.PauliZ(2),
+            qp.PauliX(1) @ qp.PauliZ(0),
+            qp.PauliX(1) @ qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(0),
+            qp.PauliX(2) @ qp.PauliZ(1),
+            qp.PauliX(2) @ qp.PauliZ(1) @ qp.PauliZ(0),
         ],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
     ]
 
-    mixer_hamiltonians = [qml.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
+    mixer_hamiltonians = [qp.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
 
     return list(zip(GRAPHS, CONSTRAINED, cost_hamiltonians, mixer_hamiltonians))
 
@@ -634,14 +634,14 @@ def make_max_clique_test_cases():
     ]
 
     cost_terms = [
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)],
-        [qml.PauliZ(0) @ qml.PauliZ(2), qml.PauliZ(0), qml.PauliZ(2), qml.PauliZ(1)],
-        [qml.PauliZ(0) @ qml.PauliZ(2), qml.PauliZ(0), qml.PauliZ(2), qml.PauliZ(1)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)],
+        [qp.PauliZ(0) @ qp.PauliZ(2), qp.PauliZ(0), qp.PauliZ(2), qp.PauliZ(1)],
+        [qp.PauliZ(0) @ qp.PauliZ(2), qp.PauliZ(0), qp.PauliZ(2), qp.PauliZ(1)],
     ]
 
-    cost_hamiltonians = [qml.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
+    cost_hamiltonians = [qp.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(5)]
 
     mixer_coeffs = [
         [0.5, 0.5, 1.0, 0.5, 0.5],
@@ -653,25 +653,25 @@ def make_max_clique_test_cases():
 
     mixer_terms = [
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(2),
-            qml.PauliX(1),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(0),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(2),
+            qp.PauliX(1),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(0),
         ],
         [
-            qml.PauliX(0),
-            qml.PauliX(0) @ qml.PauliZ(2),
-            qml.PauliX(1),
-            qml.PauliX(2),
-            qml.PauliX(2) @ qml.PauliZ(0),
+            qp.PauliX(0),
+            qp.PauliX(0) @ qp.PauliZ(2),
+            qp.PauliX(1),
+            qp.PauliX(2),
+            qp.PauliX(2) @ qp.PauliZ(0),
         ],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
-        [qml.PauliX(0), qml.PauliX(1), qml.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
+        [qp.PauliX(0), qp.PauliX(1), qp.PauliX(2)],
     ]
 
-    mixer_hamiltonians = [qml.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
+    mixer_hamiltonians = [qp.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(5)]
 
     return list(zip(GRAPHS, CONSTRAINED, cost_hamiltonians, mixer_hamiltonians))
 
@@ -700,47 +700,47 @@ def make_edge_driver_cost_test_cases():
     ]
 
     hamiltonians = [
-        qml.Hamiltonian(
+        qp.Hamiltonian(
             [-0.25, -0.25, -0.25, -0.25, -0.25, -0.25],
             [
-                qml.PauliZ(0) @ qml.PauliZ(1),
-                qml.PauliZ(0),
-                qml.PauliZ(1),
-                qml.PauliZ(1) @ qml.PauliZ(2),
-                qml.PauliZ(1),
-                qml.PauliZ(2),
+                qp.PauliZ(0) @ qp.PauliZ(1),
+                qp.PauliZ(0),
+                qp.PauliZ(1),
+                qp.PauliZ(1) @ qp.PauliZ(2),
+                qp.PauliZ(1),
+                qp.PauliZ(2),
             ],
         ),
-        qml.Hamiltonian(
+        qp.Hamiltonian(
             [-0.5, -0.5, -0.5],
             [
-                qml.PauliZ(0) @ qml.PauliZ(1),
-                qml.PauliZ(0) @ qml.PauliZ(2),
-                qml.PauliZ(1) @ qml.PauliZ(2),
+                qp.PauliZ(0) @ qp.PauliZ(1),
+                qp.PauliZ(0) @ qp.PauliZ(2),
+                qp.PauliZ(1) @ qp.PauliZ(2),
             ],
         ),
-        qml.Hamiltonian([1, 1, 1], [qml.Identity(0), qml.Identity(1), qml.Identity(2)]),
-        qml.Hamiltonian(
+        qp.Hamiltonian([1, 1, 1], [qp.Identity(0), qp.Identity(1), qp.Identity(2)]),
+        qp.Hamiltonian(
             [0.25, -0.25, -0.25, 0.25, -0.25, -0.25],
             [
-                qml.PauliZ("b") @ qml.PauliZ(1),
-                qml.PauliZ("b"),
-                qml.PauliZ(1),
-                qml.PauliZ(1) @ qml.PauliZ(2.3),
-                qml.PauliZ(1),
-                qml.PauliZ(2.3),
+                qp.PauliZ("b") @ qp.PauliZ(1),
+                qp.PauliZ("b"),
+                qp.PauliZ(1),
+                qp.PauliZ(1) @ qp.PauliZ(2.3),
+                qp.PauliZ(1),
+                qp.PauliZ(2.3),
             ],
         ),
-        qml.Hamiltonian([1, 1, 1], [qml.Identity(0), qml.Identity(1), qml.Identity(2)]),
-        qml.Hamiltonian(
+        qp.Hamiltonian([1, 1, 1], [qp.Identity(0), qp.Identity(1), qp.Identity(2)]),
+        qp.Hamiltonian(
             [0.25, -0.25, -0.25, 0.25, -0.25, -0.25],
             [
-                qml.PauliZ("b") @ qml.PauliZ(1),
-                qml.PauliZ("b"),
-                qml.PauliZ(1),
-                qml.PauliZ(1) @ qml.PauliZ(2.3),
-                qml.PauliZ(1),
-                qml.PauliZ(2.3),
+                qp.PauliZ("b") @ qp.PauliZ(1),
+                qp.PauliZ("b"),
+                qp.PauliZ(1),
+                qp.PauliZ(1) @ qp.PauliZ(2.3),
+                qp.PauliZ(1),
+                qp.PauliZ(2.3),
             ],
         ),
     ]
@@ -806,40 +806,40 @@ def make_max_weighted_cycle_test_cases():
 
     cost_terms = [
         [
-            qml.PauliZ(wires=[0]),
-            qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[3]),
-            qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[0]),
+            qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[5]),
         ],
         [
-            qml.PauliZ(wires=[0]),
-            qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[3]),
-            qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[5]),
-            qml.Identity(wires=[0]),
-            qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[3]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[5]),
-            qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[3]),
-            qml.PauliZ(wires=[3]) @ qml.PauliZ(wires=[5]),
-            qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[5]),
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[5]),
-            qml.PauliZ(wires=[3]) @ qml.PauliZ(wires=[4]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[5]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[0]),
+            qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[5]),
+            qp.Identity(wires=[0]),
+            qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[3]) @ qp.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[3]) @ qp.PauliZ(wires=[4]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[5]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[3]),
         ],
     ]
 
-    cost_hamiltonians = [qml.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(2)]
+    cost_hamiltonians = [qp.Hamiltonian(cost_coeffs[i], cost_terms[i]) for i in range(2)]
 
     mixer_coeffs = [
         [
@@ -873,35 +873,35 @@ def make_max_weighted_cycle_test_cases():
 
     mixer_terms = [
         [
-            qml.PauliX(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliX(wires=[5]),
-            qml.PauliY(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliX(wires=[5]),
-            qml.PauliY(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliY(wires=[5]),
-            qml.PauliX(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliY(wires=[5]),
-            qml.PauliX(wires=[1]) @ qml.PauliX(wires=[0]) @ qml.PauliX(wires=[3]),
-            qml.PauliY(wires=[1]) @ qml.PauliY(wires=[0]) @ qml.PauliX(wires=[3]),
-            qml.PauliY(wires=[1]) @ qml.PauliX(wires=[0]) @ qml.PauliY(wires=[3]),
-            qml.PauliX(wires=[1]) @ qml.PauliY(wires=[0]) @ qml.PauliY(wires=[3]),
-            qml.PauliX(wires=[2]) @ qml.PauliX(wires=[3]) @ qml.PauliX(wires=[4]),
-            qml.PauliY(wires=[2]) @ qml.PauliY(wires=[3]) @ qml.PauliX(wires=[4]),
-            qml.PauliY(wires=[2]) @ qml.PauliX(wires=[3]) @ qml.PauliY(wires=[4]),
-            qml.PauliX(wires=[2]) @ qml.PauliY(wires=[3]) @ qml.PauliY(wires=[4]),
-            qml.PauliX(wires=[3]) @ qml.PauliX(wires=[2]) @ qml.PauliX(wires=[1]),
-            qml.PauliY(wires=[3]) @ qml.PauliY(wires=[2]) @ qml.PauliX(wires=[1]),
-            qml.PauliY(wires=[3]) @ qml.PauliX(wires=[2]) @ qml.PauliY(wires=[1]),
-            qml.PauliX(wires=[3]) @ qml.PauliY(wires=[2]) @ qml.PauliY(wires=[1]),
-            qml.PauliX(wires=[4]) @ qml.PauliX(wires=[5]) @ qml.PauliX(wires=[2]),
-            qml.PauliY(wires=[4]) @ qml.PauliY(wires=[5]) @ qml.PauliX(wires=[2]),
-            qml.PauliY(wires=[4]) @ qml.PauliX(wires=[5]) @ qml.PauliY(wires=[2]),
-            qml.PauliX(wires=[4]) @ qml.PauliY(wires=[5]) @ qml.PauliY(wires=[2]),
-            qml.PauliX(wires=[5]) @ qml.PauliX(wires=[4]) @ qml.PauliX(wires=[0]),
-            qml.PauliY(wires=[5]) @ qml.PauliY(wires=[4]) @ qml.PauliX(wires=[0]),
-            qml.PauliY(wires=[5]) @ qml.PauliX(wires=[4]) @ qml.PauliY(wires=[0]),
-            qml.PauliX(wires=[5]) @ qml.PauliY(wires=[4]) @ qml.PauliY(wires=[0]),
+            qp.PauliX(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliX(wires=[5]),
+            qp.PauliY(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliX(wires=[5]),
+            qp.PauliY(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliY(wires=[5]),
+            qp.PauliX(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliY(wires=[5]),
+            qp.PauliX(wires=[1]) @ qp.PauliX(wires=[0]) @ qp.PauliX(wires=[3]),
+            qp.PauliY(wires=[1]) @ qp.PauliY(wires=[0]) @ qp.PauliX(wires=[3]),
+            qp.PauliY(wires=[1]) @ qp.PauliX(wires=[0]) @ qp.PauliY(wires=[3]),
+            qp.PauliX(wires=[1]) @ qp.PauliY(wires=[0]) @ qp.PauliY(wires=[3]),
+            qp.PauliX(wires=[2]) @ qp.PauliX(wires=[3]) @ qp.PauliX(wires=[4]),
+            qp.PauliY(wires=[2]) @ qp.PauliY(wires=[3]) @ qp.PauliX(wires=[4]),
+            qp.PauliY(wires=[2]) @ qp.PauliX(wires=[3]) @ qp.PauliY(wires=[4]),
+            qp.PauliX(wires=[2]) @ qp.PauliY(wires=[3]) @ qp.PauliY(wires=[4]),
+            qp.PauliX(wires=[3]) @ qp.PauliX(wires=[2]) @ qp.PauliX(wires=[1]),
+            qp.PauliY(wires=[3]) @ qp.PauliY(wires=[2]) @ qp.PauliX(wires=[1]),
+            qp.PauliY(wires=[3]) @ qp.PauliX(wires=[2]) @ qp.PauliY(wires=[1]),
+            qp.PauliX(wires=[3]) @ qp.PauliY(wires=[2]) @ qp.PauliY(wires=[1]),
+            qp.PauliX(wires=[4]) @ qp.PauliX(wires=[5]) @ qp.PauliX(wires=[2]),
+            qp.PauliY(wires=[4]) @ qp.PauliY(wires=[5]) @ qp.PauliX(wires=[2]),
+            qp.PauliY(wires=[4]) @ qp.PauliX(wires=[5]) @ qp.PauliY(wires=[2]),
+            qp.PauliX(wires=[4]) @ qp.PauliY(wires=[5]) @ qp.PauliY(wires=[2]),
+            qp.PauliX(wires=[5]) @ qp.PauliX(wires=[4]) @ qp.PauliX(wires=[0]),
+            qp.PauliY(wires=[5]) @ qp.PauliY(wires=[4]) @ qp.PauliX(wires=[0]),
+            qp.PauliY(wires=[5]) @ qp.PauliX(wires=[4]) @ qp.PauliY(wires=[0]),
+            qp.PauliX(wires=[5]) @ qp.PauliY(wires=[4]) @ qp.PauliY(wires=[0]),
         ],
-        [qml.PauliX(wires=i) for i in range(6)],
+        [qp.PauliX(wires=i) for i in range(6)],
     ]
 
-    mixer_hamiltonians = [qml.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(2)]
+    mixer_hamiltonians = [qp.Hamiltonian(mixer_coeffs[i], mixer_terms[i]) for i in range(2)]
 
     mappings = [qaoa.cycle.wires_to_edges(digraph_complete)] * 2
 
@@ -921,7 +921,7 @@ class TestCostHamiltonians:
         """Tests that the bit driver Hamiltonian has the correct output"""
 
         H = qaoa.bit_driver(range(3), 1)
-        hamiltonian = qml.Hamiltonian([1, 1, 1], [qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)])
+        hamiltonian = qp.Hamiltonian([1, 1, 1], [qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)])
         assert hamiltonian == H
 
     def test_edge_driver_errors(self):
@@ -986,7 +986,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.maxcut(graph)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qp.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
@@ -1009,7 +1009,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.max_independent_set(graph)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qp.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
@@ -1032,7 +1032,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.min_vertex_cover(graph)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qp.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
@@ -1055,7 +1055,7 @@ class TestCostHamiltonians:
         cost_h, _ = qaoa.max_clique(graph)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qp.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
@@ -1082,7 +1082,7 @@ class TestCostHamiltonians:
         cost_h, _, _ = qaoa.max_weight_cycle(graph)
 
         # check that all observables commute
-        assert all(qml.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
+        assert all(qp.is_commuting(o, cost_h.ops[0]) for o in cost_h.ops[1:])
         # check that the 1-group grouping information was set
         assert cost_h.grouping_indices is not None
         assert cost_h.grouping_indices == (tuple(range(len(cost_h.ops))),)
@@ -1096,10 +1096,10 @@ class TestUtils:
     @pytest.mark.parametrize(
         ("hamiltonian", "value"),
         (
-            (qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliZ(1)]), True),
-            (qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]), False),
-            (qml.Hamiltonian([1, 1], [qml.PauliZ(0) @ qml.Identity(1), qml.PauliZ(1)]), True),
-            (qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliX(0) @ qml.PauliZ(1)]), False),
+            (qp.Hamiltonian([1, 1], [qp.PauliZ(0), qp.PauliZ(1)]), True),
+            (qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliZ(1)]), False),
+            (qp.Hamiltonian([1, 1], [qp.PauliZ(0) @ qp.Identity(1), qp.PauliZ(1)]), True),
+            (qp.Hamiltonian([1, 1], [qp.PauliZ(0), qp.PauliX(0) @ qp.PauliZ(1)]), False),
         ),
     )
     def test_diagonal_terms(self, hamiltonian, value):
@@ -1129,7 +1129,7 @@ class TestLayers:
         ):
             qaoa.cost_layer(0.1, hamiltonian)
 
-        hamiltonian = qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliX(1)])
+        hamiltonian = qp.Hamiltonian([1, 1], [qp.PauliZ(0), qp.PauliX(1)])
 
         with pytest.raises(
             ValueError,
@@ -1139,22 +1139,22 @@ class TestLayers:
 
     mixer_layer_test_cases = [
         [
-            qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliX(1)]),
-            [qml.PauliRot(2, "X", wires=[0]), qml.PauliRot(2, "X", wires=[1])],
+            qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliX(1)]),
+            [qp.PauliRot(2, "X", wires=[0]), qp.PauliRot(2, "X", wires=[1])],
         ],
         [
-            qml.X(0) + qml.X(1),
-            [qml.PauliRot(2, "X", wires=[0]), qml.PauliRot(2, "X", wires=[1])],
+            qp.X(0) + qp.X(1),
+            [qp.PauliRot(2, "X", wires=[0]), qp.PauliRot(2, "X", wires=[1])],
         ],
         [
             qaoa.xy_mixer(Graph([(0, 1), (1, 2), (2, 0)])),
             [
-                qml.PauliRot(1.0, "XX", wires=[0, 1]),
-                qml.PauliRot(1.0, "YY", wires=[0, 1]),
-                qml.PauliRot(1.0, "XX", wires=[0, 2]),
-                qml.PauliRot(1.0, "YY", wires=[0, 2]),
-                qml.PauliRot(1.0, "XX", wires=[1, 2]),
-                qml.PauliRot(1.0, "YY", wires=[1, 2]),
+                qp.PauliRot(1.0, "XX", wires=[0, 1]),
+                qp.PauliRot(1.0, "YY", wires=[0, 1]),
+                qp.PauliRot(1.0, "XX", wires=[0, 2]),
+                qp.PauliRot(1.0, "YY", wires=[0, 2]),
+                qp.PauliRot(1.0, "XX", wires=[1, 2]),
+                qp.PauliRot(1.0, "YY", wires=[1, 2]),
             ],
         ],
     ]
@@ -1164,34 +1164,34 @@ class TestLayers:
         """Tests that the gates of the mixer layer are correct"""
 
         alpha = 1
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             out = qaoa.mixer_layer(alpha, mixer)
 
-        expected = qml.ApproxTimeEvolution(mixer, alpha, 1)
-        qml.assert_equal(out, expected)
+        expected = qp.ApproxTimeEvolution(mixer, alpha, 1)
+        qp.assert_equal(out, expected)
 
         assert q.queue[0] is out
         assert len(q) == 1
         decomp = out.decomposition()
 
         for i, j in zip(decomp, gates):
-            qml.assert_equal(i, j)
+            qp.assert_equal(i, j)
 
     cost_layer_test_cases = [
         [
-            qml.Hamiltonian([1, 1], [qml.PauliZ(0), qml.PauliZ(1)]),
-            [qml.PauliRot(2, "Z", wires=[0]), qml.PauliRot(2, "Z", wires=[1])],
+            qp.Hamiltonian([1, 1], [qp.PauliZ(0), qp.PauliZ(1)]),
+            [qp.PauliRot(2, "Z", wires=[0]), qp.PauliRot(2, "Z", wires=[1])],
         ],
         [
-            qml.Z(0) + qml.Z(1),
-            [qml.PauliRot(2, "Z", wires=[0]), qml.PauliRot(2, "Z", wires=[1])],
+            qp.Z(0) + qp.Z(1),
+            [qp.PauliRot(2, "Z", wires=[0]), qp.PauliRot(2, "Z", wires=[1])],
         ],
         [
             qaoa.maxcut(Graph([(0, 1), (1, 2), (2, 0)]))[0],
             [
-                qml.PauliRot(1.0, "ZZ", wires=[0, 1]),
-                qml.PauliRot(1.0, "ZZ", wires=[0, 2]),
-                qml.PauliRot(1.0, "ZZ", wires=[1, 2]),
+                qp.PauliRot(1.0, "ZZ", wires=[0, 1]),
+                qp.PauliRot(1.0, "ZZ", wires=[0, 2]),
+                qp.PauliRot(1.0, "ZZ", wires=[1, 2]),
             ],
         ],
     ]
@@ -1205,18 +1205,18 @@ class TestLayers:
 
         gamma = 1
 
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             out = qaoa.cost_layer(gamma, cost)
 
-        expected = qml.ApproxTimeEvolution(cost, gamma, 1)
-        qml.assert_equal(out, expected)
+        expected = qp.ApproxTimeEvolution(cost, gamma, 1)
+        qp.assert_equal(out, expected)
 
         assert q.queue[0] is out
         assert len(q) == 1
         decomp = out.decomposition()
 
         for i, j in zip(decomp, gates):
-            qml.assert_equal(i, j)
+            qp.assert_equal(i, j)
 
 
 class TestIntegration:
@@ -1241,17 +1241,17 @@ class TestIntegration:
         # pylint: disable=unused-argument
         def circuit(params, **kwargs):
             for w in wires:
-                qml.Hadamard(wires=w)
+                qp.Hadamard(wires=w)
 
-            qml.layer(qaoa_layer, 2, params[0], params[1])
+            qp.layer(qaoa_layer, 2, params[0], params[1])
 
         # Defines the device and the QAOA cost function
-        dev = qml.device("default.qubit", wires=len(wires))
+        dev = qp.device("default.qubit", wires=len(wires))
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cost_function(params):
             circuit(params)
-            return qml.expval(cost_h)
+            return qp.expval(cost_h)
 
         res = cost_function([[1, 1], [1, 1]])
         expected = -1.8260274380964299
@@ -1280,17 +1280,17 @@ class TestIntegration:
         # pylint: disable=unused-argument
         def circuit(params, **kwargs):
             for w in wires:
-                qml.Hadamard(wires=w)
+                qp.Hadamard(wires=w)
 
-            qml.layer(qaoa_layer, 2, params[0], params[1])
+            qp.layer(qaoa_layer, 2, params[0], params[1])
 
         # Defines the device and the QAOA cost function
-        dev = qml.device("default.qubit", wires=len(wires))
+        dev = qp.device("default.qubit", wires=len(wires))
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cost_function(params):
             circuit(params)
-            return qml.expval(cost_h)
+            return qp.expval(cost_h)
 
         res = cost_function([[1, 1], [1, 1]])
         expected = -1.8260274380964299
@@ -1383,14 +1383,14 @@ class TestCycles:
         h = _partial_cycle_mixer(g, edge)
 
         ops_expected = [
-            qml.PauliX(0) @ qml.PauliX(1) @ qml.PauliX(7),
-            qml.PauliY(0) @ qml.PauliY(1) @ qml.PauliX(7),
-            qml.PauliY(0) @ qml.PauliX(1) @ qml.PauliY(7),
-            qml.PauliX(0) @ qml.PauliY(1) @ qml.PauliY(7),
-            qml.PauliX(0) @ qml.PauliX(2) @ qml.PauliX(10),
-            qml.PauliY(0) @ qml.PauliY(2) @ qml.PauliX(10),
-            qml.PauliY(0) @ qml.PauliX(2) @ qml.PauliY(10),
-            qml.PauliX(0) @ qml.PauliY(2) @ qml.PauliY(10),
+            qp.PauliX(0) @ qp.PauliX(1) @ qp.PauliX(7),
+            qp.PauliY(0) @ qp.PauliY(1) @ qp.PauliX(7),
+            qp.PauliY(0) @ qp.PauliX(1) @ qp.PauliY(7),
+            qp.PauliX(0) @ qp.PauliY(1) @ qp.PauliY(7),
+            qp.PauliX(0) @ qp.PauliX(2) @ qp.PauliX(10),
+            qp.PauliY(0) @ qp.PauliY(2) @ qp.PauliX(10),
+            qp.PauliY(0) @ qp.PauliX(2) @ qp.PauliY(10),
+            qp.PauliX(0) @ qp.PauliY(2) @ qp.PauliY(10),
         ]
         coeffs_expected = [0.25, 0.25, 0.25, -0.25, 0.25, 0.25, 0.25, -0.25]
 
@@ -1411,10 +1411,10 @@ class TestCycles:
         h = _partial_cycle_mixer(g, edge)
 
         ops_expected = [
-            qml.PauliX(0) @ qml.PauliX(2) @ qml.PauliX(9),
-            qml.PauliY(0) @ qml.PauliY(2) @ qml.PauliX(9),
-            qml.PauliY(0) @ qml.PauliX(2) @ qml.PauliY(9),
-            qml.PauliX(0) @ qml.PauliY(2) @ qml.PauliY(9),
+            qp.PauliX(0) @ qp.PauliX(2) @ qp.PauliX(9),
+            qp.PauliY(0) @ qp.PauliY(2) @ qp.PauliX(9),
+            qp.PauliY(0) @ qp.PauliX(2) @ qp.PauliY(9),
+            qp.PauliX(0) @ qp.PauliY(2) @ qp.PauliY(9),
         ]
         coeffs_expected = [0.25, 0.25, 0.25, -0.25]
 
@@ -1512,7 +1512,7 @@ class TestCycles:
     @pytest.mark.parametrize("g", [nx.lollipop_graph(3, 1), lollipop_graph_rx(3, 1)])
     def test_matrix(self, g):
         """Test that the matrix function works as expected on a fixed example"""
-        h = qml.qaoa.bit_flip_mixer(g, 0)
+        h = qp.qaoa.bit_flip_mixer(g, 0)
 
         mat = matrix(h, 4)
         mat_expected = np.array(
@@ -1541,7 +1541,7 @@ class TestCycles:
     def test_matrix_rx(self):
         """Test that the matrix function works as expected on a fixed example"""
         g = rx.generators.star_graph(4, [0, 1, 2, 3])
-        h = qml.qaoa.bit_flip_mixer(g, 0)
+        h = qp.qaoa.bit_flip_mixer(g, 0)
 
         mat = matrix(h, 4)
         mat_expected = np.array(
@@ -1633,12 +1633,12 @@ class TestCycles:
         h = loss_hamiltonian(g)
 
         expected_ops = [
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(2),
-            qml.PauliZ(3),
-            qml.PauliZ(4),
-            qml.PauliZ(5),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(2),
+            qp.PauliZ(3),
+            qp.PauliZ(4),
+            qp.PauliZ(5),
         ]
         expected_coeffs = [np.log(0.5), np.log(1), np.log(1.5), np.log(2), np.log(2.5), np.log(3)]
 
@@ -1670,20 +1670,20 @@ class TestCycles:
         h = loss_hamiltonian(g)
 
         expected_ops = [
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(2),
-            qml.PauliZ(3),
-            qml.PauliZ(4),
-            qml.PauliZ(5),
-            qml.PauliZ(6),
-            qml.PauliZ(7),
-            qml.PauliZ(8),
-            qml.PauliZ(9),
-            qml.PauliZ(10),
-            qml.PauliZ(11),
-            qml.PauliZ(12),
-            qml.PauliZ(13),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(2),
+            qp.PauliZ(3),
+            qp.PauliZ(4),
+            qp.PauliZ(5),
+            qp.PauliZ(6),
+            qp.PauliZ(7),
+            qp.PauliZ(8),
+            qp.PauliZ(9),
+            qp.PauliZ(10),
+            qp.PauliZ(11),
+            qp.PauliZ(12),
+            qp.PauliZ(13),
         ]
         expected_coeffs = [
             np.log(0.5),
@@ -1754,7 +1754,7 @@ class TestCycles:
         """Test if the _square_hamiltonian_terms function returns the expected result on a fixed
         example"""
         coeffs = [1, -1, -1, 1]
-        ops = [qml.Identity(0), qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(3)]
+        ops = [qp.Identity(0), qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(3)]
 
         expected_coeffs = [
             1,
@@ -1775,22 +1775,22 @@ class TestCycles:
             1,
         ]
         expected_ops = [
-            qml.Identity(0),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(3),
-            qml.PauliZ(0),
-            qml.Identity(0),
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0) @ qml.PauliZ(3),
-            qml.PauliZ(1),
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.Identity(0),
-            qml.PauliZ(1) @ qml.PauliZ(3),
-            qml.PauliZ(3),
-            qml.PauliZ(0) @ qml.PauliZ(3),
-            qml.PauliZ(1) @ qml.PauliZ(3),
-            qml.Identity(0),
+            qp.Identity(0),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(3),
+            qp.PauliZ(0),
+            qp.Identity(0),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0) @ qp.PauliZ(3),
+            qp.PauliZ(1),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.Identity(0),
+            qp.PauliZ(1) @ qp.PauliZ(3),
+            qp.PauliZ(3),
+            qp.PauliZ(0) @ qp.PauliZ(3),
+            qp.PauliZ(1) @ qp.PauliZ(3),
+            qp.Identity(0),
         ]
 
         squared_coeffs, squared_ops = _square_hamiltonian_terms(coeffs, ops)
@@ -1809,14 +1809,14 @@ class TestCycles:
         on a manually-calculated example of a 3-node complete digraph relative to the 0 node"""
         h = _inner_out_flow_constraint_hamiltonian(g, 0)
         expected_ops = [
-            qml.Identity(0),
-            qml.PauliZ(1) @ qml.PauliZ(0),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
+            qp.Identity(0),
+            qp.PauliZ(1) @ qp.PauliZ(0),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
         ]
         expected_coeffs = [2, 2, -2, -2]
 
-        expected_hamiltonian = qml.Hamiltonian(expected_coeffs, expected_ops)
+        expected_hamiltonian = qp.Hamiltonian(expected_coeffs, expected_ops)
         assert h == expected_hamiltonian
 
     @pytest.mark.parametrize("g", [nx.complete_graph(3), rx.generators.mesh_graph(3, [0, 1, 2])])
@@ -1833,19 +1833,19 @@ class TestCycles:
         example of a 3-node complete digraph relative to the 0 node"""
         h = _inner_net_flow_constraint_hamiltonian(g, 0)
         expected_ops = [
-            qml.Identity(0),
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0) @ qml.PauliZ(2),
-            qml.PauliZ(0) @ qml.PauliZ(4),
-            qml.PauliZ(1) @ qml.PauliZ(2),
-            qml.PauliZ(1) @ qml.PauliZ(4),
-            qml.PauliZ(2) @ qml.PauliZ(4),
+            qp.Identity(0),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0) @ qp.PauliZ(2),
+            qp.PauliZ(0) @ qp.PauliZ(4),
+            qp.PauliZ(1) @ qp.PauliZ(2),
+            qp.PauliZ(1) @ qp.PauliZ(4),
+            qp.PauliZ(2) @ qp.PauliZ(4),
         ]
         expected_coeffs = [4, 2, -2, -2, -2, -2, 2]
         _, ops = h.terms()
         non_zero_terms = [(coeff, op) for coeff, op in zip(h.coeffs, ops) if coeff != 0]
         coeffs = [term[0] for term in non_zero_terms]
-        assert qml.math.allclose(coeffs, expected_coeffs)
+        assert qp.math.allclose(coeffs, expected_coeffs)
         non_zero_ops = [term[1] for term in non_zero_terms]
         for op, expected_op in zip(non_zero_ops, expected_ops):
             assert op.pauli_rep == expected_op.pauli_rep
@@ -1866,11 +1866,11 @@ class TestCycles:
         g.remove_edge(0, 1)
         h = _inner_out_flow_constraint_hamiltonian(g, 0)
         h = h.simplify()
-        expected_ops = [qml.Identity(0), qml.PauliZ(wires=[0])]
+        expected_ops = [qp.Identity(0), qp.PauliZ(wires=[0])]
         expected_coeffs = [0, 0]
 
         coeffs, ops = h.terms()
-        assert qml.math.allclose(expected_coeffs, coeffs)
+        assert qp.math.allclose(expected_coeffs, coeffs)
         for op, expected_op in zip(ops, expected_ops):
             assert op.pauli_rep == expected_op.pauli_rep
 
@@ -1884,17 +1884,17 @@ class TestCycles:
         h = _inner_net_flow_constraint_hamiltonian(g, 0)
         h = h.simplify()
         expected_ops = [
-            qml.Identity(0),
-            qml.PauliZ(0),
-            qml.PauliZ(1),
-            qml.PauliZ(3),
-            qml.PauliZ(0) @ qml.PauliZ(1),
-            qml.PauliZ(0) @ qml.PauliZ(3),
-            qml.PauliZ(1) @ qml.PauliZ(3),
+            qp.Identity(0),
+            qp.PauliZ(0),
+            qp.PauliZ(1),
+            qp.PauliZ(3),
+            qp.PauliZ(0) @ qp.PauliZ(1),
+            qp.PauliZ(0) @ qp.PauliZ(3),
+            qp.PauliZ(1) @ qp.PauliZ(3),
         ]
         expected_coeffs = [4, -2, -2, 2, 2, -2, -2]
         coeffs, ops = h.terms()
-        assert qml.math.allclose(coeffs, expected_coeffs)
+        assert qp.math.allclose(coeffs, expected_coeffs)
         for op, expected_op in zip(ops, expected_ops):
             assert op.pauli_rep == expected_op.pauli_rep
 
@@ -1922,16 +1922,16 @@ class TestCycles:
         wires = len(g.edge_list() if isinstance(g, rx.PyDiGraph) else g.edges)
 
         # We use PL to find the energies corresponding to each possible bitstring
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         # pylint: disable=unused-argument
         def states(basis_state, **kwargs):
-            qml.BasisState(basis_state, wires=range(wires))
+            qp.BasisState(basis_state, wires=range(wires))
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cost(params):
             states(params)
-            return qml.expval(h)
+            return qp.expval(h)
 
         # Calculate the set of all bitstrings
         bitstrings = itertools.product([0, 1], repeat=wires)
@@ -1976,12 +1976,12 @@ class TestCycles:
         wires = len(g.edge_list() if isinstance(g, rx.PyDiGraph) else g.edges)
 
         # We use PL to find the energies corresponding to each possible bitstring
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cost(basis_state):
-            qml.BasisState(basis_state, wires=range(wires))
-            return qml.expval(h)
+            qp.BasisState(basis_state, wires=range(wires))
+            return qp.expval(h)
 
         # Calculate the set of all bitstrings
         states = itertools.product([0, 1], repeat=wires)
@@ -2050,16 +2050,16 @@ class TestCycles:
         wires = len(g.edge_list() if isinstance(g, rx.PyDiGraph) else g.edges)
 
         # Find the energies corresponding to each possible bitstring
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         # pylint: disable=unused-argument
         def states(basis_state, **kwargs):
-            qml.BasisState(basis_state, wires=range(wires))
+            qp.BasisState(basis_state, wires=range(wires))
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cost(params):
             states(params)
-            return qml.expval(h)
+            return qp.expval(h)
 
         # Calculate the set of all bitstrings
         bitstrings = itertools.product([0, 1], repeat=wires)

--- a/tests/test_qcut.py
+++ b/tests/test_qcut.py
@@ -32,7 +32,7 @@ from networkx import __version__ as networkx_version
 from networkx import number_of_selfloops
 from scipy.stats import unitary_group
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as np
 from pennylane import qcut
 from pennylane.decomposition import gate_sets
@@ -45,9 +45,9 @@ pytestmark = pytest.mark.qcut
 
 I, X, Y, Z = (
     np.eye(2),
-    qml.PauliX.compute_matrix(),
-    qml.PauliY.compute_matrix(),
-    qml.PauliZ.compute_matrix(),
+    qp.PauliX.compute_matrix(),
+    qp.PauliY.compute_matrix(),
+    qp.PauliZ.compute_matrix(),
 )
 
 states_pure = [
@@ -57,51 +57,51 @@ states_pure = [
     np.array([1, 1j]) / np.sqrt(2),
 ]
 
-with qml.queuing.AnnotatedQueue() as q_no_cut:
-    qml.RX(0.432, wires=0)
-    qml.RY(0.543, wires="a")
-    qml.CNOT(wires=[0, "a"])
-    qml.CRZ(0.5, wires=["a", 0])
-    qml.RZ(0.240, wires=0)
-    qml.RZ(0.133, wires="a")
-    qml.expval(qml.PauliZ(wires=[0]))
+with qp.queuing.AnnotatedQueue() as q_no_cut:
+    qp.RX(0.432, wires=0)
+    qp.RY(0.543, wires="a")
+    qp.CNOT(wires=[0, "a"])
+    qp.CRZ(0.5, wires=["a", 0])
+    qp.RZ(0.240, wires=0)
+    qp.RZ(0.133, wires="a")
+    qp.expval(qp.PauliZ(wires=[0]))
 
-no_cut_tape = qml.tape.QuantumScript.from_queue(q_no_cut)
-with qml.queuing.AnnotatedQueue() as q_single_cut_tape:
-    qml.RX(0.432, wires=0)
-    qml.RY(0.543, wires=1)
-    qml.CNOT(wires=[0, 1])
-    qml.RZ(0.240, wires=0)
-    qml.RZ(0.133, wires=1)
-    qml.WireCut(wires=1)
-    qml.CNOT(wires=[1, 2])
-    qml.RX(0.432, wires=1)
-    qml.RY(0.543, wires=2)
-    qml.expval(qml.PauliZ(wires=[0]))
+no_cut_tape = qp.tape.QuantumScript.from_queue(q_no_cut)
+with qp.queuing.AnnotatedQueue() as q_single_cut_tape:
+    qp.RX(0.432, wires=0)
+    qp.RY(0.543, wires=1)
+    qp.CNOT(wires=[0, 1])
+    qp.RZ(0.240, wires=0)
+    qp.RZ(0.133, wires=1)
+    qp.WireCut(wires=1)
+    qp.CNOT(wires=[1, 2])
+    qp.RX(0.432, wires=1)
+    qp.RY(0.543, wires=2)
+    qp.expval(qp.PauliZ(wires=[0]))
 
-single_cut_tape = qml.tape.QuantumScript.from_queue(q_single_cut_tape)
-with qml.queuing.AnnotatedQueue() as q_multi_cut_tape:
-    qml.RX(0.432, wires=0)
-    qml.RY(0.543, wires="a")
-    qml.WireCut(wires=0)
-    qml.CNOT(wires=[0, "a"])
-    qml.RZ(0.240, wires=0)
-    qml.RZ(0.133, wires="a")
-    qml.WireCut(wires="a")
-    qml.CNOT(wires=["a", 2])
-    qml.RX(0.432, wires="a")
-    qml.WireCut(wires=2)
-    qml.CNOT(wires=[2, 3])
-    qml.RY(0.543, wires=2)
-    qml.RZ(0.876, wires=3)
-    qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[3]))
+single_cut_tape = qp.tape.QuantumScript.from_queue(q_single_cut_tape)
+with qp.queuing.AnnotatedQueue() as q_multi_cut_tape:
+    qp.RX(0.432, wires=0)
+    qp.RY(0.543, wires="a")
+    qp.WireCut(wires=0)
+    qp.CNOT(wires=[0, "a"])
+    qp.RZ(0.240, wires=0)
+    qp.RZ(0.133, wires="a")
+    qp.WireCut(wires="a")
+    qp.CNOT(wires=["a", 2])
+    qp.RX(0.432, wires="a")
+    qp.WireCut(wires=2)
+    qp.CNOT(wires=[2, 3])
+    qp.RY(0.543, wires=2)
+    qp.RZ(0.876, wires=3)
+    qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[3]))
 
-multi_cut_tape = qml.tape.QuantumScript.from_queue(q_multi_cut_tape)
+multi_cut_tape = qp.tape.QuantumScript.from_queue(q_multi_cut_tape)
 
 
 def get_name(obj):
     """MeasurementProcesses don't have names, so we return Measurement."""
-    return "Measurement" if isinstance(obj, qml.measurements.MeasurementProcess) else obj.name
+    return "Measurement" if isinstance(obj, qp.measurements.MeasurementProcess) else obj.name
 
 
 def kron(*args):
@@ -129,53 +129,53 @@ def fn(x):
 
 
 # tape containing mid-circuit measurements
-with qml.queuing.AnnotatedQueue() as q_mcm_tape:
-    qml.Hadamard(wires=0)
-    qml.RX(0.432, wires=0)
-    qml.RY(0.543, wires=1)
-    qml.CNOT(wires=[0, 1])
-    qml.WireCut(wires=1)
-    qml.CNOT(wires=[1, 2])
-    qml.WireCut(wires=1)
-    qml.RZ(0.321, wires=1)
-    qml.CNOT(wires=[0, 1])
-    qml.Hadamard(wires=2)
-    qml.WireCut(wires=1)
-    qml.CNOT(wires=[1, 2])
-    qml.WireCut(wires=1)
-    qml.CNOT(wires=[0, 1])
-    qml.expval(qml.PauliZ(wires=[0]))
+with qp.queuing.AnnotatedQueue() as q_mcm_tape:
+    qp.Hadamard(wires=0)
+    qp.RX(0.432, wires=0)
+    qp.RY(0.543, wires=1)
+    qp.CNOT(wires=[0, 1])
+    qp.WireCut(wires=1)
+    qp.CNOT(wires=[1, 2])
+    qp.WireCut(wires=1)
+    qp.RZ(0.321, wires=1)
+    qp.CNOT(wires=[0, 1])
+    qp.Hadamard(wires=2)
+    qp.WireCut(wires=1)
+    qp.CNOT(wires=[1, 2])
+    qp.WireCut(wires=1)
+    qp.CNOT(wires=[0, 1])
+    qp.expval(qp.PauliZ(wires=[0]))
 
 
-mcm_tape = qml.tape.QuantumScript.from_queue(q_mcm_tape)
-with qml.queuing.AnnotatedQueue() as q_frag0:
-    qml.Hadamard(wires=[0])
-    qml.RX(0.432, wires=[0])
-    qml.RY(0.543, wires=[1])
-    qml.CNOT(wires=[0, 1])
+mcm_tape = qp.tape.QuantumScript.from_queue(q_mcm_tape)
+with qp.queuing.AnnotatedQueue() as q_frag0:
+    qp.Hadamard(wires=[0])
+    qp.RX(0.432, wires=[0])
+    qp.RY(0.543, wires=[1])
+    qp.CNOT(wires=[0, 1])
     qcut.MeasureNode(wires=[1])
     qcut.PrepareNode(wires=[2])
-    qml.RZ(0.321, wires=[2])
-    qml.CNOT(wires=[0, 2])
+    qp.RZ(0.321, wires=[2])
+    qp.CNOT(wires=[0, 2])
     qcut.MeasureNode(wires=[2])
     qcut.PrepareNode(wires=[3])
-    qml.CNOT(wires=[0, 3])
-    qml.sample(qml.Projector([1], wires=[0]))
-    qml.sample(qml.Projector([1], wires=[3]))
+    qp.CNOT(wires=[0, 3])
+    qp.sample(qp.Projector([1], wires=[0]))
+    qp.sample(qp.Projector([1], wires=[3]))
 
-frag0 = qml.tape.QuantumScript.from_queue(q_frag0)
-with qml.queuing.AnnotatedQueue() as q_frag1:
+frag0 = qp.tape.QuantumScript.from_queue(q_frag0)
+with qp.queuing.AnnotatedQueue() as q_frag1:
     qcut.PrepareNode(wires=[0])
-    qml.CNOT(wires=[0, 1])
+    qp.CNOT(wires=[0, 1])
     qcut.MeasureNode(wires=[0])
-    qml.Hadamard(wires=[1])
+    qp.Hadamard(wires=[1])
     qcut.PrepareNode(wires=[2])
-    qml.CNOT(wires=[2, 1])
+    qp.CNOT(wires=[2, 1])
     qcut.MeasureNode(wires=[2])
-    qml.sample(qml.Projector([1], wires=[1]))
+    qp.sample(qp.Projector([1], wires=[1]))
 
 
-frag1 = qml.tape.QuantumScript.from_queue(q_frag1)
+frag1 = qp.tape.QuantumScript.from_queue(q_frag1)
 frag_edge_data = [
     (
         0,
@@ -322,9 +322,9 @@ class TestMeasurePrepareNodes:
     def test_initialization(self, cls):
         """Test that nodes can be initialized with wires."""
         n = cls(wires=0)
-        assert n.wires == qml.wires.Wires(0)
+        assert n.wires == qp.wires.Wires(0)
         n = cls(0)
-        assert n.wires == qml.wires.Wires(0)
+        assert n.wires == qp.wires.Wires(0)
         with pytest.raises(TypeError, match="got multiple values for argument 'wires'"):
             cls(0.5, wires=0)
 
@@ -443,30 +443,30 @@ class TestTapeToGraph:
         "obs,expected_obs",
         [
             (
-                qml.PauliZ(0) @ qml.PauliZ(2),
-                [qml.expval(qml.PauliZ(wires=[0])), qml.expval(qml.PauliZ(wires=[2]))],
+                qp.PauliZ(0) @ qp.PauliZ(2),
+                [qp.expval(qp.PauliZ(wires=[0])), qp.expval(qp.PauliZ(wires=[2]))],
             ),
             (
-                qml.Projector([0, 1], wires=[0, 1]),
-                [qml.expval(qml.Projector([0, 1], wires=[0, 1]))],
+                qp.Projector([0, 1], wires=[0, 1]),
+                [qp.expval(qp.Projector([0, 1], wires=[0, 1]))],
             ),
             (
-                qml.Hamiltonian([1, 2], [qml.PauliZ(1), qml.PauliZ(2) @ qml.PauliX(0)]),
+                qp.Hamiltonian([1, 2], [qp.PauliZ(1), qp.PauliZ(2) @ qp.PauliX(0)]),
                 [
-                    qml.expval(
-                        qml.Hamiltonian([1, 2], [qml.PauliZ(1), qml.PauliZ(2) @ qml.PauliX(0)])
+                    qp.expval(
+                        qp.Hamiltonian([1, 2], [qp.PauliZ(1), qp.PauliZ(2) @ qp.PauliX(0)])
                     )
                 ],
             ),
             (
-                qml.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]),
-                [qml.expval(qml.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]))],
+                qp.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]),
+                [qp.expval(qp.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]))],
             ),
             (
-                qml.Projector([0, 1], wires=[0, 1]) @ qml.Projector([1, 0], wires=[0, 2]),
+                qp.Projector([0, 1], wires=[0, 1]) @ qp.Projector([1, 0], wires=[0, 2]),
                 [
-                    qml.expval(qml.Projector([0, 1], wires=[0, 1])),
-                    qml.expval(qml.Projector([1, 0], wires=[0, 2])),
+                    qp.expval(qp.Projector([0, 1], wires=[0, 1])),
+                    qp.expval(qp.Projector([1, 0], wires=[0, 2])),
                 ],
             ),
         ],
@@ -477,15 +477,15 @@ class TestTapeToGraph:
         observables contained within the graph nodes
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires=2)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            qml.expval(obs)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires=2)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            qp.expval(obs)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         nodes = list(g.nodes)
 
@@ -498,12 +498,12 @@ class TestTapeToGraph:
     @pytest.mark.parametrize(
         "measurement,expected_measurement",
         [
-            (qml.expval(qml.PauliZ(wires=[0])), "expval"),
-            (qml.sample(qml.PauliZ(wires=[0])), "sample"),
-            (qml.var(qml.PauliZ(wires=[0])), "var"),
-            (qml.probs(wires=0), "probs"),
-            (qml.state(), "state"),
-            (qml.density_matrix([0]), "state"),
+            (qp.expval(qp.PauliZ(wires=[0])), "expval"),
+            (qp.sample(qp.PauliZ(wires=[0])), "sample"),
+            (qp.var(qp.PauliZ(wires=[0])), "var"),
+            (qp.probs(wires=0), "probs"),
+            (qp.state(), "state"),
+            (qp.density_matrix([0]), "state"),
         ],
     )
     def test_measurement_conversion(self, measurement, expected_measurement):
@@ -511,20 +511,20 @@ class TestTapeToGraph:
         Tests that measurements are correctly converted
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires=2)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            qml.apply(measurement)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires=2)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            qp.apply(measurement)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         nodes = list(g.nodes)
 
         node_observables = [
-            node.obj for node in nodes if isinstance(node.obj, qml.measurements.MeasurementProcess)
+            node.obj for node in nodes if isinstance(node.obj, qp.measurements.MeasurementProcess)
         ]
 
         assert node_observables[0]._shortname == expected_measurement
@@ -535,20 +535,20 @@ class TestTapeToGraph:
         converted to a graph
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires=2)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            qml.expval(qml.PauliZ(wires=[0]))
-            qml.expval(qml.PauliX(wires=[1]) @ qml.PauliY(wires=[2]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires=2)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            qp.expval(qp.PauliZ(wires=[0]))
+            qp.expval(qp.PauliX(wires=[1]) @ qp.PauliY(wires=[2]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         expected_obs = [
-            qml.expval(qml.PauliZ(wires=[0])),
-            qml.expval(qml.PauliX(wires=[1])),
-            qml.expval(qml.PauliY(wires=[2])),
+            qp.expval(qp.PauliZ(wires=[0])),
+            qp.expval(qp.PauliX(wires=[1])),
+            qp.expval(qp.PauliY(wires=[2])),
         ]
 
         g = qcut.tape_to_graph(tape)
@@ -566,26 +566,26 @@ class TestTapeToGraph:
         correctly converted to a graph with a distinct node for each wire sampled
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(wires=[0, 1, 2])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(wires=[0, 1, 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
 
         expected_nodes = [
-            qml.Hadamard(wires=[0]),
-            qml.CNOT(wires=[0, 1]),
-            qml.PauliX(wires=[1]),
-            qml.WireCut(wires=[1]),
-            qml.CNOT(wires=[1, 2]),
-            qml.sample(qml.Projector([1], wires=[0])),
-            qml.sample(qml.Projector([1], wires=[1])),
-            qml.sample(qml.Projector([1], wires=[2])),
+            qp.Hadamard(wires=[0]),
+            qp.CNOT(wires=[0, 1]),
+            qp.PauliX(wires=[1]),
+            qp.WireCut(wires=[1]),
+            qp.CNOT(wires=[1, 2]),
+            qp.sample(qp.Projector([1], wires=[0])),
+            qp.sample(qp.Projector([1], wires=[1])),
+            qp.sample(qp.Projector([1], wires=[2])),
         ]
 
         for node, expected_node in zip(g.nodes, expected_nodes):
@@ -593,7 +593,7 @@ class TestTapeToGraph:
             assert node.obj.wires == expected_node.wires
 
             if getattr(node.obj, "obs", None) is not None:
-                assert isinstance(node.obj, qml.measurements.SampleMP)
+                assert isinstance(node.obj, qp.measurements.SampleMP)
                 assert get_name(node.obj.obs) == get_name(expected_node.obs)
 
     def test_sample_tensor_obs(self):
@@ -602,15 +602,15 @@ class TestTapeToGraph:
         observables raises the correct error.
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(qml.PauliX(0) @ qml.PauliY(1))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(qp.PauliX(0) @ qp.PauliY(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(ValueError, match="Sampling from tensor products of observables "):
             qcut.tape_to_graph(tape)
 
@@ -620,28 +620,28 @@ class TestTapeToGraph:
         over individual wires is supported.
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(qml.PauliZ(0))
-            qml.sample(qml.PauliZ(1))
-            qml.sample(qml.PauliZ(2))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(qp.PauliZ(0))
+            qp.sample(qp.PauliZ(1))
+            qp.sample(qp.PauliZ(2))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
 
         expected_nodes = [
-            qml.Hadamard(wires=[0]),
-            qml.CNOT(wires=[0, 1]),
-            qml.PauliX(wires=[1]),
-            qml.WireCut(wires=[1]),
-            qml.CNOT(wires=[1, 2]),
-            qml.sample(qml.PauliZ(wires=[0])),
-            qml.sample(qml.PauliZ(wires=[1])),
-            qml.sample(qml.PauliZ(wires=[2])),
+            qp.Hadamard(wires=[0]),
+            qp.CNOT(wires=[0, 1]),
+            qp.PauliX(wires=[1]),
+            qp.WireCut(wires=[1]),
+            qp.CNOT(wires=[1, 2]),
+            qp.sample(qp.PauliZ(wires=[0])),
+            qp.sample(qp.PauliZ(wires=[1])),
+            qp.sample(qp.PauliZ(wires=[2])),
         ]
 
         for node, expected_node in zip(g.nodes, expected_nodes):
@@ -649,7 +649,7 @@ class TestTapeToGraph:
             assert node.obj.wires == expected_node.wires
 
             if getattr(node.obj, "obs", None) is not None:
-                assert isinstance(node.obj, qml.measurements.SampleMP)
+                assert isinstance(node.obj, qp.measurements.SampleMP)
                 assert get_name(node.obj.obs) == get_name(expected_node.obs)
 
 
@@ -696,23 +696,23 @@ class TestReplaceWireCut:
         wire_cut_3 = 2
         wire_cut_num = [wire_cut_1, wire_cut_2, wire_cut_3]
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires="a")
-            qml.WireCut(wires=wire_cut_1)
-            qml.CNOT(wires=[0, "a"])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires="a")
-            qml.WireCut(wires=wire_cut_2)
-            qml.CNOT(wires=["a", 2])
-            qml.RX(0.432, wires="a")
-            qml.WireCut(wires=wire_cut_3)
-            qml.CNOT(wires=[2, 3])
-            qml.RY(0.543, wires=2)
-            qml.RZ(0.876, wires=3)
-            qml.expval(qml.PauliZ(wires=[0]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires="a")
+            qp.WireCut(wires=wire_cut_1)
+            qp.CNOT(wires=[0, "a"])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires="a")
+            qp.WireCut(wires=wire_cut_2)
+            qp.CNOT(wires=["a", 2])
+            qp.RX(0.432, wires="a")
+            qp.WireCut(wires=wire_cut_3)
+            qp.CNOT(wires=[2, 3])
+            qp.RY(0.543, wires=2)
+            qp.RZ(0.876, wires=3)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         node_data = list(g.nodes(data=True))
 
@@ -745,16 +745,16 @@ class TestReplaceWireCut:
         """
         wire_cut_num = 1
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.133, wires=1)
-            qml.WireCut(wires=wire_cut_num)
-            qml.CNOT(wires=[1, 2])
-            qml.RY(0.543, wires=2)
-            qml.expval(qml.PauliZ(wires=[0]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.133, wires=1)
+            qp.WireCut(wires=wire_cut_num)
+            qp.CNOT(wires=[1, 2])
+            qp.RY(0.543, wires=2)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
 
@@ -778,14 +778,14 @@ class TestReplaceWireCut:
         i.e if it has no predecessor
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
-            qml.RX(0.432, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.133, wires=1)
-            qml.expval(qml.PauliZ(wires=[0]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
+            qp.RX(0.432, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.133, wires=1)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
 
         qcut.replace_wire_cut_nodes(g)
@@ -810,13 +810,13 @@ class TestReplaceWireCut:
         i.e if it has no successor
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.133, wires=1)
-            qml.WireCut(wires=0)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.133, wires=1)
+            qp.WireCut(wires=0)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
 
         qcut.replace_wire_cut_nodes(g)
@@ -840,14 +840,14 @@ class TestReplaceWireCut:
         Tests the successors and predecessors of a multi-wire wirecut are
         correct
         """
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.CNOT(wires=[0, "a"])
-            qml.CNOT(wires=["a", 2])
-            qml.WireCut(wires=[0, "a", 2])
-            qml.CZ(wires=[0, 2])
-            qml.Toffoli(wires=[0, "a", 2])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.CNOT(wires=[0, "a"])
+            qp.CNOT(wires=["a", 2])
+            qp.WireCut(wires=[0, "a", 2])
+            qp.CZ(wires=[0, 2])
+            qp.Toffoli(wires=[0, "a", 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
 
@@ -913,29 +913,29 @@ class TestFragmentGraph:
 
         sub_0_expected_nodes = [
             (qcut.MeasureNode(wires=[0]), {"order": 2}),
-            (qml.RX(0.432, wires=[0]), {"order": 0}),
+            (qp.RX(0.432, wires=[0]), {"order": 0}),
         ]
         sub_1_expected_nodes = [
-            (qml.RY(0.543, wires=["a"]), {"order": 1}),
+            (qp.RY(0.543, wires=["a"]), {"order": 1}),
             (qcut.PrepareNode(wires=[0]), {"order": 2}),
             (qcut.MeasureNode(wires=["a"]), {"order": 6}),
-            (qml.RZ(0.24, wires=[0]), {"order": 4}),
-            (qml.CNOT(wires=[0, "a"]), {"order": 3}),
-            (qml.expval(qml.PauliZ(wires=[0])), {"order": 13}),
-            (qml.RZ(0.133, wires=["a"]), {"order": 5}),
+            (qp.RZ(0.24, wires=[0]), {"order": 4}),
+            (qp.CNOT(wires=[0, "a"]), {"order": 3}),
+            (qp.expval(qp.PauliZ(wires=[0])), {"order": 13}),
+            (qp.RZ(0.133, wires=["a"]), {"order": 5}),
         ]
         sub_2_expected_nodes = [
-            (qml.RX(0.432, wires=["a"]), {"order": 8}),
+            (qp.RX(0.432, wires=["a"]), {"order": 8}),
             (qcut.MeasureNode(wires=[2]), {"order": 9}),
             (qcut.PrepareNode(wires=["a"]), {"order": 6}),
-            (qml.CNOT(wires=["a", 2]), {"order": 7}),
+            (qp.CNOT(wires=["a", 2]), {"order": 7}),
         ]
         sub_3_expected_nodes = [
-            (qml.CNOT(wires=[2, 3]), {"order": 10}),
-            (qml.RY(0.543, wires=[2]), {"order": 11}),
+            (qp.CNOT(wires=[2, 3]), {"order": 10}),
+            (qp.RY(0.543, wires=[2]), {"order": 11}),
             (qcut.PrepareNode(wires=[2]), {"order": 9}),
-            (qml.RZ(0.876, wires=[3]), {"order": 12}),
-            (qml.expval(qml.PauliZ(wires=[3])), {"order": 13}),
+            (qp.RZ(0.876, wires=[3]), {"order": 12}),
+            (qp.expval(qp.PauliZ(wires=[3])), {"order": 13}),
         ]
         expected_nodes = [
             sub_0_expected_nodes,
@@ -945,26 +945,26 @@ class TestFragmentGraph:
         ]
 
         sub_0_expected_edges = [
-            (qml.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
+            (qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
         ]
         sub_1_expected_edges = [
-            (qcut.PrepareNode(wires=[0]), qml.CNOT(wires=[0, "a"]), {"wire": 0}),
-            (qml.RZ(0.24, wires=[0]), qml.expval(qml.PauliZ(wires=[0])), {"wire": 0}),
-            (qml.RZ(0.133, wires=["a"]), qcut.MeasureNode(wires=["a"]), {"wire": "a"}),
-            (qml.CNOT(wires=[0, "a"]), qml.RZ(0.24, wires=[0]), {"wire": 0}),
-            (qml.CNOT(wires=[0, "a"]), qml.RZ(0.133, wires=["a"]), {"wire": "a"}),
-            (qml.RY(0.543, wires=["a"]), qml.CNOT(wires=[0, "a"]), {"wire": "a"}),
+            (qcut.PrepareNode(wires=[0]), qp.CNOT(wires=[0, "a"]), {"wire": 0}),
+            (qp.RZ(0.24, wires=[0]), qp.expval(qp.PauliZ(wires=[0])), {"wire": 0}),
+            (qp.RZ(0.133, wires=["a"]), qcut.MeasureNode(wires=["a"]), {"wire": "a"}),
+            (qp.CNOT(wires=[0, "a"]), qp.RZ(0.24, wires=[0]), {"wire": 0}),
+            (qp.CNOT(wires=[0, "a"]), qp.RZ(0.133, wires=["a"]), {"wire": "a"}),
+            (qp.RY(0.543, wires=["a"]), qp.CNOT(wires=[0, "a"]), {"wire": "a"}),
         ]
         sub_2_expected_edges = [
-            (qcut.PrepareNode(wires=["a"]), qml.CNOT(wires=["a", 2]), {"wire": "a"}),
-            (qml.CNOT(wires=["a", 2]), qml.RX(0.432, wires=["a"]), {"wire": "a"}),
-            (qml.CNOT(wires=["a", 2]), qcut.MeasureNode(wires=[2]), {"wire": 2}),
+            (qcut.PrepareNode(wires=["a"]), qp.CNOT(wires=["a", 2]), {"wire": "a"}),
+            (qp.CNOT(wires=["a", 2]), qp.RX(0.432, wires=["a"]), {"wire": "a"}),
+            (qp.CNOT(wires=["a", 2]), qcut.MeasureNode(wires=[2]), {"wire": 2}),
         ]
         sub_3_expected_edges = [
-            (qcut.PrepareNode(wires=[2]), qml.CNOT(wires=[2, 3]), {"wire": 2}),
-            (qml.CNOT(wires=[2, 3]), qml.RY(0.543, wires=[2]), {"wire": 2}),
-            (qml.CNOT(wires=[2, 3]), qml.RZ(0.876, wires=[3]), {"wire": 3}),
-            (qml.RZ(0.876, wires=[3]), qml.expval(qml.PauliZ(wires=[3])), {"wire": 3}),
+            (qcut.PrepareNode(wires=[2]), qp.CNOT(wires=[2, 3]), {"wire": 2}),
+            (qp.CNOT(wires=[2, 3]), qp.RY(0.543, wires=[2]), {"wire": 2}),
+            (qp.CNOT(wires=[2, 3]), qp.RZ(0.876, wires=[3]), {"wire": 3}),
+            (qp.RZ(0.876, wires=[3]), qp.expval(qp.PauliZ(wires=[3])), {"wire": 3}),
         ]
         expected_edges = [
             sub_0_expected_edges,
@@ -985,8 +985,8 @@ class TestFragmentGraph:
         correct nodes and edges. Focuses on the case where fragmentation results in two fragments
         that are disconnected from the final measurements.
         """
-        tape = qml.tape.QuantumScript(
-            multi_cut_tape.operations, [qml.expval(qml.PauliZ(wires=[0]))]
+        tape = qp.tape.QuantumScript(
+            multi_cut_tape.operations, [qp.expval(qp.PauliZ(wires=[0]))]
         )
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
@@ -996,15 +996,15 @@ class TestFragmentGraph:
 
         sub_0_expected_nodes = [
             (qcut.MeasureNode(wires=[0]), {"order": 2}),
-            (qml.RX(0.432, wires=[0]), {"order": 0}),
+            (qp.RX(0.432, wires=[0]), {"order": 0}),
         ]
         sub_1_expected_nodes = [
-            (qml.RY(0.543, wires=["a"]), {"order": 1}),
+            (qp.RY(0.543, wires=["a"]), {"order": 1}),
             (qcut.PrepareNode(wires=[0]), {"order": 2}),
-            (qml.RZ(0.24, wires=[0]), {"order": 4}),
-            (qml.CNOT(wires=[0, "a"]), {"order": 3}),
-            (qml.expval(qml.PauliZ(wires=[0])), {"order": 13}),
-            (qml.RZ(0.133, wires=["a"]), {"order": 5}),
+            (qp.RZ(0.24, wires=[0]), {"order": 4}),
+            (qp.CNOT(wires=[0, "a"]), {"order": 3}),
+            (qp.expval(qp.PauliZ(wires=[0])), {"order": 13}),
+            (qp.RZ(0.133, wires=["a"]), {"order": 5}),
         ]
         expected_nodes = [
             sub_0_expected_nodes,
@@ -1012,14 +1012,14 @@ class TestFragmentGraph:
         ]
 
         sub_0_expected_edges = [
-            (qml.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
+            (qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
         ]
         sub_1_expected_edges = [
-            (qcut.PrepareNode(wires=[0]), qml.CNOT(wires=[0, "a"]), {"wire": 0}),
-            (qml.RZ(0.24, wires=[0]), qml.expval(qml.PauliZ(wires=[0])), {"wire": 0}),
-            (qml.CNOT(wires=[0, "a"]), qml.RZ(0.24, wires=[0]), {"wire": 0}),
-            (qml.CNOT(wires=[0, "a"]), qml.RZ(0.133, wires=["a"]), {"wire": "a"}),
-            (qml.RY(0.543, wires=["a"]), qml.CNOT(wires=[0, "a"]), {"wire": "a"}),
+            (qcut.PrepareNode(wires=[0]), qp.CNOT(wires=[0, "a"]), {"wire": 0}),
+            (qp.RZ(0.24, wires=[0]), qp.expval(qp.PauliZ(wires=[0])), {"wire": 0}),
+            (qp.CNOT(wires=[0, "a"]), qp.RZ(0.24, wires=[0]), {"wire": 0}),
+            (qp.CNOT(wires=[0, "a"]), qp.RZ(0.133, wires=["a"]), {"wire": "a"}),
+            (qp.RY(0.543, wires=["a"]), qp.CNOT(wires=[0, "a"]), {"wire": "a"}),
         ]
         expected_edges = [
             sub_0_expected_edges,
@@ -1064,24 +1064,24 @@ class TestFragmentGraph:
         correctly
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires="a")
-            qml.WireCut(wires="a")
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires="a")
+            qp.WireCut(wires="a")
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
 
         sub_0_expected_nodes = [
             (qcut.PrepareNode(wires=[0]), {"order": 0}),
-            (qml.RX(0.432, wires=[0]), {"order": 1}),
+            (qp.RX(0.432, wires=[0]), {"order": 1}),
         ]
         sub_1_expected_nodes = [
             (qcut.MeasureNode(wires=["a"]), {"order": 3}),
-            (qml.RY(0.543, wires=["a"]), {"order": 2}),
+            (qp.RY(0.543, wires=["a"]), {"order": 2}),
         ]
         sub_2_expected_nodes = [(qcut.MeasureNode(wires=[0]), {"order": 0})]
         sub_3_expected_nodes = [(qcut.PrepareNode(wires=["a"]), {"order": 3})]
@@ -1094,10 +1094,10 @@ class TestFragmentGraph:
         ]
 
         sub_0_expected_edges = [
-            (qcut.PrepareNode(wires=[0]), qml.RX(0.432, wires=[0]), {"wire": 0})
+            (qcut.PrepareNode(wires=[0]), qp.RX(0.432, wires=[0]), {"wire": 0})
         ]
         sub_1_expected_edges = [
-            (qml.RY(0.543, wires=["a"]), qcut.MeasureNode(wires=["a"]), {"wire": "a"})
+            (qp.RY(0.543, wires=["a"]), qcut.MeasureNode(wires=["a"]), {"wire": "a"})
         ]
         sub_2_expected_edges = []
         sub_3_expected_edges = []
@@ -1132,15 +1132,15 @@ class TestFragmentGraph:
     def test_contained_cut(self):
         """Tests that fragmentation ignores `MeasureNode` and `PrepareNode` pairs that do not
         result in a disconnection"""
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.4, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RX(0.4, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.4, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RX(0.4, wires=0)
+            qp.expval(qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         fragments, communication_graph = qcut.fragment_graph(g)
@@ -1153,32 +1153,32 @@ class TestFragmentGraph:
         correctly
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(wires=[0, 1, 2])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(wires=[0, 1, 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         fragments, _ = qcut.fragment_graph(g)
 
         sub_0_expected_nodes = [
-            (qml.Hadamard(wires=[0]), {"order": 0}),
-            (qml.CNOT(wires=[0, 1]), {"order": 1}),
-            (qml.PauliX(wires=[1]), {"order": 2}),
-            (qml.sample(qml.Projector([1], wires=[0])), {"order": 5}),
+            (qp.Hadamard(wires=[0]), {"order": 0}),
+            (qp.CNOT(wires=[0, 1]), {"order": 1}),
+            (qp.PauliX(wires=[1]), {"order": 2}),
+            (qp.sample(qp.Projector([1], wires=[0])), {"order": 5}),
             (qcut.MeasureNode(wires=[1]), {"order": 3}),
         ]
 
         sub_1_expected_nodes = [
-            (qml.sample(qml.Projector([1], wires=[2])), {"order": 5}),
-            (qml.sample(qml.Projector([1], wires=[1])), {"order": 5}),
+            (qp.sample(qp.Projector([1], wires=[2])), {"order": 5}),
+            (qp.sample(qp.Projector([1], wires=[1])), {"order": 5}),
             (qcut.PrepareNode(wires=[1]), {"order": 3}),
-            (qml.CNOT(wires=[1, 2]), {"order": 4}),
+            (qp.CNOT(wires=[1, 2]), {"order": 4}),
         ]
 
         expected_nodes = [
@@ -1187,16 +1187,16 @@ class TestFragmentGraph:
         ]
 
         sub_0_expected_edges = [
-            (qml.Hadamard(wires=[0]), qml.CNOT(wires=[0, 1]), {"wire": 0}),
-            (qml.CNOT(wires=[0, 1]), qml.PauliX(wires=[1]), {"wire": 1}),
-            (qml.CNOT(wires=[0, 1]), qml.sample(qml.Projector([1], wires=[0])), {"wire": 0}),
-            (qml.PauliX(wires=[1]), qcut.MeasureNode(wires=[1]), {"wire": 1}),
+            (qp.Hadamard(wires=[0]), qp.CNOT(wires=[0, 1]), {"wire": 0}),
+            (qp.CNOT(wires=[0, 1]), qp.PauliX(wires=[1]), {"wire": 1}),
+            (qp.CNOT(wires=[0, 1]), qp.sample(qp.Projector([1], wires=[0])), {"wire": 0}),
+            (qp.PauliX(wires=[1]), qcut.MeasureNode(wires=[1]), {"wire": 1}),
         ]
 
         sub_1_expected_edges = [
-            (qcut.PrepareNode(wires=[1]), qml.CNOT(wires=[1, 2]), {"wire": 1}),
-            (qml.CNOT(wires=[1, 2]), qml.sample(qml.Projector([1], wires=[1])), {"wire": 1}),
-            (qml.CNOT(wires=[1, 2]), qml.sample(qml.Projector([1], wires=[2])), {"wire": 2}),
+            (qcut.PrepareNode(wires=[1]), qp.CNOT(wires=[1, 2]), {"wire": 1}),
+            (qp.CNOT(wires=[1, 2]), qp.sample(qp.Projector([1], wires=[1])), {"wire": 1}),
+            (qp.CNOT(wires=[1, 2]), qp.sample(qp.Projector([1], wires=[2])), {"wire": 2}),
         ]
 
         expected_edges = [
@@ -1219,59 +1219,59 @@ class TestGraphToTape:
         Tests that directed multigraphs, containing MeasureNodes and
         PrepareNodes, are correctly converted to tapes
         """
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires="a")
-            qml.WireCut(wires=[0, "a"])
-            qml.CNOT(wires=[0, "a"])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires="a")
-            qml.WireCut(wires="a")
-            qml.CNOT(wires=["a", 2])
-            qml.RX(0.432, wires="a")
-            qml.WireCut(wires=2)
-            qml.CNOT(wires=[2, 3])
-            qml.RY(0.543, wires=2)
-            qml.RZ(0.876, wires=3)
-            qml.expval(qml.PauliZ(wires=[0]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires="a")
+            qp.WireCut(wires=[0, "a"])
+            qp.CNOT(wires=[0, "a"])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires="a")
+            qp.WireCut(wires="a")
+            qp.CNOT(wires=["a", 2])
+            qp.RX(0.432, wires="a")
+            qp.WireCut(wires=2)
+            qp.CNOT(wires=[2, 3])
+            qp.RY(0.543, wires=2)
+            qp.RZ(0.876, wires=3)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
 
         tapes = [qcut.graph_to_tape(sg) for sg in subgraphs]
 
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.RX(0.432, wires=[0])
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.RX(0.432, wires=[0])
             qcut.MeasureNode(wires=[0])
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.RY(0.543, wires=["a"])
+        with qp.queuing.AnnotatedQueue() as q1:
+            qp.RY(0.543, wires=["a"])
             qcut.MeasureNode(wires=["a"])
 
-        with qml.queuing.AnnotatedQueue() as q2:
+        with qp.queuing.AnnotatedQueue() as q2:
             qcut.PrepareNode(wires=[0])
             qcut.PrepareNode(wires=["a"])
-            qml.CNOT(wires=[0, "a"])
-            qml.RZ(0.24, wires=[0])
-            qml.RZ(0.133, wires=["a"])
+            qp.CNOT(wires=[0, "a"])
+            qp.RZ(0.24, wires=[0])
+            qp.RZ(0.133, wires=["a"])
             qcut.MeasureNode(wires=["a"])
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        with qml.queuing.AnnotatedQueue() as q3:
+        with qp.queuing.AnnotatedQueue() as q3:
             qcut.PrepareNode(wires=["a"])
-            qml.CNOT(wires=["a", 2])
-            qml.RX(0.432, wires=["a"])
+            qp.CNOT(wires=["a", 2])
+            qp.RX(0.432, wires=["a"])
             qcut.MeasureNode(wires=[2])
 
-        with qml.queuing.AnnotatedQueue() as q4:
+        with qp.queuing.AnnotatedQueue() as q4:
             qcut.PrepareNode(wires=[2])
-            qml.CNOT(wires=[2, 3])
-            qml.RY(0.543, wires=[2])
-            qml.RZ(0.876, wires=[3])
+            qp.CNOT(wires=[2, 3])
+            qp.RY(0.543, wires=[2])
+            qp.RZ(0.876, wires=[3])
 
-        expected_tapes = list(map(qml.tape.QuantumScript.from_queue, [q0, q1, q2, q3, q4]))
+        expected_tapes = list(map(qp.tape.QuantumScript.from_queue, [q0, q1, q2, q3, q4]))
 
         for tape, expected_tape in zip(tapes, expected_tapes):
             compare_tapes(tape, expected_tape)
@@ -1313,31 +1313,31 @@ class TestGraphToTape:
 
         tapes = [qcut.graph_to_tape(sg) for sg in subgraphs]
 
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.Hadamard(wires=[0])
-            qml.RX(0.432, wires=[0])
-            qml.RY(0.543, wires=[1])
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.Hadamard(wires=[0])
+            qp.RX(0.432, wires=[0])
+            qp.RY(0.543, wires=[1])
+            qp.CNOT(wires=[0, 1])
             qcut.MeasureNode(wires=[1])
             qcut.PrepareNode(wires=[2])
-            qml.RZ(0.321, wires=[2])
-            qml.CNOT(wires=[0, 2])
+            qp.RZ(0.321, wires=[2])
+            qp.CNOT(wires=[0, 2])
             qcut.MeasureNode(wires=[2])
             qcut.PrepareNode(wires=[3])
-            qml.CNOT(wires=[0, 3])
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.CNOT(wires=[0, 3])
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape_0 = qml.tape.QuantumScript.from_queue(q0)
-        with qml.queuing.AnnotatedQueue() as q1:
+        tape_0 = qp.tape.QuantumScript.from_queue(q0)
+        with qp.queuing.AnnotatedQueue() as q1:
             qcut.PrepareNode(wires=[1])
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[1, 2])
             qcut.MeasureNode(wires=[1])
-            qml.Hadamard(wires=[2])
+            qp.Hadamard(wires=[2])
             qcut.PrepareNode(wires=[0])
-            qml.CNOT(wires=[0, 2])
+            qp.CNOT(wires=[0, 2])
             qcut.MeasureNode(wires=[0])
 
-        tape_1 = qml.tape.QuantumScript.from_queue(q1)
+        tape_1 = qp.tape.QuantumScript.from_queue(q1)
         expected_tapes = [tape_0, tape_1]
 
         for tape, expected_tape in zip(tapes, expected_tapes):
@@ -1374,11 +1374,11 @@ class TestGraphToTape:
         graph returned by tape_to_graph, and then combining those nodes again into a single tensor
         product in the circuit returned by graph_to_tape"""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.CNOT(wires=[0, 1])
-            qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.CNOT(wires=[0, 1])
+            qp.expval(qp.PauliZ(0) @ qp.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
         tape_out = qcut.graph_to_tape(graph)
 
@@ -1389,14 +1389,14 @@ class TestGraphToTape:
         """Tests that the graph_to_tape function correctly swaps the wires of observables when
         the tape contains mid-circuit measurements"""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.CNOT(wires=[0, 1])
             qcut.MeasureNode(wires=1)
             qcut.PrepareNode(wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.expval(qml.PauliZ(1))
+            qp.CNOT(wires=[0, 1])
+            qp.expval(qp.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
         tape_out = qcut.graph_to_tape(graph)
 
@@ -1411,25 +1411,25 @@ class TestGraphToTape:
         fragment tapes
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(wires=[0, 1, 2])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(wires=[0, 1, 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
 
         tapes = [qcut.graph_to_tape(sg) for sg in subgraphs]
 
-        frag0_expected_meas = [qml.sample(qml.Projector([1], wires=[0]))]
+        frag0_expected_meas = [qp.sample(qp.Projector([1], wires=[0]))]
         frag1_expected_meas = [
-            qml.sample(qml.Projector([1], wires=[1])),
-            qml.sample(qml.Projector([1], wires=[2])),
+            qp.sample(qp.Projector([1], wires=[1])),
+            qp.sample(qp.Projector([1], wires=[2])),
         ]
 
         for meas, expected_meas in zip(tapes[0].measurements, frag0_expected_meas):
@@ -1438,8 +1438,8 @@ class TestGraphToTape:
         # For tapes with multiple measurements, the ordering varies
         # so we check the set of wires rather that the order
         for meas, expected_meas in zip(tapes[1].measurements, frag1_expected_meas):
-            assert isinstance(meas, qml.measurements.SampleMP)
-            assert isinstance(meas.obs, qml.Projector)
+            assert isinstance(meas, qp.measurements.SampleMP)
+            assert isinstance(meas.obs, qp.Projector)
             assert meas.obs.wires in {Wires(1), Wires(2)}
 
     def test_sample_mid_circuit_meas(self):
@@ -1449,24 +1449,24 @@ class TestGraphToTape:
         correctly converted into tapes
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.RX(0.432, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.WireCut(wires=1)
-            qml.RZ(0.321, wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.Hadamard(wires=2)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.sample(wires=[0, 1, 2])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.RX(0.432, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.WireCut(wires=1)
+            qp.RZ(0.321, wires=1)
+            qp.CNOT(wires=[0, 1])
+            qp.Hadamard(wires=2)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[0, 1])
+            qp.sample(wires=[0, 1, 2])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
@@ -1474,14 +1474,14 @@ class TestGraphToTape:
         tapes = [qcut.graph_to_tape(sg) for sg in subgraphs]
 
         frag0_expected_meas = [
-            qml.sample(qml.Projector([1], wires=[0])),
-            qml.sample(qml.Projector([1], wires=[3])),
+            qp.sample(qp.Projector([1], wires=[0])),
+            qp.sample(qp.Projector([1], wires=[3])),
         ]
-        frag1_expected_meas = [qml.sample(qml.Projector([1], wires=[2]))]
+        frag1_expected_meas = [qp.sample(qp.Projector([1], wires=[2]))]
 
         for meas, expected_meas in zip(tapes[0].measurements, frag0_expected_meas):
-            assert isinstance(meas, qml.measurements.SampleMP)
-            assert isinstance(meas.obs, qml.Projector)
+            assert isinstance(meas, qp.measurements.SampleMP)
+            assert isinstance(meas.obs, qp.Projector)
             assert meas.obs.wires in {Wires(0), Wires(3)}
 
         for meas, expected_meas in zip(tapes[1].measurements, frag1_expected_meas):
@@ -1510,16 +1510,16 @@ class TestGraphToTape:
         error message.
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=1)
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.sample(wires=[0, 1])
-            qml.expval(qml.PauliZ(wires=2))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=1)
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.sample(wires=[0, 1])
+            qp.expval(qp.PauliZ(wires=2))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
@@ -1534,11 +1534,11 @@ class TestGraphToTape:
         Tests that a subgraph containing an unsupported measurement raises the
         correct error message.
         """
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=0)
-            qml.var(qml.PauliZ(wires=0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=0)
+            qp.var(qp.PauliZ(wires=0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
@@ -1556,8 +1556,8 @@ class TestGetMeasurements:
     def test_multiple_measurements_raises(self):
         """Tests if the function raises a ValueError when more than 1 fixed measurement is
         specified"""
-        group = [qml.Identity(0)]
-        meas = [qml.expval(qml.PauliX(1)), qml.expval(qml.PauliY(2))]
+        group = [qp.Identity(0)]
+        meas = [qp.expval(qp.PauliX(1)), qp.expval(qp.PauliY(2))]
 
         with pytest.raises(ValueError, match="with a single output measurement"):
             qcut._get_measurements(group, meas)
@@ -1565,8 +1565,8 @@ class TestGetMeasurements:
     def test_non_expectation_raises(self):
         """Tests if the function raises a ValueError when the fixed measurement is not an
         expectation value"""
-        group = [qml.Identity(0)]
-        meas = [qml.var(qml.PauliX(1))]
+        group = [qp.Identity(0)]
+        meas = [qp.var(qp.PauliX(1))]
 
         with pytest.raises(ValueError, match="with expectation value measurements"):
             qcut._get_measurements(group, meas)
@@ -1574,20 +1574,20 @@ class TestGetMeasurements:
     def test_no_measurements(self):
         """Tests if the function simply processes ``group`` into expectation values when an empty
         list of fixed measurements is provided"""
-        group = [qml.Identity(0)]
+        group = [qp.Identity(0)]
         meas = []
 
         out = qcut._get_measurements(group, meas)
 
         assert len(out) == len(group)
-        assert isinstance(out[0], qml.measurements.ExpectationMP)
+        assert isinstance(out[0], qp.measurements.ExpectationMP)
         assert get_name(out[0].obs) == "Identity"
         assert out[0].obs.wires[0] == 0
 
     def test_single_measurement(self):
         """Tests if the function behaves as expected for a typical example"""
-        group = [qml.PauliX(0) @ qml.PauliZ(2), qml.PauliX(0)]
-        meas = [qml.expval(qml.PauliZ(1))]
+        group = [qp.PauliX(0) @ qp.PauliZ(2), qp.PauliX(0)]
+        meas = [qp.expval(qp.PauliZ(1))]
 
         out = qcut._get_measurements(group, meas)
 
@@ -1612,8 +1612,8 @@ class TestExpandFragmentTapes:
         """
         Tests that a fragment tape expands correctly
         """
-        m = qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=2))
-        tape = qml.tape.QuantumScript(single_cut_tape.operations, [m])
+        m = qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=2))
+        tape = qp.tape.QuantumScript(single_cut_tape.operations, [m])
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
@@ -1627,62 +1627,62 @@ class TestExpandFragmentTapes:
         assert len(frag_tapes_prep) == 4
 
         frag_meas_ops = [
-            qml.RX(0.432, wires=[0]),
-            qml.RY(0.543, wires=[1]),
-            qml.CNOT(wires=[0, 1]),
-            qml.RZ(0.24, wires=[0]),
-            qml.RZ(0.133, wires=[1]),
+            qp.RX(0.432, wires=[0]),
+            qp.RY(0.543, wires=[1]),
+            qp.CNOT(wires=[0, 1]),
+            qp.RZ(0.24, wires=[0]),
+            qp.RZ(0.133, wires=[1]),
         ]
 
-        with qml.queuing.AnnotatedQueue() as q0:
+        with qp.queuing.AnnotatedQueue() as q0:
             for op in frag_meas_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[0]) @ qml.Identity(wires=[1]))
-            qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[0]) @ qp.Identity(wires=[1]))
+            qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]))
 
-        with qml.queuing.AnnotatedQueue() as q1:
+        with qp.queuing.AnnotatedQueue() as q1:
             for op in frag_meas_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[1]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[1]))
 
-        with qml.queuing.AnnotatedQueue() as q2:
+        with qp.queuing.AnnotatedQueue() as q2:
             for op in frag_meas_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[1]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[1]))
 
-        frag_meas_expected_tapes = list(map(qml.tape.QuantumScript.from_queue, [q0, q1, q2]))
+        frag_meas_expected_tapes = list(map(qp.tape.QuantumScript.from_queue, [q0, q1, q2]))
 
-        frag_prep_ops = [qml.CNOT(wires=[1, 2]), qml.RX(0.432, wires=[1]), qml.RY(0.543, wires=[2])]
+        frag_prep_ops = [qp.CNOT(wires=[1, 2]), qp.RX(0.432, wires=[1]), qp.RY(0.543, wires=[2])]
 
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.Identity(wires=[1])
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.Identity(wires=[1])
             for op in frag_prep_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[2]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[2]))
 
-        tape_10 = qml.tape.QuantumScript.from_queue(q0)
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.PauliX(wires=[1])
+        tape_10 = qp.tape.QuantumScript.from_queue(q0)
+        with qp.queuing.AnnotatedQueue() as q1:
+            qp.PauliX(wires=[1])
             for op in frag_prep_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[2]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[2]))
 
-        tape_11 = qml.tape.QuantumScript.from_queue(q1)
-        with qml.queuing.AnnotatedQueue() as q2:
-            qml.Hadamard(wires=[1])
+        tape_11 = qp.tape.QuantumScript.from_queue(q1)
+        with qp.queuing.AnnotatedQueue() as q2:
+            qp.Hadamard(wires=[1])
             for op in frag_prep_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[2]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[2]))
 
-        tape_12 = qml.tape.QuantumScript.from_queue(q2)
-        with qml.queuing.AnnotatedQueue() as q3:
-            qml.Hadamard(wires=[1])
-            qml.S(wires=[1])
+        tape_12 = qp.tape.QuantumScript.from_queue(q2)
+        with qp.queuing.AnnotatedQueue() as q3:
+            qp.Hadamard(wires=[1])
+            qp.S(wires=[1])
             for op in frag_prep_ops:
-                qml.apply(op)
-            qml.expval(qml.PauliZ(wires=[2]))
+                qp.apply(op)
+            qp.expval(qp.PauliZ(wires=[2]))
 
-        tape_13 = qml.tape.QuantumScript.from_queue(q3)
+        tape_13 = qp.tape.QuantumScript.from_queue(q3)
         frag_prep_expected_tapes = [tape_10, tape_11, tape_12, tape_13]
 
         for tape_meas, exp_tape_meas in zip(frag_tapes_meas, frag_meas_expected_tapes):
@@ -1697,21 +1697,21 @@ class TestExpandFragmentTapes:
         measurements after expansion
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=[0])
-            qml.RX(0.432, wires=[0])
-            qml.RY(0.543, wires=[1])
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=[0])
+            qp.RX(0.432, wires=[0])
+            qp.RY(0.543, wires=[1])
+            qp.CNOT(wires=[0, 1])
             qcut.MeasureNode(wires=[1])
             qcut.PrepareNode(wires=[2])
-            qml.RZ(0.321, wires=[2])
-            qml.CNOT(wires=[0, 2])
+            qp.RZ(0.321, wires=[2])
+            qp.CNOT(wires=[0, 2])
             qcut.MeasureNode(wires=[2])
             qcut.PrepareNode(wires=[3])
-            qml.CNOT(wires=[0, 3])
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.CNOT(wires=[0, 3])
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         # Here we have a fragment tape containing 2 MeasureNode and
         # PrepareNode pairs. This give 3**2 = 9 groups of Pauli measurements
         # and 4**2 = 16 preparations and thus 9*16 = 144 tapes.
@@ -1722,31 +1722,31 @@ class TestExpandFragmentTapes:
 
         all_expected_groups = [
             [
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.Identity(wires=[1])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[2])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.Identity(wires=[1])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2])),
             ],
             [
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[2])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]) @ qml.PauliX(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]) @ qp.PauliX(wires=[2])),
             ],
             [
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[2])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]) @ qml.PauliY(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]) @ qp.PauliY(wires=[2])),
             ],
             [
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[1])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliZ(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[1])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliZ(wires=[2])),
             ],
-            [qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliX(wires=[2]))],
-            [qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliY(wires=[2]))],
+            [qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliX(wires=[2]))],
+            [qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliY(wires=[2]))],
             [
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[1])),
-                qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliZ(wires=[2])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[1])),
+                qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliZ(wires=[2])),
             ],
-            [qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliX(wires=[2]))],
-            [qml.expval(qml.PauliZ(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliY(wires=[2]))],
+            [qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliX(wires=[2]))],
+            [qp.expval(qp.PauliZ(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliY(wires=[2]))],
         ]
 
         all_measurements = [tape.measurements for tape in frag_tapes]
@@ -1772,25 +1772,25 @@ class TestExpandFragmentTapes:
         preparation after expansion
         """
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.Hadamard(wires=[0])
-            qml.RX(0.432, wires=[0])
-            qml.RY(0.543, wires=[1])
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.Hadamard(wires=[0])
+            qp.RX(0.432, wires=[0])
+            qp.RY(0.543, wires=[1])
+            qp.CNOT(wires=[0, 1])
             qcut.MeasureNode(wires=[1])
             qcut.PrepareNode(wires=[2])
-            qml.RZ(0.321, wires=[2])
-            qml.CNOT(wires=[0, 2])
+            qp.RZ(0.321, wires=[2])
+            qp.CNOT(wires=[0, 2])
             qcut.MeasureNode(wires=[2])
             qcut.PrepareNode(wires=[3])
-            qml.CNOT(wires=[0, 3])
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.CNOT(wires=[0, 3])
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         fragment_configurations = qcut.expand_fragment_tape(tape)
         frag_tapes = fragment_configurations[0]
 
-        prep_ops = [[qml.Identity], [qml.PauliX], [qml.Hadamard], [qml.Hadamard, qml.S]]
+        prep_ops = [[qp.Identity], [qp.PauliX], [qp.Hadamard], [qp.Hadamard, qp.S]]
         prep_combos = list(product(prep_ops, prep_ops))
         expected_preps = [pc for pc in prep_combos for _ in range(9)]
 
@@ -1816,53 +1816,53 @@ class TestExpandFragmentTapes:
         configurations
         """
 
-        with qml.queuing.AnnotatedQueue() as q_frag:
-            qml.RY(0.543, wires=[1])
+        with qp.queuing.AnnotatedQueue() as q_frag:
+            qp.RY(0.543, wires=[1])
             qcut.PrepareNode(wires=[0])
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.24, wires=[0])
-            qml.RZ(0.133, wires=[1])
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.24, wires=[0])
+            qp.RZ(0.133, wires=[1])
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        frag = qml.tape.QuantumScript.from_queue(q_frag)
+        frag = qp.tape.QuantumScript.from_queue(q_frag)
         expanded_tapes, *_ = qcut.expand_fragment_tape(frag)
 
         ops = [
-            qml.CNOT(wires=[0, 1]),
-            qml.RZ(0.24, wires=[0]),
-            qml.RZ(0.133, wires=[1]),
-            qml.expval(qml.PauliZ(wires=[0])),
+            qp.CNOT(wires=[0, 1]),
+            qp.RZ(0.24, wires=[0]),
+            qp.RZ(0.133, wires=[1]),
+            qp.expval(qp.PauliZ(wires=[0])),
         ]
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.RY(0.543, wires=[1])
-            qml.Identity(wires=[0])
+        with qp.queuing.AnnotatedQueue() as q1:
+            qp.RY(0.543, wires=[1])
+            qp.Identity(wires=[0])
             for optr in ops:
-                qml.apply(optr)
+                qp.apply(optr)
 
-        config1 = qml.tape.QuantumScript.from_queue(q1)
-        with qml.queuing.AnnotatedQueue() as q2:
-            qml.RY(0.543, wires=[1])
-            qml.PauliX(wires=[0])
+        config1 = qp.tape.QuantumScript.from_queue(q1)
+        with qp.queuing.AnnotatedQueue() as q2:
+            qp.RY(0.543, wires=[1])
+            qp.PauliX(wires=[0])
             for optr in ops:
-                qml.apply(optr)
+                qp.apply(optr)
 
-        config2 = qml.tape.QuantumScript.from_queue(q2)
-        with qml.queuing.AnnotatedQueue() as q3:
-            qml.RY(0.543, wires=[1])
-            qml.Hadamard(wires=[0])
+        config2 = qp.tape.QuantumScript.from_queue(q2)
+        with qp.queuing.AnnotatedQueue() as q3:
+            qp.RY(0.543, wires=[1])
+            qp.Hadamard(wires=[0])
             for optr in ops:
-                qml.apply(optr)
+                qp.apply(optr)
 
-        config3 = qml.tape.QuantumScript.from_queue(q3)
-        with qml.queuing.AnnotatedQueue() as q4:
-            qml.RY(0.543, wires=[1])
-            qml.Hadamard(wires=[0])
-            qml.S(wires=[0])
+        config3 = qp.tape.QuantumScript.from_queue(q3)
+        with qp.queuing.AnnotatedQueue() as q4:
+            qp.RY(0.543, wires=[1])
+            qp.Hadamard(wires=[0])
+            qp.S(wires=[0])
             for optr in ops:
-                qml.apply(optr)
+                qp.apply(optr)
 
-        config4 = qml.tape.QuantumScript.from_queue(q4)
+        config4 = qp.tape.QuantumScript.from_queue(q4)
         expected_configs = [config1, config2, config3, config4]
 
         for tape, config in zip(expanded_tapes, expected_configs):
@@ -1880,20 +1880,20 @@ class TestExpandFragmentTapesMC:
         Tests that fragment configurations are generated correctly using the
         `expand_fragment_tapes_mc` function.
         """
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.Hadamard(wires=[0])
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.Hadamard(wires=[0])
+            qp.CNOT(wires=[0, 1])
             qcut.MeasureNode(wires=[1])
-            qml.sample(qml.Projector([1], wires=[0]))
+            qp.sample(qp.Projector([1], wires=[0]))
 
-        tape0 = qml.tape.QuantumScript.from_queue(q0)
-        with qml.queuing.AnnotatedQueue() as q1:
+        tape0 = qp.tape.QuantumScript.from_queue(q0)
+        with qp.queuing.AnnotatedQueue() as q1:
             qcut.PrepareNode(wires=[1])
-            qml.CNOT(wires=[1, 2])
-            qml.sample(qml.Projector([1], wires=[1]))
-            qml.sample(qml.Projector([1], wires=[2]))
+            qp.CNOT(wires=[1, 2])
+            qp.sample(qp.Projector([1], wires=[1]))
+            qp.sample(qp.Projector([1], wires=[2]))
 
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         tapes = [tape0, tape1]
 
         edge_data = {
@@ -1919,47 +1919,47 @@ class TestExpandFragmentTapesMC:
 
         assert np.allclose(settings, fixed_choice)
 
-        frag_0_ops = [qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])]
+        frag_0_ops = [qp.Hadamard(wires=0), qp.CNOT(wires=[0, 1])]
         frag_0_expected_meas = [
-            [qml.sample(qml.Projector([1], wires=[0])), qml.sample(qml.PauliY(wires=[1]))],
-            [qml.sample(qml.Projector([1], wires=[0])), qml.sample(qml.Identity(wires=[1]))],
-            [qml.sample(qml.Projector([1], wires=[0])), qml.sample(qml.Identity(wires=[1]))],
+            [qp.sample(qp.Projector([1], wires=[0])), qp.sample(qp.PauliY(wires=[1]))],
+            [qp.sample(qp.Projector([1], wires=[0])), qp.sample(qp.Identity(wires=[1]))],
+            [qp.sample(qp.Projector([1], wires=[0])), qp.sample(qp.Identity(wires=[1]))],
         ]
 
         expected_tapes_0 = []
         for meas in frag_0_expected_meas:
-            with qml.queuing.AnnotatedQueue() as q_expected_tape:
+            with qp.queuing.AnnotatedQueue() as q_expected_tape:
                 for op in frag_0_ops:
-                    qml.apply(op)
+                    qp.apply(op)
                 for m in meas:
-                    qml.apply(m)
+                    qp.apply(m)
 
-            expected_tape = qml.tape.QuantumScript.from_queue(q_expected_tape)
+            expected_tape = qp.tape.QuantumScript.from_queue(q_expected_tape)
             expected_tapes_0.append(expected_tape)
 
         for tape, exp_tape in zip(fragment_configurations[0], expected_tapes_0):
             compare_tapes(tape, exp_tape)
 
         frag_1_expected_preps = [
-            [qml.Hadamard(wires=[1]), qml.S(wires=[1])],
-            [qml.Identity(wires=[1])],
-            [qml.PauliX(wires=[1])],
+            [qp.Hadamard(wires=[1]), qp.S(wires=[1])],
+            [qp.Identity(wires=[1])],
+            [qp.PauliX(wires=[1])],
         ]
 
         frag_1_ops_and_meas = [
-            qml.CNOT(wires=[1, 2]),
-            qml.sample(qml.Projector([1], wires=[1])),
-            qml.sample(qml.Projector([1], wires=[2])),
+            qp.CNOT(wires=[1, 2]),
+            qp.sample(qp.Projector([1], wires=[1])),
+            qp.sample(qp.Projector([1], wires=[2])),
         ]
 
         expected_tapes_1 = []
         for preps in frag_1_expected_preps:
-            with qml.queuing.AnnotatedQueue() as q_expected_tape:
+            with qp.queuing.AnnotatedQueue() as q_expected_tape:
                 for prep in preps:
-                    qml.apply(prep)
+                    qp.apply(prep)
                 for op in frag_1_ops_and_meas:
-                    qml.apply(op)
-            expected_tape = qml.tape.QuantumScript.from_queue(q_expected_tape)
+                    qp.apply(op)
+            expected_tape = qp.tape.QuantumScript.from_queue(q_expected_tape)
             expected_tapes_1.append(expected_tape)
 
         for tape, exp_tape in zip(fragment_configurations[1], expected_tapes_1):
@@ -1994,40 +1994,40 @@ class TestExpandFragmentTapesMC:
 
         assert np.allclose(settings, fixed_choice)
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            qml.Hadamard(wires=[0])
-            qml.RX(0.432, wires=[0])
-            qml.RY(0.543, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            qml.Hadamard(wires=[2])
-            qml.RZ(0.321, wires=[2])
-            qml.CNOT(wires=[0, 2])
-            qml.PauliX(wires=[3])
-            qml.Hadamard(wires=[3])
-            qml.CNOT(wires=[0, 3])
-            qml.sample(qml.Projector([1], wires=[0]))
-            qml.sample(qml.Projector([1], wires=[3]))
-            qml.sample(qml.PauliY(wires=[1]))
-            qml.sample(qml.Identity(wires=[2]))
+        with qp.queuing.AnnotatedQueue() as q1:
+            qp.Hadamard(wires=[0])
+            qp.RX(0.432, wires=[0])
+            qp.RY(0.543, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            qp.Hadamard(wires=[2])
+            qp.RZ(0.321, wires=[2])
+            qp.CNOT(wires=[0, 2])
+            qp.PauliX(wires=[3])
+            qp.Hadamard(wires=[3])
+            qp.CNOT(wires=[0, 3])
+            qp.sample(qp.Projector([1], wires=[0]))
+            qp.sample(qp.Projector([1], wires=[3]))
+            qp.sample(qp.PauliY(wires=[1]))
+            qp.sample(qp.Identity(wires=[2]))
 
-        config1 = qml.tape.QuantumScript.from_queue(q1)
-        with qml.queuing.AnnotatedQueue() as q2:
-            qml.Hadamard(wires=[0])
-            qml.RX(0.432, wires=[0])
-            qml.RY(0.543, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            qml.PauliX(wires=[2])
-            qml.Hadamard(wires=[2])
-            qml.RZ(0.321, wires=[2])
-            qml.CNOT(wires=[0, 2])
-            qml.Identity(wires=[3])
-            qml.CNOT(wires=[0, 3])
-            qml.sample(qml.Projector([1], wires=[0]))
-            qml.sample(qml.Projector([1], wires=[3]))
-            qml.sample(qml.PauliZ(wires=[1]))
-            qml.sample(qml.PauliX(wires=[2]))
+        config1 = qp.tape.QuantumScript.from_queue(q1)
+        with qp.queuing.AnnotatedQueue() as q2:
+            qp.Hadamard(wires=[0])
+            qp.RX(0.432, wires=[0])
+            qp.RY(0.543, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            qp.PauliX(wires=[2])
+            qp.Hadamard(wires=[2])
+            qp.RZ(0.321, wires=[2])
+            qp.CNOT(wires=[0, 2])
+            qp.Identity(wires=[3])
+            qp.CNOT(wires=[0, 3])
+            qp.sample(qp.Projector([1], wires=[0]))
+            qp.sample(qp.Projector([1], wires=[3]))
+            qp.sample(qp.PauliZ(wires=[1]))
+            qp.sample(qp.PauliX(wires=[2]))
 
-        config2 = qml.tape.QuantumScript.from_queue(q2)
+        config2 = qp.tape.QuantumScript.from_queue(q2)
         expected_configs = [config1, config2]
 
         # check first fragment configs only for brevity
@@ -2043,20 +2043,20 @@ class TestExpandFragmentTapesMC:
 
         tapes = []
         for M in qcut.MC_MEASUREMENTS:
-            with qml.queuing.AnnotatedQueue() as q:
+            with qp.queuing.AnnotatedQueue() as q:
                 M(wire)
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qp.tape.QuantumScript.from_queue(q)
             tapes.append(tape)
 
         expected_measurements = [
-            qml.sample(qml.Identity(wires=["a"])),
-            qml.sample(qml.Identity(wires=["a"])),
-            qml.sample(qml.PauliX(wires=["a"])),
-            qml.sample(qml.PauliX(wires=["a"])),
-            qml.sample(qml.PauliY(wires=["a"])),
-            qml.sample(qml.PauliY(wires=["a"])),
-            qml.sample(qml.PauliZ(wires=["a"])),
-            qml.sample(qml.PauliZ(wires=["a"])),
+            qp.sample(qp.Identity(wires=["a"])),
+            qp.sample(qp.Identity(wires=["a"])),
+            qp.sample(qp.PauliX(wires=["a"])),
+            qp.sample(qp.PauliX(wires=["a"])),
+            qp.sample(qp.PauliY(wires=["a"])),
+            qp.sample(qp.PauliY(wires=["a"])),
+            qp.sample(qp.PauliZ(wires=["a"])),
+            qp.sample(qp.PauliZ(wires=["a"])),
         ]
 
         measurements = [tape.measurements[0] for tape in tapes]
@@ -2074,20 +2074,20 @@ class TestExpandFragmentTapesMC:
 
         tapes = []
         for S in qcut.MC_STATES:
-            with qml.queuing.AnnotatedQueue() as q:
+            with qp.queuing.AnnotatedQueue() as q:
                 S(wire)
-            tape = qml.tape.QuantumScript.from_queue(q)
+            tape = qp.tape.QuantumScript.from_queue(q)
             tapes.append(tape)
 
         expected_operations = [
-            [qml.Identity(wires=[3])],
-            [qml.PauliX(wires=[3])],
-            [qml.Hadamard(wires=[3])],
-            [qml.PauliX(wires=[3]), qml.Hadamard(wires=[3])],
-            [qml.Hadamard(wires=[3]), qml.S(wires=[3])],
-            [qml.PauliX(wires=[3]), qml.Hadamard(wires=[3]), qml.S(wires=[3])],
-            [qml.Identity(wires=[3])],
-            [qml.PauliX(wires=[3])],
+            [qp.Identity(wires=[3])],
+            [qp.PauliX(wires=[3])],
+            [qp.Hadamard(wires=[3])],
+            [qp.PauliX(wires=[3]), qp.Hadamard(wires=[3])],
+            [qp.Hadamard(wires=[3]), qp.S(wires=[3])],
+            [qp.PauliX(wires=[3]), qp.Hadamard(wires=[3]), qp.S(wires=[3])],
+            [qp.Identity(wires=[3])],
+            [qp.PauliX(wires=[3])],
         ]
 
         operations = [tape.operations for tape in tapes]
@@ -2124,7 +2124,7 @@ class TestMCPostprocessing:
             np.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
-            qml.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
+            qp.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
         ]
 
         postprocessed = qcut.qcut_processing_fn_sample(
@@ -2154,7 +2154,7 @@ class TestMCPostprocessing:
             np.array([[0.0], [-1.0], [-1.0]]),
             np.array([[1.0], [1.0], [1.0]]),
         ]
-        convert_fixed_samples = [qml.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
+        convert_fixed_samples = [qp.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
 
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
@@ -2183,7 +2183,7 @@ class TestMCPostprocessing:
             np.array([[0.0], [-1.0], [-1.0]]),
             np.array([[1.0], [1.0], [1.0]]),
         ]
-        convert_fixed_samples = [qml.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
+        convert_fixed_samples = [qp.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
 
         postprocessed = qcut.qcut_processing_fn_sample(
             convert_fixed_samples, communication_graph, shots
@@ -2213,7 +2213,7 @@ class TestMCPostprocessing:
             np.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
-            qml.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
+            qp.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
         ]
 
         postprocessed = qcut.qcut_processing_fn_sample(
@@ -2244,7 +2244,7 @@ class TestMCPostprocessing:
             np.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
-            qml.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
+            qp.math.convert_like(fs, autograd.numpy.ones(1)) for fs in fixed_samples
         ]
 
         fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
@@ -2305,7 +2305,7 @@ class TestMCPostprocessing:
             np.array([[0.0], [-1.0], [-1.0]]),
             np.array([[1.0], [1.0], [1.0]]),
         ]
-        convert_fixed_samples = [qml.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
+        convert_fixed_samples = [qp.math.convert_like(fs, tf.ones(1)) for fs in fixed_samples]
 
         fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
@@ -2365,7 +2365,7 @@ class TestMCPostprocessing:
             np.array([[0.0], [-1.0], [-1.0]]),
             np.array([[1.0], [1.0], [1.0]]),
         ]
-        convert_fixed_samples = [qml.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
+        convert_fixed_samples = [qp.math.convert_like(fs, torch.ones(1)) for fs in fixed_samples]
 
         fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
 
@@ -2426,7 +2426,7 @@ class TestMCPostprocessing:
             np.array([[1.0], [1.0], [1.0]]),
         ]
         convert_fixed_samples = [
-            qml.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
+            qp.math.convert_like(fs, jax.numpy.ones(1)) for fs in fixed_samples
         ]
 
         fixed_settings = np.array([[0, 7, 1], [5, 7, 2], [1, 0, 3], [5, 1, 1]])
@@ -2525,7 +2525,7 @@ class TestMCPostprocessing:
             )
 
 
-@pytest.mark.parametrize("dev_fn", [qml.devices.DefaultQubit])
+@pytest.mark.parametrize("dev_fn", [qp.devices.DefaultQubit])
 class TestCutCircuitMCTransform:
     """
     Tests that the `cut_circuit_mc` transform gives the correct results.
@@ -2539,38 +2539,38 @@ class TestCutCircuitMCTransform:
 
         dev_sim = dev_fn(wires=3, seed=seed)
 
-        @qml.qnode(dev_sim)
+        @qp.qnode(dev_sim)
         def target_circuit(v):
-            qml.RX(v, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(v, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(v, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.expval(qml.PauliZ(wires=0) @ qml.PauliZ(wires=2))
+            qp.RX(v, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.expval(qp.PauliZ(wires=0) @ qp.PauliZ(wires=2))
 
         dev = dev_fn(wires=2, seed=seed)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn, seed=seed)
-        @qml.qnode(dev, shots=20000)
+        @qp.cut_circuit_mc(classical_processing_fn=fn, seed=seed)
+        @qp.qnode(dev, shots=20000)
         def circuit(v):
-            qml.RX(v, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(v, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(v, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(v, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
         cut_res_mc = circuit(v)
@@ -2586,20 +2586,20 @@ class TestCutCircuitMCTransform:
 
         dev = dev_fn(wires=3)
 
-        @qml.qnode(dev, shots=100)
+        @qp.qnode(dev, shots=100)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
         target = circuit(v)
@@ -2618,26 +2618,26 @@ class TestCutCircuitMCTransform:
         shots = 100
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
 
         temp_shots = 333
-        cut_res = qml.set_shots(shots=temp_shots)(cut_circuit)(v)
+        cut_res = qp.set_shots(shots=temp_shots)(cut_circuit)(v)
 
         assert cut_res.shape == (temp_shots, 2)
 
@@ -2653,21 +2653,21 @@ class TestCutCircuitMCTransform:
 
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
         with pytest.raises(ValueError, match="cut_circuit_mc requires finite shots."):
@@ -2681,21 +2681,21 @@ class TestCutCircuitMCTransform:
         shots = 100
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(qp.PauliZ(0))
 
         v = 0.319
         with pytest.raises(ValueError, match="The Monte Carlo circuit cutting workflow only "):
@@ -2709,21 +2709,21 @@ class TestCutCircuitMCTransform:
 
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(shots=456)
-        @qml.qnode(dev)
+        @qp.cut_circuit_mc(shots=456)
+        @qp.qnode(dev)
         def cut_circuit(x):  # pylint: disable=unused-variable,unused-argument
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         with pytest.raises(ValueError, match="shots has been removed from cut_circuit_mc."):
             cut_circuit(5)
@@ -2735,21 +2735,21 @@ class TestCutCircuitMCTransform:
         """
         dev = dev_fn(wires=3)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=100)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=100)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0]), qml.sample(wires=[1]), qml.sample(wires=[2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0]), qp.sample(wires=[1]), qp.sample(wires=[2])
 
         v = 0.319
         with pytest.raises(
@@ -2764,21 +2764,21 @@ class TestCutCircuitMCTransform:
         """
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=100)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=100)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.expval(qml.PauliX(1))
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.expval(qp.PauliX(1))
 
         v = 0.319
         with pytest.raises(
@@ -2794,21 +2794,21 @@ class TestCutCircuitMCTransform:
         shots = 100
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, interface=None, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, interface=None, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
         res = cut_circuit(v)
@@ -2826,24 +2826,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, autograd.numpy.ones(1))
+        convert_input = qp.math.convert_like(v, autograd.numpy.ones(1))
 
         res = cut_circuit(convert_input)
 
@@ -2861,24 +2861,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, tf.ones(1))
+        convert_input = qp.math.convert_like(v, tf.ones(1))
 
         res = cut_circuit(convert_input)
 
@@ -2896,24 +2896,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, torch.ones(1))
+        convert_input = qp.math.convert_like(v, torch.ones(1))
 
         res = cut_circuit(convert_input)
 
@@ -2931,24 +2931,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, jax.numpy.ones(1))
+        convert_input = qp.math.convert_like(v, jax.numpy.ones(1))
 
         res = cut_circuit(convert_input)
 
@@ -2966,24 +2966,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, autograd.numpy.ones(1))
+        convert_input = qp.math.convert_like(v, autograd.numpy.ones(1))
         res = cut_circuit(convert_input)
 
         assert isinstance(res, type(convert_input))
@@ -2999,24 +2999,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, tf.ones(1))
+        convert_input = qp.math.convert_like(v, tf.ones(1))
         res = cut_circuit(convert_input)
 
         assert isinstance(res, type(convert_input))
@@ -3032,24 +3032,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, torch.ones(1))
+        convert_input = qp.math.convert_like(v, torch.ones(1))
         res = cut_circuit(convert_input)
 
         assert isinstance(res, type(convert_input))
@@ -3065,24 +3065,24 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def cut_circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
-        convert_input = qml.math.convert_like(v, jax.numpy.ones(1))
+        convert_input = qp.math.convert_like(v, jax.numpy.ones(1))
         res = cut_circuit(convert_input)
 
         assert isinstance(res, type(convert_input))
@@ -3096,17 +3096,17 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=3)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.RX(np.sin(x) ** 2, wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.RX(np.sin(x) ** 2, wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample(wires=[0, 1])
 
         spy = mocker.spy(qcut.cutcircuit_mc, "qcut_processing_fn_mc")
         x = np.array(0.531, requires_grad=True)
@@ -3122,15 +3122,15 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=3)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.RY(x**2, wires=2)
-            return qml.sample(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.RY(x**2, wires=2)
+            return qp.sample(wires=[0, 1])
 
         x = 0.4
         res = circuit(x)
@@ -3142,14 +3142,14 @@ class TestCutCircuitMCTransform:
         shots = 10
         dev = dev_fn(wires=2)
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample(wires=[0, 1])
 
         spy = mocker.spy(qcut.cutcircuit_mc, "qcut_processing_fn_mc")
 
@@ -3177,38 +3177,38 @@ class TestCutCircuitMCTransform:
         dev = dev_fn(wires=4)
 
         def two_qubit_unitary(param, wires):
-            qml.Hadamard(wires=[wires[0]])
-            qml.CRY(param, wires=[wires[0], wires[1]])
+            qp.Hadamard(wires=[wires[0]])
+            qp.CRY(param, wires=[wires[0], wires[1]])
 
-        @qml.cut_circuit_mc(classical_processing_fn=fn)
-        @qml.qnode(dev, shots=shots)
+        @qp.cut_circuit_mc(classical_processing_fn=fn)
+        @qp.qnode(dev, shots=shots)
         def circuit(params):
-            qml.BasisState(np.array([1]), wires=[0])
-            qml.WireCut(wires=0)
+            qp.BasisState(np.array([1]), wires=[0])
+            qp.WireCut(wires=0)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.RX(params[0], wires=0)
-            qml.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.RX(params[0], wires=0)
+            qp.CNOT(wires=[0, 1])
 
-            qml.WireCut(wires=0)
-            qml.WireCut(wires=1)
+            qp.WireCut(wires=0)
+            qp.WireCut(wires=1)
 
-            qml.CZ(wires=[0, 1])
-            qml.WireCut(wires=[0, 1])
+            qp.CZ(wires=[0, 1])
+            qp.WireCut(wires=[0, 1])
 
             two_qubit_unitary(params[1], wires=[2, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
-            qml.CRX(params[2], wires=[4, 1])
+            qp.CRX(params[2], wires=[4, 1])
 
-            return qml.sample(wires=[1, 2, 3])
+            return qp.sample(wires=[1, 2, 3])
 
         spy = mocker.spy(qcut.cutcircuit_mc, "qcut_processing_fn_mc")
 
@@ -3287,7 +3287,7 @@ class TestContractTensors:
             return r
 
         params = np.array(self.params, requires_grad=True)
-        grad = qml.grad(contract)(params)
+        grad = qp.grad(contract)(params)
 
         assert np.allclose(grad, self.expected_grad)
 
@@ -3359,27 +3359,27 @@ class TestContractTensors:
         """Test if the contraction works as expected for a more complicated example based
         upon the circuit:
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.QubitUnitary(np.eye(2 ** 3), wires=[0, 1, 2])
-            qml.QubitUnitary(np.eye(2 ** 2), wires=[3, 4])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.QubitUnitary(np.eye(2 ** 3), wires=[0, 1, 2])
+            qp.QubitUnitary(np.eye(2 ** 2), wires=[3, 4])
 
-            qml.Barrier(wires=0)
-            qml.WireCut(wires=[1, 2, 3])
+            qp.Barrier(wires=0)
+            qp.WireCut(wires=[1, 2, 3])
 
-            qml.QubitUnitary(np.eye(2 ** 1), wires=[0])
-            qml.QubitUnitary(np.eye(2 ** 4), wires=[1, 2, 3, 4])
+            qp.QubitUnitary(np.eye(2 ** 1), wires=[0])
+            qp.QubitUnitary(np.eye(2 ** 4), wires=[1, 2, 3, 4])
 
-            qml.WireCut(wires=[1, 2, 3, 4])
+            qp.WireCut(wires=[1, 2, 3, 4])
 
-            qml.QubitUnitary(np.eye(2 ** 3), wires=[0, 1, 2])
-            qml.QubitUnitary(np.eye(2 ** 2), wires=[3, 4])
-        tape = qml.tape.QuantumScript.from_queue(q)
+            qp.QubitUnitary(np.eye(2 ** 3), wires=[0, 1, 2])
+            qp.QubitUnitary(np.eye(2 ** 2), wires=[3, 4])
+        tape = qp.tape.QuantumScript.from_queue(q)
         """
         if use_opt_einsum:
             opt_einsum = pytest.importorskip("opt_einsum")
             spy = mocker.spy(opt_einsum, "contract")
         else:
-            spy = mocker.spy(qml.math, "einsum")
+            spy = mocker.spy(qp.math, "einsum")
 
         t = [
             np.arange(4**8).reshape((4,) * 8),
@@ -3453,7 +3453,7 @@ class TestQCutProcessingFn:
         results = np.concatenate([t.flatten() for t in tensors])
 
         def mock_process_tensor(r, num_prep, num_meas):
-            return qml.math.reshape(r, (4,) * (num_prep + num_meas))
+            return qp.math.reshape(r, (4,) * (num_prep + num_meas))
 
         with monkeypatch.context() as m:
             m.setattr(qcut.processing, "_process_tensor", mock_process_tensor)
@@ -3499,16 +3499,16 @@ class TestQCutProcessingFn:
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
-        dev = qml.device("default.qubit", wires=n)
+        dev = qp.device("default.qubit", wires=n)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def f(state, measurement):
-            qml.StatePrep(state, wires=range(n))
-            qml.QubitUnitary(U, wires=range(n))
-            return [qml.expval(qml.pauli.string_to_pauli_word(m)) for m in measurement]
+            qp.StatePrep(state, wires=range(n))
+            qp.QubitUnitary(U, wires=range(n))
+            return [qp.expval(qp.pauli.string_to_pauli_word(m)) for m in measurement]
 
         prod_inp = itertools.product(range(4), repeat=n)
-        prod_out = qml.pauli.partition_pauli_group(n)
+        prod_out = qp.pauli.partition_pauli_group(n)
 
         results = []
 
@@ -3516,7 +3516,7 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), autograd.numpy.ones(1))
+        results = qp.math.cast_like(np.concatenate(results), autograd.numpy.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
@@ -3548,16 +3548,16 @@ class TestQCutProcessingFn:
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
-        dev = qml.device("default.qubit", wires=n)
+        dev = qp.device("default.qubit", wires=n)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def f(state, measurement):
-            qml.StatePrep(state, wires=range(n))
-            qml.QubitUnitary(U, wires=range(n))
-            return [qml.expval(qml.pauli.string_to_pauli_word(m)) for m in measurement]
+            qp.StatePrep(state, wires=range(n))
+            qp.QubitUnitary(U, wires=range(n))
+            return [qp.expval(qp.pauli.string_to_pauli_word(m)) for m in measurement]
 
         prod_inp = itertools.product(range(4), repeat=n)
-        prod_out = qml.pauli.partition_pauli_group(n)
+        prod_out = qp.pauli.partition_pauli_group(n)
 
         results = []
 
@@ -3565,7 +3565,7 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), tf.ones(1))
+        results = qp.math.cast_like(np.concatenate(results), tf.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
@@ -3597,16 +3597,16 @@ class TestQCutProcessingFn:
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
-        dev = qml.device("default.qubit", wires=n)
+        dev = qp.device("default.qubit", wires=n)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def f(state, measurement):
-            qml.StatePrep(state, wires=range(n))
-            qml.QubitUnitary(U, wires=range(n))
-            return [qml.expval(qml.pauli.string_to_pauli_word(m)) for m in measurement]
+            qp.StatePrep(state, wires=range(n))
+            qp.QubitUnitary(U, wires=range(n))
+            return [qp.expval(qp.pauli.string_to_pauli_word(m)) for m in measurement]
 
         prod_inp = itertools.product(range(4), repeat=n)
-        prod_out = qml.pauli.partition_pauli_group(n)
+        prod_out = qp.pauli.partition_pauli_group(n)
 
         results = []
 
@@ -3614,7 +3614,7 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), torch.ones(1))
+        results = qp.math.cast_like(np.concatenate(results), torch.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
@@ -3646,16 +3646,16 @@ class TestQCutProcessingFn:
 
         # Now, create the input results vector found from executing over the product of |0>, |1>,
         # |+>, |+i> inputs and using the grouped Pauli terms for measurements
-        dev = qml.device("default.qubit", wires=n)
+        dev = qp.device("default.qubit", wires=n)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def f(state, measurement):
-            qml.StatePrep(state, wires=range(n))
-            qml.QubitUnitary(U, wires=range(n))
-            return [qml.expval(qml.pauli.string_to_pauli_word(m)) for m in measurement]
+            qp.StatePrep(state, wires=range(n))
+            qp.QubitUnitary(U, wires=range(n))
+            return [qp.expval(qp.pauli.string_to_pauli_word(m)) for m in measurement]
 
         prod_inp = itertools.product(range(4), repeat=n)
-        prod_out = qml.pauli.partition_pauli_group(n)
+        prod_out = qp.pauli.partition_pauli_group(n)
 
         results = []
 
@@ -3663,7 +3663,7 @@ class TestQCutProcessingFn:
             input = kron(*[states_pure[i] for i in inp])
             results.append(f(input, out))
 
-        results = qml.math.cast_like(np.concatenate(results), jax.numpy.ones(1))
+        results = qp.math.cast_like(np.concatenate(results), jax.numpy.ones(1))
 
         # Now apply _process_tensor
         tensor = qcut._process_tensor(results, n, n)
@@ -3679,16 +3679,16 @@ class TestQCutProcessingFn:
             pytest.importorskip("opt_einsum")
 
         ### Find the expected result
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def f(x, y, z):
-            qml.RX(x, wires=0)
+            qp.RX(x, wires=0)
             ### CUT HERE
-            qml.RY(y, wires=0)
+            qp.RY(y, wires=0)
             ### CUT HERE
-            qml.RX(z, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(z, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         x, y, z = 0.5, 0.6, 0.8
         expected_result = f(x, y, z)
@@ -3699,9 +3699,9 @@ class TestQCutProcessingFn:
         states = [np.outer(s, s.conj()) for s in states_pure]
         zero_proj = states[0]
 
-        u1 = qml.RX.compute_matrix(x)
-        u2 = qml.RY.compute_matrix(y)
-        u3 = qml.RX.compute_matrix(z)
+        u1 = qp.RX.compute_matrix(x)
+        u2 = qp.RY.compute_matrix(y)
+        u3 = qp.RX.compute_matrix(z)
         t1 = np.array([np.trace(b @ u1 @ zero_proj @ u1.conj().T) for b in meas_basis])
         t2 = np.array([[np.trace(b @ u2 @ s @ u2.conj().T) for b in meas_basis] for s in states])
         t3 = np.array([np.trace(Z @ u3 @ s @ u3.conj().T) for s in states])
@@ -3746,7 +3746,7 @@ class TestQCutProcessingFn:
 
             return qcut.qcut_processing_fn(res, g, p, m, use_opt_einsum=use_opt_einsum)
 
-        grad = qml.grad(f)(x)
+        grad = qp.grad(f)(x)
         expected_grad = (
             3 * x**2 * np.sin(x * np.pi / 2) + x**3 * np.cos(x * np.pi / 2) * np.pi / 2
         ) * f(1)
@@ -3885,18 +3885,18 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev = qml.device("default.qubit", wires=2, seed=seed)
+        dev = qp.device("default.qubit", wires=2, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         x = np.array(0.531, requires_grad=True)
@@ -3906,8 +3906,8 @@ class TestCutCircuitTransform:
         assert np.isclose(cut_circuit(x), float(circuit(x)), atol=atol)
         spy.assert_called_once()
 
-        gradient = qml.grad(circuit)(x)
-        cut_gradient = qml.grad(cut_circuit)(x)
+        gradient = qp.grad(circuit)(x)
+        cut_gradient = qp.grad(cut_circuit)(x)
 
         assert np.isclose(gradient, cut_gradient, atol=atol)
 
@@ -3922,17 +3922,17 @@ class TestCutCircuitTransform:
 
         import torch
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = torch.tensor(0.531, requires_grad=True)
         cut_circuit = qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum)
@@ -3961,17 +3961,17 @@ class TestCutCircuitTransform:
 
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = tf.Variable(0.531)
         cut_circuit = qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum)
@@ -4001,17 +4001,17 @@ class TestCutCircuitTransform:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = jnp.array(0.531)
         cut_circuit = qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum)
@@ -4031,18 +4031,18 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.RX(np.sin(x) ** 2, wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.RX(np.sin(x) ** 2, wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliZ(1))
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         x = np.array(0.531, requires_grad=True)
@@ -4051,8 +4051,8 @@ class TestCutCircuitTransform:
         assert np.isclose(cut_circuit(x), float(circuit(x)))
         spy.assert_called_once()
 
-        gradient = qml.grad(circuit)(x)
-        cut_gradient = qml.grad(cut_circuit)(x)
+        gradient = qp.grad(circuit)(x)
+        cut_gradient = qp.grad(cut_circuit)(x)
 
         assert np.isclose(gradient, cut_gradient)
 
@@ -4068,17 +4068,17 @@ class TestCutCircuitTransform:
 
         import torch
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev, interface="torch")
+        @qp.qnode(dev, interface="torch")
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = torch.tensor(0.531, requires_grad=True, dtype=torch.complex128)
 
@@ -4139,17 +4139,17 @@ class TestCutCircuitTransform:
 
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = tf.Variable(0.531)
         cut_circuit_jit = tf.function(
@@ -4215,17 +4215,17 @@ class TestCutCircuitTransform:
         import jax
         import jax.numpy as jnp
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.543, wires=1)
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RZ(0.240, wires=0)
-            qml.RZ(0.133, wires=1)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.RY(0.543, wires=1)
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RZ(0.240, wires=0)
+            qp.RZ(0.133, wires=1)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = jnp.array(0.531)
         cut_circuit_jit = jax.jit(qcut.cut_circuit(circuit, use_opt_einsum=use_opt_einsum))
@@ -4275,23 +4275,23 @@ class TestCutCircuitTransform:
             pytest.importorskip("opt_einsum")
 
         def circuit():
-            qml.RX(0.4, wires=0)
-            qml.RX(0.5, wires=1)
-            qml.RX(0.6, wires=2)
+            qp.RX(0.4, wires=0)
+            qp.RX(0.5, wires=1)
+            qp.RX(0.6, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
 
-            return qml.expval(qml.PauliX(1) @ qml.PauliY(2))
+            return qp.expval(qp.PauliX(1) @ qp.PauliY(2))
 
-        dev_uncut = qml.device("default.qubit", wires=3)
-        dev_1 = qml.device("default.qubit", wires=2)
-        dev_2 = qml.device("default.qubit", wires=["Alice", 3.14, "Bob"])
+        dev_uncut = qp.device("default.qubit", wires=3)
+        dev_1 = qp.device("default.qubit", wires=2)
+        dev_2 = qp.device("default.qubit", wires=["Alice", 3.14, "Bob"])
 
-        uncut_circuit = qml.QNode(circuit, dev_uncut)
-        cut_circuit_1 = qml.cut_circuit(qml.QNode(circuit, dev_1), use_opt_einsum=use_opt_einsum)
-        cut_circuit_2 = qml.cut_circuit(qml.QNode(circuit, dev_2), use_opt_einsum=use_opt_einsum)
+        uncut_circuit = qp.QNode(circuit, dev_uncut)
+        cut_circuit_1 = qp.cut_circuit(qp.QNode(circuit, dev_1), use_opt_einsum=use_opt_einsum)
+        cut_circuit_2 = qp.cut_circuit(qp.QNode(circuit, dev_2), use_opt_einsum=use_opt_einsum)
 
         res_expected = uncut_circuit()
         res_1 = cut_circuit_1()
@@ -4306,17 +4306,17 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.cut_circuit(use_opt_einsum=use_opt_einsum)
-        @qml.qnode(dev)
+        @qp.cut_circuit(use_opt_einsum=use_opt_einsum)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=1)
-            qml.CNOT(wires=[1, 2])
-            qml.RY(x**2, wires=2)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=1)
+            qp.CNOT(wires=[1, 2])
+            qp.RY(x**2, wires=2)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = 0.4
         res = circuit(x)
@@ -4328,16 +4328,16 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.cut_circuit(use_opt_einsum=use_opt_einsum)
-        @qml.qnode(dev)
+        @qp.cut_circuit(use_opt_einsum=use_opt_einsum)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         spy = mocker.spy(qcut.processing, "contract_tensors")
 
@@ -4368,55 +4368,55 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev_original = qml.device("default.qubit", wires=5)
+        dev_original = qp.device("default.qubit", wires=5)
 
         # We need a 4-qubit device to account for mid-circuit measurements
-        dev_cut = qml.device("default.qubit", wires=4)
+        dev_cut = qp.device("default.qubit", wires=4)
 
         def two_qubit_unitary(param, wires):
-            qml.Hadamard(wires=[wires[0]])
-            qml.CRY(param, wires=[wires[0], wires[1]])
+            qp.Hadamard(wires=[wires[0]])
+            qp.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
-            qml.WireCut(wires=0)
+            qp.BasisState(np.array([1]), wires=[0])
+            qp.WireCut(wires=0)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.RX(params[0], wires=0)
-            qml.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.RX(params[0], wires=0)
+            qp.CNOT(wires=[0, 1])
 
-            qml.WireCut(wires=0)
-            qml.WireCut(wires=1)
+            qp.WireCut(wires=0)
+            qp.WireCut(wires=1)
 
-            qml.CZ(wires=[0, 1])
-            qml.WireCut(wires=[0, 1])
+            qp.CZ(wires=[0, 1])
+            qp.WireCut(wires=[0, 1])
 
             two_qubit_unitary(params[1], wires=[2, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
-            qml.CRX(params[2], wires=[4, 1])
+            qp.CRX(params[2], wires=[4, 1])
 
-            return qml.expval(qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3))
+            return qp.expval(qp.PauliZ(1) @ qp.PauliZ(2) @ qp.PauliZ(3))
 
         params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
-        circuit = qml.QNode(f, dev_original)
-        cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut), use_opt_einsum=use_opt_einsum)
+        circuit = qp.QNode(f, dev_original)
+        cut_circuit = qcut.cut_circuit(qp.QNode(f, dev_cut), use_opt_einsum=use_opt_einsum)
 
         res_expected = circuit(params)
-        grad_expected = qml.grad(circuit)(params)
+        grad_expected = qp.grad(circuit)(params)
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         res = cut_circuit(params)
         spy.assert_called_once()
-        grad = qml.grad(cut_circuit)(params)
+        grad = qp.grad(cut_circuit)(params)
 
         assert np.isclose(res, res_expected)
         assert np.allclose(grad, grad_expected)
@@ -4435,29 +4435,29 @@ class TestCutCircuitTransform:
         if use_opt_einsum:
             pytest.importorskip("opt_einsum")
 
-        dev_original = qml.device("default.qubit", wires=4, seed=seed)
+        dev_original = qp.device("default.qubit", wires=4, seed=seed)
 
         # We need a 3-qubit device
-        dev_cut = qml.device("default.qubit", wires=3)
+        dev_cut = qp.device("default.qubit", wires=3)
         us = [unitary_group.rvs(2**2, random_state=i) for i in range(5)]
 
         def f():
-            qml.QubitUnitary(us[0], wires=[0, 1])
-            qml.QubitUnitary(us[1], wires=[2, 3])
+            qp.QubitUnitary(us[0], wires=[0, 1])
+            qp.QubitUnitary(us[1], wires=[2, 3])
 
-            qml.WireCut(wires=[1])
+            qp.WireCut(wires=[1])
 
-            qml.QubitUnitary(us[2], wires=[1, 2])
+            qp.QubitUnitary(us[2], wires=[1, 2])
 
-            qml.WireCut(wires=[1])
+            qp.WireCut(wires=[1])
 
-            qml.QubitUnitary(us[3], wires=[0, 1])
-            qml.QubitUnitary(us[4], wires=[2, 3])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(3))
+            qp.QubitUnitary(us[3], wires=[0, 1])
+            qp.QubitUnitary(us[4], wires=[2, 3])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(3))
 
-        circuit = qml.QNode(f, dev_original)
+        circuit = qp.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(
-            qml.set_shots(qml.QNode(f, dev_cut), shots=shots), use_opt_einsum=use_opt_einsum
+            qp.set_shots(qp.QNode(f, dev_cut), shots=shots), use_opt_einsum=use_opt_einsum
         )
 
         res_expected = circuit()
@@ -4477,22 +4477,22 @@ class TestCutCircuitTransformValidation:
         """Tests if a ValueError is raised when a tape with multiple measurements is requested
         to be cut"""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
-            qml.expval(qml.PauliZ(0))
-            qml.expval(qml.PauliZ(1))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
+            qp.expval(qp.PauliZ(0))
+            qp.expval(qp.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(ValueError, match="The circuit cutting workflow only supports circuits"):
             qcut.cut_circuit(tape)
 
     def test_no_measurements_raises(self):
         """Tests if a ValueError is raised when a tape with no measurement is requested
         to be cut"""
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(ValueError, match="The circuit cutting workflow only supports circuits"):
             qcut.cut_circuit(tape)
 
@@ -4500,21 +4500,21 @@ class TestCutCircuitTransformValidation:
         """Tests if a ValueError is raised when a tape with measurements that are not expectation
         values is requested to be cut"""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
-            qml.var(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
+            qp.var(qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(ValueError, match="workflow only supports circuits with expectation"):
             qcut.cut_circuit(tape)
 
     def test_fail_import(self, monkeypatch):
         """Test if an ImportError is raised when opt_einsum is requested but not installed"""
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.WireCut(wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.WireCut(wires=0)
+            qp.expval(qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with monkeypatch.context() as m:
             m.setitem(sys.modules, "opt_einsum", None)
 
@@ -4524,11 +4524,11 @@ class TestCutCircuitTransformValidation:
     def test_no_cuts_raises(self):
         """Tests if a ValueError is raised when circuit cutting is to be applied to a circuit
         without cuts"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         with pytest.raises(ValueError, match="No WireCut operations found in the circuit."):
             qcut.cut_circuit(circuit)()
@@ -4538,28 +4538,28 @@ class TestCutCircuitExpansion:
     """Test of expansion in the cut_circuit and cut_circuit_mc functions"""
 
     transform_measurement_pairs = [
-        (qcut.cut_circuit, qml.expval(qml.PauliZ(0))),
-        (qcut.cut_circuit_mc, qml.sample(wires=[0])),
+        (qcut.cut_circuit, qp.expval(qp.PauliZ(0))),
+        (qcut.cut_circuit_mc, qp.sample(wires=[0])),
     ]
 
     @pytest.mark.parametrize("cut_transform, measurement", transform_measurement_pairs)
     def test_no_expansion(self, mocker, cut_transform, measurement):
         """Test if no/trivial expansion occurs if WireCut operations are already present in the
         tape"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(0.3, wires=0)
-            qml.WireCut(wires=0)
-            qml.RY(0.4, wires=0)
-            return qml.apply(measurement)
+            qp.RX(0.3, wires=0)
+            qp.WireCut(wires=0)
+            qp.RY(0.4, wires=0)
+            return qp.apply(measurement)
 
         spy = mocker.spy(qcut.cutcircuit, "_qcut_expand_fn")
         spy_mc = mocker.spy(qcut.cutcircuit_mc, "_qcut_expand_fn")
 
-        if isinstance(measurement, qml.measurements.SampleMP):
-            circuit = qml.set_shots(circuit, shots=10)
+        if isinstance(measurement, qp.measurements.SampleMP):
+            circuit = qp.set_shots(circuit, shots=10)
         cut_transform(circuit, device_wires=[0])()
 
         assert spy.call_count == 1 or spy_mc.call_count == 1
@@ -4567,43 +4567,43 @@ class TestCutCircuitExpansion:
     @pytest.mark.parametrize("cut_transform, measurement", transform_measurement_pairs)
     def test_expansion_error(self, cut_transform, measurement):
         """Test if a ValueError is raised if expansion continues beyond the maximum depth"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(0.3, wires=0)
-            qml.RY(0.4, wires=0)
-            return qml.apply(measurement)
+            qp.RX(0.3, wires=0)
+            qp.RY(0.4, wires=0)
+            return qp.apply(measurement)
 
         with pytest.raises(ValueError, match="No WireCut operations found in the circuit."):
-            if isinstance(measurement, qml.measurements.SampleMP):
-                circuit = qml.set_shots(circuit, shots=10)
+            if isinstance(measurement, qp.measurements.SampleMP):
+                circuit = qp.set_shots(circuit, shots=10)
             cut_transform(circuit, device_wires=[0])()
 
     def test_expansion_ttn(self, mocker):
         """Test if wire cutting is compatible with the tree tensor network operation"""
 
         def block(weights, wires):
-            qml.CNOT(wires=[wires[0], wires[1]])
-            qml.RY(weights[0], wires=wires[0])
-            qml.RY(weights[1], wires=wires[1])
-            qml.WireCut(wires=wires[1])
+            qp.CNOT(wires=[wires[0], wires[1]])
+            qp.RY(weights[0], wires=wires[0])
+            qp.RY(weights[1], wires=wires[1])
+            qp.WireCut(wires=wires[1])
 
         n_wires = 4
         n_block_wires = 2
         n_params_block = 2
-        n_blocks = qml.TTN.get_n_blocks(range(n_wires), n_block_wires)
+        n_blocks = qp.TTN.get_n_blocks(range(n_wires), n_block_wires)
         template_weights = [[0.1, -0.3]] * n_blocks
 
-        dev_cut = qml.device("default.qubit", wires=2)
-        dev_big = qml.device("default.qubit", wires=4)
+        dev_cut = qp.device("default.qubit", wires=2)
+        dev_big = qp.device("default.qubit", wires=4)
 
         def circuit(template_weights):
-            qml.TTN(range(n_wires), n_block_wires, block, n_params_block, template_weights)
-            return qml.expval(qml.PauliZ(wires=n_wires - 1))
+            qp.TTN(range(n_wires), n_block_wires, block, n_params_block, template_weights)
+            return qp.expval(qp.PauliZ(wires=n_wires - 1))
 
-        qnode = qml.QNode(circuit, dev_big)
-        qnode_cut = qcut.cut_circuit(qml.QNode(circuit, dev_cut))
+        qnode = qp.QNode(circuit, dev_big)
+        qnode_cut = qcut.cut_circuit(qp.QNode(circuit, dev_cut))
 
         spy_tapes = mocker.spy(qcut.tapes, "_qcut_expand_fn")
         spy_cc = mocker.spy(qcut.cutcircuit, "_qcut_expand_fn")
@@ -4619,24 +4619,24 @@ class TestCutCircuitExpansion:
         """Test if wire cutting is compatible with the tree tensor network operation"""
 
         def block(weights, wires):
-            qml.CNOT(wires=[wires[0], wires[1]])
-            qml.RY(weights[0], wires=wires[0])
-            qml.RY(weights[1], wires=wires[1])
-            qml.WireCut(wires=wires[1])
+            qp.CNOT(wires=[wires[0], wires[1]])
+            qp.RY(weights[0], wires=wires[0])
+            qp.RY(weights[1], wires=wires[1])
+            qp.WireCut(wires=wires[1])
 
         n_wires = 4
         n_block_wires = 2
         n_params_block = 2
-        n_blocks = qml.TTN.get_n_blocks(range(n_wires), n_block_wires)
+        n_blocks = qp.TTN.get_n_blocks(range(n_wires), n_block_wires)
         template_weights = [[0.1, -0.3]] * n_blocks
 
-        dev_cut = qml.device("default.qubit", wires=2)
+        dev_cut = qp.device("default.qubit", wires=2)
 
         def circuit(template_weights):
-            qml.TTN(range(n_wires), n_block_wires, block, n_params_block, template_weights)
-            return qml.sample(wires=[n_wires - 1])
+            qp.TTN(range(n_wires), n_block_wires, block, n_params_block, template_weights)
+            return qp.sample(wires=[n_wires - 1])
 
-        qnode_cut = qcut.cut_circuit_mc(qml.set_shots(qml.QNode(circuit, dev_cut), shots=10))
+        qnode_cut = qcut.cut_circuit_mc(qp.set_shots(qp.QNode(circuit, dev_cut), shots=10))
 
         spy_tapes = mocker.spy(qcut.tapes, "_qcut_expand_fn")
         spy_mc = mocker.spy(qcut.cutcircuit_mc, "_qcut_expand_fn")
@@ -4650,7 +4650,7 @@ class TestCutCircuitExpansion:
 class TestCutStrategy:
     """Tests for class CutStrategy"""
 
-    devs = [qml.device("default.qubit", wires=n) for n in [4, 6]]
+    devs = [qp.device("default.qubit", wires=n) for n in [4, 6]]
     tape_dags = [qcut.tape_to_graph(t) for t in [no_cut_tape, multi_cut_tape]]
 
     @pytest.mark.parametrize("devices", [None, 1, devs[0]])
@@ -4660,7 +4660,7 @@ class TestCutStrategy:
         """Test if ill-initialized instances throw errors."""
 
         if (
-            isinstance(devices, qml.devices.Device)
+            isinstance(devices, qp.devices.Device)
             and imbalance_tolerance is None
             and num_fragments_probed is None
         ):
@@ -4782,7 +4782,7 @@ class TestCutStrategy:
                 else {num_fragments_probed}
             )
         elif exhaustive:
-            num_tape_gates = sum(not isinstance(n.obj, qml.WireCut) for n in tape_dag.nodes)
+            num_tape_gates = sum(not isinstance(n.obj, qp.WireCut) for n in tape_dag.nodes)
             assert {v["num_fragments"] for v in all_cut_kwargs} == set(range(2, num_tape_gates + 1))
 
     @pytest.mark.parametrize(
@@ -4857,28 +4857,28 @@ def make_weakly_connected_tape(
         inter_fragment_gate_wires = {(0, 1): 1}
     rng = np.random.default_rng(seed)
     inter_fragment_gate_wires = inter_fragment_gate_wires or {}
-    with qml.queuing.AnnotatedQueue() as q:
+    with qp.queuing.AnnotatedQueue() as q:
         for _ in range(repeats):
             for i, wire_size in enumerate(fragment_wire_sizes):
                 double_gates_per_fragment = int(double_gates_multiplier * wire_size)
                 for _ in range(double_gates_per_fragment):
                     j0, j1 = rng.choice(wire_size, size=2, replace=False)
-                    qml.CNOT(wires=[f"{i}-{j0}", f"{i}-{j1}"])
+                    qp.CNOT(wires=[f"{i}-{j0}", f"{i}-{j1}"])
                 for _ in range(single_gates_per_wire):
                     for j in range(wire_size):
-                        qml.RZ(0.5, wires=f"{i}-{j}")
+                        qp.RZ(0.5, wires=f"{i}-{j}")
             for frag_pair, num_gates in inter_fragment_gate_wires.items():
                 f0, f1 = sorted(frag_pair)
                 for _ in range(num_gates):
                     w0 = rng.choice(fragment_wire_sizes[f0])
                     w1 = rng.choice(fragment_wire_sizes[f1])
-                    qml.CNOT(wires=[f"{f0}-{w0}", f"{f1}-{w1}"])
+                    qp.CNOT(wires=[f"{f0}-{w0}", f"{f1}-{w1}"])
         for i, wire_size in enumerate(fragment_wire_sizes):
             if wire_size == 1:
-                qml.expval(qml.PauliZ(wires=[f"{i}-0"]))
+                qp.expval(qp.PauliZ(wires=[f"{i}-0"]))
             else:
-                qml.expval(qml.PauliZ(wires=[f"{i}-0"]) @ qml.PauliZ(wires=[f"{i}-{wire_size-1}"]))
-    tape = qml.tape.QuantumScript.from_queue(q)
+                qp.expval(qp.PauliZ(wires=[f"{i}-0"]) @ qp.PauliZ(wires=[f"{i}-{wire_size-1}"]))
+    tape = qp.tape.QuantumScript.from_queue(q)
     return tape
 
 
@@ -5010,18 +5010,18 @@ class TestKaHyPar:
     @pytest.mark.parametrize("dangling_measure", [False, True])
     def test_remove_existing_cuts(self, dangling_measure):
         """Test if ``WireCut`` and ``MeasureNode``/``PrepareNode`` are correctly removed."""
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires="a")
-            qml.WireCut(wires="a")
-            qml.RY(0.543, wires="a")
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires="a")
+            qp.WireCut(wires="a")
+            qp.RY(0.543, wires="a")
             qcut.MeasureNode(wires="a")
             qcut.PrepareNode(wires="a")
             if dangling_measure:
                 qcut.MeasureNode(wires="a")
-            qml.RX(0.678, wires=0)
-            qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(0.678, wires=0)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
         if dangling_measure:
             with pytest.warns(
@@ -5038,7 +5038,7 @@ class TestKaHyPar:
                 [
                     n
                     for n in graph.nodes
-                    if isinstance(n.obj, (qml.WireCut, qcut.MeasureNode, qcut.PrepareNode))
+                    if isinstance(n.obj, (qp.WireCut, qcut.MeasureNode, qcut.PrepareNode))
                 ]
             )
             == dangling_measure
@@ -5047,21 +5047,21 @@ class TestKaHyPar:
     def test_place_wire_cuts(self):
         """Test if ``WireCut`` are correctly placed with the correct order."""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.432, wires="a")
-            qml.RY(0.543, wires="a")
-            qml.CNOT(wires=[0, "a"])
-            qml.RX(0.678, wires=0)
-            qml.expval(qml.PauliZ(wires=[0]))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.432, wires="a")
+            qp.RY(0.543, wires="a")
+            qp.CNOT(wires=[0, "a"])
+            qp.RX(0.678, wires=0)
+            qp.expval(qp.PauliZ(wires=[0]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
         op0, op1, op2 = tape.operations[0], tape.operations[1], tape.operations[2]
         cut_edges = [e for e in graph.edges if e[0].obj is op0 and e[1].obj is op1]
         cut_edges += [e for e in graph.edges if e[0].obj is op1 and e[1].obj is op2]
 
         cut_graph = qcut.place_wire_cuts(graph=graph, cut_edges=cut_edges)
-        wire_cuts = [n for n in cut_graph.nodes if isinstance(n.obj, qml.WireCut)]
+        wire_cuts = [n for n in cut_graph.nodes if isinstance(n.obj, qp.WireCut)]
 
         assert len(wire_cuts) == len(cut_edges)
         assert list(cut_graph.pred[wire_cuts[0]]) == [WrappedObj(op0)]
@@ -5080,7 +5080,7 @@ class TestKaHyPar:
         "cut_strategy",
         [
             None,
-            qcut.CutStrategy(qml.device("default.qubit", wires=3)),
+            qcut.CutStrategy(qp.device("default.qubit", wires=3)),
             qcut.CutStrategy(max_free_wires=4),
             qcut.CutStrategy(max_free_wires=2),  # extreme constraint forcing exhaustive probing.
             qcut.CutStrategy(max_free_wires=2, num_fragments_probed=5),  # impossible to cut
@@ -5090,23 +5090,23 @@ class TestKaHyPar:
         """Integration tests for auto cutting pipeline."""
         pytest.importorskip("kahypar")
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RX(0.1, wires=0)
-            qml.RY(0.2, wires=1)
-            qml.RX(0.3, wires="a")
-            qml.RY(0.4, wires="b")
-            qml.CNOT(wires=[0, 1])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RX(0.1, wires=0)
+            qp.RY(0.2, wires=1)
+            qp.RX(0.3, wires="a")
+            qp.RY(0.4, wires="b")
+            qp.CNOT(wires=[0, 1])
             if with_manual_cut:
-                qml.WireCut(wires=1)
-            qml.CNOT(wires=["a", "b"])
-            qml.CNOT(wires=[1, "a"])
-            qml.CNOT(wires=[0, 1])
-            qml.CNOT(wires=["a", "b"])
-            qml.RX(0.5, wires="a")
-            qml.RY(0.6, wires="b")
-            qml.expval(qml.PauliX(wires=[0]) @ qml.PauliY(wires=["a"]) @ qml.PauliZ(wires=["b"]))
+                qp.WireCut(wires=1)
+            qp.CNOT(wires=["a", "b"])
+            qp.CNOT(wires=[1, "a"])
+            qp.CNOT(wires=[0, 1])
+            qp.CNOT(wires=["a", "b"])
+            qp.RX(0.5, wires="a")
+            qp.RY(0.6, wires="b")
+            qp.expval(qp.PauliX(wires=[0]) @ qp.PauliY(wires=["a"]) @ qp.PauliZ(wires=["b"]))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         graph = qcut.tape_to_graph(tape)
 
         if cut_strategy is None:
@@ -5211,43 +5211,43 @@ class TestAutoCutCircuit:
         """
         pytest.importorskip("kahypar")
 
-        dev_original = qml.device("default.qubit", wires=5)
+        dev_original = qp.device("default.qubit", wires=5)
 
-        dev_cut = qml.device("default.qubit", wires=free_wires)
+        dev_cut = qp.device("default.qubit", wires=free_wires)
 
         def two_qubit_unitary(param, wires):
-            qml.Hadamard(wires=[wires[0]])
-            qml.CRY(param, wires=[wires[0], wires[1]])
+            qp.Hadamard(wires=[wires[0]])
+            qp.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
+            qp.BasisState(np.array([1]), wires=[0])
 
-            qml.CNOT(wires=[0, 1])
-            qml.RX(params[0], wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.CZ(wires=[0, 1])
+            qp.CNOT(wires=[0, 1])
+            qp.RX(params[0], wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.CZ(wires=[0, 1])
 
             two_qubit_unitary(params[1], wires=[2, 3])
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
             two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
             two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
             two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
-            qml.CRX(params[2], wires=[4, 1])
+            qp.CRX(params[2], wires=[4, 1])
 
-            return qml.expval(qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3))
+            return qp.expval(qp.PauliZ(1) @ qp.PauliZ(2) @ qp.PauliZ(3))
 
         params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
-        circuit = qml.QNode(f, dev_original)
-        cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut), auto_cutter=True, max_depth=max_depth)
+        circuit = qp.QNode(f, dev_original)
+        cut_circuit = qcut.cut_circuit(qp.QNode(f, dev_cut), auto_cutter=True, max_depth=max_depth)
 
         res_expected = circuit(params)
-        grad_expected = qml.grad(circuit)(params)
+        grad_expected = qp.grad(circuit)(params)
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         res = cut_circuit(params)
         spy.assert_called_once()
-        grad = qml.grad(cut_circuit)(params)
+        grad = qp.grad(cut_circuit)(params)
 
         assert np.isclose(res, res_expected)
         assert np.allclose(grad, grad_expected)
@@ -5266,25 +5266,25 @@ class TestAutoCutCircuit:
         """
         pytest.importorskip("kahypar")
 
-        dev_original = qml.device("default.qubit", wires=4)
+        dev_original = qp.device("default.qubit", wires=4)
 
         # We need a 3-qubit device
-        dev_cut = qml.device("default.qubit", wires=3)
+        dev_cut = qp.device("default.qubit", wires=3)
         us = [unitary_group.rvs(2**2, random_state=i) for i in range(5)]
 
         def f():
-            qml.QubitUnitary(us[0], wires=[0, 1])
-            qml.QubitUnitary(us[1], wires=[2, 3])
+            qp.QubitUnitary(us[0], wires=[0, 1])
+            qp.QubitUnitary(us[1], wires=[2, 3])
 
-            qml.QubitUnitary(us[2], wires=[1, 2])
+            qp.QubitUnitary(us[2], wires=[1, 2])
 
-            qml.QubitUnitary(us[3], wires=[0, 1])
-            qml.QubitUnitary(us[4], wires=[2, 3])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(3))
+            qp.QubitUnitary(us[3], wires=[0, 1])
+            qp.QubitUnitary(us[4], wires=[2, 3])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(3))
 
-        circuit = qml.QNode(f, dev_original)
+        circuit = qp.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(
-            qml.set_shots(qml.QNode(f, dev_cut), shots=shots), auto_cutter=True
+            qp.set_shots(qp.QNode(f, dev_cut), shots=shots), auto_cutter=True
         )
 
         res_expected = circuit()
@@ -5302,16 +5302,16 @@ class TestAutoCutCircuit:
         cutting."""
         pytest.importorskip("kahypar")
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.cut_circuit(auto_cutter=True)
-        @qml.qnode(dev)
+        @qp.cut_circuit(auto_cutter=True)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.CNOT(wires=[1, 2])
-            qml.RY(x**2, wires=2)
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[1, 2])
+            qp.RY(x**2, wires=2)
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = 0.4
         res = circuit(x)
@@ -5322,16 +5322,16 @@ class TestAutoCutCircuit:
         fragments) is executed correctly after automatic cutting."""
         pytest.importorskip("kahypar")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.cut_circuit(auto_cutter=True)
-        @qml.qnode(dev)
+        @qp.cut_circuit(auto_cutter=True)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=[0]))
+            qp.RX(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=[0]))
 
         x = 0.4
         res = circuit(x)
@@ -5344,22 +5344,22 @@ class TestAutoCutCircuit:
         """
         pytest.importorskip("kahypar")
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.set_shots(100)
-        @qml.qnode(dev)
+        @qp.set_shots(100)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            qml.RY(0.5, wires=1)
-            qml.RX(1.3, wires=2)
+            qp.RX(x, wires=0)
+            qp.RY(0.5, wires=1)
+            qp.RX(1.3, wires=2)
 
-            qml.CNOT(wires=[0, 1])
-            qml.CNOT(wires=[1, 2])
+            qp.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[1, 2])
 
-            qml.RX(x, wires=0)
-            qml.RY(0.7, wires=1)
-            qml.RX(2.3, wires=2)
-            return qml.sample(wires=[0, 2])
+            qp.RX(x, wires=0)
+            qp.RY(0.7, wires=1)
+            qp.RX(2.3, wires=2)
+            return qp.sample(wires=[0, 2])
 
         v = 0.319
         target = circuit(v)
@@ -5397,30 +5397,30 @@ class TestAutoCutCircuit:
         pytest.importorskip("kahypar")
 
         def block(weights, wires):
-            qml.CNOT(wires=[wires[0], wires[1]])
-            qml.RY(weights[0], wires=wires[0])
-            qml.RY(weights[1], wires=wires[1])
+            qp.CNOT(wires=[wires[0], wires[1]])
+            qp.RY(weights[0], wires=wires[0])
+            qp.RY(weights[1], wires=wires[1])
 
         n_wires = 8
         n_block_wires = 2
         n_params_block = 2
-        n_blocks = qml.MPS.get_n_blocks(range(n_wires), n_block_wires)
+        n_blocks = qp.MPS.get_n_blocks(range(n_wires), n_block_wires)
         template_weights = [[0.1, -0.3]] * n_blocks
 
         device_size = 2
-        cut_strategy = qml.qcut.CutStrategy(max_free_wires=device_size)
+        cut_strategy = qp.qcut.CutStrategy(max_free_wires=device_size)
 
         if measure_all_wires:
-            obs = [qml.PauliZ(i) for i in range(n_wires)]
+            obs = [qp.PauliZ(i) for i in range(n_wires)]
             obs = reduce(lambda a, b: a @ b, obs)
         else:
-            obs = qml.PauliZ(n_wires - 1)
+            obs = qp.PauliZ(n_wires - 1)
 
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.MPS(range(n_wires), n_block_wires, block, n_params_block, template_weights)
-            qml.expval(obs)
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.MPS(range(n_wires), n_block_wires, block, n_params_block, template_weights)
+            qp.expval(obs)
 
-        tape0 = qml.tape.QuantumScript.from_queue(q0)
+        tape0 = qp.tape.QuantumScript.from_queue(q0)
         [tape], _ = decompose(tape0, gate_set=gate_sets.ROTATIONS_PLUS_CNOT)
         graph = qcut.tape_to_graph(tape)
         cut_graph = qcut.find_and_place_cuts(
@@ -5457,59 +5457,59 @@ class TestCutCircuitWithHamiltonians:
         4: ─────────────────────────╰RY──H─────╰C─────────╰C──┤
         """
 
-        dev_original = qml.device("default.qubit", wires=5)
-        dev_cut = qml.device("default.qubit", wires=4)
+        dev_original = qp.device("default.qubit", wires=5)
+        dev_cut = qp.device("default.qubit", wires=4)
 
-        hamiltonian = qml.Hamiltonian(
+        hamiltonian = qp.Hamiltonian(
             [1.0, 1.0],
-            [qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3), qml.PauliY(0) @ qml.PauliX(1)],
+            [qp.PauliZ(1) @ qp.PauliZ(2) @ qp.PauliZ(3), qp.PauliY(0) @ qp.PauliX(1)],
         )
 
         def two_qubit_unitary(param, wires):
-            qml.Hadamard(wires=[wires[0]])
-            qml.CRY(param, wires=[wires[0], wires[1]])
+            qp.Hadamard(wires=[wires[0]])
+            qp.CRY(param, wires=[wires[0], wires[1]])
 
         def f(params):
-            qml.BasisState(np.array([1]), wires=[0])
-            qml.WireCut(wires=0)
+            qp.BasisState(np.array([1]), wires=[0])
+            qp.WireCut(wires=0)
 
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.RX(params[0], wires=0)
-            qml.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.RX(params[0], wires=0)
+            qp.CNOT(wires=[0, 1])
 
-            qml.WireCut(wires=0)
-            qml.WireCut(wires=1)
+            qp.WireCut(wires=0)
+            qp.WireCut(wires=1)
 
-            qml.CZ(wires=[0, 1])
-            qml.WireCut(wires=[0, 1])
+            qp.CZ(wires=[0, 1])
+            qp.WireCut(wires=[0, 1])
 
             two_qubit_unitary(params[1], wires=[2, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(params[2] ** 2, wires=[3, 4])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sin(params[3]), wires=[3, 2])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.sqrt(params[4]), wires=[4, 3])
-            qml.WireCut(wires=3)
+            qp.WireCut(wires=3)
             two_qubit_unitary(np.cos(params[1]), wires=[3, 2])
-            qml.CRX(params[2], wires=[4, 1])
+            qp.CRX(params[2], wires=[4, 1])
 
-            return qml.expval(hamiltonian)
+            return qp.expval(hamiltonian)
 
         params = np.array([0.4, 0.5, 0.6, 0.7, 0.8], requires_grad=True)
 
-        circuit = qml.QNode(f, dev_original)
-        cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut))
+        circuit = qp.QNode(f, dev_original)
+        cut_circuit = qcut.cut_circuit(qp.QNode(f, dev_cut))
 
         res_expected = circuit(params)
-        grad_expected = qml.grad(circuit)(params)
+        grad_expected = qp.grad(circuit)(params)
 
         spy = mocker.spy(qcut.cutcircuit, "qcut_processing_fn")
         res = cut_circuit(params)
         assert spy.call_count == len(hamiltonian.ops)
 
-        grad = qml.grad(cut_circuit)(params)
+        grad = qp.grad(cut_circuit)(params)
 
         assert np.isclose(res, res_expected)
         assert np.allclose(grad, grad_expected)
@@ -5527,35 +5527,35 @@ class TestCutCircuitWithHamiltonians:
         """
         pytest.importorskip("kahypar")
 
-        dev_original = qml.device("default.qubit")
+        dev_original = qp.device("default.qubit")
 
-        hamiltonian = qml.Hamiltonian(
+        hamiltonian = qp.Hamiltonian(
             [1.0, 1.0, 1.0],
             [
-                qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3),
-                qml.PauliZ(1) @ qml.PauliZ(2),
-                qml.PauliZ(0) @ qml.PauliZ(1),
+                qp.PauliZ(1) @ qp.PauliZ(2) @ qp.PauliZ(3),
+                qp.PauliZ(1) @ qp.PauliZ(2),
+                qp.PauliZ(0) @ qp.PauliZ(1),
             ],
             grouping_type="qwc",
         )
 
         # We need a 3-qubit device
-        dev_cut = qml.device("default.qubit")
+        dev_cut = qp.device("default.qubit")
         us = [unitary_group.rvs(2**2, random_state=i) for i in range(5)]
 
         def f():
-            qml.QubitUnitary(us[0], wires=[0, 1])
-            qml.QubitUnitary(us[1], wires=[2, 3])
-            qml.QubitUnitary(us[2], wires=[1, 2])
-            qml.QubitUnitary(us[3], wires=[0, 1])
-            qml.QubitUnitary(us[4], wires=[2, 3])
-            return qml.expval(hamiltonian)
+            qp.QubitUnitary(us[0], wires=[0, 1])
+            qp.QubitUnitary(us[1], wires=[2, 3])
+            qp.QubitUnitary(us[2], wires=[1, 2])
+            qp.QubitUnitary(us[3], wires=[0, 1])
+            qp.QubitUnitary(us[4], wires=[2, 3])
+            return qp.expval(hamiltonian)
 
-        circuit = qml.QNode(f, dev_original)
+        circuit = qp.QNode(f, dev_original)
         cut_circuit = qcut.cut_circuit(
-            qml.QNode(f, dev_cut), auto_cutter=True, device_wires=qml.wires.Wires(range(3))
+            qp.QNode(f, dev_cut), auto_cutter=True, device_wires=qp.wires.Wires(range(3))
         )
-        cut_tape = qml.workflow.construct_tape(cut_circuit, level=0)()
+        cut_tape = qp.workflow.construct_tape(cut_circuit, level=0)()
 
         res_expected = circuit()
 
@@ -5572,35 +5572,35 @@ class TestCutCircuitWithHamiltonians:
         pytest.importorskip("kahypar")
 
         def block(weights, wires):
-            qml.CNOT(wires=[wires[0], wires[1]])
-            qml.RY(weights[0], wires=wires[0])
-            qml.RY(weights[1], wires=wires[1])
+            qp.CNOT(wires=[wires[0], wires[1]])
+            qp.RY(weights[0], wires=wires[0])
+            qp.RY(weights[1], wires=wires[1])
 
         n_wires = 8
         n_block_wires = 2
         n_params_block = 2
-        n_blocks = qml.MPS.get_n_blocks(range(n_wires), n_block_wires)
+        n_blocks = qp.MPS.get_n_blocks(range(n_wires), n_block_wires)
         template_weights = [[0.1, -0.3]] * n_blocks
 
         device_size = 2
-        cut_strategy = qml.qcut.CutStrategy(max_free_wires=device_size)
+        cut_strategy = qp.qcut.CutStrategy(max_free_wires=device_size)
 
-        hamiltonian = qml.Hamiltonian(
+        hamiltonian = qp.Hamiltonian(
             [1.0, 1.0],
             [
-                qml.PauliZ(1) @ qml.PauliZ(8) @ qml.PauliZ(3),
-                qml.PauliY(5) @ qml.PauliX(4),
+                qp.PauliZ(1) @ qp.PauliZ(8) @ qp.PauliZ(3),
+                qp.PauliY(5) @ qp.PauliX(4),
             ],
         )
 
-        with qml.queuing.AnnotatedQueue() as q0:
-            qml.MPS(range(n_wires), n_block_wires, block, n_params_block, template_weights)
-            qml.expval(hamiltonian)
+        with qp.queuing.AnnotatedQueue() as q0:
+            qp.MPS(range(n_wires), n_block_wires, block, n_params_block, template_weights)
+            qp.expval(hamiltonian)
 
-        tape0 = qml.tape.QuantumScript.from_queue(q0)
+        tape0 = qp.tape.QuantumScript.from_queue(q0)
 
         [tape], _ = decompose(tape0, gate_set=gate_sets.ROTATIONS_PLUS_CNOT)
-        tapes, _ = qml.transforms.split_non_commuting(tape, grouping_strategy=None)
+        tapes, _ = qp.transforms.split_non_commuting(tape, grouping_strategy=None)
 
         frag_lens = [5, 7]
         frag_ords = [[1, 6], [3, 6]]
@@ -5621,46 +5621,46 @@ class TestCutCircuitWithHamiltonians:
     def test_hamiltonian_with_tape(self):
         """Test that an expand function that generates multiple tapes is applied before the transform and the transform
         returns correct results."""
-        ops = [qml.Identity(0), qml.PauliZ(0), qml.PauliZ(1), qml.PauliZ(2)]
+        ops = [qp.Identity(0), qp.PauliZ(0), qp.PauliZ(1), qp.PauliZ(2)]
         coeffs = [0.4567, 0.25, 0.25, 0.5]
 
-        H = qml.Hamiltonian(observables=ops, coeffs=coeffs)
+        H = qp.Hamiltonian(observables=ops, coeffs=coeffs)
 
-        dev = qml.device("lightning.qubit", wires=4)
+        dev = qp.device("lightning.qubit", wires=4)
 
         circuit = [
-            qml.IsingXX(0.1234, wires=[0, 3]),
-            qml.WireCut(0),
+            qp.IsingXX(0.1234, wires=[0, 3]),
+            qp.WireCut(0),
         ]
 
-        tape = qml.tape.QuantumScript(circuit, measurements=[qml.expval(H)])
-        cut_tapes, proc_fn = qml.cut_circuit(tape, device_wires=range(3))
+        tape = qp.tape.QuantumScript(circuit, measurements=[qp.expval(H)])
+        cut_tapes, proc_fn = qp.cut_circuit(tape, device_wires=range(3))
 
         assert np.allclose(
-            qml.execute([tape], dev, None)[0], proc_fn(qml.execute(cut_tapes, dev, None))
+            qp.execute([tape], dev, None)[0], proc_fn(qp.execute(cut_tapes, dev, None))
         )
 
     def test_raise_with_hamiltonian(self):
         """Test that exception is correctly raise when caclulating expectation values of multiple Hamiltonians"""
 
-        dev_cut = qml.device("default.qubit", wires=4)
+        dev_cut = qp.device("default.qubit", wires=4)
 
-        hamiltonian = qml.Hamiltonian(
+        hamiltonian = qp.Hamiltonian(
             [1.0, 1.0],
-            [qml.PauliZ(1) @ qml.PauliZ(2) @ qml.PauliZ(3), qml.PauliY(0) @ qml.PauliX(1)],
+            [qp.PauliZ(1) @ qp.PauliZ(2) @ qp.PauliZ(3), qp.PauliY(0) @ qp.PauliX(1)],
         )
 
         def f():
-            qml.CNOT(wires=[0, 1])
-            qml.WireCut(wires=0)
-            qml.RX(1.0, wires=0)
-            qml.CNOT(wires=[0, 1])
+            qp.CNOT(wires=[0, 1])
+            qp.WireCut(wires=0)
+            qp.RX(1.0, wires=0)
+            qp.CNOT(wires=[0, 1])
 
-            return [qml.expval(hamiltonian), qml.expval(hamiltonian)]
+            return [qp.expval(hamiltonian), qp.expval(hamiltonian)]
 
         with pytest.raises(
             NotImplementedError,
             match="Hamiltonian expansion is supported only with a single Hamiltonian",
         ):
-            cut_circuit = qcut.cut_circuit(qml.QNode(f, dev_cut))
+            cut_circuit = qcut.cut_circuit(qp.QNode(f, dev_cut))
             cut_circuit()

--- a/tests/test_qcut.py
+++ b/tests/test_qcut.py
@@ -452,11 +452,7 @@ class TestTapeToGraph:
             ),
             (
                 qp.Hamiltonian([1, 2], [qp.PauliZ(1), qp.PauliZ(2) @ qp.PauliX(0)]),
-                [
-                    qp.expval(
-                        qp.Hamiltonian([1, 2], [qp.PauliZ(1), qp.PauliZ(2) @ qp.PauliX(0)])
-                    )
-                ],
+                [qp.expval(qp.Hamiltonian([1, 2], [qp.PauliZ(1), qp.PauliZ(2) @ qp.PauliX(0)]))],
             ),
             (
                 qp.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0]),
@@ -944,9 +940,7 @@ class TestFragmentGraph:
             sub_3_expected_nodes,
         ]
 
-        sub_0_expected_edges = [
-            (qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
-        ]
+        sub_0_expected_edges = [(qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})]
         sub_1_expected_edges = [
             (qcut.PrepareNode(wires=[0]), qp.CNOT(wires=[0, "a"]), {"wire": 0}),
             (qp.RZ(0.24, wires=[0]), qp.expval(qp.PauliZ(wires=[0])), {"wire": 0}),
@@ -985,9 +979,7 @@ class TestFragmentGraph:
         correct nodes and edges. Focuses on the case where fragmentation results in two fragments
         that are disconnected from the final measurements.
         """
-        tape = qp.tape.QuantumScript(
-            multi_cut_tape.operations, [qp.expval(qp.PauliZ(wires=[0]))]
-        )
+        tape = qp.tape.QuantumScript(multi_cut_tape.operations, [qp.expval(qp.PauliZ(wires=[0]))])
         g = qcut.tape_to_graph(tape)
         qcut.replace_wire_cut_nodes(g)
         subgraphs, _ = qcut.fragment_graph(g)
@@ -1011,9 +1003,7 @@ class TestFragmentGraph:
             sub_1_expected_nodes,
         ]
 
-        sub_0_expected_edges = [
-            (qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})
-        ]
+        sub_0_expected_edges = [(qp.RX(0.432, wires=[0]), qcut.MeasureNode(wires=[0]), {"wire": 0})]
         sub_1_expected_edges = [
             (qcut.PrepareNode(wires=[0]), qp.CNOT(wires=[0, "a"]), {"wire": 0}),
             (qp.RZ(0.24, wires=[0]), qp.expval(qp.PauliZ(wires=[0])), {"wire": 0}),
@@ -1093,9 +1083,7 @@ class TestFragmentGraph:
             sub_3_expected_nodes,
         ]
 
-        sub_0_expected_edges = [
-            (qcut.PrepareNode(wires=[0]), qp.RX(0.432, wires=[0]), {"wire": 0})
-        ]
+        sub_0_expected_edges = [(qcut.PrepareNode(wires=[0]), qp.RX(0.432, wires=[0]), {"wire": 0})]
         sub_1_expected_edges = [
             (qp.RY(0.543, wires=["a"]), qcut.MeasureNode(wires=["a"]), {"wire": "a"})
         ]

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -686,7 +686,7 @@ class TestTapeConstruction:
         jitted_qnode1 = jax.jit(qn)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
+            NotImplementedError, match=r"The JAX-JIT interface doesn't support \w+.counts."
         ):
             _ = jitted_qnode1(0.123)
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -702,7 +702,7 @@ class TestTapeConstruction:
         jitted_qnode2 = jax.jit(circuit2)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
+            NotImplementedError, match=r"The JAX-JIT interface doesn't support \w+.counts."
         ):
             jitted_qnode2(0.123)
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -1522,9 +1522,7 @@ class TestCompilePipelineIntegration:
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            return (
-                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
-            ), null_postprocessing
+            return (qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),), null_postprocessing
 
         @just_pauli_x_out
         @qp.qnode(dev, interface=None, diff_method=None)
@@ -1580,9 +1578,7 @@ class TestCompilePipelineIntegration:
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            return (
-                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
-            ), null_postprocessing
+            return (qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),), null_postprocessing
 
         @qp.transform
         def repeat_operations(

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 from scipy.sparse import csr_matrix
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -44,9 +44,9 @@ from pennylane.workflow.set_shots import set_shots
 def test_transform_program_prop_is_deprecated():
     """Tests that the deprecation warning is raised."""
 
-    @qml.qnode(qml.device("reference.qubit"))
+    @qp.qnode(qp.device("reference.qubit"))
     def circuit():
-        return qml.expval(qml.Z(0))
+        return qp.expval(qp.Z(0))
 
     with pytest.warns(
         PennyLaneDeprecationWarning,
@@ -61,7 +61,7 @@ def dummyfunc():
 
 
 # pylint: disable=unused-argument
-class CustomDevice(qml.devices.Device):
+class CustomDevice(qp.devices.Device):
     """A null device that just returns 0."""
 
     def __repr__(self):
@@ -71,7 +71,7 @@ class CustomDevice(qml.devices.Device):
         return (0,)
 
 
-class CustomDeviceWithDiffMethod(qml.devices.Device):
+class CustomDeviceWithDiffMethod(qp.devices.Device):
     """A device that defines a derivative."""
 
     def execute(self, circuits, execution_config=None):
@@ -85,12 +85,12 @@ class CustomDeviceWithDiffMethod(qml.devices.Device):
 def test_no_measure():
     """Test that failing to specify a measurement
     raises an exception"""
-    dev = qml.device("default.qubit")
+    dev = qp.device("default.qubit")
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x):
-        qml.RX(x, wires=0)
-        return qml.PauliY(0)
+        qp.RX(x, wires=0)
+        return qp.PauliY(0)
 
     with pytest.raises(QuantumFunctionError, match="must return either a single measurement"):
         _ = circuit(0.65)
@@ -100,7 +100,7 @@ def test_copy():
     """Test that a shallow copy also copies the execute kwargs, gradient kwargs, and transform program."""
     dev = CustomDevice()
 
-    qn = qml.QNode(dummyfunc, dev)
+    qn = qp.QNode(dummyfunc, dev)
     copied_qn = copy.copy(qn)
     assert copied_qn is not qn
     assert copied_qn.execute_kwargs == qn.execute_kwargs
@@ -121,15 +121,15 @@ class TestUpdate:
 
     def test_new_object_creation(self):
         """Test that a new object is created rather than mutated"""
-        dev = qml.device("default.qubit")
-        dummy_qn = qml.QNode(dummyfunc, dev)
+        dev = qp.device("default.qubit")
+        dummy_qn = qp.QNode(dummyfunc, dev)
         updated_qn = dummy_qn.update(device=dummy_qn.device)
         assert updated_qn is not dummy_qn
 
     def test_empty_update(self):
         """Test that providing no update parameters throws an error."""
-        dev = qml.device("default.qubit")
-        dummy_qn = qml.QNode(dummyfunc, dev)
+        dev = qp.device("default.qubit")
+        dummy_qn = qp.QNode(dummyfunc, dev)
         with pytest.raises(
             ValueError, match="Must specify at least one configuration property to update."
         ):
@@ -137,14 +137,14 @@ class TestUpdate:
 
     def test_update_args(self):
         """Test that arguments of QNode can be updated"""
-        dev = qml.device("default.qubit")
-        dummy_qn = qml.QNode(dummyfunc, dev)
+        dev = qp.device("default.qubit")
+        dummy_qn = qp.QNode(dummyfunc, dev)
 
         def circuit(x):
-            qml.RZ(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RY(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.RZ(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RY(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         new_circuit = dummy_qn.update(func=circuit)
         assert new_circuit.func is circuit
@@ -152,29 +152,29 @@ class TestUpdate:
     @pytest.mark.torch
     def test_update_kwargs(self):
         """Test that keyword arguments can be updated"""
-        dev = qml.device("default.qubit")
-        dummy_qn = qml.QNode(dummyfunc, dev)
+        dev = qp.device("default.qubit")
+        dummy_qn = qp.QNode(dummyfunc, dev)
 
         def circuit(x):
-            qml.RZ(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RY(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.RZ(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RY(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         assert dummy_qn.interface == "auto"
         new_circuit = dummy_qn.update(func=circuit).update(interface="torch")
-        assert qml.math.get_interface(new_circuit(1)) == "torch"
+        assert qp.math.get_interface(new_circuit(1)) == "torch"
 
     def test_update_gradient_kwargs(self):
         """Test that gradient kwargs are updated correctly"""
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
 
-        @qml.qnode(dev, gradient_kwargs={"atol": 1})
+        @qp.qnode(dev, gradient_kwargs={"atol": 1})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RY(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.RZ(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RY(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         assert set(circuit.gradient_kwargs.keys()) == {"atol"}
 
@@ -189,14 +189,14 @@ class TestUpdate:
 
     def test_update_multiple_arguments(self):
         """Test that multiple parameters can be updated at once."""
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RZ(x, wires=0)
-            qml.CNOT(wires=[0, 1])
-            qml.RY(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.RZ(x, wires=0)
+            qp.CNOT(wires=[0, 1])
+            qp.RY(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         assert circuit.diff_method == "best"
         assert not circuit.execute_kwargs["device_vjp"]
@@ -206,18 +206,18 @@ class TestUpdate:
 
     def test_update_transform_program(self):
         """Test that the transform program is properly preserved"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.transforms.combine_global_phases
-        @qml.qnode(dev)
+        @qp.transforms.combine_global_phases
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RZ(x, wires=0)
-            qml.GlobalPhase(phi=1)
-            qml.CNOT(wires=[0, 1])
-            qml.RY(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.RZ(x, wires=0)
+            qp.GlobalPhase(phi=1)
+            qp.CNOT(wires=[0, 1])
+            qp.RY(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
-        assert qml.transforms.combine_global_phases in circuit.compile_pipeline
+        assert qp.transforms.combine_global_phases in circuit.compile_pipeline
         assert len(circuit.compile_pipeline) == 1
         new_circuit = circuit.update(diff_method="parameter-shift")
         assert new_circuit.diff_method == "parameter-shift"
@@ -232,53 +232,53 @@ class TestInitialization:
 
         # Default behavior: no shots from either device or qnode
         # shots should be None
-        @qml.qnode(qml.device("default.qubit"))
+        @qp.qnode(qp.device("default.qubit"))
         def f():
-            return qml.state()
+            return qp.state()
 
         assert not f.shots
 
         # Shots should be set correctly set from the qnode init
-        @qml.qnode(qml.device("default.qubit"), shots=10)
+        @qp.qnode(qp.device("default.qubit"), shots=10)
         def f2():
-            return qml.state()
+            return qp.state()
 
         assert f2._shots_override_device  # pylint: disable=protected-access
-        assert f2.shots == qml.measurements.Shots(10)
+        assert f2.shots == qp.measurements.Shots(10)
 
         # Shots from device should be set correctly
         with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
 
-            @qml.qnode(qml.device("default.qubit", shots=5))
+            @qp.qnode(qp.device("default.qubit", shots=5))
             def f3():
-                return qml.state()
+                return qp.state()
 
-        assert f3.shots == qml.measurements.Shots(5)
+        assert f3.shots == qp.measurements.Shots(5)
 
         # Shots from device and also from qnode, then qnode should take precedence
         with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
 
-            @qml.qnode(qml.device("default.qubit", shots=500), shots=None)
+            @qp.qnode(qp.device("default.qubit", shots=500), shots=None)
             def f4():
-                return qml.state()
+                return qp.state()
 
-        assert f4.shots == qml.measurements.Shots(None)
+        assert f4.shots == qp.measurements.Shots(None)
 
     def test_cache_initialization_maxdiff_1(self):
         """Test that when max_diff = 1, the cache initializes to false."""
 
-        @qml.qnode(qml.device("default.qubit"), max_diff=1)
+        @qp.qnode(qp.device("default.qubit"), max_diff=1)
         def f():
-            return qml.state()
+            return qp.state()
 
         assert f.execute_kwargs["cache"] == "auto"
 
     def test_cache_initialization_maxdiff_2(self):
         """Test that when max_diff = 2, the cache initialization to True."""
 
-        @qml.qnode(qml.device("default.qubit"), max_diff=2)
+        @qp.qnode(qp.device("default.qubit"), max_diff=2)
         def f():
-            return qml.state()
+            return qp.state()
 
         assert f.execute_kwargs["cache"] == "auto"
 
@@ -291,15 +291,15 @@ class TestValidation:
     def test_return_behaviour_consistency(self, return_type):
         """Test that the QNode return typing stays consistent"""
 
-        @qml.qnode(qml.device("default.qubit"))
+        @qp.qnode(qp.device("default.qubit"))
         def circuit(return_type):
-            return return_type([qml.expval(qml.Z(0))])
+            return return_type([qp.expval(qp.Z(0))])
 
         assert isinstance(circuit(return_type), return_type)
 
     def test_invalid_interface(self):
         """Test that an exception is raised for an invalid interface"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
         test_interface = "something"
         expected_error = rf"'{test_interface}' is not a valid Interface\. Please use one of the supported interfaces: \[.*\]\."
 
@@ -309,14 +309,14 @@ class TestValidation:
     def test_changing_invalid_interface(self):
         """Test that an exception is raised for an invalid interface
         on a pre-existing QNode"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
         test_interface = "something"
 
         @qnode(dev)
         def circuit(x):
             """a circuit."""
-            qml.RX(x, wires=0)
-            return qml.probs(wires=0)
+            qp.RX(x, wires=0)
+            return qp.probs(wires=0)
 
         expected_error = rf"'{test_interface}' is not a valid Interface\. Please use one of the supported interfaces: \[.*\]\."
 
@@ -332,7 +332,7 @@ class TestValidation:
     def test_diff_method(self):
         """Test that a user-supplied diff method correctly returns the right
         diff method."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         qn = QNode(dummyfunc, dev, diff_method="best")
         assert qn.diff_method == "best"
@@ -374,20 +374,20 @@ class TestValidation:
     @pytest.mark.autograd
     def test_gradient_transform(self, mocker):
         """Test passing a gradient transform directly to a QNode"""
-        dev = qml.device("default.qubit", wires=1)
-        spy = mocker.spy(qml.gradients.finite_difference, "finite_diff_coeffs")
+        dev = qp.device("default.qubit", wires=1)
+        spy = mocker.spy(qp.gradients.finite_difference, "finite_diff_coeffs")
 
-        @qnode(dev, diff_method=qml.gradients.finite_diff)
+        @qnode(dev, diff_method=qp.gradients.finite_diff)
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        qml.grad(circuit)(pnp.array(0.5, requires_grad=True))
+        qp.grad(circuit)(pnp.array(0.5, requires_grad=True))
         spy.assert_called()
 
     def test_unknown_diff_method_string(self):
         """Test that an exception is raised for an unknown differentiation method string"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         with pytest.raises(
             QuantumFunctionError,
@@ -397,7 +397,7 @@ class TestValidation:
 
     def test_unknown_diff_method_type(self):
         """Test that an exception is raised for an unknown differentiation method type"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         with pytest.raises(
             ValueError,
@@ -409,42 +409,42 @@ class TestValidation:
         """Tests that a DeviceError is raised with the adjoint differentiation method
         when the device has finite shots"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @qnode(dev, diff_method="adjoint")
         def circ():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         with pytest.raises(
             QuantumFunctionError,
             match="does not support adjoint with requested circuit",
         ):
-            qml.set_shots(circ, shots=1)()
+            qp.set_shots(circ, shots=1)()
 
     @pytest.mark.autograd
     def test_sparse_diffmethod_error(self):
         """Test that an error is raised when the observable is SparseHamiltonian and the
         differentiation method is not parameter-shift."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         @qnode(dev, diff_method="backprop")
         def circuit(param):
-            qml.RX(param, wires=0)
-            return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
+            qp.RX(param, wires=0)
+            return qp.expval(qp.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
             QuantumFunctionError,
             match="does not support backprop with requested circuit",
         ):
-            qml.grad(circuit, argnums=0)([0.5])
+            qp.grad(circuit, argnums=0)([0.5])
 
     def test_qnode_print(self):
         """Test that printing a QNode object yields the right information."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         def func(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(func, dev)
 
@@ -464,12 +464,12 @@ class TestValidation:
     def test_diff_method_none(self, tol):
         """Test that diff_method=None creates a QNode with no interface, and no
         device swapping."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @qnode(dev, diff_method=None)
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.interface == "auto"
         assert circuit.device is dev
@@ -478,14 +478,14 @@ class TestValidation:
         assert np.allclose(circuit(0.5), np.cos(0.5), atol=tol, rtol=0)
 
         with pytest.warns(UserWarning, match="Attempted to differentiate a function with no"):
-            grad = qml.grad(circuit)(0.5)
+            grad = qp.grad(circuit)(0.5)
 
         assert np.allclose(grad, 0)
 
     def test_not_giving_mode_kwarg_does_not_raise_warning(self):
         """Test that not providing a value for mode does not raise a warning."""
         with warnings.catch_warnings(record=True) as record:
-            _ = qml.QNode(lambda f: f, qml.device("default.qubit", wires=1))
+            _ = qp.QNode(lambda f: f, qp.device("default.qubit", wires=1))
 
         assert len(record) == 0
 
@@ -498,61 +498,61 @@ class TestPyTreeStructure:
     @pytest.mark.parametrize(
         "measurement",
         [
-            lambda: ({"probs": qml.probs()},),
-            lambda: qml.probs(),
+            lambda: ({"probs": qp.probs()},),
+            lambda: qp.probs(),
             lambda: [
-                [qml.probs(wires=1), {"a": qml.probs(wires=0)}, qml.expval(qml.Z(0))],
-                {"probs": qml.probs(wires=0), "exp": qml.expval(qml.X(1))},
+                [qp.probs(wires=1), {"a": qp.probs(wires=0)}, qp.expval(qp.Z(0))],
+                {"probs": qp.probs(wires=0), "exp": qp.expval(qp.X(1))},
             ],
-            lambda: {"exp": qml.expval(qml.Z(0))},
+            lambda: {"exp": qp.expval(qp.Z(0))},
             lambda: {
                 "layer1": {
                     "layer2": {
-                        "probs": qml.probs(wires=[0, 1]),
-                        "expval": qml.expval(qml.PauliY(1)),
+                        "probs": qp.probs(wires=[0, 1]),
+                        "expval": qp.expval(qp.PauliY(1)),
                     },
-                    "single_prob": qml.probs(wires=0),
+                    "single_prob": qp.probs(wires=0),
                 }
             },
             lambda: (
-                [qml.probs(wires=1), {"exp": qml.expval(qml.PauliZ(0))}],
-                qml.expval(qml.PauliX(1)),
+                [qp.probs(wires=1), {"exp": qp.expval(qp.PauliZ(0))}],
+                qp.expval(qp.PauliX(1)),
             ),
             lambda: [
-                (qml.expval(qml.PauliX(0)), qml.var(qml.PauliY(1))),
-                (qml.probs(wires=[1]), {"nested": qml.probs(wires=[0])}),
+                (qp.expval(qp.PauliX(0)), qp.var(qp.PauliY(1))),
+                (qp.probs(wires=[1]), {"nested": qp.probs(wires=[0])}),
             ],
             lambda: [
                 {
-                    "first_layer": qml.probs(wires=0),
+                    "first_layer": qp.probs(wires=0),
                     "second_layer": [
-                        qml.expval(qml.PauliX(1)),
-                        {"nested_exp": qml.expval(qml.PauliY(0))},
+                        qp.expval(qp.PauliX(1)),
+                        {"nested_exp": qp.expval(qp.PauliY(0))},
                     ],
                 },
-                (qml.probs(wires=[0, 1]), {"final": qml.expval(qml.PauliZ(0))}),
+                (qp.probs(wires=[0, 1]), {"final": qp.expval(qp.PauliZ(0))}),
             ],
         ],
     )
     def test_pytree_structure_preservation(self, measurement):
         """Test that the result stucture matches the measurement structure."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.set_shots(100)
-        @qml.qnode(dev)
+        @qp.set_shots(100)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1, wires=0)
-            qml.RY(2, wires=1)
-            qml.measure(0)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(1, wires=0)
+            qp.RY(2, wires=1)
+            qp.measure(0)
+            qp.CNOT(wires=[0, 1])
             return measurement()
 
         result = circuit()
 
-        result_structure = qml.pytrees.flatten(result)[1]
-        measurement_structure = qml.pytrees.flatten(
-            measurement(), is_leaf=lambda obj: isinstance(obj, qml.measurements.MeasurementProcess)
+        result_structure = qp.pytrees.flatten(result)[1]
+        measurement_structure = qp.pytrees.flatten(
+            measurement(), is_leaf=lambda obj: isinstance(obj, qp.measurements.MeasurementProcess)
         )[1]
 
         assert result_structure == measurement_structure
@@ -560,20 +560,20 @@ class TestPyTreeStructure:
     @pytest.mark.parametrize(
         "measurement",
         [
-            lambda: qml.math.hstack([qml.expval(qml.Z(i)) for i in range(2)]),
-            lambda: qml.math.stack([qml.expval(qml.Z(i)) for i in range(2)]),
+            lambda: qp.math.hstack([qp.expval(qp.Z(i)) for i in range(2)]),
+            lambda: qp.math.stack([qp.expval(qp.Z(i)) for i in range(2)]),
         ],
     )
     def test_tensor_measurement(self, measurement):
         """Tests that measurements of tensor type are handled correctly"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1, wires=0)
-            qml.RY(2, wires=1)
-            qml.measure(0)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(1, wires=0)
+            qp.RY(2, wires=1)
+            qp.measure(0)
+            qp.CNOT(wires=[0, 1])
             return measurement()
 
         result = circuit()
@@ -587,12 +587,12 @@ class TestTapeConstruction:
     def test_returning_non_measurements(self):
         """Test that an exception is raised if a non-measurement
         is returned from the QNode."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def func0(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
             return 5
 
         qn = QNode(func0, dev)
@@ -601,10 +601,10 @@ class TestTapeConstruction:
             qn(5, 1)
 
         def func2(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0)), 5
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0)), 5
 
         qn = QNode(func2, dev)
 
@@ -612,9 +612,9 @@ class TestTapeConstruction:
             qn(5, 1)
 
         def func3(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
             return []
 
         qn = QNode(func3, dev)
@@ -625,14 +625,14 @@ class TestTapeConstruction:
     def test_inconsistent_measurement_order(self):
         """Test that an exception is raised if measurements are returned in an
         order different to how they were queued on the tape"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def func(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
-            m = qml.expval(qml.PauliZ(0))
-            return qml.expval(qml.PauliX(1)), m
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
+            m = qp.expval(qp.PauliZ(0))
+            return qp.expval(qp.PauliX(1)), m
 
         qn = QNode(func, dev)
 
@@ -645,16 +645,16 @@ class TestTapeConstruction:
     def test_consistent_measurement_order(self):
         """Test evaluation proceeds as expected if measurements are returned in the
         same order to how they were queued on the tape"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         contents = []
 
         def func(x, y):
-            op1 = qml.RX(x, wires=0)
-            op2 = qml.RY(y, wires=1)
-            op3 = qml.CNOT(wires=[0, 1])
-            m1 = qml.expval(qml.PauliZ(0))
-            m2 = qml.expval(qml.PauliX(1))
+            op1 = qp.RX(x, wires=0)
+            op2 = qp.RY(y, wires=1)
+            op3 = qp.CNOT(wires=[0, 1])
+            m1 = qp.expval(qp.PauliZ(0))
+            m2 = qp.expval(qp.PauliX(1))
             contents.append(op1)
             contents.append(op2)
             contents.append(op3)
@@ -663,7 +663,7 @@ class TestTapeConstruction:
             return [m1, m2]
 
         qn = QNode(func, dev)
-        tape = qml.workflow.construct_tape(qn)(5, 1)
+        tape = qp.workflow.construct_tape(qn)(5, 1)
         assert tape.operations == contents[0:3]
         assert tape.measurements == contents[3:]
 
@@ -674,50 +674,50 @@ class TestTapeConstruction:
         jitting raises an error."""
         import jax
 
-        dev = qml.device(dev_name, wires=2)
+        dev = qp.device(dev_name, wires=2)
 
         def circuit1(param):
-            qml.Hadamard(0)
-            qml.RX(param, wires=1)
-            qml.CNOT([1, 0])
-            return qml.counts()
+            qp.Hadamard(0)
+            qp.RX(param, wires=1)
+            qp.CNOT([1, 0])
+            return qp.counts()
 
-        qn = qml.set_shots(qml.QNode(circuit1, dev), shots=5)
+        qn = qp.set_shots(qp.QNode(circuit1, dev), shots=5)
         jitted_qnode1 = jax.jit(qn)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
+            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
         ):
             _ = jitted_qnode1(0.123)
 
         # Test with qnode decorator syntax
-        @qml.set_shots(5)
-        @qml.qnode(dev)
+        @qp.set_shots(5)
+        @qp.qnode(dev)
         def circuit2(param):
-            qml.Hadamard(0)
-            qml.RX(param, wires=1)
-            qml.CNOT([1, 0])
-            return qml.counts()
+            qp.Hadamard(0)
+            qp.RX(param, wires=1)
+            qp.CNOT([1, 0])
+            return qp.counts()
 
         jitted_qnode2 = jax.jit(circuit2)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
+            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
         ):
             jitted_qnode2(0.123)
 
 
 def test_decorator(tol):
     """Test that the decorator correctly creates a QNode."""
-    dev = qml.device("default.qubit", wires=2)
+    dev = qp.device("default.qubit", wires=2)
 
     @qnode(dev)
     def func(x, y):
         """My function docstring"""
-        qml.RX(x, wires=0)
-        qml.RY(y, wires=1)
-        qml.CNOT(wires=[0, 1])
-        return qml.expval(qml.PauliZ(0))
+        qp.RX(x, wires=0)
+        qp.RY(y, wires=1)
+        qp.CNOT(wires=[0, 1])
+        return qp.expval(qp.PauliZ(0))
 
     assert isinstance(func, QNode)
     assert func.__doc__ == "My function docstring"
@@ -743,19 +743,19 @@ class TestIntegration:
         returns results in the expected interface"""
 
         def func():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
         qn = QNode(func, dev, interface=interface)
 
-        with qml.Tracker(dev, persistent=True) as tracker:
+        with qp.Tracker(dev, persistent=True) as tracker:
             for _ in range(2):
                 res = qn()
 
         assert tracker.totals["executions"] == 2
-        assert qml.math.get_interface(res) == interface
+        assert qp.math.get_interface(res) == interface
 
         qn2 = QNode(func, dev, interface=interface)
 
@@ -764,7 +764,7 @@ class TestIntegration:
                 res = qn2()
 
         assert tracker.totals["executions"] == 5
-        assert qml.math.get_interface(res) == interface
+        assert qp.math.get_interface(res) == interface
 
         # qubit of different interface
         qn3 = QNode(func, dev, interface="autograd")
@@ -772,21 +772,21 @@ class TestIntegration:
             res = qn3()
 
         assert tracker.totals["executions"] == 6
-        assert qml.math.get_interface(res) == "autograd"
+        assert qp.math.get_interface(res) == "autograd"
 
     def test_num_exec_caching_with_backprop(self):
         """Tests that with diff_method='backprop', the number of executions
         recorded is correct."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         cache = {}
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit():
-            qml.RY(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RY(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        with qml.Tracker(dev, persistent=True) as tracker:
+        with qp.Tracker(dev, persistent=True) as tracker:
             for _ in range(15):
                 circuit()
 
@@ -798,23 +798,23 @@ class TestIntegration:
     def test_num_exec_caching_device_swap_two_exec(self):
         """Tests that when diff_method='backprop', the number of executions recorded is
         correct even with multiple QNode evaluations."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         cache = {}
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit0():
-            qml.RY(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RY(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        with qml.Tracker(dev, persistent=True) as tracker:
+        with qp.Tracker(dev, persistent=True) as tracker:
             for _ in range(15):
                 circuit0()
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit2():
-            qml.RZ(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         with tracker:
             for _ in range(15):
@@ -835,7 +835,7 @@ class TestIntegration:
         This test relies on the fact that exactly one term of the estimated
         jacobian will match the expected analytical value.
         """
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         x = pnp.array(0.543, requires_grad=True)
         y = pnp.array(-0.654, requires_grad=True)
@@ -848,12 +848,12 @@ class TestIntegration:
             dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs
         )  # <--- we only choose one trainable parameter
         def circuit(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        res = qml.grad(circuit)(x, y)
+        res = qp.grad(circuit)(x, y)
         assert len(res) == 2
 
         expected = (0, np.cos(y) * np.cos(x))
@@ -865,14 +865,14 @@ class TestIntegration:
     @pytest.mark.parametrize("first_par", np.linspace(0.15, np.pi - 0.3, 3))
     @pytest.mark.parametrize("sec_par", np.linspace(0.15, np.pi - 0.3, 3))
     @pytest.mark.parametrize(
-        "return_type", [qml.expval(qml.PauliZ(1)), qml.var(qml.PauliZ(1)), qml.probs(wires=[1])]
+        "return_type", [qp.expval(qp.PauliZ(1)), qp.var(qp.PauliZ(1)), qp.probs(wires=[1])]
     )
     @pytest.mark.parametrize(
         "mv_return, mv_res",
         [
-            (qml.expval, lambda x: np.sin(x / 2) ** 2),
-            (qml.var, lambda x: np.sin(x / 2) ** 2 - np.sin(x / 2) ** 4),
-            (qml.probs, lambda x: [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2]),
+            (qp.expval, lambda x: np.sin(x / 2) ** 2),
+            (qp.var, lambda x: np.sin(x / 2) ** 2 - np.sin(x / 2) ** 4),
+            (qp.probs, lambda x: [np.cos(x / 2) ** 2, np.sin(x / 2) ** 2]),
         ],
     )
     def test_defer_meas_if_mcm_unsupported(
@@ -881,27 +881,27 @@ class TestIntegration:
         """Tests that the transform using the deferred measurement principle is
         applied if the device doesn't support mid-circuit measurements
         natively."""
-        dev = qml.device(dev_name, wires=3)
+        dev = qp.device(dev_name, wires=3)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def cry_qnode(x, y):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(x, wires=0)
-            qml.CRY(y, wires=[0, 1])
-            return qml.apply(return_type)
+            qp.Hadamard(1)
+            qp.RY(x, wires=0)
+            qp.CRY(y, wires=[0, 1])
+            return qp.apply(return_type)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def conditional_ry_qnode(x, y):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(x, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(y, wires=1)
-            return qml.apply(return_type), mv_return(op=m_0)
+            qp.Hadamard(1)
+            qp.RY(x, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(y, wires=1)
+            return qp.apply(return_type), mv_return(op=m_0)
 
-        spy = mocker.spy(qml.defer_measurements, "_tape_transform")
+        spy = mocker.spy(qp.defer_measurements, "_tape_transform")
         r1 = cry_qnode(first_par, sec_par)
         r2 = conditional_ry_qnode(first_par, sec_par)
 
@@ -911,36 +911,36 @@ class TestIntegration:
 
     @pytest.mark.parametrize("basis_state", [[1, 0], [0, 1]])
     def test_sampling_with_mcm(self, basis_state, mocker):
-        """Tests that a QNode with qml.sample and mid-circuit measurements
+        """Tests that a QNode with qp.sample and mid-circuit measurements
         returns the expected results."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         first_par = np.pi
 
-        @qml.set_shots(1000)
-        @qml.qnode(dev)
+        @qp.set_shots(1000)
+        @qp.qnode(dev)
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.BasisState(basis_state, wires=[0, 1])
-            qml.CRY(x, wires=[0, 1])
-            return qml.sample(qml.PauliZ(1))
+            qp.BasisState(basis_state, wires=[0, 1])
+            qp.CRY(x, wires=[0, 1])
+            return qp.sample(qp.PauliZ(1))
 
-        @qml.set_shots(1000)
-        @qml.qnode(dev)
+        @qp.set_shots(1000)
+        @qp.qnode(dev)
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.BasisState(basis_state, wires=[0, 1])
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.sample(qml.PauliZ(1))
+            qp.BasisState(basis_state, wires=[0, 1])
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.sample(qp.PauliZ(1))
 
         r1 = cry_qnode(first_par)
         r2 = conditional_ry_qnode(first_par)
         assert np.allclose(r1, r2)
 
-        cry_qnode_deferred = qml.defer_measurements(cry_qnode)
-        conditional_ry_qnode_deferred = qml.defer_measurements(conditional_ry_qnode)
+        cry_qnode_deferred = qp.defer_measurements(cry_qnode)
+        conditional_ry_qnode_deferred = qp.defer_measurements(conditional_ry_qnode)
 
         r1 = cry_qnode_deferred(first_par)
         r2 = conditional_ry_qnode_deferred(first_par)
@@ -952,27 +952,27 @@ class TestIntegration:
         """Test conditional operations with TensorFlow."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
-        dm_conditional_ry_qnode = qml.defer_measurements(conditional_ry_qnode)
+        dm_conditional_ry_qnode = qp.defer_measurements(conditional_ry_qnode)
 
         x_ = -0.654
         x1 = tf.Variable(x_, dtype=tf.float64)
@@ -1003,25 +1003,25 @@ class TestIntegration:
         """Test conditional operations with Torch."""
         import torch
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         x1 = torch.tensor(-0.654, dtype=torch.float64, requires_grad=True)
         x2 = torch.tensor(-0.654, dtype=torch.float64, requires_grad=True)
@@ -1042,25 +1042,25 @@ class TestIntegration:
         import jax
 
         jnp = jax.numpy
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        @qml.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         x1 = jnp.array(-0.654)
         x2 = jnp.array(-0.654)
@@ -1073,33 +1073,33 @@ class TestIntegration:
 
     def test_qnode_does_not_support_nested_queuing(self):
         """Test that operators in QNodes are not queued to surrounding contexts."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.PauliZ(0)
-            return qml.expval(qml.PauliX(0))
+            qp.PauliZ(0)
+            return qp.expval(qp.PauliX(0))
 
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             circuit()
 
-        tape = qml.workflow.construct_tape(circuit)()
+        tape = qp.workflow.construct_tape(circuit)()
         assert q.queue == []  # pylint: disable=use-implicit-booleaness-not-comparison
         assert len(tape.operations) == 1
 
     def test_qnode_preserves_inferred_numpy_interface(self):
         """Tests that the QNode respects the inferred numpy interface."""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         x = np.array(0.8)
         res = circuit(x)
-        assert qml.math.get_interface(res) == "numpy"
+        assert qp.math.get_interface(res) == "numpy"
 
     def test_qnode_default_interface(self):
         """Tests that the default interface is set correctly for a QNode."""
@@ -1107,17 +1107,17 @@ class TestIntegration:
         # pylint: disable=import-outside-toplevel
         import networkx as nx
 
-        @qml.qnode(qml.device("default.qubit"))
+        @qp.qnode(qp.device("default.qubit"))
         def circuit(graph: nx.Graph):
             for a in graph.nodes:
-                qml.Hadamard(wires=a)
+                qp.Hadamard(wires=a)
             for a, b in graph.edges:
-                qml.CZ(wires=[a, b])
-            return qml.expval(qml.PauliZ(0))
+                qp.CZ(wires=[a, b])
+            return qp.expval(qp.PauliZ(0))
 
         graph = nx.complete_graph(3)
         res = circuit(graph)
-        assert qml.math.get_interface(res) == "numpy"
+        assert qp.math.get_interface(res) == "numpy"
 
     def test_qscript_default_interface(self):
         """Tests that the default interface is set correctly for a QuantumScript."""
@@ -1125,10 +1125,10 @@ class TestIntegration:
         # pylint: disable=import-outside-toplevel
         import networkx as nx
 
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
 
         # pylint: disable=too-few-public-methods
-        class DummyCustomGraphOp(qml.operation.Operation):
+        class DummyCustomGraphOp(qp.operation.Operation):
             """Dummy custom operation for testing purposes."""
 
             def __init__(self, graph: nx.Graph):
@@ -1137,18 +1137,18 @@ class TestIntegration:
             def decomposition(self) -> list:
                 return []
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(DummyCustomGraphOp, null_decomp)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(DummyCustomGraphOp, null_decomp)
             graph = nx.complete_graph(3)
-            tape = qml.tape.QuantumScript([DummyCustomGraphOp(graph)], [qml.expval(qml.PauliZ(0))])
-            res = qml.execute([tape], dev)
-            assert qml.math.get_interface(res) == "numpy"
+            tape = qp.tape.QuantumScript([DummyCustomGraphOp(graph)], [qp.expval(qp.PauliZ(0))])
+            res = qp.execute([tape], dev)
+            assert qp.math.get_interface(res) == "numpy"
 
     def test_error_device_vjp_unsuppoprted(self):
         """Test that an error is raised in the device_vjp is unsupported."""
 
-        class DummyDev(qml.devices.Device):
-            def execute(self, circuits, execution_config=qml.devices.ExecutionConfig()):
+        class DummyDev(qp.devices.Device):
+            def execute(self, circuits, execution_config=qp.devices.ExecutionConfig()):
                 return 0
 
             def supports_derivatives(self, execution_config=None, circuit=None):
@@ -1157,9 +1157,9 @@ class TestIntegration:
             def supports_vjp(self, execution_config=None, circuit=None) -> bool:
                 return execution_config and execution_config.gradient_method == "vjp_grad"
 
-        @qml.qnode(DummyDev(), diff_method="parameter-shift", device_vjp=True)
+        @qp.qnode(DummyDev(), diff_method="parameter-shift", device_vjp=True)
         def circuit():
-            return qml.expval(qml.Z(0))
+            return qp.expval(qp.Z(0))
 
         with pytest.raises(QuantumFunctionError, match="device_vjp=True is not supported"):
             circuit()
@@ -1176,18 +1176,18 @@ class TestIntegration:
     def test_error_if_differentiate_diff_method_None(self, interface):
         """Test that an error is raised if differentiating a qnode with diff_method=None"""
 
-        @qml.qnode(qml.device("reference.qubit", wires=1), diff_method=None)
+        @qp.qnode(qp.device("reference.qubit", wires=1), diff_method=None)
         def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.Z(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.Z(0))
 
-        x = qml.math.asarray(0.5, like=interface, requires_grad=True)
+        x = qp.math.asarray(0.5, like=interface, requires_grad=True)
 
         res = circuit(x)  # execution works fine
-        assert qml.math.allclose(res, np.cos(0.5))
+        assert qp.math.allclose(res, np.cos(0.5))
 
         with pytest.raises(QuantumFunctionError, match="with diff_method=None"):
-            qml.math.grad(circuit)(x)
+            qp.math.grad(circuit)(x)
 
 
 class TestShots:
@@ -1195,12 +1195,12 @@ class TestShots:
 
     def test_shots_setter_error(self):
         """Tests that an error is raised when setting shots on a QNode."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(a):
-            qml.RX(a, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(a, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         with pytest.raises(AttributeError, match="Shots cannot be set on a qnode instance"):
             circuit.shots = 5
@@ -1212,12 +1212,12 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="shots on device is deprecated",
         ):
-            dev = qml.device("default.qubit", wires=1, shots=10)
+            dev = qp.device("default.qubit", wires=1, shots=10)
 
         @qnode(dev)
         def circuit(a):
-            qml.RX(a, wires=0)
-            return qml.sample(qml.PauliZ(wires=0))
+            qp.RX(a, wires=0)
+            return qp.sample(qp.PauliZ(wires=0))
 
         assert len(circuit(0.8)) == 10
         with pytest.warns(
@@ -1232,12 +1232,12 @@ class TestShots:
     def test_specify_shots_per_call_expval(self):
         """Tests that shots can be set per call for an expectation value.
         Note: this test has a vanishingly small probability to fail."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            return qml.expval(qml.PauliZ(wires=0))
+            qp.Hadamard(wires=0)
+            return qp.expval(qp.PauliZ(wires=0))
 
         # check that the circuit is analytic
         res1 = [circuit() for _ in range(100)]
@@ -1266,11 +1266,11 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="shots on device is deprecated",
         ):
-            dev = qml.device("default.qubit", wires=2, shots=10)
+            dev = qp.device("default.qubit", wires=2, shots=10)
 
         def circuit(a, shots=0):
-            qml.RX(a, wires=shots)
-            return qml.sample(qml.PauliZ(wires=0))
+            qp.RX(a, wires=shots)
+            return qp.sample(qp.PauliZ(wires=0))
 
         with pytest.warns(
             UserWarning, match="The 'shots' argument name is reserved for overriding"
@@ -1278,15 +1278,15 @@ class TestShots:
             circuit = QNode(circuit, dev)
 
         assert len(circuit(0.8)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8)
+        tape = qp.workflow.construct_tape(circuit)(0.8)
         assert tape.operations[0].wires.labels == (0,)
 
         assert len(circuit(0.8, shots=1)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, shots=1)
+        tape = qp.workflow.construct_tape(circuit)(0.8, shots=1)
         assert tape.operations[0].wires.labels == (1,)
 
         assert len(circuit(0.8, shots=0)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, shots=0)
+        tape = qp.workflow.construct_tape(circuit)(0.8, shots=0)
         assert tape.operations[0].wires.labels == (0,)
 
     # pylint: disable=unexpected-keyword-arg
@@ -1297,11 +1297,11 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="shots on device is deprecated",
         ):
-            dev = qml.device("default.qubit", wires=[0, 1], shots=10)
+            dev = qp.device("default.qubit", wires=[0, 1], shots=10)
 
         def ansatz0(a, shots):
-            qml.RX(a, wires=shots)
-            return qml.sample(qml.PauliZ(wires=0))
+            qp.RX(a, wires=shots)
+            return qp.sample(qp.PauliZ(wires=0))
 
         # assert that warning is still raised
         with pytest.warns(
@@ -1310,10 +1310,10 @@ class TestShots:
             circuit = QNode(ansatz0, dev)
 
         assert len(circuit(0.8, 1)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, 1)
+        tape = qp.workflow.construct_tape(circuit)(0.8, 1)
         assert tape.operations[0].wires.labels == (1,)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         with pytest.warns(
             UserWarning, match="The 'shots' argument name is reserved for overriding"
@@ -1321,22 +1321,22 @@ class TestShots:
 
             @qnode(dev, shots=10)
             def ansatz1(a, shots):
-                qml.RX(a, wires=shots)
-                return qml.sample(qml.PauliZ(wires=0))
+                qp.RX(a, wires=shots)
+                return qp.sample(qp.PauliZ(wires=0))
 
         assert len(ansatz1(0.8, shots=0)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, 0)
+        tape = qp.workflow.construct_tape(circuit)(0.8, 0)
         assert tape.operations[0].wires.labels == (0,)
 
     def test_warning_finite_shots_dev(self):
         """Tests that a warning is raised when caching is used with finite shots."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(5)
-        @qml.qnode(dev, cache={})
+        @qp.set_shots(5)
+        @qp.qnode(dev, cache={})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # no warning on the first execution
         circuit(0.3)
@@ -1346,56 +1346,56 @@ class TestShots:
     # pylint: disable=unexpected-keyword-arg
     def test_warning_finite_shots_override(self):
         """Tests that a warning is raised when caching is used with finite shots."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(5)
-        @qml.qnode(dev, cache={})
+        @qp.set_shots(5)
+        @qp.qnode(dev, cache={})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # no warning on the first execution
         circuit(0.3)
         with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
-            qml.set_shots(circuit, shots=5)(0.3)
+            qp.set_shots(circuit, shots=5)(0.3)
 
     def test_warning_finite_shots_tape(self):
         """Tests that a warning is raised when caching is used with finite shots."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RZ(0.3, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RZ(0.3, wires=0)
+            qp.expval(qp.PauliZ(0))
 
         tape = QuantumScript.from_queue(q, shots=5)
         # no warning on the first execution
         cache = {}
-        qml.execute([tape], dev, None, cache=cache)
+        qp.execute([tape], dev, None, cache=cache)
         with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
-            qml.execute([tape], dev, None, cache=cache)
+            qp.execute([tape], dev, None, cache=cache)
 
         cache2 = {}
         with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
-            qml.execute([tape, tape], dev, cache=cache2)
+            qp.execute([tape, tape], dev, cache=cache2)
 
     def test_no_caching_by_default(self):
         """Test that caching is turned off by default."""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        tape = qml.tape.QuantumScript([qml.H(0)], [qml.sample(wires=0)], shots=1000)
+        tape = qp.tape.QuantumScript([qp.H(0)], [qp.sample(wires=0)], shots=1000)
 
-        res1, res2 = qml.execute([tape, tape], dev)
+        res1, res2 = qp.execute([tape, tape], dev)
         assert not np.allclose(res1, res2)
 
     def test_no_warning_infinite_shots(self):
         """Tests that no warning is raised when caching is used with infinite shots."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev, cache={})
+        @qp.qnode(dev, cache={})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message="Cached execution with finite shots detected")
@@ -1405,17 +1405,17 @@ class TestShots:
     @pytest.mark.autograd
     def test_no_warning_internal_cache_reuse(self):
         """Tests that no warning is raised when only the internal cache is reused."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(5)
-        @qml.qnode(dev, cache=True)
+        @qp.set_shots(5)
+        @qp.qnode(dev, cache=True)
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.probs(wires=0)
+            qp.RZ(x, wires=0)
+            return qp.probs(wires=0)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message="Cached execution with finite shots detected")
-            qml.jacobian(circuit, argnums=0)(0.3)
+            qp.jacobian(circuit, argnums=0)(0.3)
 
     # pylint: disable=unexpected-keyword-arg
     @pytest.mark.parametrize(
@@ -1429,17 +1429,17 @@ class TestShots:
     )
     def test_tape_shots_set_on_call(self, shots, total_shots, shot_vector):
         """test that shots are placed on the tape if they are specified during a call."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def func(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(func, dev)
 
         # No override
-        tape = qml.workflow.construct_tape(qn)(0.1, 0.2)
+        tape = qp.workflow.construct_tape(qn)(0.1, 0.2)
         assert tape.shots.total_shots is None
 
         # Override
@@ -1447,19 +1447,19 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="Specifying 'shots' when executing a QNode is deprecated",
         ):
-            tape = qml.workflow.construct_tape(qn)(0.1, 0.2, shots=shots)
+            tape = qp.workflow.construct_tape(qn)(0.1, 0.2, shots=shots)
         assert tape.shots.total_shots == total_shots
         assert tape.shots.shot_vector == shot_vector
 
         # Decorator syntax
         @qnode(dev)
         def qn2(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
 
         # No override
-        tape = qml.workflow.construct_tape(qn2)(0.1, 0.2)
+        tape = qp.workflow.construct_tape(qn2)(0.1, 0.2)
         assert tape.shots.total_shots is None
 
         # Override
@@ -1467,45 +1467,45 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="Specifying 'shots' when executing a QNode is deprecated",
         ):
-            tape = qml.workflow.construct_tape(qn2)(0.1, 0.2, shots=shots)
+            tape = qp.workflow.construct_tape(qn2)(0.1, 0.2, shots=shots)
         assert tape.shots.total_shots == total_shots
         assert tape.shots.shot_vector == shot_vector
 
     def test_shots_not_updated_with_device(self):
         """Test that _shots is not updated when updating the QNode with a new device."""
         with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
-            dev1 = qml.device("default.qubit", wires=1, shots=100)
-        qn = qml.QNode(dummyfunc, dev1)
-        assert qn._shots == qml.measurements.Shots(100)
+            dev1 = qp.device("default.qubit", wires=1, shots=100)
+        qn = qp.QNode(dummyfunc, dev1)
+        assert qn._shots == qp.measurements.Shots(100)
 
         # _shots should take precedence over device shots
         with pytest.warns(PennyLaneDeprecationWarning, match="shots on device is deprecated"):
-            dev2 = qml.device("default.qubit", wires=1, shots=200)
+            dev2 = qp.device("default.qubit", wires=1, shots=200)
         with pytest.warns(
             UserWarning, match="The device's shots value does not match the QNode's shots value."
         ):
             updated_qnode = qn.update(device=dev2)
-        assert updated_qnode._shots == qml.measurements.Shots(100)
+        assert updated_qnode._shots == qp.measurements.Shots(100)
 
     def test_shots_preserved_in_other_updates(self):
         """Test that _shots is preserved when updating other QNode parameters."""
-        dev = qml.device("default.qubit", wires=1)
-        qn = qml.set_shots(qml.QNode(dummyfunc, dev), shots=50)
-        assert qn._shots == qml.measurements.Shots(50)
+        dev = qp.device("default.qubit", wires=1)
+        qn = qp.set_shots(qp.QNode(dummyfunc, dev), shots=50)
+        assert qn._shots == qp.measurements.Shots(50)
 
         # Update something unrelated to shots or device
         updated_qnode = qn.update(diff_method="parameter-shift")
-        assert updated_qnode._shots == qml.measurements.Shots(50)
+        assert updated_qnode._shots == qp.measurements.Shots(50)
 
     def test_shots_direct_update(self):
         """Test that QNode shots can be updated directly using the update_shots method."""
-        dev = qml.device("default.qubit", wires=1)
-        qn = qml.set_shots(qml.QNode(dummyfunc, dev), shots=30)
-        assert qn._shots == qml.measurements.Shots(30)
+        dev = qp.device("default.qubit", wires=1)
+        qn = qp.set_shots(qp.QNode(dummyfunc, dev), shots=30)
+        assert qn._shots == qp.measurements.Shots(30)
 
         # Update shots directly using update_shots method
         updated_qnode = qn.update_shots(shots=75)
-        assert updated_qnode._shots == qml.measurements.Shots(75)
+        assert updated_qnode._shots == qp.measurements.Shots(75)
 
 
 class TestCompilePipelineIntegration:
@@ -1513,28 +1513,28 @@ class TestCompilePipelineIntegration:
 
     def test_transform_program_modifies_circuit(self):
         """Test qnode integration with a transform that turns the circuit into just a pauli x."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         def null_postprocessing(results):
             return results[0]
 
-        @qml.transform
+        @qp.transform
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript([qml.PauliX(0)], tape.measurements),
+                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
             ), null_postprocessing
 
         @just_pauli_x_out
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.compile_pipeline[0].tape_transform == just_pauli_x_out.tape_transform
 
-        assert qml.math.allclose(circuit(0.1), -1)
+        assert qp.math.allclose(circuit(0.1), -1)
 
         with circuit.device.tracker as tracker:
             circuit(0.1)
@@ -1546,81 +1546,81 @@ class TestCompilePipelineIntegration:
     def test_transform_program_modifies_results(self):
         """Test integration with a transform that modifies the result output."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.transform
+        @qp.transform
         def pin_result(
             tape: QuantumScript, requested_result
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            def postprocessing(_: qml.typing.ResultBatch) -> qml.typing.Result:
+            def postprocessing(_: qp.typing.ResultBatch) -> qp.typing.Result:
                 return requested_result
 
             return (tape,), postprocessing
 
         @pin_result(requested_result=3.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.compile_pipeline[0].tape_transform == pin_result.tape_transform
         assert circuit.compile_pipeline[0].kwargs == {"requested_result": 3.0}
 
-        assert qml.math.allclose(circuit(0.1), 3.0)
+        assert qp.math.allclose(circuit(0.1), 3.0)
 
     def test_transform_order_circuit_processing(self):
         """Test that transforms are applied in the correct order in integration."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def null_postprocessing(results):
             return results[0]
 
-        @qml.transform
+        @qp.transform
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript([qml.PauliX(0)], tape.measurements),
+                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
             ), null_postprocessing
 
-        @qml.transform
+        @qp.transform
         def repeat_operations(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            new_tape = qml.tape.QuantumScript(
+            new_tape = qp.tape.QuantumScript(
                 tape.operations + copy.deepcopy(tape.operations), tape.measurements
             )
             return (new_tape,), null_postprocessing
 
         @repeat_operations
         @just_pauli_x_out
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit1(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         with circuit1.device.tracker as tracker:
-            assert qml.math.allclose(circuit1(0.1), 1.0)
+            assert qp.math.allclose(circuit1(0.1), 1.0)
 
         assert tracker.history["resources"][0].gate_types["PauliX"] == 2
 
         @just_pauli_x_out
         @repeat_operations
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit2(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         with circuit2.device.tracker as tracker:
-            assert qml.math.allclose(circuit2(0.1), -1.0)
+            assert qp.math.allclose(circuit2(0.1), -1.0)
 
         assert tracker.history["resources"][0].gate_types["PauliX"] == 1
 
     def test_transform_order_postprocessing(self):
         """Test that transform postprocessing is called in the right order."""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def scale_by_factor(results, factor):
             return results[0] * factor
@@ -1628,53 +1628,53 @@ class TestCompilePipelineIntegration:
         def add_shift(results, shift):
             return results[0] + shift
 
-        @qml.transform
+        @qp.transform
         def scale_output(
             tape: QuantumScript, factor
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (tape,), partial(scale_by_factor, factor=factor)
 
-        @qml.transform
+        @qp.transform
         def shift_output(tape: QuantumScript, shift) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (tape,), partial(add_shift, shift=shift)
 
         @shift_output(shift=1.0)
         @scale_output(factor=2.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit1():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         # first add one, then scale by 2.0.  Outer postprocessing transforms are applied first
-        assert qml.math.allclose(circuit1(), 4.0)
+        assert qp.math.allclose(circuit1(), 4.0)
 
         @scale_output(factor=2.0)
         @shift_output(shift=1.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit2():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         # first scale by 2, then add one. Outer postprocessing transforms are applied first
-        assert qml.math.allclose(circuit2(), 3.0)
+        assert qp.math.allclose(circuit2(), 3.0)
 
     def test_scaling_shots_transform(self):
         """Test a transform that scales the number of shots used in an execution."""
 
         # note that this won't work with the old device interface :(
-        dev = qml.devices.DefaultQubit()
+        dev = qp.devices.DefaultQubit()
 
         def num_of_shots_from_sample(results):
             return len(results[0])
 
-        @qml.transform
+        @qp.transform
         def use_n_shots(tape: QuantumScript, n) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript(tape.operations, tape.measurements, shots=n),
+                qp.tape.QuantumScript(tape.operations, tape.measurements, shots=n),
             ), num_of_shots_from_sample
 
         @use_n_shots(n=100)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit():
-            return qml.sample(wires=0)
+            return qp.sample(wires=0)
 
         assert circuit() == 100
 
@@ -1688,7 +1688,7 @@ class TestNewDeviceIntegration:
         """Test that a qnode can be initialized with the new device without error."""
 
         def f():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(f, self.dev)
         assert qn.device is self.dev
@@ -1697,7 +1697,7 @@ class TestNewDeviceIntegration:
         """Test that the repr works with the new device."""
 
         def f():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(f, self.dev)
         assert (
@@ -1708,21 +1708,21 @@ class TestNewDeviceIntegration:
     def test_device_with_custom_diff_method_name(self):
         """Test a device that has its own custom diff method."""
 
-        class CustomDeviceWithDiffMethod2(qml.devices.DefaultQubit):
+        class CustomDeviceWithDiffMethod2(qp.devices.DefaultQubit):
             """A device with a custom derivative named hello."""
 
             def supports_derivatives(self, execution_config=None, circuit=None):
                 return getattr(execution_config, "gradient_method", None) == "hello"
 
             def setup_execution_config(
-                self, config: qml.devices.ExecutionConfig | None = None, circuit=None
+                self, config: qp.devices.ExecutionConfig | None = None, circuit=None
             ):
                 if config.gradient_method in {"best", "hello"}:
                     return replace(config, gradient_method="hello", use_device_gradient=True)
                 return config
 
             def compute_derivatives(
-                self, circuits, execution_config: qml.devices.ExecutionConfig | None = None
+                self, circuits, execution_config: qp.devices.ExecutionConfig | None = None
             ):
                 if self.tracker.active:
                     self.tracker.update(derivative_config=execution_config)
@@ -1731,15 +1731,15 @@ class TestNewDeviceIntegration:
 
         dev = CustomDeviceWithDiffMethod2()
 
-        @qml.qnode(dev, diff_method="hello")
+        @qp.qnode(dev, diff_method="hello")
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.diff_method == "hello"
 
         with dev.tracker:
-            qml.grad(circuit)(qml.numpy.array(0.5))
+            qp.grad(circuit)(qp.numpy.array(0.5))
 
         assert dev.tracker.history["derivative_config"][0].gradient_method == "hello"
         assert dev.tracker.history["derivative_batches"] == [1]
@@ -1747,11 +1747,11 @@ class TestNewDeviceIntegration:
     def test_shots_integration(self):
         """Test that shots provided at call time are passed through the workflow."""
 
-        dev = qml.devices.DefaultQubit()
+        dev = qp.devices.DefaultQubit()
 
-        @qml.qnode(dev, diff_method=None)
+        @qp.qnode(dev, diff_method=None)
         def circuit():
-            return qml.sample(wires=(0, 1))
+            return qp.sample(wires=(0, 1))
 
         with pytest.raises(DeviceError, match="not accepted for analytic simulation"):
             circuit()
@@ -1761,10 +1761,10 @@ class TestNewDeviceIntegration:
             match="Specifying 'shots' when executing a QNode is deprecated",
         ):
             results = circuit(shots=10)  # pylint: disable=unexpected-keyword-arg
-            assert qml.math.allclose(results, np.zeros((10, 2)))
+            assert qp.math.allclose(results, np.zeros((10, 2)))
 
             results = circuit(shots=20)  # pylint: disable=unexpected-keyword-arg
-            assert qml.math.allclose(results, np.zeros((20, 2)))
+            assert qp.math.allclose(results, np.zeros((20, 2)))
 
 
 class TestMCMConfiguration:
@@ -1772,14 +1772,14 @@ class TestMCMConfiguration:
 
     def test_one_shot_error_without_shots(self):
         """Test that an error is raised if mcm_method="one-shot" with no shots"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
         param = np.pi / 4
 
-        @qml.qnode(dev, mcm_method="one-shot")
+        @qp.qnode(dev, mcm_method="one-shot")
         def f(x):
-            qml.RX(x, 0)
-            _ = qml.measure(0)
-            return qml.probs(wires=[0, 1])
+            qp.RX(x, 0)
+            _ = qp.measure(0)
+            return qp.probs(wires=[0, 1])
 
         with pytest.raises(
             ValueError,
@@ -1790,15 +1790,15 @@ class TestMCMConfiguration:
     def test_invalid_postselect_mode_error(self):
         """Test that an error is raised if the requested postselect_mode is invalid"""
         shots = 100
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def f(x):
-            qml.RX(x, 0)
-            _ = qml.measure(0, postselect=1)
-            return qml.sample(wires=[0, 1])
+            qp.RX(x, 0)
+            _ = qp.measure(0, postselect=1)
+            return qp.sample(wires=[0, 1])
 
         with pytest.raises(ValueError, match="'foo' is not a valid postselect_mode"):
-            _ = qml.set_shots(qml.QNode(f, dev, postselect_mode="foo"), shots=shots)
+            _ = qp.set_shots(qp.QNode(f, dev, postselect_mode="foo"), shots=shots)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", [None, "best"])
@@ -1810,17 +1810,17 @@ class TestMCMConfiguration:
         shots = 100
         postselect = 1
         param = jax.numpy.array(np.pi / 2)
-        spy = mocker.spy(qml.defer_measurements, "_tape_transform")
-        spy_one_shot = mocker.spy(qml.dynamic_one_shot, "_tape_transform")
+        spy = mocker.spy(qp.defer_measurements, "_tape_transform")
+        spy_one_shot = mocker.spy(qp.dynamic_one_shot, "_tape_transform")
 
-        dev = qml.device("default.qubit", wires=4, seed=jax.random.PRNGKey(seed))
+        dev = qp.device("default.qubit", wires=4, seed=jax.random.PRNGKey(seed))
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev, diff_method=diff_method, mcm_method="deferred")
+        @qp.set_shots(shots)
+        @qp.qnode(dev, diff_method=diff_method, mcm_method="deferred")
         def f(x):
-            qml.RX(x, 0)
-            qml.measure(0, postselect=postselect)
-            return qml.sample(wires=0)
+            qp.RX(x, 0)
+            qp.measure(0, postselect=postselect)
+            return qp.sample(wires=0)
 
         f_jit = jax.jit(f)
         res = f(param)
@@ -1831,8 +1831,8 @@ class TestMCMConfiguration:
 
         assert len(res) < shots
         assert len(res_jit) == shots
-        assert qml.math.allclose(res, postselect)
-        assert qml.math.allclose(res_jit, postselect)
+        assert qp.math.allclose(res, postselect)
+        assert qp.math.allclose(res_jit, postselect)
 
     @pytest.mark.jax
     @pytest.mark.parametrize("diff_method", [None, "best"])
@@ -1845,14 +1845,14 @@ class TestMCMConfiguration:
         postselect = 1
         param = jax.numpy.array(np.pi / 2)
 
-        dev = qml.device("default.qubit", wires=4, seed=jax.random.PRNGKey(seed))
+        dev = qp.device("default.qubit", wires=4, seed=jax.random.PRNGKey(seed))
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev, diff_method=diff_method, mcm_method="deferred", postselect_mode="hw-like")
+        @qp.set_shots(shots)
+        @qp.qnode(dev, diff_method=diff_method, mcm_method="deferred", postselect_mode="hw-like")
         def f(x):
-            qml.RX(x, 0)
-            qml.measure(0, postselect=postselect)
-            return qml.sample(wires=0)
+            qp.RX(x, 0)
+            qp.measure(0, postselect=postselect)
+            return qp.sample(wires=0)
 
         f_jit = jax.jit(f)
 
@@ -1866,14 +1866,14 @@ class TestMCMConfiguration:
 
     def test_single_branch_statistics_error_without_qjit(self):
         """Test that an error is raised if attempting to use mcm_method="single-branch-statistics
-        without qml.qjit"""
-        dev = qml.device("reference.qubit", wires=1)
+        without qp.qjit"""
+        dev = qp.device("reference.qubit", wires=1)
 
-        @qml.qnode(dev, mcm_method="single-branch-statistics")
+        @qp.qnode(dev, mcm_method="single-branch-statistics")
         def circuit(x):
-            qml.RX(x, 0)
-            qml.measure(0, postselect=1)
-            return qml.sample(wires=0)
+            qp.RX(x, 0)
+            qp.measure(0, postselect=1)
+            return qp.sample(wires=0)
 
         param = np.pi / 4
         with pytest.raises(ValueError, match="Cannot use mcm_method='single-branch-statistics'"):
@@ -1887,28 +1887,28 @@ class TestMCMConfiguration:
         if postselect_mode == "fill-shots" and mcm_method != "deferred":
             pytest.skip("fill-shots is disabled for anything but deferred.")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        original_config = qml.devices.MCMConfig(
+        original_config = qp.devices.MCMConfig(
             postselect_mode=postselect_mode, mcm_method=mcm_method
         )
 
-        @qml.qnode(dev, postselect_mode=postselect_mode, mcm_method=mcm_method)
+        @qp.qnode(dev, postselect_mode=postselect_mode, mcm_method=mcm_method)
         def circuit(x, mp):
-            qml.RX(x, 0)
-            qml.measure(0, postselect=1)
-            return mp(qml.PauliZ(0))
+            qp.RX(x, 0)
+            qp.measure(0, postselect=1)
+            return mp(qp.PauliZ(0))
 
-        _ = qml.set_shots(circuit, shots=10)(1.8, qml.expval)
+        _ = qp.set_shots(circuit, shots=10)(1.8, qp.expval)
         assert circuit.execute_kwargs["postselect_mode"] == original_config.postselect_mode
         assert circuit.execute_kwargs["mcm_method"] == original_config.mcm_method
 
         if mcm_method != "one-shot":
-            _ = circuit(1.8, qml.expval)
+            _ = circuit(1.8, qp.expval)
             assert circuit.execute_kwargs["postselect_mode"] == original_config.postselect_mode
             assert circuit.execute_kwargs["mcm_method"] == original_config.mcm_method
 
-        _ = qml.set_shots(circuit, shots=10)(1.8, qml.expval)
+        _ = qp.set_shots(circuit, shots=10)(1.8, qp.expval)
         assert circuit.execute_kwargs["postselect_mode"] == original_config.postselect_mode
         assert circuit.execute_kwargs["mcm_method"] == original_config.mcm_method
 
@@ -1922,33 +1922,33 @@ class TestTapeExpansion:
     )
     def test_device_expansion(self, diff_method, grad_on_execution, mocker):
         """Test expansion of an unsupported operation on the device"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         # pylint: disable=too-few-public-methods
-        class UnsupportedOp(qml.operation.Operation):
+        class UnsupportedOp(qp.operation.Operation):
             """custom unsupported op."""
 
             num_wires = 1
 
             def decomposition(self):
-                return [qml.RX(3 * self.data[0], wires=self.wires)]
+                return [qp.RX(3 * self.data[0], wires=self.wires)]
 
-        @qml.register_resources({qml.RX: 1})
+        @qp.register_resources({qp.RX: 1})
         def _decomp(param, wires):
-            qml.RX(3 * param, wires)
+            qp.RX(3 * param, wires)
 
         @qnode(dev, diff_method=diff_method, grad_on_execution=grad_on_execution)
         def circuit(x):
             UnsupportedOp(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         if diff_method == "adjoint" and grad_on_execution:
             spy = mocker.spy(circuit.device, "execute_and_compute_derivatives")
         else:
             spy = mocker.spy(circuit.device, "execute")
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(UnsupportedOp, _decomp)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(UnsupportedOp, _decomp)
             x = pnp.array(0.5)
             circuit(x)
 
@@ -1961,10 +1961,10 @@ class TestTapeExpansion:
     def test_no_gradient_expansion(self):
         """Test that an unsupported operation with defined gradient recipe is not expanded"""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         # pylint: disable=too-few-public-methods
-        class UnsupportedOp(qml.operation.Operation):
+        class UnsupportedOp(qp.operation.Operation):
             """custom unsupported op."""
 
             num_wires = 1
@@ -1974,82 +1974,82 @@ class TestTapeExpansion:
             grad_recipe = ([[3 / 2, 1, np.pi / 6], [-3 / 2, 1, -np.pi / 6]],)
 
             def decomposition(self):
-                return [qml.RX(3 * self.data[0], wires=self.wires)]
+                return [qp.RX(3 * self.data[0], wires=self.wires)]
 
-        with qml.decomposition.local_decomps():
+        with qp.decomposition.local_decomps():
 
-            @qml.register_resources({qml.RX: 1})
+            @qp.register_resources({qp.RX: 1})
             def _decomp(data, wires):
-                qml.RX(3 * data, wires)
+                qp.RX(3 * data, wires)
 
-            qml.add_decomps(UnsupportedOp, _decomp)
+            qp.add_decomps(UnsupportedOp, _decomp)
 
             @qnode(dev, interface="autograd", diff_method="parameter-shift", max_diff=2)
             def circuit(x):
                 UnsupportedOp(x, wires=0)
-                return qml.expval(qml.PauliZ(0))
+                return qp.expval(qp.PauliZ(0))
 
             x = pnp.array(0.5, requires_grad=True)
-            qml.grad(circuit)(x)
+            qp.grad(circuit)(x)
 
             # check second derivative
-            assert np.allclose(qml.grad(qml.grad(circuit))(x), -9 * np.cos(3 * x))
+            assert np.allclose(qp.grad(qp.grad(circuit))(x), -9 * np.cos(3 * x))
 
     @pytest.mark.autograd
     def test_gradient_expansion(self, mocker):
         """Test that a *supported* operation with no gradient recipe is
         expanded when applying the gradient transform, but not for execution."""
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         # pylint: disable=too-few-public-methods
-        class PhaseShift(qml.PhaseShift):
+        class PhaseShift(qp.PhaseShift):
             """custom phase shift."""
 
             grad_method = None
 
             def decomposition(self):
-                return [qml.RY(3 * self.data[0], wires=self.wires)]
+                return [qp.RY(3 * self.data[0], wires=self.wires)]
 
-        with qml.decomposition.local_decomps():
+        with qp.decomposition.local_decomps():
 
-            @qml.register_resources({qml.RY: 1})
+            @qp.register_resources({qp.RY: 1})
             def custom_decomposition(param, wires):
-                qml.RY(3 * param, wires=wires)
+                qp.RY(3 * param, wires=wires)
 
-            qml.add_decomps(PhaseShift, custom_decomposition)
+            qp.add_decomps(PhaseShift, custom_decomposition)
 
             @qnode(dev, diff_method="parameter-shift", max_diff=2)
             def circuit(x):
-                qml.Hadamard(wires=0)
+                qp.Hadamard(wires=0)
                 PhaseShift(x, wires=0)
-                return qml.expval(qml.PauliX(0))
+                return qp.expval(qp.PauliX(0))
 
             x = pnp.array(0.5, requires_grad=True)
             circuit(x)
 
-            res = qml.grad(circuit)(x)
+            res = qp.grad(circuit)(x)
 
             assert np.allclose(res, -3 * np.sin(3 * x))
 
             # test second order derivatives
-            res = qml.grad(qml.grad(circuit))(x)
+            res = qp.grad(qp.grad(circuit))(x)
             assert np.allclose(res, -9 * np.cos(3 * x))
 
     def test_hamiltonian_expansion_analytic(self):
         """Test result if there are non-commuting groups and the number of shots is None"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+        obs = [qp.PauliX(0), qp.PauliX(0) @ qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)]
         c = np.array([-0.6543, 0.24, 0.54])
-        H = qml.Hamiltonian(c, obs)
+        H = qp.Hamiltonian(c, obs)
         H.compute_grouping()
 
         assert len(H.grouping_indices) == 2
 
         @qnode(dev)
         def circuit():
-            return qml.expval(H)
+            return qp.expval(H)
 
         res = circuit()
         assert np.allclose(res, c[2], atol=0.1)
@@ -2059,21 +2059,21 @@ def test_resets_after_execution_error():
     """Test that the interface is reset to ``"auto"`` if an error occurs during execution."""
 
     # pylint: disable=too-few-public-methods
-    class BadOp(qml.operation.Operator):
+    class BadOp(qp.operation.Operator):
         """An operator that will cause an error during execution."""
 
-    @qml.qnode(qml.device("default.qubit"))
+    @qp.qnode(qp.device("default.qubit"))
     def circuit(x):
         BadOp(x, wires=0)
-        return qml.state()
+        return qp.state()
 
-    if qml.decomposition.enabled_graph():
+    if qp.decomposition.enabled_graph():
         with pytest.raises(DeviceError):
             with pytest.warns(DecompositionWarning):
-                circuit(qml.numpy.array(0.1))
+                circuit(qp.numpy.array(0.1))
     else:
         with pytest.raises(DeviceError):
-            circuit(qml.numpy.array(0.1))
+            circuit(qp.numpy.array(0.1))
 
     assert circuit.interface == "auto"
 
@@ -2084,10 +2084,10 @@ class TestPrivateFunctions:
     def test_make_execution_config_with_no_qnode(self):
         """Test that the _make_execution_config function correctly creates an execution config."""
         diff_method = "best"
-        mcm_config = qml.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
+        mcm_config = qp.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
         config = _make_execution_config(None, diff_method, mcm_config)
 
-        expected_config = qml.devices.ExecutionConfig(
+        expected_config = qp.devices.ExecutionConfig(
             interface="numpy",
             gradient_keyword_arguments={},
             use_device_jacobian_product=False,
@@ -2106,16 +2106,16 @@ class TestPrivateFunctions:
         else:
             grad_on_execution = None
 
-        @qml.qnode(qml.device("default.qubit"), interface=interface)
+        @qp.qnode(qp.device("default.qubit"), interface=interface)
         def circuit():
-            qml.H(0)
-            return qml.probs()
+            qp.H(0)
+            return qp.probs()
 
         diff_method = "best"
-        mcm_config = qml.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
+        mcm_config = qp.devices.MCMConfig(postselect_mode="fill-shots", mcm_method="deferred")
         config = _make_execution_config(circuit, diff_method, mcm_config)
 
-        expected_config = qml.devices.ExecutionConfig(
+        expected_config = qp.devices.ExecutionConfig(
             interface=interface,
             gradient_keyword_arguments={},
             use_device_jacobian_product=False,
@@ -2137,31 +2137,31 @@ class TestSetShots:
             PennyLaneDeprecationWarning,
             match="shots on device is deprecated",
         ):
-            dev_with_shots = qml.device("default.qubit", wires=1, shots=42)
-        qn_with_device_shots = qml.QNode(dummyfunc, dev_with_shots)
-        assert qn_with_device_shots._shots == qml.measurements.Shots(42)
+            dev_with_shots = qp.device("default.qubit", wires=1, shots=42)
+        qn_with_device_shots = qp.QNode(dummyfunc, dev_with_shots)
+        assert qn_with_device_shots._shots == qp.measurements.Shots(42)
 
         # Test that QNode defaults to analytic mode when device has no shots
-        dev_analytic = qml.device("default.qubit", wires=1)
-        qnode_analytic = qml.QNode(dummyfunc, dev_analytic)
+        dev_analytic = qp.device("default.qubit", wires=1)
+        qnode_analytic = qp.QNode(dummyfunc, dev_analytic)
         assert qnode_analytic._shots.total_shots is None
 
         # Test that qnode creation with shots parameter initializes _shots correctly
-        qn_with_shots = qml.QNode(dummyfunc, dev_with_shots)
-        assert qn_with_shots._shots == qml.measurements.Shots(42)
+        qn_with_shots = qp.QNode(dummyfunc, dev_with_shots)
+        assert qn_with_shots._shots == qp.measurements.Shots(42)
 
     def test_shots_override_warning(self):
         """Test that a warning is raised when both set_shots transform and shots parameter are used."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         # First apply set_shots to override device shots
-        modified_circuit = qml.set_shots(circuit, shots=50)
-        assert modified_circuit._shots == qml.measurements.Shots(50)
+        modified_circuit = qp.set_shots(circuit, shots=50)
+        assert modified_circuit._shots == qp.measurements.Shots(50)
         assert modified_circuit._shots_override_device is True
 
         # Then try to pass shots parameter when calling the QNode
@@ -2181,79 +2181,79 @@ class TestSetShots:
 
     def test_set_shots_direct_decorator(self):
         """Test set_shots with partial decorator syntax."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(shots=50)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
-        assert circuit._shots == qml.measurements.Shots(50)
+        assert circuit._shots == qp.measurements.Shots(50)
         result = circuit()
         assert len(result) == 50
 
     def test_set_shots_partial_decorator(self):
         """Test set_shots with partial decorator syntax."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(shots=50)
-        @qml.set_shots(10)
-        @qml.qnode(dev)
+        @qp.set_shots(10)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
-        assert circuit._shots == qml.measurements.Shots(50)
+        assert circuit._shots == qp.measurements.Shots(50)
         result = circuit()
         assert len(result) == 50
 
     def test_set_shots_direct_application_argshots(self):
         """Test applying set_shots directly to an existing QNode."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(10)
-        @qml.qnode(dev)
+        @qp.set_shots(10)
+        @qp.qnode(dev)
         def original_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         # Apply set_shots directly
         new_circuit = set_shots(original_circuit, 75)
 
-        assert original_circuit._shots == qml.measurements.Shots(10)
-        assert new_circuit._shots == qml.measurements.Shots(75)
+        assert original_circuit._shots == qp.measurements.Shots(10)
+        assert new_circuit._shots == qp.measurements.Shots(75)
 
         result = new_circuit()
         assert len(result) == 75
 
     def test_set_shots_direct_application(self):
         """Test applying set_shots directly to an existing QNode."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(10)
-        @qml.qnode(dev)
+        @qp.set_shots(10)
+        @qp.qnode(dev)
         def original_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         # Apply set_shots directly
         new_circuit = set_shots(original_circuit, shots=75)
 
-        assert original_circuit._shots == qml.measurements.Shots(10)
-        assert new_circuit._shots == qml.measurements.Shots(75)
+        assert original_circuit._shots == qp.measurements.Shots(10)
+        assert new_circuit._shots == qp.measurements.Shots(75)
 
         result = new_circuit()
         assert len(result) == 75
 
     def test_set_shots_with_shot_vector(self):
         """Test set_shots with shot vectors."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         shot_vector = [(10, 3), (5, 2)]  # 10 shots × 3 times, 5 shots × 2 times
         new_circuit = set_shots(circuit, shots=shot_vector)
@@ -2266,36 +2266,36 @@ class TestSetShots:
 
     def test_set_shots_analytic_mode(self):
         """Test set_shots with None for analytic mode."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(shots=None)
-        @qml.set_shots(100)
-        @qml.qnode(dev)
+        @qp.set_shots(100)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit._shots is None or circuit._shots.total_shots is None
         result = circuit()
         assert isinstance(result, (float, np.floating))
-        assert qml.math.allclose(result, np.cos(1.0))
+        assert qp.math.allclose(result, np.cos(1.0))
 
     def test_set_shots_preserves_original_qnode(self):
         """Test that set_shots creates a new QNode without modifying the original."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(20)
-        @qml.qnode(dev)
+        @qp.set_shots(20)
+        @qp.qnode(dev)
         def original_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         new_circuit = set_shots(original_circuit, shots=100)
 
         # Original should be unchanged
-        assert original_circuit._shots == qml.measurements.Shots(20)
+        assert original_circuit._shots == qp.measurements.Shots(20)
         # New circuit should have updated shots
-        assert new_circuit._shots == qml.measurements.Shots(100)
+        assert new_circuit._shots == qp.measurements.Shots(100)
 
         # Both should be different objects
         assert original_circuit is not new_circuit
@@ -2328,14 +2328,14 @@ class TestSetShots:
 
     def test_set_shots_with_measurements_requiring_shots(self):
         """Test set_shots works correctly with measurements that require shots."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         @set_shots(shots=1000)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.counts()
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.counts()
 
         result = circuit()
         assert isinstance(result, dict)
@@ -2343,12 +2343,12 @@ class TestSetShots:
 
     def test_set_shots_preserves_qnode_properties(self):
         """Test that set_shots preserves other QNode properties."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev, diff_method="parameter-shift", interface="autograd")
+        @qp.qnode(dev, diff_method="parameter-shift", interface="autograd")
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         new_circuit = set_shots(circuit, shots=100)
 
@@ -2368,17 +2368,17 @@ class TestSetShots:
         self, original_shots, override_shots, expected_tracking
     ):
         """Test that QNode shots properly override device shots during execution."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(original_shots)
-        @qml.qnode(dev, diff_method=None)
+        @qp.set_shots(original_shots)
+        @qp.qnode(dev, diff_method=None)
         def circuit():
-            qml.RX(1.23, wires=0)
-            return qml.probs(wires=0)
+            qp.RX(1.23, wires=0)
+            return qp.probs(wires=0)
 
         # Test override behavior
         modified_circuit = set_shots(circuit, shots=override_shots)
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             modified_circuit()
 
         if expected_tracking == "no_tracking":
@@ -2395,39 +2395,39 @@ class TestSetShots:
     )
     def test_diff_method_adaptation(self, device_shots, override_shots, expected_executions):
         """Test that diff_method adapts when shots change."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.set_shots(device_shots)
-        @qml.qnode(dev, diff_method="best")
+        @qp.set_shots(device_shots)
+        @qp.qnode(dev, diff_method="best")
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        param = qml.numpy.array(0.5, requires_grad=True)
+        param = qp.numpy.array(0.5, requires_grad=True)
 
         # Test original execution count
-        with qml.Tracker(dev) as tracker:
-            qml.grad(circuit)(param)
+        with qp.Tracker(dev) as tracker:
+            qp.grad(circuit)(param)
         assert len(tracker.history["executions"]) == expected_executions[0]
 
         # Test modified execution count
         modified_circuit = set_shots(circuit, shots=override_shots)
-        with qml.Tracker(dev) as tracker:
-            qml.grad(modified_circuit)(param)
+        with qp.Tracker(dev) as tracker:
+            qp.grad(modified_circuit)(param)
         assert len(tracker.history["executions"]) == expected_executions[1]
 
     def test_set_shots_integer_to_shot_vector(self):
         """Test converting from integer shots to shot vector."""
-        dev = qml.device("default.qubit", wires=1)  # Start with integer shots
+        dev = qp.device("default.qubit", wires=1)  # Start with integer shots
 
-        @qml.set_shots(50)
-        @qml.qnode(dev)
+        @qp.set_shots(50)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         # Verify original has integer shots
-        assert circuit._shots == qml.measurements.Shots(50)
+        assert circuit._shots == qp.measurements.Shots(50)
         original_result = circuit()
         assert len(original_result) == 50
         assert not isinstance(original_result, tuple)  # Single array, not tuple of arrays
@@ -2452,15 +2452,15 @@ class TestSetShots:
         assert len(vector_result[4]) == 15  # Fifth group: 15 shots
 
         # Original circuit should be unchanged
-        assert circuit._shots == qml.measurements.Shots(50)
+        assert circuit._shots == qp.measurements.Shots(50)
 
     def test_no_warning_if_shots_not_updated(self):
         """Test that no warning is raised if set_shots is called but the shots value is unchanged."""
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            return qml.sample(qml.PauliZ(0))
+            return qp.sample(qp.PauliZ(0))
 
         # No warning should be raised when calling with the same shots value
         with warnings.catch_warnings(record=True) as record:
@@ -2482,12 +2482,12 @@ class TestSetShots:
 
     def test_no_warning_if_shots_not_updated_set_shots(self):
         """Test that no warning is raised if set_shots is called but the shots value is unchanged."""
-        dev = qml.device("default.qubit")
+        dev = qp.device("default.qubit")
 
-        @qml.set_shots(shots=100)
-        @qml.qnode(dev)
+        @qp.set_shots(shots=100)
+        @qp.qnode(dev)
         def circuit():
-            return qml.sample(qml.PauliZ(0))
+            return qp.sample(qp.PauliZ(0))
 
         # No warning should be raised when calling with the same shots value
         result = circuit.update(diff_method="parameter-shift")()
@@ -2495,16 +2495,16 @@ class TestSetShots:
 
     def test_set_shots_positional_preserves_qnode_properties(self):
         """Test that @set_shots(500) preserves QNode properties."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(100)
-        @qml.qnode(dev, diff_method="parameter-shift", interface="autograd")
+        @qp.qnode(dev, diff_method="parameter-shift", interface="autograd")
         def circuit(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # Check that shots are set correctly
-        assert circuit._shots == qml.measurements.Shots(100)
+        assert circuit._shots == qp.measurements.Shots(100)
 
         # Check that other properties are preserved
         assert circuit.diff_method == "parameter-shift"
@@ -2513,45 +2513,45 @@ class TestSetShots:
 
     def test_set_shots_positional_decorator_integer(self):
         """Test @set_shots(500) positional decorator syntax with integer shots."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(500)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
-        assert circuit._shots == qml.measurements.Shots(500)
+        assert circuit._shots == qp.measurements.Shots(500)
         result = circuit()
         assert len(result) == 500
 
     def test_set_shots_positional_decorator_none(self):
         """Test @set_shots(None) positional decorator syntax for analytic mode."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(None)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit._shots is None or circuit._shots.total_shots is None
         result = circuit()
         assert isinstance(result, (float, np.floating))
         # Analytic result should be cos(1.0)
-        assert qml.math.allclose(result, np.cos(1.0))
+        assert qp.math.allclose(result, np.cos(1.0))
 
     def test_set_shots_positional_decorator_shot_vector(self):
         """Test @set_shots(shot_vector) positional decorator syntax with shot vectors."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         shot_vector = [(20, 2), (15, 3)]  # 20 shots × 2, 15 shots × 3
 
         @set_shots(shot_vector)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.sample(qp.PauliZ(0))
 
         assert circuit._shots.total_shots == 85  # 20*2 + 15*3
         assert circuit._shots.shot_vector == ((20, 2), (15, 3))
@@ -2561,19 +2561,19 @@ class TestSetShots:
 
     def test_set_shots_positional_vs_keyword_equivalence(self):
         """Test that @set_shots(500) and @set_shots(shots=500) are equivalent."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(None)  # Use analytic mode for exact comparison
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def positional_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         @set_shots(shots=None)  # Use analytic mode for exact comparison
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def keyword_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # Both should have analytic mode
         assert positional_circuit._shots is None or positional_circuit._shots.total_shots is None
@@ -2582,27 +2582,27 @@ class TestSetShots:
         # Both should produce the same results for analytic case
         pos_result = positional_circuit()
         kw_result = keyword_circuit()
-        assert qml.math.allclose(pos_result, kw_result)
+        assert qp.math.allclose(pos_result, kw_result)
 
         # Should equal the expected analytic result
         expected = np.cos(1.0)
-        assert qml.math.allclose(pos_result, expected)
-        assert qml.math.allclose(kw_result, expected)
+        assert qp.math.allclose(pos_result, expected)
+        assert qp.math.allclose(kw_result, expected)
 
     def test_set_shots_positional_vs_direct_equivalence(self):
         """Test that @set_shots(500) and set_shots(qnode, shots=500) are equivalent."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def base_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         @set_shots(None)  # Use analytic mode for exact comparison
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def positional_circuit():
-            qml.RX(1.0, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # Apply set_shots directly to base circuit
         direct_circuit = set_shots(base_circuit, shots=None)
@@ -2614,28 +2614,28 @@ class TestSetShots:
         # Both should produce the same results
         pos_result = positional_circuit()
         direct_result = direct_circuit()
-        assert qml.math.allclose(pos_result, direct_result)
+        assert qp.math.allclose(pos_result, direct_result)
 
         # Should equal the expected analytic result
         expected = np.cos(1.0)
-        assert qml.math.allclose(pos_result, expected)
-        assert qml.math.allclose(direct_result, expected)
+        assert qp.math.allclose(pos_result, expected)
+        assert qp.math.allclose(direct_result, expected)
 
     def test_set_shots_positional_analytic_vs_shot_difference(self):
         """Test that @set_shots(None) vs @set_shots(1000) produce different behaviors."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(None)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def analytic_circuit():
-            qml.Hadamard(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         @set_shots(1000)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def shot_circuit():
-            qml.Hadamard(wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # Analytic should be exactly 0.0
         analytic_results = [analytic_circuit() for _ in range(10)]
@@ -2649,15 +2649,15 @@ class TestSetShots:
 
     def test_set_shots_positional_complex_shot_patterns(self):
         """Test @set_shots with complex shot patterns."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         # Test with tuple (shots, copies) format
         @set_shots([(10, 5), (20, 3), 50])
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.sample()
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.sample()
 
         # Total shots: 10*5 + 20*3 + 50 = 50 + 60 + 50 = 160
         assert circuit._shots.total_shots == 160
@@ -2668,36 +2668,36 @@ class TestSetShots:
 
     def test_set_shots_positional_nested_decorators(self):
         """Test @set_shots works with other decorators."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.transforms.cancel_inverses  # Another transform
+        @qp.transforms.cancel_inverses  # Another transform
         @set_shots(250)
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(1.0, wires=0)
-            qml.RX(-1.0, wires=0)  # Should be cancelled
-            return qml.sample(qml.PauliZ(0))
+            qp.RX(1.0, wires=0)
+            qp.RX(-1.0, wires=0)  # Should be cancelled
+            return qp.sample(qp.PauliZ(0))
 
-        assert circuit._shots == qml.measurements.Shots(250)
+        assert circuit._shots == qp.measurements.Shots(250)
         result = circuit()
         assert len(result) == 250
 
     def test_set_shots_positional_multiple_calls_consistent(self):
         """Test that @set_shots(500) produces consistent behavior across multiple calls."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @set_shots(None)  # Analytic mode
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.RX(0.5, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(0.5, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # Multiple calls should give exactly the same result in analytic mode
         results = [circuit() for _ in range(5)]
         expected = np.cos(0.5)
 
         for result in results:
-            assert qml.math.allclose(result, expected)
+            assert qp.math.allclose(result, expected)
 
         # All results should be identical
-        assert all(qml.math.allclose(results[0], r) for r in results[1:])
+        assert all(qp.math.allclose(results[0], r) for r in results[1:])

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -405,7 +405,7 @@ class TestTapeConstruction:
         jitted_qnode2 = jax.jit(circuit2)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
+            NotImplementedError, match=r"The JAX-JIT interface doesn't support \w+.counts."
         ):
             jitted_qnode2(0.123)
 

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -24,7 +24,7 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 from scipy.sparse import csr_matrix
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import QNode
 from pennylane import numpy as pnp
 from pennylane import qnode
@@ -39,7 +39,7 @@ def dummyfunc():
     return None
 
 
-class DummyDevice(qml.devices.LegacyDevice):
+class DummyDevice(qp.devices.LegacyDevice):
     """A minimal device that does not do anything."""
 
     author = "some string"
@@ -101,8 +101,8 @@ class TestValidation:
         @qnode(dev)
         def circuit(x):
             """a circuit."""
-            qml.RX(x, wires=0)
-            return qml.probs(wires=0)
+            qp.RX(x, wires=0)
+            return qp.probs(wires=0)
 
         expected_error = rf"'{test_interface}' is not a valid Interface\. Please use one of the supported interfaces: \[.*\]\."
 
@@ -146,10 +146,10 @@ class TestValidation:
             match="does not support adjoint with requested circuit.",
         ):
 
-            @qml.set_shots(1)
+            @qp.set_shots(1)
             @qnode(dev, diff_method="adjoint")
             def circ():
-                return qml.expval(qml.PauliZ(0))
+                return qp.expval(qp.PauliZ(0))
 
             circ()
 
@@ -161,22 +161,22 @@ class TestValidation:
 
         @qnode(dev, diff_method="backprop")
         def circuit(param):
-            qml.RX(param, wires=0)
-            return qml.expval(qml.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
+            qp.RX(param, wires=0)
+            return qp.expval(qp.SparseHamiltonian(csr_matrix(np.eye(4)), [0, 1]))
 
         with pytest.raises(
             QuantumFunctionError,
             match="does not support backprop with requested circuit.",
         ):
-            qml.grad(circuit, argnums=0)([0.5])
+            qp.grad(circuit, argnums=0)([0.5])
 
     def test_qnode_print(self):
         """Test that printing a QNode object yields the right information."""
         dev = DefaultQubitLegacy(wires=1)
 
         def func(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(func, dev)
 
@@ -196,7 +196,7 @@ class TestValidation:
         assert np.allclose(qn(0.5), np.cos(0.5), rtol=0)
 
         with pytest.warns(UserWarning, match="Attempted to differentiate a function with no"):
-            grad = qml.grad(qn)(0.5)
+            grad = qp.grad(qn)(0.5)
 
         assert np.allclose(grad, 0)
 
@@ -204,13 +204,13 @@ class TestValidation:
         """Test that checks that the tracker is switched to the new device."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(params):
-            qml.RX(params, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(params, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        with qml.Tracker(dev) as tracker:
-            circuit(qml.numpy.array(0.1, requires_grad=True))
+        with qp.Tracker(dev) as tracker:
+            circuit(qp.numpy.array(0.1, requires_grad=True))
 
         assert tracker.totals == {"executions": 1, "batches": 1, "batch_len": 1}
         assert np.allclose(tracker.history.pop("results")[0], 0.99500417)
@@ -235,18 +235,18 @@ class TestValidation:
         except for the deprecation warnings which will be caught by the fixture."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.qnode(dev, interface="autograd")
+        @qp.qnode(dev, interface="autograd")
         def circuit(params):
-            qml.RX(params, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(params, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-        circuit(qml.numpy.array(0.1, requires_grad=True))
+        circuit(qp.numpy.array(0.1, requires_grad=True))
 
     def test_not_giving_mode_kwarg_does_not_raise_warning(self):
         """Test that not providing a value for mode does not raise a warning."""
 
         with warnings.catch_warnings(record=True) as record:
-            qml.QNode(lambda f: f, DefaultQubitLegacy(wires=1))
+            qp.QNode(lambda f: f, DefaultQubitLegacy(wires=1))
 
         assert len(record) == 0
 
@@ -259,10 +259,10 @@ class TestTapeConstruction:
         dev = DefaultQubitLegacy(wires=2)
 
         def func(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
         qn = QNode(func, dev)
 
@@ -270,7 +270,7 @@ class TestTapeConstruction:
         y = pnp.array(0.54, requires_grad=True)
 
         res = qn(x, y)
-        tape = qml.workflow.construct_tape(qn)(x, y)
+        tape = qp.workflow.construct_tape(qn)(x, y)
 
         assert isinstance(tape, QuantumScript)
         assert len(tape.operations) == 3
@@ -278,13 +278,13 @@ class TestTapeConstruction:
         assert tape.num_params == 2
         assert tape.shots.total_shots is None
 
-        expected = qml.execute([tape], dev, None)
+        expected = qp.execute([tape], dev, None)
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
         # when called, a new quantum tape is constructed
         old_tape = tape
         res2 = qn(x, y)
-        new_tape = qml.workflow.construct_tape(qn)(x, y)
+        new_tape = qp.workflow.construct_tape(qn)(x, y)
 
         assert np.allclose(res, res2, atol=tol, rtol=0)
         assert new_tape is not old_tape
@@ -295,9 +295,9 @@ class TestTapeConstruction:
         dev = DefaultQubitLegacy(wires=2)
 
         def func0(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
             return 5
 
         qn = QNode(func0, dev)
@@ -306,10 +306,10 @@ class TestTapeConstruction:
             qn(5, 1)
 
         def func2(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0)), 5
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0)), 5
 
         qn = QNode(func2, dev)
 
@@ -317,9 +317,9 @@ class TestTapeConstruction:
             qn(5, 1)
 
         def func3(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
             return []
 
         qn = QNode(func3, dev)
@@ -333,11 +333,11 @@ class TestTapeConstruction:
         dev = DefaultQubitLegacy(wires=2)
 
         def func(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            qml.CNOT(wires=[0, 1])
-            m = qml.expval(qml.PauliZ(0))
-            return qml.expval(qml.PauliX(1)), m
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.CNOT(wires=[0, 1])
+            m = qp.expval(qp.PauliZ(0))
+            return qp.expval(qp.PauliX(1)), m
 
         qn = QNode(func, dev)
 
@@ -355,11 +355,11 @@ class TestTapeConstruction:
         contents = []
 
         def func(x, y):
-            op1 = qml.RX(x, wires=0)
-            op2 = qml.RY(y, wires=1)
-            op3 = qml.CNOT(wires=[0, 1])
-            m1 = qml.expval(qml.PauliZ(0))
-            m2 = qml.expval(qml.PauliX(1))
+            op1 = qp.RX(x, wires=0)
+            op2 = qp.RY(y, wires=1)
+            op3 = qp.CNOT(wires=[0, 1])
+            m1 = qp.expval(qp.PauliZ(0))
+            m2 = qp.expval(qp.PauliX(1))
             contents.append(op1)
             contents.append(op2)
             contents.append(op3)
@@ -368,7 +368,7 @@ class TestTapeConstruction:
             return [m1, m2]
 
         qn = QNode(func, dev)
-        tape = qml.workflow.construct_tape(qn)(5, 1)
+        tape = qp.workflow.construct_tape(qn)(5, 1)
         assert tape.operations == contents[0:3]
         assert tape.measurements == contents[3:]
 
@@ -381,31 +381,31 @@ class TestTapeConstruction:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit1(param):
-            qml.Hadamard(0)
-            qml.RX(param, wires=1)
-            qml.CNOT([1, 0])
-            return qml.counts()
+            qp.Hadamard(0)
+            qp.RX(param, wires=1)
+            qp.CNOT([1, 0])
+            return qp.counts()
 
-        qn = qml.set_shots(qml.QNode(circuit1, dev), shots=5)
+        qn = qp.set_shots(qp.QNode(circuit1, dev), shots=5)
         jitted_qnode1 = jax.jit(qn)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
+            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
         ):
             jitted_qnode1(0.123)
 
         # Test with qnode decorator syntax
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit2(param):
-            qml.Hadamard(0)
-            qml.RX(param, wires=1)
-            qml.CNOT([1, 0])
-            return qml.counts()
+            qp.Hadamard(0)
+            qp.RX(param, wires=1)
+            qp.CNOT([1, 0])
+            return qp.counts()
 
         jitted_qnode2 = jax.jit(circuit2)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qml.counts."
+            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
         ):
             jitted_qnode2(0.123)
 
@@ -417,10 +417,10 @@ def test_decorator(tol):
     @qnode(dev)
     def func(x, y):
         """My function docstring"""
-        qml.RX(x, wires=0)
-        qml.RY(y, wires=1)
-        qml.CNOT(wires=[0, 1])
-        return qml.expval(qml.PauliZ(0))
+        qp.RX(x, wires=0)
+        qp.RY(y, wires=1)
+        qp.CNOT(wires=[0, 1])
+        return qp.expval(qp.PauliZ(0))
 
     assert isinstance(func, QNode)
     assert func.__doc__ == "My function docstring"
@@ -429,20 +429,20 @@ def test_decorator(tol):
     y = pnp.array(0.54, requires_grad=True)
 
     res = func(x, y)
-    tape = qml.workflow.construct_tape(func)(x, y)
+    tape = qp.workflow.construct_tape(func)(x, y)
 
     assert isinstance(tape, QuantumScript)
     assert len(tape.operations) == 3
     assert len(tape.observables) == 1
     assert tape.num_params == 2
 
-    expected = qml.execute([tape], dev, None)
+    expected = qp.execute([tape], dev, None)
     assert np.allclose(res, expected, atol=tol, rtol=0)
 
     # when called, a new quantum tape is constructed
     old_tape = tape
     res2 = func(x, y)
-    new_tape = qml.workflow.construct_tape(func)(x, y)
+    new_tape = qp.workflow.construct_tape(func)(x, y)
 
     assert np.allclose(res, res2, atol=tol, rtol=0)
     assert new_tape is not old_tape
@@ -456,9 +456,9 @@ class TestIntegration:
         """Test that number of executions are tracked in the autograd interface."""
 
         def func():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
         dev = DefaultQubitLegacy(wires=2)
         qn = QNode(func, dev, interface="autograd")
@@ -480,9 +480,9 @@ class TestIntegration:
         """Test that number of executions are tracked in the tf interface."""
 
         def func():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
         dev = DefaultQubitLegacy(wires=2)
         qn = QNode(func, dev, interface=interface)
@@ -509,9 +509,9 @@ class TestIntegration:
         """Test that number of executions are tracked in the torch interface."""
 
         def func():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
         dev = DefaultQubitLegacy(wires=2)
         qn = QNode(func, dev, interface=interface)
@@ -540,10 +540,10 @@ class TestIntegration:
 
         cache = {}
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit():
-            qml.RY(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RY(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         for _ in range(15):
             circuit()
@@ -561,18 +561,18 @@ class TestIntegration:
 
         cache = {}
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit0():
-            qml.RY(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RY(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         for _ in range(15):
             circuit0()
 
-        @qml.qnode(dev, diff_method="backprop", cache=cache)
+        @qp.qnode(dev, diff_method="backprop", cache=cache)
         def circuit2():
-            qml.RZ(0.345, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(0.345, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         for _ in range(15):
             circuit2()
@@ -605,12 +605,12 @@ class TestIntegration:
             dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs
         )  # <--- we only choose one trainable parameter
         def circuit(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        res = qml.grad(circuit)(x, y)
+        res = qp.grad(circuit)(x, y)
         assert len(res) == 2
 
         expected = (0, np.cos(y) * np.cos(x))
@@ -622,50 +622,50 @@ class TestIntegration:
         QNode construction if the device supports mid-circuit measurements."""
         dev = DefaultQubitLegacy(wires=3)
         mocker.patch.object(
-            qml.devices.LegacyDevice, "_capabilities", {"supports_mid_measure": True}
+            qp.devices.LegacyDevice, "_capabilities", {"supports_mid_measure": True}
         )
-        spy = mocker.spy(qml.defer_measurements, "_tape_transform")
+        spy = mocker.spy(qp.defer_measurements, "_tape_transform")
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.PauliX(0)
-            qml.measure(0)
-            return qml.expval(qml.PauliZ(1))
+            qp.PauliX(0)
+            qp.measure(0)
+            return qp.expval(qp.PauliZ(1))
 
         circuit.construct(tuple(), {})
 
         spy.assert_not_called()
-        tape = qml.workflow.construct_tape(circuit)()
+        tape = qp.workflow.construct_tape(circuit)()
         assert len(tape.operations) == 2
-        assert isinstance(tape.operations[1], qml.ops.MidMeasure)
+        assert isinstance(tape.operations[1], qp.ops.MidMeasure)
 
     @pytest.mark.parametrize("basis_state", [[1, 0], [0, 1]])
     def test_sampling_with_mcm(self, basis_state, mocker):
-        """Tests that a QNode with qml.sample and mid-circuit measurements
+        """Tests that a QNode with qp.sample and mid-circuit measurements
         returns the expected results."""
         dev = DefaultQubitLegacy(wires=3)
 
         first_par = np.pi
 
-        @qml.set_shots(1000)
-        @qml.qnode(dev)
+        @qp.set_shots(1000)
+        @qp.qnode(dev)
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.BasisState(basis_state, wires=[0, 1])
-            qml.CRY(x, wires=[0, 1])
-            return qml.sample(qml.PauliZ(1))
+            qp.BasisState(basis_state, wires=[0, 1])
+            qp.CRY(x, wires=[0, 1])
+            return qp.sample(qp.PauliZ(1))
 
-        @qml.set_shots(1000)
-        @qml.qnode(dev)
+        @qp.set_shots(1000)
+        @qp.qnode(dev)
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.BasisState(basis_state, wires=[0, 1])
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.sample(qml.PauliZ(1))
+            qp.BasisState(basis_state, wires=[0, 1])
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.sample(qp.PauliZ(1))
 
-        spy = mocker.spy(qml.defer_measurements, "_tape_transform")
+        spy = mocker.spy(qp.defer_measurements, "_tape_transform")
         r1 = cry_qnode(first_par)
         r2 = conditional_ry_qnode(first_par)
         assert np.allclose(r1, r2)
@@ -679,24 +679,24 @@ class TestIntegration:
 
         dev = DefaultQubitLegacy(wires=3)
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
-        @qml.defer_measurements
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.defer_measurements
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         x_ = -0.654
         x1 = tf.Variable(x_, dtype=tf.float64)
@@ -722,23 +722,23 @@ class TestIntegration:
 
         dev = DefaultQubitLegacy(wires=3)
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=interface, diff_method="parameter-shift")
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         x1 = torch.tensor(-0.654, dtype=torch.float64, requires_grad=True)
         x2 = torch.tensor(-0.654, dtype=torch.float64, requires_grad=True)
@@ -761,23 +761,23 @@ class TestIntegration:
         jnp = jax.numpy
         dev = DefaultQubitLegacy(wires=3)
 
-        @qml.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
         def cry_qnode(x):
             """QNode where we apply a controlled Y-rotation."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            qml.CRY(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            qp.CRY(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(1))
 
-        @qml.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
+        @qp.qnode(dev, interface=jax_interface, diff_method="parameter-shift")
         def conditional_ry_qnode(x):
             """QNode where the defer measurements transform is applied by
             default under the hood."""
-            qml.Hadamard(1)
-            qml.RY(1.234, wires=0)
-            m_0 = qml.measure(0)
-            qml.cond(m_0, qml.RY)(x, wires=1)
-            return qml.expval(qml.PauliZ(1))
+            qp.Hadamard(1)
+            qp.RY(1.234, wires=0)
+            m_0 = qp.measure(0)
+            qp.cond(m_0, qp.RY)(x, wires=1)
+            return qp.expval(qp.PauliZ(1))
 
         x1 = jnp.array(-0.654)
         x2 = jnp.array(-0.654)
@@ -792,15 +792,15 @@ class TestIntegration:
         """Test that operators in QNodes are not queued to surrounding contexts."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.PauliZ(0)
-            return qml.expval(qml.PauliX(0))
+            qp.PauliZ(0)
+            return qp.expval(qp.PauliX(0))
 
-        with qml.queuing.AnnotatedQueue() as q:
+        with qp.queuing.AnnotatedQueue() as q:
             circuit()
 
-        tape = qml.workflow.construct_tape(circuit)()
+        tape = qp.workflow.construct_tape(circuit)()
         assert q.queue == []  # pylint: disable=use-implicit-booleaness-not-comparison
         assert len(tape.operations) == 1
 
@@ -818,10 +818,10 @@ class TestShots:
             dev = DefaultQubitLegacy(wires=1, shots=10)
 
             @qnode(dev)
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def circuit(a):
-                qml.RX(a, wires=0)
-                return qml.sample(qml.PauliZ(wires=0))
+                qp.RX(a, wires=0)
+                return qp.sample(qp.PauliZ(wires=0))
 
             assert len(circuit(0.8)) == 10
             with pytest.warns(
@@ -840,8 +840,8 @@ class TestShots:
 
         @qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            return qml.expval(qml.PauliZ(wires=0))
+            qp.Hadamard(wires=0)
+            return qp.expval(qp.PauliZ(wires=0))
 
         # check that the circuit is analytic
         res1 = [circuit() for _ in range(100)]
@@ -869,8 +869,8 @@ class TestShots:
         dev = DefaultQubitLegacy(wires=2, shots=10)
 
         def circuit(a, shots=0):
-            qml.RX(a, wires=shots)
-            return qml.sample(qml.PauliZ(wires=0))
+            qp.RX(a, wires=shots)
+            return qp.sample(qp.PauliZ(wires=0))
 
         with pytest.warns(
             PennyLaneDeprecationWarning,
@@ -882,15 +882,15 @@ class TestShots:
                 circuit = QNode(circuit, dev)
 
         assert len(circuit(0.8)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8)
+        tape = qp.workflow.construct_tape(circuit)(0.8)
         assert tape.operations[0].wires.labels == (0,)
 
         assert len(circuit(0.8, shots=1)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, shots=1)
+        tape = qp.workflow.construct_tape(circuit)(0.8, shots=1)
         assert tape.operations[0].wires.labels == (1,)
 
         assert len(circuit(0.8, shots=0)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, shots=0)
+        tape = qp.workflow.construct_tape(circuit)(0.8, shots=0)
         assert tape.operations[0].wires.labels == (0,)
 
     # pylint: disable=unexpected-keyword-arg
@@ -900,8 +900,8 @@ class TestShots:
         dev = DefaultQubitLegacy(wires=[0, 1])
 
         def ansatz0(a, shots):
-            qml.RX(a, wires=shots)
-            return qml.sample(qml.PauliZ(wires=0))
+            qp.RX(a, wires=shots)
+            return qp.sample(qp.PauliZ(wires=0))
 
         # assert that warning is still raised
         with pytest.warns(
@@ -910,7 +910,7 @@ class TestShots:
             circuit = QNode(ansatz0, dev, shots=10)
 
         assert len(circuit(0.8, 1)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, 1)
+        tape = qp.workflow.construct_tape(circuit)(0.8, 1)
         assert tape.operations[0].wires.labels == (1,)
 
         dev = DefaultQubitLegacy(wires=2)
@@ -921,11 +921,11 @@ class TestShots:
 
             @qnode(dev, shots=10)
             def ansatz1(a, shots):
-                qml.RX(a, wires=shots)
-                return qml.sample(qml.PauliZ(wires=0))
+                qp.RX(a, wires=shots)
+                return qp.sample(qp.PauliZ(wires=0))
 
         assert len(ansatz1(0.8, shots=0)) == 10
-        tape = qml.workflow.construct_tape(circuit)(0.8, 0)
+        tape = qp.workflow.construct_tape(circuit)(0.8, 0)
         assert tape.operations[0].wires.labels == (0,)
 
     # pylint: disable=unexpected-keyword-arg
@@ -940,8 +940,8 @@ class TestShots:
 
             @qnode(dev)
             def circuit(a):
-                qml.RX(a, wires=0)
-                return qml.sample(qml.PauliZ(wires=0))
+                qp.RX(a, wires=0)
+                return qp.sample(qp.PauliZ(wires=0))
 
         assert dev.shots == 3
         with pytest.warns(
@@ -960,10 +960,10 @@ class TestShots:
             match="shots on device is deprecated",
         ):
 
-            @qml.qnode(dev, cache={})
+            @qp.qnode(dev, cache={})
             def circuit(x):
-                qml.RZ(x, wires=0)
-                return qml.expval(qml.PauliZ(0))
+                qp.RZ(x, wires=0)
+                return qp.expval(qp.PauliZ(0))
 
         # no warning on the first execution
         circuit(0.3)
@@ -975,40 +975,40 @@ class TestShots:
         """Tests that a warning is raised when caching is used with finite shots."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.set_shots(5)
-        @qml.qnode(dev, cache={})
+        @qp.set_shots(5)
+        @qp.qnode(dev, cache={})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         # no warning on the first execution
         circuit(0.3)
         with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
-            qml.set_shots(shots=5)(circuit)(0.3)
+            qp.set_shots(shots=5)(circuit)(0.3)
 
     def test_warning_finite_shots_tape(self):
         """Tests that a warning is raised when caching is used with finite shots."""
         dev = DefaultQubitLegacy(wires=1)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.RZ(0.3, wires=0)
-            qml.expval(qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.RZ(0.3, wires=0)
+            qp.expval(qp.PauliZ(0))
 
         tape = QuantumScript.from_queue(q, shots=5)
         # no warning on the first execution
         cache = {}
-        qml.execute([tape], dev, None, cache=cache)
+        qp.execute([tape], dev, None, cache=cache)
         with pytest.warns(UserWarning, match="Cached execution with finite shots detected"):
-            qml.execute([tape], dev, None, cache=cache)
+            qp.execute([tape], dev, None, cache=cache)
 
     def test_no_warning_infinite_shots(self):
         """Tests that no warning is raised when caching is used with infinite shots."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.qnode(dev, cache={})
+        @qp.qnode(dev, cache={})
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RZ(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message="Cached execution with finite shots detected")
@@ -1020,15 +1020,15 @@ class TestShots:
         """Tests that no warning is raised when only the internal cache is reused."""
         dev = DefaultQubitLegacy(wires=1)
 
-        @qml.set_shots(5)
-        @qml.qnode(dev, cache=True)
+        @qp.set_shots(5)
+        @qp.qnode(dev, cache=True)
         def circuit(x):
-            qml.RZ(x, wires=0)
-            return qml.probs(wires=0)
+            qp.RZ(x, wires=0)
+            return qp.probs(wires=0)
 
         with warnings.catch_warnings():
             warnings.filterwarnings("error", message="Cached execution with finite shots detected")
-            qml.jacobian(circuit, argnums=0)(0.3)
+            qp.jacobian(circuit, argnums=0)(0.3)
 
     # pylint: disable=unexpected-keyword-arg
     @pytest.mark.parametrize(
@@ -1045,9 +1045,9 @@ class TestShots:
         dev = DefaultQubitLegacy(wires=2, shots=5)
 
         def func(x, y):
-            qml.RX(x, wires=0)
-            qml.RY(y, wires=1)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
 
         with pytest.warns(
             PennyLaneDeprecationWarning,
@@ -1057,7 +1057,7 @@ class TestShots:
             qn = QNode(func, dev)
 
         # No override
-        tape = qml.workflow.construct_tape(qn)(0.1, 0.2)
+        tape = qp.workflow.construct_tape(qn)(0.1, 0.2)
         assert tape.shots.total_shots == 5
 
         # Override
@@ -1065,7 +1065,7 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="Specifying 'shots' when executing a QNode is deprecated",
         ):
-            tape = qml.workflow.construct_tape(qn)(0.1, 0.2, shots=shots)
+            tape = qp.workflow.construct_tape(qn)(0.1, 0.2, shots=shots)
         assert tape.shots.total_shots == total_shots
         assert tape.shots.shot_vector == shot_vector
 
@@ -1077,12 +1077,12 @@ class TestShots:
 
             @qnode(dev)
             def qn2(x, y):
-                qml.RX(x, wires=0)
-                qml.RY(y, wires=1)
-                return qml.expval(qml.PauliZ(0))
+                qp.RX(x, wires=0)
+                qp.RY(y, wires=1)
+                return qp.expval(qp.PauliZ(0))
 
         # No override
-        tape = qml.workflow.construct_tape(qn2)(0.1, 0.2)
+        tape = qp.workflow.construct_tape(qn2)(0.1, 0.2)
         assert tape.shots.total_shots == 5
 
         # Override
@@ -1090,7 +1090,7 @@ class TestShots:
             PennyLaneDeprecationWarning,
             match="Specifying 'shots' when executing a QNode is deprecated",
         ):
-            tape = qml.workflow.construct_tape(qn2)(0.1, 0.2, shots=shots)
+            tape = qp.workflow.construct_tape(qn2)(0.1, 0.2, shots=shots)
         assert tape.shots.total_shots == total_shots
         assert tape.shots.shot_vector == shot_vector
 
@@ -1103,23 +1103,23 @@ class TestCompilePipelineIntegration:
         def null_postprocessing(results):
             return results[0]
 
-        @qml.transform
+        @qp.transform
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript([qml.PauliX(0)], tape.measurements),
+                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
             ), null_postprocessing
 
         @just_pauli_x_out
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.compile_pipeline[0].tape_transform == just_pauli_x_out.tape_transform
 
-        assert qml.math.allclose(circuit(0.1), -1)
+        assert qp.math.allclose(circuit(0.1), -1)
 
         with circuit.device.tracker as tracker:
             circuit(0.1)
@@ -1133,25 +1133,25 @@ class TestCompilePipelineIntegration:
 
         dev = DefaultQubitLegacy(wires=2)
 
-        @qml.transform
+        @qp.transform
         def pin_result(
             tape: QuantumScript, requested_result
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            def postprocessing(_: qml.typing.ResultBatch) -> qml.typing.Result:
+            def postprocessing(_: qp.typing.ResultBatch) -> qp.typing.Result:
                 return requested_result
 
             return (tape,), postprocessing
 
         @pin_result(requested_result=3.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         assert circuit.compile_pipeline[0].tape_transform == pin_result.tape_transform
         assert circuit.compile_pipeline[0].kwargs == {"requested_result": 3.0}
 
-        assert qml.math.allclose(circuit(0.1), 3.0)
+        assert qp.math.allclose(circuit(0.1), 3.0)
 
     def test_transform_order_circuit_processing(self):
         """Test that transforms are applied in the correct order in integration."""
@@ -1161,44 +1161,44 @@ class TestCompilePipelineIntegration:
         def null_postprocessing(results):
             return results[0]
 
-        @qml.transform
+        @qp.transform
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript([qml.PauliX(0)], tape.measurements),
+                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
             ), null_postprocessing
 
-        @qml.transform
+        @qp.transform
         def repeat_operations(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            new_tape = qml.tape.QuantumScript(
+            new_tape = qp.tape.QuantumScript(
                 tape.operations + copy.deepcopy(tape.operations), tape.measurements
             )
             return (new_tape,), null_postprocessing
 
         @repeat_operations
         @just_pauli_x_out
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit1(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         with circuit1.device.tracker as tracker:
-            assert qml.math.allclose(circuit1(0.1), 1.0)
+            assert qp.math.allclose(circuit1(0.1), 1.0)
 
         assert tracker.history["resources"][0].gate_types["PauliX"] == 2
 
         @just_pauli_x_out
         @repeat_operations
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit2(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, 0)
+            return qp.expval(qp.PauliZ(0))
 
         with circuit2.device.tracker as tracker:
-            assert qml.math.allclose(circuit2(0.1), -1.0)
+            assert qp.math.allclose(circuit2(0.1), -1.0)
 
         assert tracker.history["resources"][0].gate_types["PauliX"] == 1
 
@@ -1213,59 +1213,59 @@ class TestCompilePipelineIntegration:
         def add_shift(results, shift):
             return results[0] + shift
 
-        @qml.transform
+        @qp.transform
         def scale_output(
             tape: QuantumScript, factor
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (tape,), partial(scale_by_factor, factor=factor)
 
-        @qml.transform
+        @qp.transform
         def shift_output(tape: QuantumScript, shift) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (tape,), partial(add_shift, shift=shift)
 
         @shift_output(shift=1.0)
         @scale_output(factor=2.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit1():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         # first add one, then scale by 2.0.  Outer postprocessing transforms are applied first
-        assert qml.math.allclose(circuit1(), 4.0)
+        assert qp.math.allclose(circuit1(), 4.0)
 
         @scale_output(factor=2.0)
         @shift_output(shift=1.0)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit2():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         # first scale by 2, then add one. Outer postprocessing transforms are applied first
-        assert qml.math.allclose(circuit2(), 3.0)
+        assert qp.math.allclose(circuit2(), 3.0)
 
     def test_scaling_shots_transform(self):
         """Test a transform that scales the number of shots used in an execution."""
 
         # note that this won't work with the old device interface :(
-        dev = qml.devices.DefaultQubit()
+        dev = qp.devices.DefaultQubit()
 
         def num_of_shots_from_sample(results):
             return len(results[0])
 
-        @qml.transform
+        @qp.transform
         def use_n_shots(tape: QuantumScript, n) -> tuple[QuantumScriptBatch, PostprocessingFn]:
             return (
-                qml.tape.QuantumScript(tape.operations, tape.measurements, shots=n),
+                qp.tape.QuantumScript(tape.operations, tape.measurements, shots=n),
             ), num_of_shots_from_sample
 
         @use_n_shots(n=100)
-        @qml.qnode(dev, interface=None, diff_method=None)
+        @qp.qnode(dev, interface=None, diff_method=None)
         def circuit():
-            return qml.sample(wires=0)
+            return qp.sample(wires=0)
 
         assert circuit() == 100
 
 
 # pylint: disable=unused-argument
-class CustomDevice(qml.devices.Device):
+class CustomDevice(qp.devices.Device):
     """A null device that just returns 0."""
 
     def __repr__(self):
@@ -1288,30 +1288,30 @@ class TestTapeExpansion:
         dev = DefaultQubitLegacy(wires=1)
 
         # pylint: disable=too-few-public-methods
-        class UnsupportedOp(qml.operation.Operation):
+        class UnsupportedOp(qp.operation.Operation):
             """custom unsupported op."""
 
             num_wires = 1
 
             def decomposition(self):
-                return [qml.RX(3 * self.data[0], wires=self.wires)]
+                return [qp.RX(3 * self.data[0], wires=self.wires)]
 
-        @qml.register_resources({qml.RX: 1})
+        @qp.register_resources({qp.RX: 1})
         def _decomp(param, wires):
-            qml.RX(3 * param, wires)
+            qp.RX(3 * param, wires)
 
         @qnode(dev, diff_method=diff_method, grad_on_execution=mode)
         def circuit(x):
             UnsupportedOp(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         if diff_method == "adjoint" and mode:
             spy = mocker.spy(circuit.device, "execute_and_compute_derivatives")
         else:
             spy = mocker.spy(circuit.device, "execute")
 
-        with qml.decomposition.local_decomps():
-            qml.add_decomps(UnsupportedOp, _decomp)
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(UnsupportedOp, _decomp)
             x = pnp.array(0.5)
             circuit(x)
 
@@ -1327,7 +1327,7 @@ class TestTapeExpansion:
         dev = DefaultQubitLegacy(wires=1)
 
         # pylint: disable=too-few-public-methods
-        class UnsupportedOp(qml.operation.Operation):
+        class UnsupportedOp(qp.operation.Operation):
             """custom unsupported op."""
 
             num_wires = 1
@@ -1336,26 +1336,26 @@ class TestTapeExpansion:
             grad_recipe = ([[3 / 2, 1, np.pi / 6], [-3 / 2, 1, -np.pi / 6]],)
 
             def decomposition(self):
-                return [qml.RX(3 * self.data[0], wires=self.wires)]
+                return [qp.RX(3 * self.data[0], wires=self.wires)]
 
-        with qml.decomposition.local_decomps():
+        with qp.decomposition.local_decomps():
 
-            @qml.register_resources({qml.RX: 1})
+            @qp.register_resources({qp.RX: 1})
             def _decomp(data, wires):
-                qml.RX(3 * data, wires)
+                qp.RX(3 * data, wires)
 
-            qml.add_decomps(UnsupportedOp, _decomp)
+            qp.add_decomps(UnsupportedOp, _decomp)
 
             @qnode(dev, interface="autograd", diff_method="parameter-shift", max_diff=2)
             def circuit(x):
                 UnsupportedOp(x, wires=0)
-                return qml.expval(qml.PauliZ(0))
+                return qp.expval(qp.PauliZ(0))
 
             x = pnp.array(0.5, requires_grad=True)
-            qml.grad(circuit)(x)
+            qp.grad(circuit)(x)
 
             # check second derivative
-            assert np.allclose(qml.grad(qml.grad(circuit))(x), -9 * np.cos(3 * x))
+            assert np.allclose(qp.grad(qp.grad(circuit))(x), -9 * np.cos(3 * x))
 
     @pytest.mark.autograd
     def test_gradient_expansion(self, mocker):
@@ -1364,53 +1364,53 @@ class TestTapeExpansion:
         dev = DefaultQubitLegacy(wires=1)
 
         # pylint: disable=too-few-public-methods
-        class PhaseShift(qml.PhaseShift):
+        class PhaseShift(qp.PhaseShift):
             """custom phase shift."""
 
             grad_method = None
 
             def decomposition(self):
-                return [qml.RY(3 * self.data[0], wires=self.wires)]
+                return [qp.RY(3 * self.data[0], wires=self.wires)]
 
-        with qml.decomposition.local_decomps():
+        with qp.decomposition.local_decomps():
 
-            @qml.register_resources({qml.RY: 1})
+            @qp.register_resources({qp.RY: 1})
             def custom_decomposition(param, wires):
-                qml.RY(3 * param, wires=wires)
+                qp.RY(3 * param, wires=wires)
 
-            qml.add_decomps(PhaseShift, custom_decomposition)
+            qp.add_decomps(PhaseShift, custom_decomposition)
 
             @qnode(dev, diff_method="parameter-shift", max_diff=2)
             def circuit(x):
-                qml.Hadamard(wires=0)
+                qp.Hadamard(wires=0)
                 PhaseShift(x, wires=0)
-                return qml.expval(qml.PauliX(0))
+                return qp.expval(qp.PauliX(0))
 
             x = pnp.array(0.5, requires_grad=True)
             circuit(x)
 
-            res = qml.grad(circuit)(x)
+            res = qp.grad(circuit)(x)
 
             assert np.allclose(res, -3 * np.sin(3 * x))
 
             # test second order derivatives
-            res = qml.grad(qml.grad(circuit))(x)
+            res = qp.grad(qp.grad(circuit))(x)
             assert np.allclose(res, -9 * np.cos(3 * x))
 
     def test_hamiltonian_expansion_analytic(self):
         """Test result if there are non-commuting groups and the number of shots is None"""
         dev = DefaultQubitLegacy(wires=3, shots=None)
 
-        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+        obs = [qp.PauliX(0), qp.PauliX(0) @ qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)]
         c = np.array([-0.6543, 0.24, 0.54])
-        H = qml.Hamiltonian(c, obs)
+        H = qp.Hamiltonian(c, obs)
         H.compute_grouping()
 
         assert len(H.grouping_indices) == 2
 
         @qnode(dev)
         def circuit():
-            return qml.expval(H)
+            return qp.expval(H)
 
         res = circuit()
         assert np.allclose(res, c[2], atol=0.1)
@@ -1420,19 +1420,19 @@ class TestTapeExpansion:
         are non-commuting groups and the number of shots is finite"""
         dev = DefaultQubitLegacy(wires=3)
 
-        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+        obs = [qp.PauliX(0), qp.PauliX(0) @ qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)]
         c = np.array([-0.6543, 0.24, 0.54])
-        H = qml.Hamiltonian(c, obs)
+        H = qp.Hamiltonian(c, obs)
         H.compute_grouping()
 
         assert len(H.grouping_indices) == 2
 
-        @qml.set_shots(50000)
+        @qp.set_shots(50000)
         @qnode(dev)
         def circuit():
-            return qml.expval(H)
+            return qp.expval(H)
 
-        spy = mocker.spy(qml.devices._legacy_device, "split_non_commuting")
+        spy = mocker.spy(qp.devices._legacy_device, "split_non_commuting")
         res = circuit()
         assert np.allclose(res, c[2], atol=0.3)
 
@@ -1447,21 +1447,21 @@ class TestTapeExpansion:
 
         dev = DefaultQubitLegacy(wires=3)
 
-        obs = [qml.PauliX(0), qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.PauliZ(1)]
+        obs = [qp.PauliX(0), qp.PauliX(0) @ qp.PauliZ(1), qp.PauliZ(0) @ qp.PauliZ(1)]
         c = np.array([-0.6543, 0.24, 0.54])
-        H = qml.Hamiltonian(c, obs)
+        H = qp.Hamiltonian(c, obs)
 
         if grouping:
             H.compute_grouping()
             assert len(H.grouping_indices) == 2
 
-        @qml.set_shots(50000)
+        @qp.set_shots(50000)
         @qnode(dev)
         def circuit():
-            return qml.expval(H), qml.expval(H)
+            return qp.expval(H), qp.expval(H)
 
         res = circuit()
-        assert qml.math.allclose(res, [0.54, 0.54], atol=0.05)
+        assert qp.math.allclose(res, [0.54, 0.54], atol=0.05)
         assert res[0] == res[1]
 
 
@@ -1534,19 +1534,19 @@ class TestDefaultQubitLegacySeeding:
         dev1 = DefaultQubitLegacy(wires=2, seed=seed)
         dev2 = DefaultQubitLegacy(wires=2, seed=seed)
 
-        @qml.set_shots(num_shots)
-        @qml.qnode(dev1)
+        @qp.set_shots(num_shots)
+        @qp.qnode(dev1)
         def circuit1():
-            qml.Hadamard(0)
-            qml.CNOT([0, 1])
-            return qml.sample(wires=[0, 1])
+            qp.Hadamard(0)
+            qp.CNOT([0, 1])
+            return qp.sample(wires=[0, 1])
 
-        @qml.set_shots(num_shots)
-        @qml.qnode(dev2)
+        @qp.set_shots(num_shots)
+        @qp.qnode(dev2)
         def circuit2():
-            qml.Hadamard(0)
-            qml.CNOT([0, 1])
-            return qml.sample(wires=[0, 1])
+            qp.Hadamard(0)
+            qp.CNOT([0, 1])
+            return qp.sample(wires=[0, 1])
 
         # Execute both circuits - they should produce identical results
         # since both devices start fresh with the same seed
@@ -1568,19 +1568,19 @@ class TestDefaultQubitLegacySeeding:
         dev1 = DefaultQubitLegacy(wires=2, seed=seed)
         dev2 = DefaultQubitLegacy(wires=2, seed=seed)
 
-        @qml.set_shots(num_shots)
-        @qml.qnode(dev1)
+        @qp.set_shots(num_shots)
+        @qp.qnode(dev1)
         def circuit1():
-            qml.Hadamard(0)
-            qml.CNOT([0, 1])
-            return qml.classical_shadow(wires=[0, 1], seed=seed)
+            qp.Hadamard(0)
+            qp.CNOT([0, 1])
+            return qp.classical_shadow(wires=[0, 1], seed=seed)
 
-        @qml.set_shots(num_shots)
-        @qml.qnode(dev2)
+        @qp.set_shots(num_shots)
+        @qp.qnode(dev2)
         def circuit2():
-            qml.Hadamard(0)
-            qml.CNOT([0, 1])
-            return qml.classical_shadow(wires=[0, 1], seed=seed)
+            qp.Hadamard(0)
+            qp.CNOT([0, 1])
+            return qp.classical_shadow(wires=[0, 1], seed=seed)
 
         result1 = circuit1()
         result2 = circuit2()
@@ -1676,11 +1676,11 @@ class TestDefaultQubitLegacySeeding:
 
         dev = DefaultQubitLegacy(wires=2, seed=seed)
 
-        @qml.set_shots(num_shots)
-        @qml.qnode(dev)
+        @qp.set_shots(num_shots)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(0)
-            return qml.classical_shadow(wires=[0], seed=seed)
+            qp.Hadamard(0)
+            return qp.classical_shadow(wires=[0], seed=seed)
 
         # First execution
         result1 = circuit()
@@ -1708,8 +1708,8 @@ class TestDefaultQubitLegacySeeding:
         dev = DefaultQubitLegacy(wires=1, shots=num_shots, seed=seed)
 
         # Create a simple tape for execution
-        tape = qml.tape.QuantumScript(
-            [qml.Hadamard(0)], [qml.classical_shadow(wires=[0], seed=seed)]
+        tape = qp.tape.QuantumScript(
+            [qp.Hadamard(0)], [qp.classical_shadow(wires=[0], seed=seed)]
         )
 
         # First execution

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -390,7 +390,7 @@ class TestTapeConstruction:
         jitted_qnode1 = jax.jit(qn)
 
         with pytest.raises(
-            NotImplementedError, match="The JAX-JIT interface doesn't support qp.counts."
+            NotImplementedError, match=r"The JAX-JIT interface doesn't support \w+.counts."
         ):
             jitted_qnode1(0.123)
 

--- a/tests/test_qnode_legacy.py
+++ b/tests/test_qnode_legacy.py
@@ -1107,9 +1107,7 @@ class TestCompilePipelineIntegration:
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            return (
-                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
-            ), null_postprocessing
+            return (qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),), null_postprocessing
 
         @just_pauli_x_out
         @qp.qnode(dev, interface=None, diff_method=None)
@@ -1165,9 +1163,7 @@ class TestCompilePipelineIntegration:
         def just_pauli_x_out(
             tape: QuantumScript,
         ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-            return (
-                qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),
-            ), null_postprocessing
+            return (qp.tape.QuantumScript([qp.PauliX(0)], tape.measurements),), null_postprocessing
 
         @qp.transform
         def repeat_operations(
@@ -1708,9 +1704,7 @@ class TestDefaultQubitLegacySeeding:
         dev = DefaultQubitLegacy(wires=1, shots=num_shots, seed=seed)
 
         # Create a simple tape for execution
-        tape = qp.tape.QuantumScript(
-            [qp.Hadamard(0)], [qp.classical_shadow(wires=[0], seed=seed)]
-        )
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)], [qp.classical_shadow(wires=[0], seed=seed)])
 
         # First execution
         result1 = dev.execute(tape)

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -20,7 +20,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.exceptions import QueuingError
 from pennylane.queuing import AnnotatedQueue, QueuingManager, WrappedObj
 
@@ -32,37 +32,37 @@ class TestStopRecording:
     def test_stop_recording_on_function_inside_QNode(self):
         """Test that the stop_recording transform when applied to a function
         is not recorded by a QNode"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @QueuingManager.stop_recording()
         def my_op():
-            return [qml.RX(0.123, wires=0), qml.RY(2.32, wires=0), qml.RZ(1.95, wires=0)]
+            return [qp.RX(0.123, wires=0), qp.RY(2.32, wires=0), qp.RZ(1.95, wires=0)]
 
         res = []
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def my_circuit():
             res.extend(my_op())
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
-        tape = qml.workflow.construct_tape(my_circuit)()
+        tape = qp.workflow.construct_tape(my_circuit)()
 
         assert len(tape.operations) == 0
         assert len(res) == 3
 
     def test_stop_recording_directly_on_op(self):
         """Test that stop_recording transform works when directly applied to an op"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
         res = []
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def my_circuit():
-            op1 = QueuingManager.stop_recording()(qml.RX)(np.pi / 4.0, wires=0)
-            op2 = qml.RY(np.pi / 4.0, wires=0)
+            op1 = QueuingManager.stop_recording()(qp.RX)(np.pi / 4.0, wires=0)
+            op2 = qp.RY(np.pi / 4.0, wires=0)
             res.extend([op1, op2])
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
-        tape = qml.workflow.construct_tape(my_circuit)()
+        tape = qp.workflow.construct_tape(my_circuit)()
 
         assert len(tape.operations) == 1
         assert tape.operations[0] == res[1]
@@ -75,43 +75,43 @@ class TestStopRecording:
         @QueuingManager.stop_recording()
         def my_op():
             return [
-                qml.RX(0.123, wires=0),
-                qml.RY(2.32, wires=0),
-                qml.RZ(1.95, wires=0),
+                qp.RX(0.123, wires=0),
+                qp.RY(2.32, wires=0),
+                qp.RZ(1.95, wires=0),
             ]
 
         # the stop_recording function will still work outside of any queuing contexts
         res = my_op()
         assert len(res) == 3
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def my_circuit():
             my_op()
 
             with QueuingManager.stop_recording():
-                qml.PauliX(wires=0)
+                qp.PauliX(wires=0)
                 my_op()
 
-            qml.Hadamard(wires=0)
+            qp.Hadamard(wires=0)
             my_op()
-            return qml.state()
+            return qp.state()
 
-        tape = qml.workflow.construct_tape(my_circuit)()
+        tape = qp.workflow.construct_tape(my_circuit)()
 
         assert len(tape.operations) == 1
         assert tape.operations[0].name == "Hadamard"
 
     def test_stop_recording_qnode(self):
         """A stop_recording QNode is unaffected"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         @QueuingManager.stop_recording()
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def my_circuit():
-            qml.RX(np.pi, wires=0)
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(np.pi, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
         result = my_circuit()
         assert result == -1.0
@@ -132,12 +132,12 @@ class TestQueuingManager:
     def test_append_no_context(self):
         """Test that append does not fail when no context is present."""
 
-        QueuingManager.append(qml.PauliZ(0))
+        QueuingManager.append(qp.PauliZ(0))
 
     def test_remove_no_context(self):
         """Test that remove does not fail when no context is present."""
 
-        QueuingManager.remove(qml.PauliZ(0))
+        QueuingManager.remove(qp.PauliZ(0))
 
     def test_no_active_context(self):
         """Test that if there are no active contexts, active_context() returns None"""
@@ -151,17 +151,17 @@ class TestAnnotatedQueue:
         """Test that remove passes silently if the object is not in the queue"""
 
         q2 = AnnotatedQueue()
-        q2.remove(qml.PauliX(0))
+        q2.remove(qp.PauliX(0))
 
     def test_append_qubit_gates(self):
         """Test that gates are successfully appended to the queue."""
         with AnnotatedQueue() as q:
             ops = [
-                qml.RX(0.5, wires=0),
-                qml.RY(-10.1, wires=1),
-                qml.CNOT(wires=[0, 1]),
-                qml.PhaseShift(-1.1, wires=18),
-                qml.T(wires=99),
+                qp.RX(0.5, wires=0),
+                qp.RY(-10.1, wires=1),
+                qp.CNOT(wires=[0, 1]),
+                qp.PhaseShift(-1.1, wires=18),
+                qp.T(wires=99),
             ]
         assert q.queue == ops
 
@@ -172,10 +172,10 @@ class TestAnnotatedQueue:
             # wire repetition is deliberate, Queue contains no checks/logic
             # for circuits
             ops = [
-                qml.Hadamard(wires=0),
-                qml.PauliX(wires=1),
-                qml.PauliY(wires=1),
-                qml.Hermitian(np.ones([2, 2]), wires=7),
+                qp.Hadamard(wires=0),
+                qp.PauliX(wires=1),
+                qp.PauliY(wires=1),
+                qp.Hermitian(np.ones([2, 2]), wires=7),
             ]
         assert q.queue == ops
 
@@ -184,15 +184,15 @@ class TestAnnotatedQueue:
         are successfully added to the queue, as well as the `Prod` object."""
 
         with AnnotatedQueue() as q:
-            A = qml.PauliZ(0)
-            B = qml.PauliY(1)
+            A = qp.PauliZ(0)
+            B = qp.PauliY(1)
             prod_op = A @ B
         assert q.queue == [prod_op]
         assert prod_op.operands == (A, B)
 
     def test_get_info(self):
         """Test that get_info correctly returns an annotation"""
-        A = qml.RZ(0.5, wires=1)
+        A = qp.RZ(0.5, wires=1)
 
         with AnnotatedQueue() as q:
             q.append(A, inv=True)
@@ -204,16 +204,16 @@ class TestAnnotatedQueue:
         for a non-existent object"""
 
         with AnnotatedQueue() as q:
-            qml.PauliZ(0)
+            qp.PauliZ(0)
 
-        B = qml.PauliY(1)
+        B = qp.PauliY(1)
 
         with pytest.raises(QueuingError, match="not in the queue"):
             q.get_info(B)
 
     def test_get_info_none(self):
         """Test that get_info returns None if there is no active queuing context"""
-        A = qml.RZ(0.5, wires=1)
+        A = qp.RZ(0.5, wires=1)
 
         with AnnotatedQueue() as q:
             q.append(A, inv=True)
@@ -222,7 +222,7 @@ class TestAnnotatedQueue:
 
     def test_update_info(self):
         """Test that update_info correctly updates an annotation"""
-        A = qml.RZ(0.5, wires=1)
+        A = qp.RZ(0.5, wires=1)
 
         with AnnotatedQueue() as q:
             q.append(A, inv=True)
@@ -243,9 +243,9 @@ class TestAnnotatedQueue:
         for a non-existent object."""
 
         with AnnotatedQueue() as q:
-            qml.PauliZ(0)
+            qp.PauliZ(0)
 
-        B = qml.PauliY(1)
+        B = qp.PauliY(1)
 
         q.update_info(B, inv=True)
         assert len(q.queue) == 1
@@ -262,7 +262,7 @@ class TestAnnotatedQueue:
                 for _ in range(n):
                     pauli(0)
 
-        args = [(q1, qml.PauliX), (q2, qml.PauliY)]
+        args = [(q1, qp.PauliX), (q2, qp.PauliY)]
         ThreadPool(2).map(queue_pauli, args)
         assert len(q1) == n
         assert len(q2) == n
@@ -271,9 +271,9 @@ class TestAnnotatedQueue:
 
 
 test_observables = [
-    qml.PauliZ(0) @ qml.PauliZ(1),
-    qml.Hamiltonian(
-        [0.1, 0.2, 0.3], [qml.PauliZ(0) @ qml.PauliZ(1), qml.PauliY(1), qml.Identity(2)]
+    qp.PauliZ(0) @ qp.PauliZ(1),
+    qp.Hamiltonian(
+        [0.1, 0.2, 0.3], [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliY(1), qp.Identity(2)]
     ),
 ]
 
@@ -285,39 +285,39 @@ class TestApplyOp:
         """Test that applying an operation without an active
         context raises an error"""
         with pytest.raises(RuntimeError, match="No queuing context"):
-            qml.apply(qml.PauliZ(0))
+            qp.apply(qp.PauliZ(0))
 
     def test_default_queue_operation_inside(self):
         """Test applying an operation instantiated within the queuing
         context to the existing active queue"""
-        with qml.queuing.AnnotatedQueue() as q:
-            op1 = qml.PauliZ(0)
-            op2 = qml.apply(op1)
+        with qp.queuing.AnnotatedQueue() as q:
+            op1 = qp.PauliZ(0)
+            op2 = qp.apply(op1)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         assert tape.operations == [op1, op2]
 
     def test_default_queue_operation_outside(self):
         """Test applying an operation instantiated outside a queuing context
         to an existing active queue"""
-        op = qml.PauliZ(0)
+        op = qp.PauliZ(0)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.apply(op)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.apply(op)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         assert tape.operations == [op]
 
     @pytest.mark.parametrize("obs", test_observables)
     def test_default_queue_measurements_outside(self, obs):
         """Test applying a measurement instantiated outside a queuing context
         to an existing active queue"""
-        op = qml.expval(obs)
+        op = qp.expval(obs)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.apply(op)
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.apply(op)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         assert tape.measurements == [op]
 
     @pytest.mark.parametrize("obs", test_observables)
@@ -325,37 +325,37 @@ class TestApplyOp:
         """Test applying a measurement instantiated inside a queuing context
         to an existing active queue"""
 
-        with qml.queuing.AnnotatedQueue() as q:
-            op1 = qml.expval(obs)
-            op2 = qml.apply(op1)
+        with qp.queuing.AnnotatedQueue() as q:
+            op1 = qp.expval(obs)
+            op2 = qp.apply(op1)
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         assert tape.measurements == [op1, op2]
 
     def test_different_queue_operation_inside(self):
         """Test applying an operation instantiated within the queuing
         context to a specfied queuing context"""
-        with qml.queuing.AnnotatedQueue() as q1:
-            with qml.queuing.AnnotatedQueue() as q2:
-                op1 = qml.PauliZ(0)
-                op2 = qml.apply(op1, q1)
+        with qp.queuing.AnnotatedQueue() as q1:
+            with qp.queuing.AnnotatedQueue() as q2:
+                op1 = qp.PauliZ(0)
+                op2 = qp.apply(op1, q1)
 
-            tape2 = qml.tape.QuantumScript.from_queue(q2)
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+            tape2 = qp.tape.QuantumScript.from_queue(q2)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         assert tape1.operations == [op2]
         assert tape2.operations == [op1]
 
     def test_different_queue_operation_outside(self):
         """Test applying an operation instantiated outside a queuing context
         to a specfied queuing context"""
-        op = qml.PauliZ(0)
+        op = qp.PauliZ(0)
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            with qml.queuing.AnnotatedQueue() as q2:
-                qml.apply(op, q1)
+        with qp.queuing.AnnotatedQueue() as q1:
+            with qp.queuing.AnnotatedQueue() as q2:
+                qp.apply(op, q1)
 
-            tape2 = qml.tape.QuantumScript.from_queue(q2)
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+            tape2 = qp.tape.QuantumScript.from_queue(q2)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         assert tape1.operations == [op]
         assert tape2.operations == []
 
@@ -363,14 +363,14 @@ class TestApplyOp:
     def test_different_queue_measurements_outside(self, obs):
         """Test applying a measurement instantiated outside a queuing context
         to a specfied queuing context"""
-        op = qml.expval(obs)
+        op = qp.expval(obs)
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            with qml.queuing.AnnotatedQueue() as q2:
-                qml.apply(op, q1)
+        with qp.queuing.AnnotatedQueue() as q1:
+            with qp.queuing.AnnotatedQueue() as q2:
+                qp.apply(op, q1)
 
-            tape2 = qml.tape.QuantumScript.from_queue(q2)
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+            tape2 = qp.tape.QuantumScript.from_queue(q2)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         assert tape1.measurements == [op]
         assert tape2.measurements == []
 
@@ -379,34 +379,34 @@ class TestApplyOp:
         """Test applying a measurement instantiated inside a queuing context
         to a specfied queuing context"""
 
-        with qml.queuing.AnnotatedQueue() as q1:
-            with qml.queuing.AnnotatedQueue() as q2:
-                op1 = qml.expval(obs)
-                op2 = qml.apply(op1, q1)
+        with qp.queuing.AnnotatedQueue() as q1:
+            with qp.queuing.AnnotatedQueue() as q2:
+                op1 = qp.expval(obs)
+                op2 = qp.apply(op1, q1)
 
-            tape2 = qml.tape.QuantumScript.from_queue(q2)
-        tape1 = qml.tape.QuantumScript.from_queue(q1)
+            tape2 = qp.tape.QuantumScript.from_queue(q2)
+        tape1 = qp.tape.QuantumScript.from_queue(q1)
         assert tape1.measurements == [op2]
         assert tape2.measurements == [op1]
 
     def test_apply_no_queue_method(self):
         """Test that an object with no queue method is still
         added to the queuing context"""
-        with qml.queuing.AnnotatedQueue() as q1:
-            with qml.queuing.AnnotatedQueue() as q2:
-                op1 = qml.apply(5)
-                op2 = qml.apply(6, q1)
+        with qp.queuing.AnnotatedQueue() as q1:
+            with qp.queuing.AnnotatedQueue() as q2:
+                op1 = qp.apply(5)
+                op2 = qp.apply(6, q1)
 
         assert q1.queue == [op2]
         assert q2.queue == [op1]
 
     def test_apply_plus_dequeuing(self):
-        """Test that operations queued with qml.apply don't get dequeued by subsequent ops."""
+        """Test that operations queued with qp.apply don't get dequeued by subsequent ops."""
 
-        h = qml.H(0)
-        with qml.queuing.AnnotatedQueue() as q1:
-            op1 = qml.apply(h)
-            op2 = qml.adjoint(h)
+        h = qp.H(0)
+        with qp.queuing.AnnotatedQueue() as q1:
+            op1 = qp.apply(h)
+            op2 = qp.adjoint(h)
 
         assert q1.queue == [op1, op2]
 
@@ -415,7 +415,7 @@ class TestWrappedObj:
     """Tests for the ``WrappedObj`` class"""
 
     @pytest.mark.parametrize(
-        "obj", [qml.PauliX(0), qml.expval(qml.PauliZ(0)), [0, 1, 2], ("a", "b")]
+        "obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")]
     )
     def test_wrapped_obj_init(self, obj):
         """Test that ``WrappedObj`` is initialized correctly"""
@@ -424,7 +424,7 @@ class TestWrappedObj:
 
     @pytest.mark.parametrize(
         "obj1, obj2",
-        [(qml.PauliX(0), qml.PauliZ(0)), (qml.PauliX(0), qml.PauliX(0)), ((1,), (1, 2))],
+        [(qp.PauliX(0), qp.PauliZ(0)), (qp.PauliX(0), qp.PauliX(0)), ((1,), (1, 2))],
     )
     def test_wrapped_obj_eq_false(self, obj1, obj2):
         """Test that ``WrappedObj.__eq__`` returns False when expected."""
@@ -435,17 +435,17 @@ class TestWrappedObj:
     def test_wrapped_obj_eq_false_other_obj(self):
         """Test that WrappedObj.__eq__ returns False when the object being compared is not
         a WrappedObj."""
-        op = qml.PauliX(0)
+        op = qp.PauliX(0)
         wo = WrappedObj(op)
         assert wo != op
 
     def test_wrapped_obj_eq_true(self):
         """Test that ``WrappedObj.__eq__`` returns True when expected."""
-        op = qml.PauliX(0)
+        op = qp.PauliX(0)
         assert WrappedObj(op) == WrappedObj(op)
 
     @pytest.mark.parametrize(
-        "obj", [qml.PauliX(0), qml.expval(qml.PauliZ(0)), [0, 1, 2], ("a", "b")]
+        "obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")]
     )
     def test_wrapped_obj_hash(self, obj):
         """Test that ``WrappedObj.__hash__`` is the object id."""
@@ -474,12 +474,12 @@ def test_process_queue_error_if_not_operator_or_measurement():
     q = AnnotatedQueue()
     q.append(1)
     with pytest.raises(QueuingError, match="not an object that can be processed"):
-        qml.queuing.process_queue(q)
+        qp.queuing.process_queue(q)
 
 
 def test_queue_category_none_deprecation():
 
-    class DummyOp(qml.operation.Operator):  # pylint: disable=too-few-public-methods
+    class DummyOp(qp.operation.Operator):  # pylint: disable=too-few-public-methods
         _queue_category = None
         num_wires = 1
         num_params = 0
@@ -488,5 +488,5 @@ def test_queue_category_none_deprecation():
     q.append(DummyOp(wires=[0]))
     match = "an object to get queued with `_queue_category=None` is deprecated"
 
-    with pytest.warns(qml.exceptions.PennyLaneDeprecationWarning, match=match):
-        qml.queuing.process_queue(q)
+    with pytest.warns(qp.exceptions.PennyLaneDeprecationWarning, match=match):
+        qp.queuing.process_queue(q)

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -272,9 +272,7 @@ class TestAnnotatedQueue:
 
 test_observables = [
     qp.PauliZ(0) @ qp.PauliZ(1),
-    qp.Hamiltonian(
-        [0.1, 0.2, 0.3], [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliY(1), qp.Identity(2)]
-    ),
+    qp.Hamiltonian([0.1, 0.2, 0.3], [qp.PauliZ(0) @ qp.PauliZ(1), qp.PauliY(1), qp.Identity(2)]),
 ]
 
 
@@ -414,9 +412,7 @@ class TestApplyOp:
 class TestWrappedObj:
     """Tests for the ``WrappedObj`` class"""
 
-    @pytest.mark.parametrize(
-        "obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")]
-    )
+    @pytest.mark.parametrize("obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")])
     def test_wrapped_obj_init(self, obj):
         """Test that ``WrappedObj`` is initialized correctly"""
         wo = WrappedObj(obj)
@@ -444,9 +440,7 @@ class TestWrappedObj:
         op = qp.PauliX(0)
         assert WrappedObj(op) == WrappedObj(op)
 
-    @pytest.mark.parametrize(
-        "obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")]
-    )
+    @pytest.mark.parametrize("obj", [qp.PauliX(0), qp.expval(qp.PauliZ(0)), [0, 1, 2], ("a", "b")])
     def test_wrapped_obj_hash(self, obj):
         """Test that ``WrappedObj.__hash__`` is the object id."""
         wo = WrappedObj(obj)

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -17,7 +17,7 @@ Unit tests for pennylane.registers.
 
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.wires import Wires
 
 
@@ -79,7 +79,7 @@ class TestRegisters:
         The expected result is a dictionary that has elements ordered first by appearance from left
         to right, then by nestedness (also known as DFS traversal order)."""
 
-        wire_dict = qml.registers(wire_dict)
+        wire_dict = qp.registers(wire_dict)
 
         assert wire_dict == expected_register
 
@@ -103,4 +103,4 @@ class TestRegisters:
     def test_errors_for_registers(self, wire_dict, expected_error_msg):
         """Test that the registers function raises the right error for given Wires dictionaries"""
         with pytest.raises(ValueError, match=expected_error_msg):
-            qml.registers(wire_dict)
+            qp.registers(wire_dict)

--- a/tests/test_return_types.py
+++ b/tests/test_return_types.py
@@ -18,19 +18,19 @@ Unit tests for the new return types.
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.exceptions import DeviceError
 from pennylane.measurements import MeasurementProcess
 
 
 def _get_all_shots(shot_vector):
     """Helper function to get the total number of shots from a shot vector."""
-    return qml.measurements.Shots(shot_vector).num_copies
+    return qp.measurements.Shots(shot_vector).num_copies
 
 
 def _get_all_shot_copies(shot_vector):
     """Helper function to get the total number of shot copies from a shot vector."""
-    return list(qml.measurements.Shots(shot_vector))
+    return list(qp.measurements.Shots(shot_vector))
 
 
 test_wires = [2, 3, 4]
@@ -45,19 +45,19 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("wires", test_wires)
     def test_state_default(self, wires, interface, shots):
         """Return state with default.qubit."""
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
         if shots:
             pytest.skip("cannot return analytic measurements with finite shots.")
         program = dev.preprocess_transforms()
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -71,19 +71,19 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("d_wires", test_wires)
     def test_density_matrix(self, d_wires, device, interface, shots):
         """Return density matrix."""
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=range(0, d_wires))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
         if shots:
             pytest.skip("cannot return analytic measurements with finite shots.")
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -95,17 +95,17 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("device", devices)
     def test_expval(self, device, interface, shots):
         """Return a single expval."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -117,17 +117,17 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("device", devices)
     def test_var(self, device, interface, shots):
         """Return a single var."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -139,19 +139,19 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("device", devices)
     def test_vn_entropy(self, device, interface, shots):
         """Return a single vn entropy."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=0)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
         if shots:
             pytest.skip("cannot return analytic measurements with finite shots.")
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -163,19 +163,19 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("device", devices)
     def test_mutual_info(self, device, interface, shots):
         """Return a single mutual information."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
         if shots:
             pytest.skip("cannot return analytic measurements with finite shots.")
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -188,8 +188,8 @@ class TestSingleReturnExecute:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -197,17 +197,17 @@ class TestSingleReturnExecute:
     @pytest.mark.parametrize("op,wires", probs_data)
     def test_probs(self, op, wires, device, interface, shots):
         """Return a single prob."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -219,23 +219,23 @@ class TestSingleReturnExecute:
         assert res[0].shape == (2 ** len(wires),)
         assert isinstance(res[0], (np.ndarray, np.float64))
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_sample(self, measurement, interface, shots):
         """Test the sample measurement."""
         if shots is None:
             pytest.skip("Sample requires finite shots.")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -244,23 +244,23 @@ class TestSingleReturnExecute:
         assert isinstance(res[0], (np.ndarray, np.float64))
         assert res[0].shape == (shots,) if measurement.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, measurement, interface, shots):
         """Test the counts measurement."""
         if shots is None:
             pytest.skip("Counts requires finite shots.")
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -282,17 +282,17 @@ class TestMultipleReturns:
     @pytest.mark.parametrize("device", devices)
     def test_multiple_expval(self, device, shots):
         """Return multiple expvals."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -307,17 +307,17 @@ class TestMultipleReturns:
     @pytest.mark.parametrize("device", devices)
     def test_multiple_var(self, device, shots):
         """Return multiple vars."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=0)), qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=0)), qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -335,10 +335,10 @@ class TestMultipleReturns:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -346,17 +346,17 @@ class TestMultipleReturns:
     @pytest.mark.parametrize("op1,wires1,op2,wires2", multi_probs_data)
     def test_multiple_prob(self, op1, op2, wires1, wires2, device, shots):
         """Return multiple probs."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -381,24 +381,24 @@ class TestMultipleReturns:
     def test_mix_meas(self, op1, wires1, op2, wires2, wires3, wires4, device, shots):
         """Return multiple different measurements."""
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
         if shots:
             pytest.skip("cannot return analytic measurements with finite shots.")
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         if wires1 is None:
@@ -428,17 +428,17 @@ class TestMultipleReturns:
     @pytest.mark.parametrize("wires", wires)
     def test_list_multiple_expval(self, wires, device, shots):
         """Return a comprehension list of multiple expvals."""
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=i)) for i in range(0, wires)]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=i)) for i in range(0, wires)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -449,23 +449,23 @@ class TestMultipleReturns:
             assert res[0][i].shape == ()
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_expval_sample(self, measurement, shots, device):
         """Test the expval and sample measurements together."""
         if shots is None:
             pytest.skip("Sample requires finite shots.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         # Expval
@@ -477,23 +477,23 @@ class TestMultipleReturns:
         assert res[0][1].shape == (shots,) if measurement.obs else (shots, 1)
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_expval_counts(self, measurement, shots, device):
         """Test the expval and counts measurements together."""
         if shots is None:
             pytest.skip("Counts requires finite shots.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         # Expval
@@ -505,27 +505,27 @@ class TestMultipleReturns:
         assert sum(res[0][1].values()) == shots
 
 
-pauliz = qml.PauliZ(wires=1)
-proj = qml.Projector([1], wires=1)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
+pauliz = qp.PauliZ(wires=1)
+proj = qp.Projector([1], wires=1)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
 
 # Note: mutual info and vn_entropy do not support some shot vectors
-# qml.mutual_info(wires0=[0], wires1=[1]), qml.vn_entropy(wires=[0])]
+# qp.mutual_info(wires0=[0], wires1=[1]), qp.vn_entropy(wires=[0])]
 single_scalar_output_measurements = [
-    qml.expval(pauliz),
-    qml.var(pauliz),
-    qml.expval(proj),
-    qml.var(proj),
-    qml.expval(hermitian),
-    qml.var(hermitian),
+    qp.expval(pauliz),
+    qp.var(pauliz),
+    qp.expval(proj),
+    qp.var(proj),
+    qp.expval(hermitian),
+    qp.var(hermitian),
 ]
 
 herm = np.diag([1, 2, 3, 4])
 probs_data = [
     (None, [0]),
     (None, [0, 1]),
-    (qml.PauliZ(0), None),
-    (qml.Hermitian(herm, wires=[1, 0]), None),
+    (qp.PauliZ(0), None),
+    (qp.Hermitian(herm, wires=[1, 0]), None),
 ]
 
 shot_vectors = [[10, 1000], [1, 10, 10, 1000], [1, (10, 2), 1000]]
@@ -540,17 +540,17 @@ class TestShotVector:
     @pytest.mark.parametrize("measurement", single_scalar_output_measurements)
     def test_scalar(self, shot_vector, measurement, device):
         """Test a single scalar-valued measurement."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -562,17 +562,17 @@ class TestShotVector:
     @pytest.mark.parametrize("op,wires", probs_data)
     def test_probs(self, shot_vector, op, wires, device):
         """Test a single probability measurement."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -585,19 +585,19 @@ class TestShotVector:
     @pytest.mark.parametrize("wires", [[0], [2, 0], [1, 0], [2, 0, 1]])
     def test_density_matrix(self, shot_vector, wires, device):
         """Test a density matrix measurement."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
         if shot_vector:
             pytest.skip("cannot return analytic measurements with finite shots.")
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -607,20 +607,20 @@ class TestShotVector:
         dim = 2 ** len(wires)
         assert all(r.shape == (dim, dim) for r in res[0])
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_samples(self, shot_vector, measurement, device):
         """Test the sample measurement."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -629,20 +629,20 @@ class TestShotVector:
         for r, shots in zip(res[0], all_shot_copies):
             assert r.shape == (shots,) if measurement.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement, device):
         """Test the counts measurement."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -660,17 +660,17 @@ class TestSameMeasurementShotVector:
 
     def test_scalar(self, shot_vector, device):
         """Test multiple scalar-valued measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(0)), qml.var(qml.PauliZ(1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(0)), qp.var(qp.PauliZ(1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -684,8 +684,8 @@ class TestSameMeasurementShotVector:
     probs_data2 = [
         (None, [2]),
         (None, [2, 3]),
-        (qml.PauliZ(2), None),
-        (qml.Hermitian(herm, wires=[3, 2]), None),
+        (qp.PauliZ(2), None),
+        (qp.Hermitian(herm, wires=[3, 2]), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -693,17 +693,17 @@ class TestSameMeasurementShotVector:
     @pytest.mark.parametrize("op2,wires2", reversed(probs_data2))
     def test_probs(self, shot_vector, op1, wires1, op2, wires2, device):
         """Test multiple probability measurements."""
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -718,21 +718,21 @@ class TestSameMeasurementShotVector:
             assert r[0].shape == (2 ** len(wires1),)
             assert r[1].shape == (2 ** len(wires2),)
 
-    @pytest.mark.parametrize("measurement1", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.sample(qml.PauliX(1)), qml.sample(wires=[1])])
+    @pytest.mark.parametrize("measurement1", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.sample(qp.PauliX(1)), qp.sample(wires=[1])])
     def test_samples(self, shot_vector, measurement1, measurement2, device):
         """Test multiple sample measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -745,21 +745,21 @@ class TestSameMeasurementShotVector:
             expected2 = (shots,) if measurement2.obs else (shots, 1)
             assert r[1].shape == expected2
 
-    @pytest.mark.parametrize("measurement1", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement1", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement1, measurement2, device):
         """Test multiple counts measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -775,60 +775,60 @@ class TestSameMeasurementShotVector:
 # Shot vector multi measurement tests - test data
 # -------------------------------------------------
 
-pauliz_w2 = qml.PauliZ(wires=2)
-proj_w2 = qml.Projector([1], wires=2)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
-tensor_product = qml.PauliZ(wires=2) @ qml.PauliX(wires=1)
+pauliz_w2 = qp.PauliZ(wires=2)
+proj_w2 = qp.Projector([1], wires=2)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
+tensor_product = qp.PauliZ(wires=2) @ qp.PauliX(wires=1)
 
 # Expval/Var with Probs
 
 scalar_probs_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.probs(wires=[2, 0])),
-    (qml.expval(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.expval(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.expval(pauliz_w2), qp.probs(wires=[2, 0])),
+    (qp.expval(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.expval(tensor_product), qp.probs(wires=[2, 0])),
     # Var
-    (qml.var(qml.PauliZ(wires=1)), qml.probs(wires=[0, 1])),
-    (qml.var(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.var(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.var(qp.PauliZ(wires=1)), qp.probs(wires=[0, 1])),
+    (qp.var(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.var(tensor_product), qp.probs(wires=[2, 0])),
 ]
 
 # Expval/Var with Sample
 
 scalar_sample_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.sample(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.sample(op=qp.PauliZ(0))),
 ]
 
 scalar_sample_no_obs_multi = [
-    (qml.expval(qml.PauliZ(wires=1)), qml.sample()),
-    (qml.expval(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.sample()),
+    (qp.expval(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
 ]
 
 # Expval/Var with Counts
 
 scalar_counts_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.counts(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.counts(op=qp.PauliZ(0))),
 ]
 
 scalar_counts_no_obs_multi = [
-    (qml.expval(qml.PauliZ(wires=1)), qml.counts()),
-    (qml.expval(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.counts()),
+    (qp.expval(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
 ]
 
 
@@ -841,17 +841,17 @@ class TestMixMeasurementsShotVector:
     @pytest.mark.parametrize("meas1,meas2", scalar_probs_multi)
     def test_scalar_probs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and probability measurements"""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -879,18 +879,18 @@ class TestMixMeasurementsShotVector:
     def test_scalar_sample_with_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and sample measurements where sample takes an
         observable."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -917,17 +917,17 @@ class TestMixMeasurementsShotVector:
     @pytest.mark.xfail
     def test_scalar_sample_no_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and computational basis sample measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -955,18 +955,18 @@ class TestMixMeasurementsShotVector:
     def test_scalar_counts_with_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and counts measurements where counts takes an
         observable."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -995,18 +995,18 @@ class TestMixMeasurementsShotVector:
     @pytest.mark.parametrize("meas1,meas2", scalar_counts_no_obs_multi)
     def test_scalar_counts_no_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and computational basis counts measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -1025,31 +1025,31 @@ class TestMixMeasurementsShotVector:
                 else:
                     assert isinstance(r, dict)
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_sample(self, shot_vector, sample_obs, device):
         """Test probs and sample measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         meas1_wires = [0, 1]
         meas2_wires = [2]
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.sample(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.sample(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.sample(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.sample(wires=meas2_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -1075,31 +1075,31 @@ class TestMixMeasurementsShotVector:
                     expected = (shots,) if sample_obs else (shots, 1)
                     assert r.shape == expected
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_counts(self, shot_vector, sample_obs, device):
         """Test probs and counts measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         meas1_wires = [0, 1]
         meas2_wires = [2]
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.counts(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.counts(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.counts(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.counts(wires=meas2_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -1131,34 +1131,34 @@ class TestMixMeasurementsShotVector:
     def test_sample_counts(self, shot_vector, sample_wires, counts_wires, device):
         """Test sample and counts measurements, each measurement with custom
         samples or computational basis state samples."""
-        dev = qml.device(device, wires=6)
+        dev = qp.device(device, wires=6)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
 
             # 1. Sample obs and Counts obs
             if len(sample_wires) == 1 and len(counts_wires) == 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(qp.PauliX(counts_wires))
 
             # 2. Sample no obs and Counts obs
             if len(sample_wires) > 1 and len(counts_wires) == 1:
-                return qml.sample(wires=sample_wires), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(wires=sample_wires), qp.counts(qp.PauliX(counts_wires))
 
             # 3. Sample obs and Counts no obs
             if len(sample_wires) == 1 and len(counts_wires) > 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(wires=counts_wires)
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(wires=counts_wires)
 
             # 4. Sample no obs and Counts no obs
-            return qml.sample(wires=sample_wires), qml.counts(wires=counts_wires)
+            return qp.sample(wires=sample_wires), qp.counts(wires=counts_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -1185,23 +1185,23 @@ class TestMixMeasurementsShotVector:
     def test_scalar_probs_sample_counts(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued, probability, sample and counts measurements all
         in a single qfunc."""
-        dev = qml.device(device, wires=5)
+        dev = qp.device(device, wires=5)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.apply(meas1),
-                qml.apply(meas2),
-                qml.sample(qml.PauliX(4)),
-                qml.counts(qml.PauliX(3)),
+                qp.apply(meas1),
+                qp.apply(meas2),
+                qp.sample(qp.PauliX(4)),
+                qp.counts(qp.PauliX(3)),
             )
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_all_shots(shot_vector)
@@ -1243,32 +1243,32 @@ class TestDeviceNewUnits:
         class DummyMeasurement(MeasurementProcess):
             _shortname = "SomeUnsupportedReturnType"
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires=0)
-            DummyMeasurement(obs=qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires=0)
+            DummyMeasurement(obs=qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
-        dev = qml.device("default.qubit", wires=3)
+        tape = qp.tape.QuantumScript.from_queue(q)
+        dev = qp.device("default.qubit", wires=3)
         with pytest.raises(
             DeviceError,
             match="not accepted for analytic simulation on default.qubit",
         ):
             program = dev.preprocess_transforms()
-            qml.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
+            qp.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
 
     def test_state_return_with_other_types(self):
         """Test that an exception is raised when a state is returned along with another return
         type"""
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires=0)
-            qml.state()
-            qml.expval(qml.PauliZ(1))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires=0)
+            qp.state()
+            qp.expval(qp.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
-        res = qml.execute(tapes=[tape], device=dev, diff_method=None)[0]
+        tape = qp.tape.QuantumScript.from_queue(q)
+        res = qp.execute(tapes=[tape], device=dev, diff_method=None)[0]
         assert isinstance(res, tuple) and len(res) == 2
         assert np.array_equal(res[0], [0.0, 0.0, 1.0, 0.0])
         assert res[1] == 1.0
@@ -1276,27 +1276,27 @@ class TestDeviceNewUnits:
     def test_entropy_no_custom_wires(self):
         """Test that entropy cannot be returned with custom wires."""
 
-        dev = qml.device("default.qubit", wires=["a", 1])
+        dev = qp.device("default.qubit", wires=["a", 1])
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires="a")
-            qml.vn_entropy(wires=["a"])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires="a")
+            qp.vn_entropy(wires=["a"])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         program = dev.preprocess_transforms()
-        res = qml.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
+        res = qp.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
         assert res == (0,)
 
     def test_custom_wire_labels_error(self):
         """Tests that an error is raised when mutual information is measured
         with custom wire labels"""
-        dev = qml.device("default.qubit", wires=["a", "b"])
+        dev = qp.device("default.qubit", wires=["a", "b"])
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires="a")
-            qml.mutual_info(wires0=["a"], wires1=["b"])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires="a")
+            qp.mutual_info(wires0=["a"], wires1=["b"])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         program = dev.preprocess_transforms()
-        res = qml.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
+        res = qp.execute(tapes=[tape], device=dev, diff_method=None, transform_program=program)
         assert res == (0,)

--- a/tests/test_return_types_legacy.py
+++ b/tests/test_return_types_legacy.py
@@ -19,19 +19,19 @@ import numpy as np
 import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.exceptions import QuantumFunctionError
 from pennylane.measurements import MeasurementProcess
 
 
 def _get_num_shot_copies(shot_vector):
     """Helper function to get the total number of shots from a shot vector."""
-    return qml.measurements.Shots(shot_vector).num_copies
+    return qp.measurements.Shots(shot_vector).num_copies
 
 
 def _get_all_shot_copies(shot_vector):
     """Helper function to get the total number of shot copies from a shot vector."""
-    return list(qml.measurements.Shots(shot_vector))
+    return list(qp.measurements.Shots(shot_vector))
 
 
 test_wires = [2, 3, 4]
@@ -47,14 +47,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -69,14 +69,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=range(0, d_wires))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -90,14 +90,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -111,14 +111,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -132,14 +132,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=0)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -153,14 +153,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -173,8 +173,8 @@ class TestSingleReturnExecute:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -184,14 +184,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -203,7 +203,7 @@ class TestSingleReturnExecute:
         assert res[0].shape == (2 ** len(wires),)
         assert isinstance(res[0], np.ndarray)
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_sample(self, measurement, interface, shots):
         """Test the sample measurement."""
         if shots is None:
@@ -212,14 +212,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -228,7 +228,7 @@ class TestSingleReturnExecute:
         assert isinstance(res[0], np.ndarray)
         assert res[0].shape == (shots,) if measurement.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, measurement, interface, shots):
         """Test the counts measurement."""
         if shots is None:
@@ -237,14 +237,14 @@ class TestSingleReturnExecute:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)],
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)],
             device=dev,
             diff_method=None,
             interface=interface,
@@ -268,14 +268,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -292,14 +292,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=0)), qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=0)), qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -317,10 +317,10 @@ class TestMultipleReturns:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -330,14 +330,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -364,19 +364,19 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         if wires1 is None:
@@ -408,14 +408,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=i)) for i in range(0, wires)]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=i)) for i in range(0, wires)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         assert isinstance(res[0], tuple)
@@ -425,7 +425,7 @@ class TestMultipleReturns:
             assert isinstance(res[0][i], np.ndarray)
             assert res[0][i].shape == ()
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_expval_sample(self, measurement, shots):
         """Test the expval and sample measurements together."""
         if shots is None:
@@ -434,14 +434,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         # Expval
@@ -452,7 +452,7 @@ class TestMultipleReturns:
         assert isinstance(res[0][1], np.ndarray)
         assert res[0][1].shape == (shots,) if measurement.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_expval_counts(self, measurement, shots):
         """Test the expval and counts measurements together."""
         if shots is None:
@@ -461,14 +461,14 @@ class TestMultipleReturns:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shots)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         # Expval
@@ -480,27 +480,27 @@ class TestMultipleReturns:
         assert sum(res[0][1].values()) == shots
 
 
-pauliz = qml.PauliZ(wires=1)
-proj = qml.Projector([1], wires=1)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
+pauliz = qp.PauliZ(wires=1)
+proj = qp.Projector([1], wires=1)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
 
 # Note: mutual info and vn_entropy do not support some shot vectors
-# qml.mutual_info(wires0=[0], wires1=[1]), qml.vn_entropy(wires=[0])]
+# qp.mutual_info(wires0=[0], wires1=[1]), qp.vn_entropy(wires=[0])]
 single_scalar_output_measurements = [
-    qml.expval(pauliz),
-    qml.var(pauliz),
-    qml.expval(proj),
-    qml.var(proj),
-    qml.expval(hermitian),
-    qml.var(hermitian),
+    qp.expval(pauliz),
+    qp.var(pauliz),
+    qp.expval(proj),
+    qp.var(proj),
+    qp.expval(hermitian),
+    qp.var(hermitian),
 ]
 
 herm = np.diag([1, 2, 3, 4])
 probs_data = [
     (None, [0]),
     (None, [0, 1]),
-    (qml.PauliZ(0), None),
-    (qml.Hermitian(herm, wires=[1, 0]), None),
+    (qp.PauliZ(0), None),
+    (qp.Hermitian(herm, wires=[1, 0]), None),
 ]
 
 shot_vectors = [[10, 1000], [1, 10, 10, 1000], [1, (10, 2), 1000]]
@@ -517,14 +517,14 @@ class TestShotVector:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -539,14 +539,14 @@ class TestShotVector:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -565,14 +565,14 @@ class TestShotVector:
         dev = DefaultQubitLegacy(wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -582,20 +582,20 @@ class TestShotVector:
         dim = 2 ** len(wires)
         assert all(r.shape == (dim, dim) for r in res[0])
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_samples(self, shot_vector, measurement):
         """Test the sample measurement."""
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -608,20 +608,20 @@ class TestShotVector:
             else:
                 assert r.shape == (shots,)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement):
         """Test the counts measurement."""
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -641,14 +641,14 @@ class TestSameMeasurementShotVector:
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(0)), qml.var(qml.PauliZ(1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(0)), qp.var(qp.PauliZ(1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -662,8 +662,8 @@ class TestSameMeasurementShotVector:
     probs_data2 = [
         (None, [2]),
         (None, [2, 3]),
-        (qml.PauliZ(2), None),
-        (qml.Hermitian(herm, wires=[3, 2]), None),
+        (qp.PauliZ(2), None),
+        (qp.Hermitian(herm, wires=[3, 2]), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -674,14 +674,14 @@ class TestSameMeasurementShotVector:
         dev = DefaultQubitLegacy(wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -696,21 +696,21 @@ class TestSameMeasurementShotVector:
             assert r[0].shape == (2 ** len(wires1),)
             assert r[1].shape == (2 ** len(wires2),)
 
-    @pytest.mark.parametrize("measurement1", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.sample(qml.PauliX(1)), qml.sample(wires=[1])])
+    @pytest.mark.parametrize("measurement1", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.sample(qp.PauliX(1)), qp.sample(wires=[1])])
     def test_samples(self, shot_vector, measurement1, measurement2):
         """Test multiple sample measurements."""
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -720,21 +720,21 @@ class TestSameMeasurementShotVector:
             shape = () if shots == 1 else (shots,)
             assert all(res_item.shape == shape for res_item in r)
 
-    @pytest.mark.parametrize("measurement1", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement1", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement1, measurement2):
         """Test multiple counts measurements."""
         dev = DefaultQubitLegacy(wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -750,60 +750,60 @@ class TestSameMeasurementShotVector:
 # Shot vector multi measurement tests - test data
 # -------------------------------------------------
 
-pauliz_w2 = qml.PauliZ(wires=2)
-proj_w2 = qml.Projector([1], wires=2)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
-tensor_product = qml.PauliZ(wires=2) @ qml.PauliX(wires=1)
+pauliz_w2 = qp.PauliZ(wires=2)
+proj_w2 = qp.Projector([1], wires=2)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
+tensor_product = qp.PauliZ(wires=2) @ qp.PauliX(wires=1)
 
 # Expval/Var with Probs
 
 scalar_probs_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.probs(wires=[2, 0])),
-    (qml.expval(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.expval(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.expval(pauliz_w2), qp.probs(wires=[2, 0])),
+    (qp.expval(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.expval(tensor_product), qp.probs(wires=[2, 0])),
     # Var
-    (qml.var(qml.PauliZ(wires=1)), qml.probs(wires=[0, 1])),
-    (qml.var(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.var(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.var(qp.PauliZ(wires=1)), qp.probs(wires=[0, 1])),
+    (qp.var(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.var(tensor_product), qp.probs(wires=[2, 0])),
 ]
 
 # Expval/Var with Sample
 
 scalar_sample_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.sample(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.sample(op=qp.PauliZ(0))),
 ]
 
 scalar_sample_no_obs_multi = [
-    (qml.expval(qml.PauliZ(wires=1)), qml.sample()),
-    (qml.expval(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.sample()),
+    (qp.expval(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
 ]
 
 # Expval/Var with Counts
 
 scalar_counts_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.counts(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.counts(op=qp.PauliZ(0))),
 ]
 
 scalar_counts_no_obs_multi = [
-    (qml.expval(qml.PauliZ(wires=1)), qml.counts()),
-    (qml.expval(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.counts()),
+    (qp.expval(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
 ]
 
 
@@ -818,14 +818,14 @@ class TestMixMeasurementsShotVector:
         dev = DefaultQubitLegacy(wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -853,14 +853,14 @@ class TestMixMeasurementsShotVector:
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -886,14 +886,14 @@ class TestMixMeasurementsShotVector:
         dev = DefaultQubitLegacy(wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -921,14 +921,14 @@ class TestMixMeasurementsShotVector:
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -961,14 +961,14 @@ class TestMixMeasurementsShotVector:
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -987,7 +987,7 @@ class TestMixMeasurementsShotVector:
                 else:
                     assert isinstance(r, dict)
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_sample(self, shot_vector, sample_obs):
         """Test probs and sample measurements."""
         dev = DefaultQubitLegacy(wires=3)
@@ -996,22 +996,22 @@ class TestMixMeasurementsShotVector:
         meas1_wires = [0, 1]
         meas2_wires = [2]
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.sample(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.sample(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.sample(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.sample(wires=meas2_wires)
 
-        qnode = qml.QNode(circuit, dev)
+        qnode = qp.QNode(circuit, dev)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -1036,7 +1036,7 @@ class TestMixMeasurementsShotVector:
                         expected = (shots,)
                         assert r.shape == expected
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_counts(self, shot_vector, sample_obs):
         """Test probs and counts measurements."""
         dev = DefaultQubitLegacy(wires=3)
@@ -1045,22 +1045,22 @@ class TestMixMeasurementsShotVector:
         meas1_wires = [0, 1]
         meas2_wires = [2]
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.counts(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.counts(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.counts(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.counts(wires=meas2_wires)
 
-        qnode = qml.QNode(circuit, dev)
+        qnode = qp.QNode(circuit, dev)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -1093,31 +1093,31 @@ class TestMixMeasurementsShotVector:
         dev = DefaultQubitLegacy(wires=6)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
-        @qml.set_shots(shot_vector)
-        @qml.qnode(device=dev)
+        @qp.set_shots(shot_vector)
+        @qp.qnode(device=dev)
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
 
             # 1. Sample obs and Counts obs
             if len(sample_wires) == 1 and len(counts_wires) == 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(qp.PauliX(counts_wires))
 
             # 2. Sample no obs and Counts obs
             if len(sample_wires) > 1 and len(counts_wires) == 1:
-                return qml.sample(wires=sample_wires), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(wires=sample_wires), qp.counts(qp.PauliX(counts_wires))
 
             # 3. Sample obs and Counts no obs
             if len(sample_wires) == 1 and len(counts_wires) > 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(wires=counts_wires)
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(wires=counts_wires)
 
             # 4. Sample no obs and Counts no obs
-            return qml.sample(wires=sample_wires), qml.counts(wires=counts_wires)
+            return qp.sample(wires=sample_wires), qp.counts(wires=counts_wires)
 
-        qnode = qml.QNode(circuit, dev)
+        qnode = qp.QNode(circuit, dev)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -1148,19 +1148,19 @@ class TestMixMeasurementsShotVector:
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.apply(meas1),
-                qml.apply(meas2),
-                qml.sample(qml.PauliX(4)),
-                qml.counts(qml.PauliX(3)),
+                qp.apply(meas1),
+                qp.apply(meas2),
+                qp.sample(qp.PauliX(4)),
+                qp.counts(qp.PauliX(3)),
             )
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev), shots=shot_vector)
 
-        res = qml.execute(
-            tapes=[qml.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
+        res = qp.execute(
+            tapes=[qp.workflow.construct_tape(qnode)(0.5)], device=dev, diff_method=None
         )
 
         all_shots = _get_num_shot_copies(shot_vector)
@@ -1205,18 +1205,18 @@ class TestQubitDeviceNewUnits:
         class DummyMeasurement(MeasurementProcess):
             _shortname = "SomeUnsupportedReturnType"
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires=0)
-            DummyMeasurement(obs=qml.PauliZ(0))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires=0)
+            DummyMeasurement(obs=qp.PauliZ(0))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         dev = DefaultQubitLegacy(wires=3)
 
         with pytest.raises(
             QuantumFunctionError,
             match="Unsupported return type specified for observable",
         ):
-            qml.execute(tapes=[tape], device=dev, diff_method=None)
+            qp.execute(tapes=[tape], device=dev, diff_method=None)
 
     def test_state_return_with_other_types(self):
         """Test that an exception is raised when a state is returned along with another return
@@ -1224,44 +1224,44 @@ class TestQubitDeviceNewUnits:
 
         dev = DefaultQubitLegacy(wires=2)
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires=0)
-            qml.state()
-            qml.expval(qml.PauliZ(1))
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires=0)
+            qp.state()
+            qp.expval(qp.PauliZ(1))
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(
             QuantumFunctionError,
             match="The state or density matrix cannot be returned in combination with other return types",
         ):
-            qml.execute(tapes=[tape], device=dev, diff_method=None)
+            qp.execute(tapes=[tape], device=dev, diff_method=None)
 
     def test_vn_entropy_no_custom_wires(self):
         """Test that vn_entropy cannot be returned with custom wires."""
 
         dev = DefaultQubitLegacy(wires=["a", 1])
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires="a")
-            qml.vn_entropy(wires=["a"])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires="a")
+            qp.vn_entropy(wires=["a"])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         with pytest.raises(
             QuantumFunctionError,
             match="Returning the Von Neumann entropy is not supported when using custom wire labels",
         ):
-            qml.execute(tapes=[tape], device=dev, diff_method=None)
+            qp.execute(tapes=[tape], device=dev, diff_method=None)
 
     def test_custom_wire_labels_error(self):
         """Tests that an error is raised when mutual information is measured
         with custom wire labels"""
         dev = DefaultQubitLegacy(wires=["a", "b"])
 
-        with qml.queuing.AnnotatedQueue() as q:
-            qml.PauliX(wires="a")
-            qml.mutual_info(wires0=["a"], wires1=["b"])
+        with qp.queuing.AnnotatedQueue() as q:
+            qp.PauliX(wires="a")
+            qp.mutual_info(wires0=["a"], wires1=["b"])
 
-        tape = qml.tape.QuantumScript.from_queue(q)
+        tape = qp.tape.QuantumScript.from_queue(q)
         msg = "Returning the mutual information is not supported when using custom wire labels"
         with pytest.raises(QuantumFunctionError, match=msg):
-            qml.execute(tapes=[tape], device=dev, diff_method=None)
+            qp.execute(tapes=[tape], device=dev, diff_method=None)

--- a/tests/test_return_types_qnode.py
+++ b/tests/test_return_types_qnode.py
@@ -18,21 +18,21 @@ Unit tests for the new return types with QNode.
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 
 test_wires = [2, 3, 4]
 devices = ["default.qubit", "lightning.qubit", "default.mixed", "default.qutrit"]
 
 
 def qubit_ansatz(x):
-    qml.Hadamard(wires=[0])
-    qml.CRX(x, wires=[0, 1])
+    qp.Hadamard(wires=[0])
+    qp.CRX(x, wires=[0, 1])
 
 
 def qutrit_ansatz(x):
-    qml.THadamard(wires=[0])
+    qp.THadamard(wires=[0])
     mat = np.exp(1j * x) * np.eye(9)
-    qml.QutritUnitary(mat, wires=[0, 1])
+    qp.QutritUnitary(mat, wires=[0, 1])
 
 
 class TestIntegrationSingleReturn:
@@ -41,13 +41,13 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize("wires", test_wires)
     def test_state_default(self, wires):
         """Return state with default.qubit."""
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.state()
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert res.shape == (2**wires,)
@@ -56,13 +56,13 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize("wires", test_wires)
     def test_state_mixed(self, wires):
         """Return state with default.mixed."""
-        dev = qml.device("default.mixed", wires=wires)
+        dev = qp.device("default.mixed", wires=wires)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.state()
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert res.shape == (2**wires, 2**wires)
@@ -72,14 +72,14 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize("d_wires", test_wires)
     def test_density_matrix(self, d_wires, device):
         """Return density matrix with default.qubit."""
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.density_matrix(wires=range(0, d_wires))
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         dim = 3 if device == "default.qutrit" else 2
@@ -89,19 +89,19 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize("device", devices)
     def test_expval(self, device):
         """Return a single expval."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.expval(
-                qml.PauliZ(wires=1) if device != "default.qutrit" else qml.GellMann(1, 3)
+            return qp.expval(
+                qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
-        assert qml.math.shape(res) == ()
+        assert qp.math.shape(res) == ()
         assert isinstance(res, (np.ndarray, np.float64, float))
 
     @pytest.mark.parametrize("device", devices)
@@ -109,36 +109,36 @@ class TestIntegrationSingleReturn:
     def test_expval_single_return_in_list(self, device, shots):
         """Test that the return shape is expected for a single expectation value in a list."""
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
-        obs = qml.PauliZ(wires=1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs = qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
 
         def circuit(x):
             func(x)
-            return [qml.expval(obs)]
+            return [qp.expval(obs)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(0.5)
 
-        assert qml.math.shape(res) == ((1,) if shots is None else (2, 1))
+        assert qp.math.shape(res) == ((1,) if shots is None else (2, 1))
 
     @pytest.mark.parametrize("device", devices)
     def test_var(self, device):
         """Return a single var."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.var(
-                qml.PauliZ(wires=1) if device != "default.qutrit" else qml.GellMann(1, 3)
+            return qp.var(
+                qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
-        assert qml.math.shape(res) == ()
+        assert qp.math.shape(res) == ()
         assert isinstance(res, (np.ndarray, np.float64, float))
 
     @pytest.mark.parametrize("device", devices)
@@ -147,29 +147,29 @@ class TestIntegrationSingleReturn:
         if device == "default.qutrit":
             pytest.skip("DefaultQutrit does not support VnEntropy.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.vn_entropy(wires=0)
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert res.shape == ()
         assert isinstance(res, (np.ndarray, np.float64))
 
-    @pytest.mark.xfail(reason="qml.execute shot vec support required with new return types")
+    @pytest.mark.xfail(reason="qp.execute shot vec support required with new return types")
     @pytest.mark.filterwarnings("ignore:Requested Von Neumann entropy with finite shots")
     def test_vn_entropy_shot_vec_error(self):
         """Test an error is raised when using shot vectors with vn_entropy."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.set_shots([1, 10, 10, 1000])
-        @qml.qnode(device=dev)
+        @qp.set_shots([1, 10, 10, 1000])
+        @qp.qnode(device=dev)
         def circuit(x):
             qubit_ansatz(x)
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
         with pytest.raises(
             NotImplementedError, match="mutual information is not supported with shot vectors"
@@ -182,29 +182,29 @@ class TestIntegrationSingleReturn:
         if device == "default.qutrit":
             pytest.skip("DefaultQutrit does not support MutualInfo.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert res.shape == ()
         assert isinstance(res, (np.ndarray, np.float64))
 
-    @pytest.mark.xfail(reason="qml.execute shot vec support required with new return types")
+    @pytest.mark.xfail(reason="qp.execute shot vec support required with new return types")
     @pytest.mark.filterwarnings("ignore:Requested mutual information with finite shots")
     def test_mutual_info_shot_vec_error(self):
         """Test an error is raised when using shot vectors with mutual_info."""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.set_shots([1, 10, 10, 1000])
-        @qml.qnode(device=dev)
+        @qp.set_shots([1, 10, 10, 1000])
+        @qp.qnode(device=dev)
         def circuit(x):
             qubit_ansatz(x)
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
         with pytest.raises(
             NotImplementedError, match="mutual information is not supported with shot vectors"
@@ -215,8 +215,8 @@ class TestIntegrationSingleReturn:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     @pytest.mark.parametrize("device", devices)
@@ -227,13 +227,13 @@ class TestIntegrationSingleReturn:
             pytest.skip(
                 "Skip Lightning (wire reordering unsupported) and Qutrit (unsuported observables)."
             )
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.probs(op=op, wires=wires)
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         if wires is None:
@@ -243,8 +243,8 @@ class TestIntegrationSingleReturn:
         assert isinstance(res, (np.ndarray, np.float64))
 
     probs_data_qutrit = [
-        (qml.GellMann(0, 3), None),
-        (qml.THermitian(np.eye(9), wires=[1, 0]), None),
+        (qp.GellMann(0, 3), None),
+        (qp.THermitian(np.eye(9), wires=[1, 0]), None),
         (None, [0]),
         (None, [0, 1]),
     ]
@@ -252,13 +252,13 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize("op,wires", probs_data_qutrit)
     def test_probs_qutrit(self, op, wires):
         """Return a single prob."""
-        dev = qml.device("default.qutrit", wires=3)
+        dev = qp.device("default.qutrit", wires=3)
 
         def circuit(x):
             qutrit_ansatz(x)
-            return qml.probs(op=op, wires=wires)
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         if wires is None:
@@ -271,28 +271,28 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize(
         "measurement",
         [
-            qml.sample(qml.PauliZ(0)),
-            qml.sample(wires=[0]),
-            qml.sample(wires=[0, 1]),
-            qml.sample(qml.GellMann(0, 3)),
+            qp.sample(qp.PauliZ(0)),
+            qp.sample(wires=[0]),
+            qp.sample(wires=[0, 1]),
+            qp.sample(qp.GellMann(0, 3)),
         ],
     )
     def test_sample(self, measurement, device, shots=100):
         """Test the sample measurement."""
         if device == "default.qutrit":
-            if isinstance(measurement.obs, qml.PauliZ):
+            if isinstance(measurement.obs, qp.PauliZ):
                 pytest.skip("DefaultQutrit doesn't support qubit observables.")
-        elif isinstance(measurement.obs, qml.GellMann):
+        elif isinstance(measurement.obs, qp.GellMann):
             pytest.skip("DefaultQubitLegacy doesn't support qutrit observables.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.apply(measurement)
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(0.5)
 
         assert isinstance(res, (np.ndarray, np.float64))
@@ -306,28 +306,28 @@ class TestIntegrationSingleReturn:
     @pytest.mark.parametrize(
         "measurement",
         [
-            qml.counts(qml.PauliZ(0)),
-            qml.counts(wires=[0]),
-            qml.counts(wires=[0, 1]),
-            qml.counts(qml.GellMann(0, 3)),
+            qp.counts(qp.PauliZ(0)),
+            qp.counts(wires=[0]),
+            qp.counts(wires=[0, 1]),
+            qp.counts(qp.GellMann(0, 3)),
         ],
     )
     def test_counts(self, measurement, device, shots=100):
         """Test the counts measurement."""
         if device == "default.qutrit":
-            if isinstance(measurement.obs, qml.PauliZ):
+            if isinstance(measurement.obs, qp.PauliZ):
                 pytest.skip("DefaultQutrit doesn't support qubit observables.")
-        elif isinstance(measurement.obs, qml.GellMann):
+        elif isinstance(measurement.obs, qp.GellMann):
             pytest.skip("DefaultQubitLegacy doesn't support qutrit observables.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.apply(measurement)
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(0.5)
 
         assert isinstance(res, dict)
@@ -346,14 +346,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return state with default.qubit."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == (2**wires,)
@@ -364,14 +364,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return state with default.mixed."""
         import tensorflow as tf
 
-        dev = qml.device("default.mixed", wires=wires)
+        dev = qp.device("default.mixed", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == (2**wires, 2**wires)
@@ -385,14 +385,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return density matrix."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=range(0, d_wires))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == (2**d_wires, 2**d_wires)
@@ -403,14 +403,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return a single expval."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == ()
@@ -421,14 +421,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return a single var."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == ()
@@ -439,14 +439,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return a single vn entropy."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=0)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == ()
@@ -457,14 +457,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return a single mutual information."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert res.shape == ()
@@ -474,8 +474,8 @@ class TestIntegrationSingleReturnTensorFlow:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     @pytest.mark.parametrize("device", devices)
@@ -484,14 +484,14 @@ class TestIntegrationSingleReturnTensorFlow:
         """Return a single prob."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         if wires is None:
@@ -502,7 +502,7 @@ class TestIntegrationSingleReturnTensorFlow:
 
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
-        "measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0]), qml.sample(wires=[0, 1])]
+        "measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0]), qp.sample(wires=[0, 1])]
     )
     def test_sample(self, measurement, device, shots=100):
         """Test the sample measurement."""
@@ -511,14 +511,14 @@ class TestIntegrationSingleReturnTensorFlow:
         if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for Tf.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, tf.Tensor)
@@ -530,20 +530,20 @@ class TestIntegrationSingleReturnTensorFlow:
 
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
-        "measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0]), qml.counts(wires=[0, 1])]
+        "measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0]), qp.counts(wires=[0, 1])]
     )
     def test_counts(self, measurement, device, shots=100):
         """Test the counts measurement."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, dict)
@@ -562,14 +562,14 @@ class TestIntegrationSingleReturnTorch:
         """Return state with default.qubit."""
         import torch
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == (2**wires,)
@@ -580,14 +580,14 @@ class TestIntegrationSingleReturnTorch:
         """Return state with default.mixed."""
         import torch
 
-        dev = qml.device("default.mixed", wires=wires)
+        dev = qp.device("default.mixed", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == (2**wires, 2**wires)
@@ -599,14 +599,14 @@ class TestIntegrationSingleReturnTorch:
         """Return density matrix."""
         import torch
 
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=range(0, d_wires))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == (2**d_wires, 2**d_wires)
@@ -617,14 +617,14 @@ class TestIntegrationSingleReturnTorch:
         """Return a single expval."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == ()
@@ -635,14 +635,14 @@ class TestIntegrationSingleReturnTorch:
         """Return a single var."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == ()
@@ -653,14 +653,14 @@ class TestIntegrationSingleReturnTorch:
         """Return a single vn entropy."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=0)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == ()
@@ -671,14 +671,14 @@ class TestIntegrationSingleReturnTorch:
         """Return a single mutual information."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert res.shape == ()
@@ -688,8 +688,8 @@ class TestIntegrationSingleReturnTorch:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     @pytest.mark.parametrize("device", devices)
@@ -698,14 +698,14 @@ class TestIntegrationSingleReturnTorch:
         """Return a single prob."""
         import torch
 
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         if wires is None:
@@ -716,7 +716,7 @@ class TestIntegrationSingleReturnTorch:
 
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
-        "measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0]), qml.sample(wires=[0, 1])]
+        "measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0]), qp.sample(wires=[0, 1])]
     )
     def test_sample(self, measurement, device, shots=100):
         """Test the sample measurement."""
@@ -725,14 +725,14 @@ class TestIntegrationSingleReturnTorch:
         if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for Torch.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, torch.Tensor)
@@ -743,7 +743,7 @@ class TestIntegrationSingleReturnTorch:
             assert res.shape == (shots, 2)
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, measurement, device, shots=100):
         """Test the counts measurement."""
         import torch
@@ -751,14 +751,14 @@ class TestIntegrationSingleReturnTorch:
         if device == "default.mixed":
             pytest.skip("Counts need to be rewritten for Torch and default mixed.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, dict)
@@ -778,14 +778,14 @@ class TestIntegrationSingleReturnJax:
 
         import jax
 
-        dev = qml.device("default.qubit", wires=wires)
+        dev = qp.device("default.qubit", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == (2**wires,)
@@ -796,14 +796,14 @@ class TestIntegrationSingleReturnJax:
         """Return state with default.mixed."""
         import jax
 
-        dev = qml.device("default.mixed", wires=wires)
+        dev = qp.device("default.mixed", wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.state()
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.state()
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == (2**wires, 2**wires)
@@ -815,14 +815,14 @@ class TestIntegrationSingleReturnJax:
         """Return density matrix."""
         import jax
 
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.density_matrix(wires=range(0, d_wires))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.density_matrix(wires=range(0, d_wires))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == (2**d_wires, 2**d_wires)
@@ -833,14 +833,14 @@ class TestIntegrationSingleReturnJax:
         """Return a single expval."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == ()
@@ -851,14 +851,14 @@ class TestIntegrationSingleReturnJax:
         """Return a single var."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == ()
@@ -869,14 +869,14 @@ class TestIntegrationSingleReturnJax:
         """Return a single vn entropy."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.vn_entropy(wires=0)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.vn_entropy(wires=0)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == ()
@@ -887,14 +887,14 @@ class TestIntegrationSingleReturnJax:
         """Return a single mutual information."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.mutual_info(wires0=[0], wires1=[1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.mutual_info(wires0=[0], wires1=[1])
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert res.shape == ()
@@ -904,8 +904,8 @@ class TestIntegrationSingleReturnJax:
     probs_data = [
         (None, [0]),
         (None, [0, 1]),
-        (qml.PauliZ(0), None),
-        (qml.Hermitian(herm, wires=[1, 0]), None),
+        (qp.PauliZ(0), None),
+        (qp.Hermitian(herm, wires=[1, 0]), None),
     ]
 
     @pytest.mark.parametrize("device", devices)
@@ -914,14 +914,14 @@ class TestIntegrationSingleReturnJax:
         """Return a single prob."""
         import jax
 
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         if wires is None:
@@ -932,7 +932,7 @@ class TestIntegrationSingleReturnJax:
 
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
-        "measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0]), qml.sample(wires=[0, 1])]
+        "measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0]), qp.sample(wires=[0, 1])]
     )
     def test_sample(self, measurement, device, shots=100):
         """Test the sample measurement."""
@@ -941,14 +941,14 @@ class TestIntegrationSingleReturnJax:
         if device == "default.mixed":
             pytest.skip("Sample need to be rewritten for each interface in default mixed.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, jax.numpy.ndarray)
@@ -960,20 +960,20 @@ class TestIntegrationSingleReturnJax:
 
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
-        "measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0]), qml.counts(wires=[0, 1])]
+        "measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0]), qp.counts(wires=[0, 1])]
     )
     def test_counts(self, measurement, device, shots=100):
         """Test the counts measurement."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, dict)
@@ -993,60 +993,60 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("device", devices)
     def test_multiple_expval(self, device):
         """Return multiple expvals."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         obs1 = (
-            qml.Projector([0], wires=0)
+            qp.Projector([0], wires=0)
             if device != "default.qutrit"
-            else qml.THermitian(np.eye(3), wires=0)
+            else qp.THermitian(np.eye(3), wires=0)
         )
-        obs2 = qml.PauliZ(wires=1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs2 = qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.expval(obs1), qml.expval(obs2)
+            return qp.expval(obs1), qp.expval(obs2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
         assert len(res) == 2
 
         assert isinstance(res[0], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[0]) == ()
+        assert qp.math.shape(res[0]) == ()
 
         assert isinstance(res[1], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[1]) == ()
+        assert qp.math.shape(res[1]) == ()
 
     @pytest.mark.parametrize("device", devices)
     def test_multiple_var(self, device):
         """Return multiple vars."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         obs1 = (
-            qml.Projector([0], wires=0)
+            qp.Projector([0], wires=0)
             if device != "default.qutrit"
-            else qml.THermitian(np.eye(3), wires=0)
+            else qp.THermitian(np.eye(3), wires=0)
         )
-        obs2 = qml.PauliZ(wires=1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs2 = qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
         func = qutrit_ansatz if device == "default.qutrit" else qubit_ansatz
 
         def circuit(x):
             func(x)
-            return qml.var(obs1), qml.var(obs2)
+            return qp.var(obs1), qp.var(obs2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
         assert len(res) == 2
 
         assert isinstance(res[0], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[0]) == ()
+        assert qp.math.shape(res[0]) == ()
 
         assert isinstance(res[1], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[1]) == ()
+        assert qp.math.shape(res[1]) == ()
 
     # op1, wires1, op2, wires2
     multi_probs_data = [
@@ -1054,10 +1054,10 @@ class TestIntegrationMultipleReturns:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -1068,13 +1068,13 @@ class TestIntegrationMultipleReturns:
         if device == "default.qutrit":
             pytest.skip("Separate test for DefaultQutrit.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
             qubit_ansatz(x)
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
@@ -1093,10 +1093,10 @@ class TestIntegrationMultipleReturns:
         assert res[1].shape == (2 ** len(wires2),)
 
     multi_probs_data_qutrit = [
-        (qml.GellMann(0, 3), None, qml.GellMann(1, 3), None),
-        (None, [0], qml.GellMann(1, 3), None),
-        (qml.GellMann(0, 3), None, None, [1]),
-        (qml.GellMann(1, 3), None, qml.GellMann(0, 3), None),
+        (qp.GellMann(0, 3), None, qp.GellMann(1, 3), None),
+        (None, [0], qp.GellMann(1, 3), None),
+        (qp.GellMann(0, 3), None, None, [1]),
+        (qp.GellMann(1, 3), None, qp.GellMann(0, 3), None),
         (None, [0], None, [0]),
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
@@ -1106,13 +1106,13 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("op1,wires1,op2,wires2", multi_probs_data_qutrit)
     def test_multiple_prob_qutrit(self, op1, op2, wires1, wires2):
         """Return multiple probs."""
-        dev = qml.device("default.qutrit", wires=2)
+        dev = qp.device("default.qutrit", wires=2)
 
         def circuit(x):
             qutrit_ansatz(x)
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
@@ -1139,18 +1139,18 @@ class TestIntegrationMultipleReturns:
         if device == "default.qutrit":
             pytest.skip("Different test for DefaultQutrit.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
             qubit_ansatz(x)
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         if wires1 is None:
@@ -1163,16 +1163,16 @@ class TestIntegrationMultipleReturns:
         assert len(res) == 4
 
         assert isinstance(res[0], (np.ndarray, np.float64))
-        assert qml.math.shape(res[0]) == (2 ** len(wires1),)
+        assert qp.math.shape(res[0]) == (2 ** len(wires1),)
 
         assert isinstance(res[1], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[1]) == ()
+        assert qp.math.shape(res[1]) == ()
 
         assert isinstance(res[2], (np.ndarray, np.float64))
-        assert qml.math.shape(res[2]) == (2 ** len(wires2),)
+        assert qp.math.shape(res[2]) == (2 ** len(wires2),)
 
         assert isinstance(res[3], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[3]) == ()
+        assert qp.math.shape(res[3]) == ()
 
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize("op1,wires1,op2,wires2", multi_probs_data_qutrit)
@@ -1181,18 +1181,18 @@ class TestIntegrationMultipleReturns:
         """Return multiple different measurements."""
         pytest.skip("Non-commuting observables don't work correctly for qutrits yet.")
 
-        dev = qml.device("default.qutrit", wires=2)
+        dev = qp.device("default.qutrit", wires=2)
 
         def circuit(x):
             qutrit_ansatz(x)
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.var(qml.GellMann(wires3, 3)),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.GellMann(wires4, 3)),
+                qp.probs(op=op1, wires=wires1),
+                qp.var(qp.GellMann(wires3, 3)),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.GellMann(wires4, 3)),
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         if wires1 is None:
@@ -1219,25 +1219,25 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
         "measurement",
-        [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0]), qml.sample(qml.GellMann(0, 3))],
+        [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0]), qp.sample(qp.GellMann(0, 3))],
     )
     def test_expval_sample(self, measurement, device, shots=100):
         """Test the expval and sample measurements together."""
         if device == "default.qutrit":
-            if isinstance(measurement.obs, qml.PauliZ):
+            if isinstance(measurement.obs, qp.PauliZ):
                 pytest.skip("DefaultQutrit doesn't support qubit observables.")
-        elif isinstance(measurement.obs, qml.GellMann):
+        elif isinstance(measurement.obs, qp.GellMann):
             pytest.skip("DefaultQubitLegacy doesn't support qutrit observables.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qubit_ansatz if device != "default.qutrit" else qutrit_ansatz
-        obs = qml.PauliZ(1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs = qp.PauliZ(1) if device != "default.qutrit" else qp.GellMann(1, 3)
 
         def circuit(x):
             func(x)
-            return qml.expval(obs), qml.apply(measurement)
+            return qp.expval(obs), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(0.5)
 
         # Expval
@@ -1251,25 +1251,25 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("device", devices)
     @pytest.mark.parametrize(
         "measurement",
-        [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0]), qml.counts(qml.GellMann(0, 3))],
+        [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0]), qp.counts(qp.GellMann(0, 3))],
     )
     def test_expval_counts(self, measurement, device, shots=100):
         """Test the expval and counts measurements together."""
         if device == "default.qutrit":
-            if isinstance(measurement.obs, qml.PauliZ):
+            if isinstance(measurement.obs, qp.PauliZ):
                 pytest.skip("DefaultQutrit doesn't support qubit observables.")
-        elif isinstance(measurement.obs, qml.GellMann):
+        elif isinstance(measurement.obs, qp.GellMann):
             pytest.skip("DefaultQubitLegacy doesn't support qutrit observables.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
         func = qubit_ansatz if device != "default.qutrit" else qutrit_ansatz
-        obs = qml.PauliZ(1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs = qp.PauliZ(1) if device != "default.qutrit" else qp.GellMann(1, 3)
 
         def circuit(x):
             func(x)
-            return qml.expval(obs), qml.apply(measurement)
+            return qp.expval(obs), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(0.5)
 
         # Expval
@@ -1286,21 +1286,21 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("wires", wires)
     def test_list_one_expval(self, wires, device):
         """Return a comprehension list of one expvals."""
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
         func = qubit_ansatz if device != "default.qutrit" else qutrit_ansatz
-        obs = qml.PauliZ(0) if device != "default.qutrit" else qml.GellMann(0, 3)
+        obs = qp.PauliZ(0) if device != "default.qutrit" else qp.GellMann(0, 3)
 
         def circuit(x):
             func(x)
-            return [qml.expval(obs)]
+            return [qp.expval(obs)]
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, list)
         assert len(res) == 1
         assert isinstance(res[0], (np.ndarray, np.float64, float))
-        assert qml.math.shape(res[0]) == ()
+        assert qp.math.shape(res[0]) == ()
 
     shot_vectors = [None, [10, 1000], [1, 10, 10, 1000], [1, (10, 2), 1000]]
 
@@ -1309,19 +1309,19 @@ class TestIntegrationMultipleReturns:
     @pytest.mark.parametrize("shot_vector", shot_vectors)
     def test_list_multiple_expval(self, wires, device, shot_vector):
         """Return a comprehension list of multiple expvals."""
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
         func = qubit_ansatz if device != "default.qutrit" else qutrit_ansatz
-        obs = qml.PauliZ if device != "default.qutrit" else qml.GellMann
+        obs = qp.PauliZ if device != "default.qutrit" else qp.GellMann
 
         def circuit(x):
             func(x)
             # pylint:disable=unexpected-keyword-arg
             return [
-                qml.expval(obs(wires=i) if device != "default.qutrit" else obs(wires=i, index=3))
+                qp.expval(obs(wires=i) if device != "default.qutrit" else obs(wires=i, index=3))
                 for i in range(0, wires)
             ]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         if shot_vector is None:
@@ -1329,7 +1329,7 @@ class TestIntegrationMultipleReturns:
             assert len(res) == wires
             for r in res:
                 assert isinstance(r, (np.ndarray, np.float64, float))
-                assert qml.math.shape(r) == ()
+                assert qp.math.shape(r) == ()
 
         else:
             for r in res:
@@ -1338,38 +1338,38 @@ class TestIntegrationMultipleReturns:
 
                 for t in r:
                     assert isinstance(t, (np.ndarray, np.float64, float))
-                    assert qml.math.shape(t) == ()
+                    assert qp.math.shape(t) == ()
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("comp_basis_sampling", [qml.sample(), qml.counts()])
+    @pytest.mark.parametrize("comp_basis_sampling", [qp.sample(), qp.counts()])
     def test_sample_counts_no_obs(self, device, comp_basis_sampling):
-        """Measuring qml.sample()/qml.counts() works with other measurements even with the same wire being measured."""
+        """Measuring qp.sample()/qp.counts() works with other measurements even with the same wire being measured."""
         if device == "default.qutrit":
             pytest.skip("Non-commuting observables don't work correctly for qutrits yet.")
 
         shot_num = 1000
         num_wires = 2
-        dev = qml.device(device, wires=num_wires)
+        dev = qp.device(device, wires=num_wires)
         func = qubit_ansatz if device != "default.qutrit" else qutrit_ansatz
-        obs = qml.PauliZ(1) if device != "default.qutrit" else qml.GellMann(1, 3)
+        obs = qp.PauliZ(1) if device != "default.qutrit" else qp.GellMann(1, 3)
 
         def circuit(x):
             func(x)
-            return qml.apply(comp_basis_sampling), qml.expval(obs), qml.probs(wires=[0])
+            return qp.apply(comp_basis_sampling), qp.expval(obs), qp.probs(wires=[0])
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_num)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_num)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
 
-        if isinstance(comp_basis_sampling, qml.measurements.SampleMP):
+        if isinstance(comp_basis_sampling, qp.measurements.SampleMP):
             assert res[0].shape == (shot_num, num_wires)
         else:
             assert isinstance(res[0], dict)
 
-        assert isinstance(res[1], (qml.numpy.ndarray, qml.numpy.float64))
+        assert isinstance(res[1], (qp.numpy.ndarray, qp.numpy.float64))
         assert res[1].shape == ()
-        assert isinstance(res[2], (qml.numpy.ndarray, qml.numpy.float64))
+        assert isinstance(res[2], (qp.numpy.ndarray, qp.numpy.float64))
         assert res[2].shape == (2,)
 
 
@@ -1387,14 +1387,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Return multiple expvals."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.Projector([0], wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.Projector([0], wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, tuple)
@@ -1411,14 +1411,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Return multiple vars."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=0)), qml.var(qml.Hermitian([[1, 0], [0, 1]], wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=0)), qp.var(qp.Hermitian([[1, 0], [0, 1]], wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, tuple)
@@ -1436,10 +1436,10 @@ class TestIntegrationMultipleReturnsTensorflow:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -1449,14 +1449,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Return multiple probs."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, tuple)
@@ -1482,19 +1482,19 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Return multiple different measurements."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         if wires1 is None:
@@ -1519,7 +1519,7 @@ class TestIntegrationMultipleReturnsTensorflow:
         assert res[3].shape == ()
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_expval_sample(self, measurement, device, shots=100):
         """Test the expval and sample measurements together."""
         import tensorflow as tf
@@ -1527,14 +1527,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample must be reworked with interfaces.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(tf.Variable(0.5))
 
         # Expval
@@ -1546,22 +1546,22 @@ class TestIntegrationMultipleReturnsTensorflow:
         assert res[1].shape == (shots,)
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_expval_counts(self, measurement, device, shots=100):
         """Test the expval and counts measurements together."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         if device == "default.mixed":
             pytest.skip("Mixed as array must be reworked for shots.")
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(tf.Variable(0.5))
 
         # Expval
@@ -1580,14 +1580,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         """Return a comprehension list of one expvals."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=0))]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=0))]
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(tf.Variable(0.5))
 
         assert isinstance(res, list)
@@ -1607,14 +1607,14 @@ class TestIntegrationMultipleReturnsTensorflow:
         if device == "default.mixed" and shot_vector:
             pytest.skip("No support for shot vector and Tensorflow because use of .T in statistics")
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=i)) for i in range(0, wires)]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=i)) for i in range(0, wires)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(tf.Variable(0.5))
 
         if shot_vector is None:
@@ -1648,14 +1648,14 @@ class TestIntegrationMultipleReturnsTorch:
         """Return multiple expvals."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.Projector([0], wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.Projector([0], wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, tuple)
@@ -1672,14 +1672,14 @@ class TestIntegrationMultipleReturnsTorch:
         """Return multiple vars."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=0)), qml.var(qml.Hermitian([[1, 0], [0, 1]], wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=0)), qp.var(qp.Hermitian([[1, 0], [0, 1]], wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, tuple)
@@ -1697,10 +1697,10 @@ class TestIntegrationMultipleReturnsTorch:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -1710,14 +1710,14 @@ class TestIntegrationMultipleReturnsTorch:
         """Return multiple probs."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, tuple)
@@ -1743,19 +1743,19 @@ class TestIntegrationMultipleReturnsTorch:
         """Return multiple different measurements."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         if wires1 is None:
@@ -1780,7 +1780,7 @@ class TestIntegrationMultipleReturnsTorch:
         assert res[3].shape == ()
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_expval_sample(self, measurement, device, shots=100):
         """Test the expval and sample measurements together."""
         import torch
@@ -1788,14 +1788,14 @@ class TestIntegrationMultipleReturnsTorch:
         if device in ["default.mixed", "default.qubit"]:
             pytest.skip("Sample need to be rewritten for interfaces.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         # Expval
@@ -1807,7 +1807,7 @@ class TestIntegrationMultipleReturnsTorch:
         assert res[1].shape == (shots,)
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_expval_counts(self, measurement, device, shots=100):
         """Test the expval and counts measurements together."""
         import torch
@@ -1815,14 +1815,14 @@ class TestIntegrationMultipleReturnsTorch:
         if device == "default.mixed":
             pytest.skip("Counts need to be rewritten for interfaces.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         # Expval
@@ -1841,14 +1841,14 @@ class TestIntegrationMultipleReturnsTorch:
         """Return a comprehension list of one expvals."""
         import torch
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=0))]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=0))]
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         assert isinstance(res, list)
@@ -1869,14 +1869,14 @@ class TestIntegrationMultipleReturnsTorch:
         if device == "default.mixed" and shot_vector:
             pytest.skip("No support for shot vector and mixed device with Torch.")
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=i)) for i in range(0, wires)]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=i)) for i in range(0, wires)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(torch.tensor(0.5, requires_grad=True))
 
         if shot_vector is None:
@@ -1910,14 +1910,14 @@ class TestIntegrationMultipleReturnJax:
         """Return multiple expvals."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.Projector([0], wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.Projector([0], wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, tuple)
@@ -1934,14 +1934,14 @@ class TestIntegrationMultipleReturnJax:
         """Return multiple vars."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.var(qml.PauliZ(wires=0)), qml.var(qml.Hermitian([[1, 0], [0, 1]], wires=1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.var(qp.PauliZ(wires=0)), qp.var(qp.Hermitian([[1, 0], [0, 1]], wires=1))
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, tuple)
@@ -1959,10 +1959,10 @@ class TestIntegrationMultipleReturnJax:
         (None, [0], None, [0, 1]),
         (None, [0, 1], None, [0]),
         (None, [0, 1], None, [0, 1]),
-        (qml.PauliZ(0), None, qml.PauliZ(1), None),
-        (None, [0], qml.PauliZ(1), None),
-        (qml.PauliZ(0), None, None, [0]),
-        (qml.PauliZ(1), None, qml.PauliZ(0), None),
+        (qp.PauliZ(0), None, qp.PauliZ(1), None),
+        (None, [0], qp.PauliZ(1), None),
+        (qp.PauliZ(0), None, None, [0]),
+        (qp.PauliZ(1), None, qp.PauliZ(0), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -1972,14 +1972,14 @@ class TestIntegrationMultipleReturnJax:
         """Return multiple probs."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, tuple)
@@ -2005,19 +2005,19 @@ class TestIntegrationMultipleReturnJax:
         """Return multiple different measurements."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.probs(op=op1, wires=wires1),
-                qml.vn_entropy(wires=wires3),
-                qml.probs(op=op2, wires=wires2),
-                qml.expval(qml.PauliZ(wires=wires4)),
+                qp.probs(op=op1, wires=wires1),
+                qp.vn_entropy(wires=wires3),
+                qp.probs(op=op2, wires=wires2),
+                qp.expval(qp.PauliZ(wires=wires4)),
             )
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         if wires1 is None:
@@ -2042,7 +2042,7 @@ class TestIntegrationMultipleReturnJax:
         assert res[3].shape == ()
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_expval_sample(self, measurement, device, shots=100):
         """Test the expval and sample measurements together."""
         import jax
@@ -2050,14 +2050,14 @@ class TestIntegrationMultipleReturnJax:
         if device == "default.mixed":
             pytest.skip("Sample need to be rewritten for interfaces.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(jax.numpy.array(0.5))
 
         # Expval
@@ -2069,7 +2069,7 @@ class TestIntegrationMultipleReturnJax:
         assert res[1].shape == (shots,)
 
     @pytest.mark.parametrize("device", devices)
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_expval_counts(self, measurement, device, shots=100):
         """Test the expval and counts measurements together."""
         import jax
@@ -2077,14 +2077,14 @@ class TestIntegrationMultipleReturnJax:
         if device == "default.mixed":
             pytest.skip("Counts need to be rewritten for interfaces and mixed device.")
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(1)), qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(1)), qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shots)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shots)
         res = qnode(jax.numpy.array(0.5))
 
         # Expval
@@ -2103,14 +2103,14 @@ class TestIntegrationMultipleReturnJax:
         """Return a comprehension list of one expvals."""
         import jax
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=0))]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=0))]
 
-        qnode = qml.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(jax.numpy.array(0.5))
 
         assert isinstance(res, list)
@@ -2130,14 +2130,14 @@ class TestIntegrationMultipleReturnJax:
         if device == "default.mixed" and shot_vector:
             pytest.skip("No support for shot vector and mixed device with Jax")
 
-        dev = qml.device(device, wires=wires)
+        dev = qp.device(device, wires=wires)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return [qml.expval(qml.PauliZ(wires=i)) for i in range(0, wires)]
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return [qp.expval(qp.PauliZ(wires=i)) for i in range(0, wires)]
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(jax.numpy.array(0.5))
 
         if shot_vector is None:
@@ -2157,27 +2157,27 @@ class TestIntegrationMultipleReturnJax:
                     assert t.shape == ()
 
 
-pauliz = qml.PauliZ(wires=1)
-proj = qml.Projector([1], wires=1)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
+pauliz = qp.PauliZ(wires=1)
+proj = qp.Projector([1], wires=1)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
 
 # Note: mutual info and vn_entropy do not support some shot vectors
-# qml.mutual_info(wires0=[0], wires1=[1]), qml.vn_entropy(wires=[0])]
+# qp.mutual_info(wires0=[0], wires1=[1]), qp.vn_entropy(wires=[0])]
 single_scalar_output_measurements = [
-    qml.expval(pauliz),
-    qml.var(pauliz),
-    qml.expval(proj),
-    qml.var(proj),
-    qml.expval(hermitian),
-    qml.var(hermitian),
+    qp.expval(pauliz),
+    qp.var(pauliz),
+    qp.expval(proj),
+    qp.var(proj),
+    qp.expval(hermitian),
+    qp.var(hermitian),
 ]
 
 herm = np.diag([1, 2, 3, 4])
 probs_data = [
     (None, [0]),
     (None, [0, 1]),
-    (qml.PauliZ(0), None),
-    (qml.Hermitian(herm, wires=[1, 0]), None),
+    (qp.PauliZ(0), None),
+    (qp.Hermitian(herm, wires=[1, 0]), None),
 ]
 
 shot_vectors = [[10, 1000], [1, 10, 10, 1000], [1, (10, 2), 1000]]
@@ -2193,14 +2193,14 @@ class TestIntegrationShotVectors:
     @pytest.mark.parametrize("measurement", single_scalar_output_measurements)
     def test_scalar(self, shot_vector, measurement, device):
         """Test a single scalar-valued measurement."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2213,16 +2213,16 @@ class TestIntegrationShotVectors:
     @pytest.mark.parametrize("op,wires", probs_data)
     def test_probs(self, shot_vector, op, wires, device):
         """Test a single probability measurement."""
-        dev = qml.device("default.qubit", wires=2)
-        shot_vector = qml.measurements.Shots(shot_vector)
+        dev = qp.device("default.qubit", wires=2)
+        shot_vector = qp.measurements.Shots(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op, wires=wires)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op, wires=wires)
 
         # Diff method is to be set to None otherwise use Interface execute
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2234,19 +2234,19 @@ class TestIntegrationShotVectors:
 
         assert all(r.shape == (2 ** len(wires_to_use),) for r in res)
 
-    @pytest.mark.parametrize("measurement", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
     def test_samples(self, shot_vector, measurement, device):
         """Test the sample measurement."""
-        dev = qml.device(device, wires=2)
-        shot_vector = qml.measurements.Shots(shot_vector)
+        dev = qp.device(device, wires=2)
+        shot_vector = qp.measurements.Shots(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
         # Diff method is to be set to None otherwise use Interface execute
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -2255,19 +2255,19 @@ class TestIntegrationShotVectors:
         for r, shots in zip(res, all_shot_copies):
             assert r.shape == (shots,) if measurement.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement, device):
         """Test the counts measurement."""
-        dev = qml.device(device, wires=2)
-        shot_vector = qml.measurements.Shots(shot_vector)
+        dev = qp.device(device, wires=2)
+        shot_vector = qp.measurements.Shots(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement)
 
         # Diff method is to be set to None otherwise use Interface execute
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2285,15 +2285,15 @@ class TestIntegrationSameMeasurementShotVector:
 
     def test_scalar(self, shot_vector, device):
         """Test multiple scalar-valued measurements."""
-        dev = qml.device(device, wires=2)
-        shot_vector = qml.measurements.Shots(shot_vector)
+        dev = qp.device(device, wires=2)
+        shot_vector = qp.measurements.Shots(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.expval(qml.PauliX(0)), qml.var(qml.PauliZ(1))
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.expval(qp.PauliX(0)), qp.var(qp.PauliZ(1))
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2307,8 +2307,8 @@ class TestIntegrationSameMeasurementShotVector:
     probs_data2 = [
         (None, [2]),
         (None, [2, 3]),
-        (qml.PauliZ(2), None),
-        (qml.Hermitian(herm, wires=[3, 2]), None),
+        (qp.PauliZ(2), None),
+        (qp.Hermitian(herm, wires=[3, 2]), None),
     ]
 
     # pylint: disable=too-many-arguments
@@ -2316,14 +2316,14 @@ class TestIntegrationSameMeasurementShotVector:
     @pytest.mark.parametrize("op2,wires2", reversed(probs_data2))
     def test_probs(self, shot_vector, op1, wires1, op2, wires2, device):
         """Test multiple probability measurements."""
-        dev = qml.device(device, wires=4)
+        dev = qp.device(device, wires=4)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.probs(op=op1, wires=wires1), qml.probs(op=op2, wires=wires2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.probs(op=op1, wires=wires1), qp.probs(op=op2, wires=wires2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2338,18 +2338,18 @@ class TestIntegrationSameMeasurementShotVector:
             assert r[0].shape == (2 ** len(wires1),)
             assert r[1].shape == (2 ** len(wires2),)
 
-    @pytest.mark.parametrize("measurement1", [qml.sample(qml.PauliZ(0)), qml.sample(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.sample(qml.PauliX(1)), qml.sample(wires=[1])])
+    @pytest.mark.parametrize("measurement1", [qp.sample(qp.PauliZ(0)), qp.sample(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.sample(qp.PauliX(1)), qp.sample(wires=[1])])
     def test_samples(self, shot_vector, measurement1, measurement2, device):
         """Test multiple sample measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shot_copies = _get_all_shot_copies(shot_vector)
@@ -2359,18 +2359,18 @@ class TestIntegrationSameMeasurementShotVector:
             assert r[0].shape == (shots,) if measurement1.obs else (shots, 1)
             assert r[1].shape == (shots,) if measurement2.obs else (shots, 1)
 
-    @pytest.mark.parametrize("measurement1", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
-    @pytest.mark.parametrize("measurement2", [qml.counts(qml.PauliZ(0)), qml.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement1", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
+    @pytest.mark.parametrize("measurement2", [qp.counts(qp.PauliZ(0)), qp.counts(wires=[0])])
     def test_counts(self, shot_vector, measurement1, measurement2, device):
         """Test multiple counts measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(measurement1), qml.apply(measurement2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(measurement1), qp.apply(measurement2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2386,62 +2386,62 @@ class TestIntegrationSameMeasurementShotVector:
 # Shot vector multi measurement tests - test data
 # -------------------------------------------------
 
-pauliz_w2 = qml.PauliZ(wires=2)
-proj_w2 = qml.Projector([1], wires=2)
-hermitian = qml.Hermitian(np.diag([1, 2]), wires=0)
-tensor_product = qml.PauliZ(wires=2) @ qml.PauliX(wires=1)
+pauliz_w2 = qp.PauliZ(wires=2)
+proj_w2 = qp.Projector([1], wires=2)
+hermitian = qp.Hermitian(np.diag([1, 2]), wires=0)
+tensor_product = qp.PauliZ(wires=2) @ qp.PauliX(wires=1)
 
 # Expval/Var with Probs
 
 scalar_probs_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.probs(wires=[2, 0])),
-    (qml.expval(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.expval(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.expval(pauliz_w2), qp.probs(wires=[2, 0])),
+    (qp.expval(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.expval(tensor_product), qp.probs(wires=[2, 0])),
     # Var
-    (qml.var(qml.PauliZ(wires=1)), qml.probs(wires=[0, 1])),
-    (qml.var(proj_w2), qml.probs(wires=[1, 0])),
-    (qml.var(tensor_product), qml.probs(wires=[2, 0])),
+    (qp.var(qp.PauliZ(wires=1)), qp.probs(wires=[0, 1])),
+    (qp.var(proj_w2), qp.probs(wires=[1, 0])),
+    (qp.var(tensor_product), qp.probs(wires=[2, 0])),
 ]
 
 # Expval/Var with Sample
 
 scalar_sample_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.sample(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.sample(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.sample(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.sample(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.sample(op=qp.PauliZ(0))),
 ]
 
 scalar_sample_no_obs_multi = [
     # TODO: for copy=1, the wires syntax has a bug
     # -----
-    (qml.expval(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.sample(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.sample(wires=[0, 1])),
 ]
 
 # Expval/Var with Counts
 
 scalar_counts_multi = [
     # Expval
-    (qml.expval(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.expval(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.expval(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.expval(tensor_product), qp.counts(op=qp.PauliZ(0))),
     # Var
-    (qml.var(proj_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(pauliz_w2), qml.counts(op=qml.PauliZ(1) @ qml.PauliZ(0))),
-    (qml.var(tensor_product), qml.counts(op=qml.PauliZ(0))),
+    (qp.var(proj_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(pauliz_w2), qp.counts(op=qp.PauliZ(1) @ qp.PauliZ(0))),
+    (qp.var(tensor_product), qp.counts(op=qp.PauliZ(0))),
 ]
 
 scalar_counts_no_obs_multi = [
     # TODO: for copy=1, the wires syntax has a bug
     # -----
-    (qml.expval(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
-    (qml.var(qml.PauliZ(wires=1)), qml.counts(wires=[0, 1])),
+    (qp.expval(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
+    (qp.var(qp.PauliZ(wires=1)), qp.counts(wires=[0, 1])),
 ]
 
 
@@ -2453,14 +2453,14 @@ class TestIntegrationMultipleMeasurementsShotVector:
     @pytest.mark.parametrize("meas1,meas2", scalar_probs_multi)
     def test_scalar_probs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and probability measurements"""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2488,15 +2488,15 @@ class TestIntegrationMultipleMeasurementsShotVector:
     def test_scalar_sample_with_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and sample measurements where sample takes an
         observable."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2523,14 +2523,14 @@ class TestIntegrationMultipleMeasurementsShotVector:
     @pytest.mark.xfail
     def test_scalar_sample_no_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and computational basis sample measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2558,15 +2558,15 @@ class TestIntegrationMultipleMeasurementsShotVector:
     def test_scalar_counts_with_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and counts measurements where counts takes an
         observable."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2596,16 +2596,16 @@ class TestIntegrationMultipleMeasurementsShotVector:
     @pytest.mark.xfail
     def test_scalar_counts_no_obs(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued and computational basis counts measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
-            return qml.apply(meas1), qml.apply(meas2)
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
+            return qp.apply(meas1), qp.apply(meas2)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2628,10 +2628,10 @@ class TestIntegrationMultipleMeasurementsShotVector:
                 else:
                     assert r.shape == (shots,)
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_sample(self, shot_vector, sample_obs, device):
         """Test probs and sample measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
 
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
@@ -2639,16 +2639,16 @@ class TestIntegrationMultipleMeasurementsShotVector:
         meas2_wires = [2]
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.sample(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.sample(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.sample(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.sample(wires=meas2_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2674,26 +2674,26 @@ class TestIntegrationMultipleMeasurementsShotVector:
                     expected = (shots, 1) if sample_obs is None else (shots,)
                     assert r.shape == expected
 
-    @pytest.mark.parametrize("sample_obs", [qml.PauliZ, None])
+    @pytest.mark.parametrize("sample_obs", [qp.PauliZ, None])
     def test_probs_counts(self, shot_vector, sample_obs, device):
         """Test probs and counts measurements."""
-        dev = qml.device(device, wires=3)
+        dev = qp.device(device, wires=3)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         meas1_wires = [0, 1]
         meas2_wires = [2]
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             if sample_obs is not None:
                 # Observable provided to sample
-                return qml.probs(wires=meas1_wires), qml.counts(sample_obs(meas2_wires))
+                return qp.probs(wires=meas1_wires), qp.counts(sample_obs(meas2_wires))
 
             # Only wires provided to sample
-            return qml.probs(wires=meas1_wires), qml.counts(wires=meas2_wires)
+            return qp.probs(wires=meas1_wires), qp.counts(wires=meas2_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2725,29 +2725,29 @@ class TestIntegrationMultipleMeasurementsShotVector:
     def test_sample_counts(self, shot_vector, sample_wires, counts_wires, device):
         """Test sample and counts measurements, each measurement with custom
         samples or computational basis state samples."""
-        dev = qml.device(device, wires=6)
+        dev = qp.device(device, wires=6)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
 
             # 1. Sample obs and Counts obs
             if len(sample_wires) == 1 and len(counts_wires) == 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(qp.PauliX(counts_wires))
 
             # 2. Sample no obs and Counts obs
             if len(sample_wires) > 1 and len(counts_wires) == 1:
-                return qml.sample(wires=sample_wires), qml.counts(qml.PauliX(counts_wires))
+                return qp.sample(wires=sample_wires), qp.counts(qp.PauliX(counts_wires))
 
             # 3. Sample obs and Counts no obs
             if len(sample_wires) == 1 and len(counts_wires) > 1:
-                return qml.sample(qml.PauliY(sample_wires)), qml.counts(wires=counts_wires)
+                return qp.sample(qp.PauliY(sample_wires)), qp.counts(wires=counts_wires)
 
             # 4. Sample no obs and Counts no obs
-            return qml.sample(wires=sample_wires), qml.counts(wires=counts_wires)
+            return qp.sample(wires=sample_wires), qp.counts(wires=counts_wires)
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
         res = qnode(0.5)
 
         all_shots = _get_all_shots(shot_vector)
@@ -2778,20 +2778,20 @@ class TestIntegrationMultipleMeasurementsShotVector:
     def test_scalar_probs_sample_counts(self, shot_vector, meas1, meas2, device):
         """Test scalar-valued, probability, sample and counts measurements all
         in a single qfunc."""
-        dev = qml.device(device, wires=5)
+        dev = qp.device(device, wires=5)
         raw_shot_vector = _get_all_shot_copies(shot_vector)
 
         def circuit(x):
-            qml.Hadamard(wires=[0])
-            qml.CRX(x, wires=[0, 1])
+            qp.Hadamard(wires=[0])
+            qp.CRX(x, wires=[0, 1])
             return (
-                qml.apply(meas1),
-                qml.apply(meas2),
-                qml.sample(qml.PauliX(4)),
-                qml.counts(qml.PauliX(3)),
+                qp.apply(meas1),
+                qp.apply(meas2),
+                qp.sample(qp.PauliX(4)),
+                qp.counts(qp.PauliX(3)),
             )
 
-        qnode = qml.set_shots(qml.QNode(circuit, dev, diff_method=None), shots=shot_vector)
+        qnode = qp.set_shots(qp.QNode(circuit, dev, diff_method=None), shots=shot_vector)
 
         res = qnode(0.5)
 
@@ -2831,22 +2831,22 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "autograd"])
     def test_multiple_expval_autograd(self, interface, device):
         """Return Jacobian of multiple expvals."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.Projector([0], wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.Projector([0], wires=0)), qp.expval(qp.PauliZ(wires=1))
 
-        x = qml.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = qp.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
 
         def cost(a):
-            return qml.numpy.hstack(circuit(a))
+            return qp.numpy.hstack(circuit(a))
 
-        res = qml.jacobian(cost)(x)
+        res = qp.jacobian(cost)(x)
 
         assert isinstance(res, (np.ndarray, np.float64))
         assert res.shape == (2, 3)
@@ -2858,15 +2858,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple expvals."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
         x = torch.tensor([0.1, 0.2, 0.3])
 
@@ -2885,15 +2885,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple expvals."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
         x = tf.Variable([0.1, 0.2, 0.3])
 
@@ -2912,16 +2912,16 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple measurements with Tf Autograph."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         @tf.function
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
         # Autograph does not support multiple measurements with different shape.
 
@@ -2943,15 +2943,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple expvals."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
         res = jax.jacobian(circuit)(x)
@@ -2969,15 +2969,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple expvals with Jitting."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliZ(wires=1))
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.expval(qp.PauliZ(wires=1))
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
         res = jax.jit(jax.jacobian(circuit))(x)
@@ -2992,22 +2992,22 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "autograd"])
     def test_multiple_probs_autograd(self, interface, device):
         """Return Jacobian of multiple probs."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.probs(op=qml.PauliZ(wires=0)), qml.probs(wires=[1])
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.probs(op=qp.PauliZ(wires=0)), qp.probs(wires=[1])
 
-        x = qml.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = qp.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
 
         def cost(a):
-            return qml.numpy.stack(circuit(a))
+            return qp.numpy.stack(circuit(a))
 
-        res = qml.jacobian(cost)(x)
+        res = qp.jacobian(cost)(x)
 
         assert isinstance(res, (np.ndarray, np.float64))
         assert res.shape == (2, 2, 3)
@@ -3019,15 +3019,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple probs."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.probs(op=qml.PauliZ(wires=0)), qml.probs(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.probs(op=qp.PauliZ(wires=0)), qp.probs(wires=1)
 
         x = torch.tensor([0.1, 0.2, 0.3])
 
@@ -3046,15 +3046,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple probs."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.probs(op=qml.PauliZ(wires=0)), qml.probs(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.probs(op=qp.PauliZ(wires=0)), qp.probs(wires=1)
 
         x = tf.Variable([0.1, 0.2, 0.3])
 
@@ -3074,15 +3074,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple probs."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.probs(op=qml.PauliZ(wires=0)), qml.probs(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.probs(op=qp.PauliZ(wires=0)), qp.probs(wires=1)
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
 
@@ -3101,15 +3101,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple probs with Jax jit."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.probs(op=qml.PauliZ(wires=0)), qml.probs(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.probs(op=qp.PauliZ(wires=0)), qp.probs(wires=1)
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
 
@@ -3125,22 +3125,22 @@ class TestIntegrationJacobianBackpropMultipleReturns:
     @pytest.mark.parametrize("interface", ["auto", "autograd"])
     def test_multiple_meas_autograd(self, interface, device):
         """Return Jacobian of multiple measurements."""
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.probs(wires=[0, 1]), qml.vn_entropy(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.probs(wires=[0, 1]), qp.vn_entropy(wires=1)
 
-        x = qml.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
+        x = qp.numpy.array([0.1, 0.2, 0.3], requires_grad=True)
 
         def cost(a):
-            return qml.numpy.hstack(circuit(a))
+            return qp.numpy.hstack(circuit(a))
 
-        res = qml.jacobian(cost)(x)
+        res = qp.jacobian(cost)(x)
 
         assert isinstance(res, (np.ndarray, np.float64))
         assert res.shape == (6, 3)
@@ -3152,15 +3152,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple measurements."""
         import torch
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.probs(wires=[0, 1]), qml.vn_entropy(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.probs(wires=[0, 1]), qp.vn_entropy(wires=1)
 
         x = torch.tensor([0.1, 0.2, 0.3])
 
@@ -3184,18 +3184,18 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple measurements."""
         import tensorflow as tf
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
             return (
-                qml.expval(qml.PauliZ(wires=0)),
-                qml.probs(wires=[0, 1]),
-                qml.var(qml.PauliZ(wires=0)),
+                qp.expval(qp.PauliZ(wires=0)),
+                qp.probs(wires=[0, 1]),
+                qp.var(qp.PauliZ(wires=0)),
             )
 
         x = tf.Variable([0.1, 0.2, 0.3])
@@ -3216,15 +3216,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple measurements."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.probs(wires=[0, 1]), qml.vn_entropy(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.probs(wires=[0, 1]), qp.vn_entropy(wires=1)
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
 
@@ -3248,15 +3248,15 @@ class TestIntegrationJacobianBackpropMultipleReturns:
         """Return Jacobian of multiple measurements with Jax jit."""
         import jax
 
-        dev = qml.device(device, wires=2)
+        dev = qp.device(device, wires=2)
 
-        @qml.qnode(dev, interface=interface)
+        @qp.qnode(dev, interface=interface)
         def circuit(a):
-            qml.RX(a[0], wires=0)
-            qml.CNOT(wires=(0, 1))
-            qml.RY(a[1], wires=1)
-            qml.RZ(a[2], wires=1)
-            return qml.expval(qml.PauliZ(wires=0)), qml.probs(wires=[0, 1]), qml.vn_entropy(wires=1)
+            qp.RX(a[0], wires=0)
+            qp.CNOT(wires=(0, 1))
+            qp.RY(a[1], wires=1)
+            qp.RZ(a[2], wires=1)
+            return qp.expval(qp.PauliZ(wires=0)), qp.probs(wires=[0, 1]), qp.vn_entropy(wires=1)
 
         x = jax.numpy.array([0.1, 0.2, 0.3])
 
@@ -3276,9 +3276,9 @@ class TestIntegrationJacobianBackpropMultipleReturns:
 
 def _get_all_shots(shot_vector):
     """Helper function to get the total number of shots from a shot vector."""
-    return qml.measurements.Shots(shot_vector).num_copies
+    return qp.measurements.Shots(shot_vector).num_copies
 
 
 def _get_all_shot_copies(shot_vector):
     """Helper function to get the total number of shot copies from a shot vector."""
-    return list(qml.measurements.Shots(shot_vector))
+    return list(qp.measurements.Shots(shot_vector))

--- a/tests/test_return_types_qnode.py
+++ b/tests/test_return_types_qnode.py
@@ -131,9 +131,7 @@ class TestIntegrationSingleReturn:
 
         def circuit(x):
             func(x)
-            return qp.var(
-                qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3)
-            )
+            return qp.var(qp.PauliZ(wires=1) if device != "default.qutrit" else qp.GellMann(1, 3))
 
         qnode = qp.QNode(circuit, dev, diff_method=None)
         res = qnode(0.5)

--- a/tests/test_tensor_measurements.py
+++ b/tests/test_tensor_measurements.py
@@ -20,7 +20,7 @@ import functools
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import expval, sample, var
 
 Z = np.array([[1, 0], [0, -1]])
@@ -30,11 +30,11 @@ VARPHI = np.linspace(0.02, 3, 5)
 
 
 def ansatz(a, b, c):
-    qml.RX(a, wires=0)
-    qml.RX(b, wires=1)
-    qml.RX(c, wires=2)
-    qml.CNOT(wires=[0, 1])
-    qml.CNOT(wires=[1, 2])
+    qp.RX(a, wires=0)
+    qp.RX(b, wires=1)
+    qp.RX(c, wires=2)
+    qp.CNOT(wires=[0, 1])
+    qp.CNOT(wires=[1, 2])
 
 
 # pylint: disable=too-many-arguments
@@ -53,19 +53,19 @@ class TestTensorExpval:
     def test_tensor_product(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product ZxZ gives the same result as simply
         using an Hermitian matrix"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit1(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(0) @ qml.PauliZ(2))
+            return expval(qp.PauliZ(0) @ qp.PauliZ(2))
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit2(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.Hermitian(np.kron(Z, Z), wires=[0, 2]))
+            return expval(qp.Hermitian(np.kron(Z, Z), wires=[0, 2]))
 
         res1 = circuit1(theta, phi, varphi)
         res2 = circuit2(theta, phi, varphi)
@@ -75,25 +75,25 @@ class TestTensorExpval:
     def test_combine_tensor_with_non_tensor(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product along with a non-tensor product
         continues to function correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit1(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(0) @ qml.PauliZ(2)), expval(qml.PauliZ(1))
+            return expval(qp.PauliZ(0) @ qp.PauliZ(2)), expval(qp.PauliZ(1))
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit2(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.Hermitian(np.kron(Z, Z), wires=[0, 2]))
+            return expval(qp.Hermitian(np.kron(Z, Z), wires=[0, 2]))
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit3(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(1))
+            return expval(qp.PauliZ(1))
 
         res1 = circuit1(theta, phi, varphi)
         res2 = circuit2(theta, phi, varphi), circuit3(theta, phi, varphi)
@@ -102,13 +102,13 @@ class TestTensorExpval:
 
     def test_paulix_tensor_pauliy(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliX(0) @ qml.PauliY(2))
+            return expval(qp.PauliX(0) @ qp.PauliY(2))
 
         res = circuit(theta, phi, varphi)
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
@@ -118,15 +118,15 @@ class TestTensorExpval:
     @pytest.mark.autograd
     def test_paulix_tensor_pauliy_gradient(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliX(0) @ qml.PauliY(2))
+            return expval(qp.PauliX(0) @ qp.PauliY(2))
 
-        dcircuit = qml.grad(circuit, 0)
+        dcircuit = qp.grad(circuit, 0)
         res = dcircuit(theta, phi, varphi)
         expected = np.cos(theta) * np.sin(phi) * np.sin(varphi)
 
@@ -134,13 +134,13 @@ class TestTensorExpval:
 
     def test_pauliz_tensor_identity(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliZ and Identity works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2))
+            return expval(qp.PauliZ(0) @ qp.Identity(1) @ qp.PauliZ(2))
 
         res = circuit(theta, phi, varphi)
         expected = np.cos(varphi) * np.cos(phi)
@@ -149,13 +149,13 @@ class TestTensorExpval:
 
     def test_pauliz_tensor_hadamard(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliZ and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2))
+            return expval(qp.PauliZ(0) @ qp.Hadamard(1) @ qp.PauliY(2))
 
         res = circuit(theta, phi, varphi)
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
@@ -164,7 +164,7 @@ class TestTensorExpval:
 
     def test_hermitian(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving an Hermitian matrix works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
         A = np.array(
             [
@@ -175,11 +175,11 @@ class TestTensorExpval:
             ]
         )
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.PauliZ(0) @ qml.Hermitian(A, [1, 2]))
+            return expval(qp.PauliZ(0) @ qp.Hermitian(A, [1, 2]))
 
         res = circuit(theta, phi, varphi)
         expected = 0.5 * (
@@ -193,7 +193,7 @@ class TestTensorExpval:
 
     def test_hermitian_tensor_hermitian(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
         A1 = np.array([[1, 2], [2, 4]])
 
@@ -206,11 +206,11 @@ class TestTensorExpval:
             ]
         )
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return expval(qml.Hermitian(A1, 0) @ qml.Hermitian(A2, [1, 2]))
+            return expval(qp.Hermitian(A1, 0) @ qp.Hermitian(A2, [1, 2]))
 
         res = circuit(theta, phi, varphi)
         expected = 0.25 * (
@@ -236,20 +236,20 @@ class TestTensorExpval:
         self, shots, theta, phi, varphi, tolerance, seed
     ):
         """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
-        dev = qml.device("default.qubit", wires=2, seed=seed)
+        dev = qp.device("default.qubit", wires=2, seed=seed)
 
         A = np.array(
             [[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]]
         )
 
         # pylint: disable=unused-argument
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
-            qml.RY(a, wires=0)
-            qml.RY(b, wires=1)
-            qml.CNOT(wires=[0, 1])
-            return expval(qml.Hermitian(A, 0) @ qml.Identity(1))
+            qp.RY(a, wires=0)
+            qp.RY(b, wires=1)
+            qp.CNOT(wires=[0, 1])
+            return expval(qp.Hermitian(A, 0) @ qp.Identity(1))
 
         res = circuit(theta, phi, varphi)
 
@@ -275,13 +275,13 @@ class TestTensorVar:
 
     def test_paulix_tensor_pauliy(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return var(qml.PauliX(0) @ qml.PauliY(2))
+            return var(qp.PauliX(0) @ qp.PauliY(2))
 
         res = circuit(theta, phi, varphi)
         expected = (
@@ -297,13 +297,13 @@ class TestTensorVar:
 
     def test_pauliz_tensor_hadamard(self, shots, theta, phi, varphi, tolerance, seed):
         """Test that a tensor product involving PauliZ and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return var(qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2))
+            return var(qp.PauliZ(0) @ qp.Hadamard(1) @ qp.PauliY(2))
 
         res = circuit(theta, phi, varphi)
         expected = (
@@ -316,8 +316,8 @@ class TestTensorVar:
         assert np.allclose(res, expected, **tolerance)
 
     def test_tensor_hermitian(self, shots, theta, phi, varphi, tolerance, seed):
-        """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        """Test that a tensor product involving qp.Hermitian works correctly"""
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
         A = np.array(
             [
@@ -328,11 +328,11 @@ class TestTensorVar:
             ]
         )
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return var(qml.PauliZ(0) @ qml.Hermitian(A, [1, 2]))
+            return var(qp.PauliZ(0) @ qp.Hermitian(A, [1, 2]))
 
         res = circuit(theta, phi, varphi)
         expected = (
@@ -380,13 +380,13 @@ class TestTensorSample:
     # pylint: disable=unused-argument
     def test_paulix_tensor_pauliz(self, theta, phi, varphi, tol_stochastic, seed):
         """Test that a tensor product involving PauliX and PauliZ works correctly"""
-        dev = qml.device("default.qubit", wires=2, seed=seed)
+        dev = qp.device("default.qubit", wires=2, seed=seed)
 
-        @qml.set_shots(1_000_000)
-        @qml.qnode(dev)
+        @qp.set_shots(1_000_000)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            return sample(qml.PauliX(0) @ qml.PauliZ(1))
+            qp.Hadamard(wires=0)
+            return sample(qp.PauliX(0) @ qp.PauliZ(1))
 
         s1 = circuit()
 
@@ -395,13 +395,13 @@ class TestTensorSample:
 
     def test_paulix_tensor_pauliy(self, theta, phi, varphi, tol_stochastic, seed):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(1_000_000)
-        @qml.qnode(dev, diff_method="parameter-shift")
+        @qp.set_shots(1_000_000)
+        @qp.qnode(dev, diff_method="parameter-shift")
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return sample(qml.PauliX(0) @ qml.PauliY(2))
+            return sample(qp.PauliX(0) @ qp.PauliY(2))
 
         s1 = circuit(theta, phi, varphi)
 
@@ -410,13 +410,13 @@ class TestTensorSample:
 
     def test_pauliz_tensor_hadamard(self, theta, phi, varphi, tol_stochastic, seed):
         """Test that a tensor product involving PauliZ and hadamard works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
-        @qml.set_shots(1_000_000)
-        @qml.qnode(dev, diff_method="parameter-shift")
+        @qp.set_shots(1_000_000)
+        @qp.qnode(dev, diff_method="parameter-shift")
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return sample(qml.PauliZ(0) @ qml.Hadamard(1) @ qml.PauliY(2))
+            return sample(qp.PauliZ(0) @ qp.Hadamard(1) @ qp.PauliY(2))
 
         s1 = circuit(theta, phi, varphi)
 
@@ -424,8 +424,8 @@ class TestTensorSample:
         assert np.allclose(s1**2, 1, atol=tol_stochastic, rtol=0)
 
     def test_tensor_hermitian(self, theta, phi, varphi, tol_stochastic, seed):
-        """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("default.qubit", wires=3, seed=seed)
+        """Test that a tensor product involving qp.Hermitian works correctly"""
+        dev = qp.device("default.qubit", wires=3, seed=seed)
 
         A = np.array(
             [
@@ -436,11 +436,11 @@ class TestTensorSample:
             ]
         )
 
-        @qml.set_shots(1_000_000)
-        @qml.qnode(dev, diff_method=None)
+        @qp.set_shots(1_000_000)
+        @qp.qnode(dev, diff_method=None)
         def circuit(a, b, c):
             ansatz(a, b, c)
-            return sample(qml.PauliZ(0) @ qml.Hermitian(A, [1, 2]))
+            return sample(qp.PauliZ(0) @ qp.Hermitian(A, [1, 2]))
 
         s1 = circuit(theta, phi, varphi)
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -20,7 +20,7 @@ import copy
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as pnp
 
 
@@ -29,11 +29,11 @@ def generate_cost_fn(ansatz, hamiltonian, device, **kwargs):
     to the parameters provided to an ansatz"""
     shots = kwargs.pop("shots", None)
 
-    @qml.set_shots(shots)  # Set shots for the QNode
-    @qml.qnode(device, **kwargs)
+    @qp.set_shots(shots)  # Set shots for the QNode
+    @qp.qnode(device, **kwargs)
     def res(params):
         ansatz(params, wires=device.wires)
-        return qml.expval(hamiltonian)
+        return qp.expval(hamiltonian)
 
     return res
 
@@ -51,29 +51,29 @@ H_TWO_QUBITS = np.array(
 COEFFS = [(0.5, 1.2, -0.7), (2.2, -0.2, 0.0), (0.33,)]
 
 OBSERVABLES = [
-    (qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)),
-    (qml.PauliX(0) @ qml.PauliZ(1), qml.PauliY(0) @ qml.PauliZ(1), qml.PauliZ(1)),
-    (qml.Hermitian(H_TWO_QUBITS, [0, 1]),),
+    (qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1)),
+    (qp.PauliX(0) @ qp.PauliZ(1), qp.PauliY(0) @ qp.PauliZ(1), qp.PauliZ(1)),
+    (qp.Hermitian(H_TWO_QUBITS, [0, 1]),),
 ]
 
 OBSERVABLES_NO_HERMITIAN = [
-    (qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)),
-    (qml.PauliX(0) @ qml.PauliZ(1), qml.PauliY(0) @ qml.PauliZ(1), qml.PauliZ(1)),
+    (qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1)),
+    (qp.PauliX(0) @ qp.PauliZ(1), qp.PauliY(0) @ qp.PauliZ(1), qp.PauliZ(1)),
 ]
 
 hamiltonians_with_expvals = [
-    ((-0.6,), (qml.PauliZ(0),), [-0.6 * 1.0]),
-    ((1.0,), (qml.PauliX(0),), [0.0]),
-    ((0.5, 1.2), (qml.PauliZ(0), qml.PauliX(0)), [0.5 * 1.0, 0]),
-    ((0.5, 1.2), (qml.PauliZ(0), qml.PauliX(1)), [0.5 * 1.0, 0]),
-    ((0.5, 1.2), (qml.PauliZ(0), qml.PauliZ(0)), [0.5 * 1.0, 1.2 * 1.0]),
-    ((0.5, 1.2), (qml.PauliZ(0), qml.PauliZ(1)), [0.5 * 1.0, 1.2 * 1.0]),
+    ((-0.6,), (qp.PauliZ(0),), [-0.6 * 1.0]),
+    ((1.0,), (qp.PauliX(0),), [0.0]),
+    ((0.5, 1.2), (qp.PauliZ(0), qp.PauliX(0)), [0.5 * 1.0, 0]),
+    ((0.5, 1.2), (qp.PauliZ(0), qp.PauliX(1)), [0.5 * 1.0, 0]),
+    ((0.5, 1.2), (qp.PauliZ(0), qp.PauliZ(0)), [0.5 * 1.0, 1.2 * 1.0]),
+    ((0.5, 1.2), (qp.PauliZ(0), qp.PauliZ(1)), [0.5 * 1.0, 1.2 * 1.0]),
 ]
 
 zero_hamiltonians_with_expvals = [
     ([], [], [0]),
-    ((0, 0), (qml.PauliZ(0), qml.PauliZ(1)), [0]),
-    ((0, 0, 0), (qml.PauliX(0) @ qml.Identity(1), qml.PauliX(0), qml.PauliX(1)), [0]),
+    ((0, 0), (qp.PauliZ(0), qp.PauliZ(1)), [0]),
+    ((0, 0, 0), (qp.PauliX(0) @ qp.Identity(1), qp.PauliX(0), qp.PauliX(1)), [0]),
 ]
 
 big_hamiltonian_coeffs = np.array(
@@ -97,24 +97,24 @@ big_hamiltonian_coeffs = np.array(
 )
 
 big_hamiltonian_ops = [
-    qml.Identity(wires=[0]),
-    qml.PauliZ(wires=[0]),
-    qml.PauliZ(wires=[1]),
-    qml.PauliZ(wires=[2]),
-    qml.PauliZ(wires=[3]),
-    qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[1]),
-    qml.PauliY(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliX(wires=[2]) @ qml.PauliY(wires=[3]),
-    qml.PauliY(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliX(wires=[2]) @ qml.PauliX(wires=[3]),
-    qml.PauliX(wires=[0]) @ qml.PauliX(wires=[1]) @ qml.PauliY(wires=[2]) @ qml.PauliY(wires=[3]),
-    qml.PauliX(wires=[0]) @ qml.PauliY(wires=[1]) @ qml.PauliY(wires=[2]) @ qml.PauliX(wires=[3]),
-    qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[2]),
-    qml.PauliZ(wires=[0]) @ qml.PauliZ(wires=[3]),
-    qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2]),
-    qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[3]),
-    qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[3]),
+    qp.Identity(wires=[0]),
+    qp.PauliZ(wires=[0]),
+    qp.PauliZ(wires=[1]),
+    qp.PauliZ(wires=[2]),
+    qp.PauliZ(wires=[3]),
+    qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[1]),
+    qp.PauliY(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliX(wires=[2]) @ qp.PauliY(wires=[3]),
+    qp.PauliY(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliX(wires=[2]) @ qp.PauliX(wires=[3]),
+    qp.PauliX(wires=[0]) @ qp.PauliX(wires=[1]) @ qp.PauliY(wires=[2]) @ qp.PauliY(wires=[3]),
+    qp.PauliX(wires=[0]) @ qp.PauliY(wires=[1]) @ qp.PauliY(wires=[2]) @ qp.PauliX(wires=[3]),
+    qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[2]),
+    qp.PauliZ(wires=[0]) @ qp.PauliZ(wires=[3]),
+    qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2]),
+    qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[3]),
+    qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[3]),
 ]
 
-big_hamiltonian = qml.Hamiltonian(big_hamiltonian_coeffs, big_hamiltonian_ops)
+big_hamiltonian = qp.Hamiltonian(big_hamiltonian_coeffs, big_hamiltonian_ops)
 
 big_hamiltonian_grad = (
     np.array(
@@ -142,40 +142,40 @@ big_hamiltonian_grad = (
 # pylint: disable=unused-argument
 def custom_fixed_ansatz(params, wires=None):
     """Custom fixed ansatz"""
-    qml.RX(0.5, wires=0)
-    qml.RX(-1.2, wires=1)
-    qml.Hadamard(wires=0)
-    qml.CNOT(wires=[0, 1])
-    qml.Hadamard(wires=1)
-    qml.CNOT(wires=[0, 1])
+    qp.RX(0.5, wires=0)
+    qp.RX(-1.2, wires=1)
+    qp.Hadamard(wires=0)
+    qp.CNOT(wires=[0, 1])
+    qp.Hadamard(wires=1)
+    qp.CNOT(wires=[0, 1])
 
 
 def custom_var_ansatz(params, wires=None):
     """Custom parametrized ansatz"""
     for p in params:
-        qml.RX(p, wires=wires[0])
+        qp.RX(p, wires=wires[0])
 
-    qml.CNOT(wires=[wires[0], wires[1]])
+    qp.CNOT(wires=[wires[0], wires[1]])
 
     for p in params:
-        qml.RX(-p, wires=wires[1])
+        qp.RX(-p, wires=wires[1])
 
-    qml.CNOT(wires=[wires[0], wires[1]])
+    qp.CNOT(wires=[wires[0], wires[1]])
 
 
 def amp_embed_and_strong_ent_layer(params, wires=None):
     """Ansatz combining amplitude embedding and
     strongly entangling layers"""
-    qml.templates.embeddings.AmplitudeEmbedding(params[0], wires=wires)
-    qml.templates.layers.StronglyEntanglingLayers(params[1], wires=wires)
+    qp.templates.embeddings.AmplitudeEmbedding(params[0], wires=wires)
+    qp.templates.layers.StronglyEntanglingLayers(params[1], wires=wires)
 
 
 ANSAETZE = [
     lambda params, wires=None: None,
     custom_fixed_ansatz,
     custom_var_ansatz,
-    qml.templates.embeddings.AmplitudeEmbedding,
-    qml.templates.layers.StronglyEntanglingLayers,
+    qp.templates.embeddings.AmplitudeEmbedding,
+    qp.templates.layers.StronglyEntanglingLayers,
     amp_embed_and_strong_ent_layer,
 ]
 
@@ -185,14 +185,14 @@ ANSAETZE = [
 EMPTY_PARAMS = []
 VAR_PARAMS = [0.5]
 EMBED_PARAMS = np.array([1 / np.sqrt(2**3)] * 2**3)
-LAYER_PARAMS = np.random.random(qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3))
+LAYER_PARAMS = np.random.random(qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=3))
 
 CIRCUITS = [
     (lambda params, wires=None: None, EMPTY_PARAMS),
     (custom_fixed_ansatz, EMPTY_PARAMS),
     (custom_var_ansatz, VAR_PARAMS),
-    (qml.templates.layers.StronglyEntanglingLayers, LAYER_PARAMS),
-    (qml.templates.embeddings.AmplitudeEmbedding, EMBED_PARAMS),
+    (qp.templates.layers.StronglyEntanglingLayers, LAYER_PARAMS),
+    (qp.templates.embeddings.AmplitudeEmbedding, EMBED_PARAMS),
     (amp_embed_and_strong_ent_layer, (EMBED_PARAMS, LAYER_PARAMS)),
 ]
 
@@ -200,33 +200,33 @@ CIRCUITS = [
 # Queues
 
 QUEUE_HAMILTONIANS_1 = [
-    qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
-    qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
+    qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliZ(1)]),
+    qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliZ(1)]),
 ]
 
 QUEUE_HAMILTONIANS_2 = [
-    qml.Hamiltonian([1], [qml.PauliX(0)]),
-    qml.Hamiltonian([5], [qml.PauliX(0) @ qml.PauliZ(1)]),
+    qp.Hamiltonian([1], [qp.PauliX(0)]),
+    qp.Hamiltonian([5], [qp.PauliX(0) @ qp.PauliZ(1)]),
 ]
 
 QUEUES = [
     [
-        qml.PauliX(0),
-        qml.PauliZ(1),
-        qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
-        qml.PauliX(0),
-        qml.Hamiltonian([1], [qml.PauliX(0)]),
-        qml.Hamiltonian([2, 1], [qml.PauliX(0), qml.PauliZ(1)]),
+        qp.PauliX(0),
+        qp.PauliZ(1),
+        qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliZ(1)]),
+        qp.PauliX(0),
+        qp.Hamiltonian([1], [qp.PauliX(0)]),
+        qp.Hamiltonian([2, 1], [qp.PauliX(0), qp.PauliZ(1)]),
     ],
     [
-        qml.PauliX(0),
-        qml.PauliZ(1),
-        qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)]),
-        qml.PauliX(0),
-        qml.PauliZ(1),
-        qml.PauliX(0) @ qml.PauliZ(1),
-        qml.Hamiltonian([1], [qml.PauliX(0) @ qml.PauliZ(1)]),
-        qml.Hamiltonian([1, 1, 2], [qml.PauliX(0), qml.PauliZ(1), qml.PauliX(0) @ qml.PauliZ(1)]),
+        qp.PauliX(0),
+        qp.PauliZ(1),
+        qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliZ(1)]),
+        qp.PauliX(0),
+        qp.PauliZ(1),
+        qp.PauliX(0) @ qp.PauliZ(1),
+        qp.Hamiltonian([1], [qp.PauliX(0) @ qp.PauliZ(1)]),
+        qp.Hamiltonian([1, 1, 2], [qp.PauliX(0), qp.PauliZ(1), qp.PauliX(0) @ qp.PauliZ(1)]),
     ],
 ]
 
@@ -243,8 +243,8 @@ class TestVQE:
     @pytest.mark.parametrize("coeffs, observables", list(zip(COEFFS, OBSERVABLES)))
     def test_cost_evaluate(self, params, ansatz, coeffs, observables):
         """Tests that the cost function evaluates properly"""
-        hamiltonian = qml.Hamiltonian(coeffs, observables)
-        dev = qml.device("default.qubit", wires=3)
+        hamiltonian = qp.Hamiltonian(coeffs, observables)
+        dev = qp.device("default.qubit", wires=3)
         expval = generate_cost_fn(ansatz, hamiltonian, dev)
         assert expval(params).dtype == np.float64
         assert np.shape(expval(params)) == ()  # expval should be scalar
@@ -254,8 +254,8 @@ class TestVQE:
     )
     def test_cost_expvals(self, coeffs, observables, expected):
         """Tests that the cost function returns correct expectation values"""
-        dev = qml.device("default.qubit", wires=2)
-        hamiltonian = qml.Hamiltonian(coeffs, observables)
+        dev = qp.device("default.qubit", wires=2)
+        hamiltonian = qp.Hamiltonian(coeffs, observables)
         cost = generate_cost_fn(lambda params, **kwargs: None, hamiltonian, dev)
         assert cost([]) == sum(expected)
 
@@ -267,32 +267,32 @@ class TestVQE:
         """Test that a Hamiltonian cost function is the same with and without
         grouping optimization when using the Torch interface."""
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
 
         hamiltonian1 = copy.copy(big_hamiltonian)
         hamiltonian2 = copy.copy(big_hamiltonian)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="torch",
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="torch",
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
 
         exec_opt = tracker.totals["executions"]
@@ -315,32 +315,32 @@ class TestVQE:
         """Test that a Hamiltonian cost function is the same with and without
         grouping optimization when using the TensorFlow interface."""
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
 
         hamiltonian1 = copy.copy(big_hamiltonian)
         hamiltonian2 = copy.copy(big_hamiltonian)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="tf",
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="tf",
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
         exec_opt = tracker.totals["executions"]
 
@@ -361,14 +361,14 @@ class TestVQE:
         """Test that a Hamiltonian cost function is the same with and without
         grouping optimization when using the autograd interface."""
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
 
         hamiltonian1 = copy.copy(big_hamiltonian)
         hamiltonian2 = copy.copy(big_hamiltonian)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="autograd",
@@ -376,7 +376,7 @@ class TestVQE:
             shots=shots,
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="autograd",
@@ -384,11 +384,11 @@ class TestVQE:
             shots=shots,
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
         exec_opt = tracker.totals["executions"]
 
@@ -408,43 +408,43 @@ class TestVQE:
         grouping optimization when using the autograd interface, even when
         there are non-unique Hamiltonian terms."""
 
-        dev = qml.device("default.qubit", wires=5)
+        dev = qp.device("default.qubit", wires=5)
         obs = [
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[4]),  # <---- These two terms
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[2]),  # <---- are equal
-            qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[0]),
-            qml.PauliZ(wires=[3]) @ qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[4]),  # <---- These two terms
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[2]),  # <---- are equal
+            qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[0]),
+            qp.PauliZ(wires=[3]) @ qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[3]),
         ]
 
         coeffs = (np.random.rand(len(obs)) - 0.5) * 2
-        hamiltonian1 = qml.Hamiltonian(coeffs, obs)
-        hamiltonian2 = qml.Hamiltonian(coeffs, obs)
+        hamiltonian1 = qp.Hamiltonian(coeffs, obs)
+        hamiltonian2 = qp.Hamiltonian(coeffs, obs)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="autograd",
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="autograd",
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
         exec_opt = tracker.totals["executions"]
 
@@ -464,43 +464,43 @@ class TestVQE:
         grouping optimization when using the Torch interface, even when there
         are non-unique Hamiltonian terms."""
 
-        dev = qml.device("default.qubit", wires=5)
+        dev = qp.device("default.qubit", wires=5)
         obs = [
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[4]),  # <---- These two terms
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[2]),  # <---- are equal
-            qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[0]),
-            qml.PauliZ(wires=[3]) @ qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[4]),  # <---- These two terms
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[2]),  # <---- are equal
+            qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[0]),
+            qp.PauliZ(wires=[3]) @ qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[3]),
         ]
 
         coeffs = (np.random.rand(len(obs)) - 0.5) * 2
-        hamiltonian1 = qml.Hamiltonian(coeffs, obs)
-        hamiltonian2 = qml.Hamiltonian(coeffs, obs)
+        hamiltonian1 = qp.Hamiltonian(coeffs, obs)
+        hamiltonian2 = qp.Hamiltonian(coeffs, obs)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="torch",
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="torch",
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
         exec_opt = tracker.totals["executions"]
 
@@ -520,43 +520,43 @@ class TestVQE:
         grouping optimization when using the TensorFlow interface, even when
         there are non-unique Hamiltonian terms."""
 
-        dev = qml.device("default.qubit", wires=5)
+        dev = qp.device("default.qubit", wires=5)
         obs = [
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[4]),  # <---- These two terms
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[2]),  # <---- are equal
-            qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[1]) @ qml.PauliZ(wires=[2]),
-            qml.PauliZ(wires=[2]) @ qml.PauliZ(wires=[0]),
-            qml.PauliZ(wires=[3]) @ qml.PauliZ(wires=[1]),
-            qml.PauliZ(wires=[4]) @ qml.PauliZ(wires=[3]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[4]),  # <---- These two terms
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[2]),  # <---- are equal
+            qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[1]) @ qp.PauliZ(wires=[2]),
+            qp.PauliZ(wires=[2]) @ qp.PauliZ(wires=[0]),
+            qp.PauliZ(wires=[3]) @ qp.PauliZ(wires=[1]),
+            qp.PauliZ(wires=[4]) @ qp.PauliZ(wires=[3]),
         ]
 
         coeffs = (np.random.rand(len(obs)) - 0.5) * 2
-        hamiltonian1 = qml.Hamiltonian(coeffs, obs)
-        hamiltonian2 = qml.Hamiltonian(coeffs, obs)
+        hamiltonian1 = qp.Hamiltonian(coeffs, obs)
+        hamiltonian2 = qp.Hamiltonian(coeffs, obs)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             interface="tf",
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             interface="tf",
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=5)
         _rng = np.random.default_rng(seed)
         w = _rng.random(shape)
 
-        with qml.Tracker(dev) as tracker:
+        with qp.Tracker(dev) as tracker:
             c1 = cost(w)
         exec_opt = tracker.totals["executions"]
 
@@ -575,38 +575,38 @@ class TestVQE:
         """Test that the gradient of a Hamiltonian cost function is accessible
         and correct when using observable grouping optimization and the
         autograd interface."""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
 
         hamiltonian1 = copy.copy(big_hamiltonian)
         hamiltonian2 = copy.copy(big_hamiltonian)
         hamiltonian1.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian1,
             dev,
             diff_method="parameter-shift",
         )
         cost2 = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian2,
             dev,
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         # TODO: This is another case of a magic number in the sense that no other number allows
         #       this test to pass. This is likely because the expected `big_hamiltonian_grad`
         #       was calculated using this exact seed. This test needs to be revisited.
         _rng = pnp.random.default_rng(1967)
         w = _rng.uniform(low=0, high=2 * np.pi, size=shape, requires_grad=True)
 
-        with qml.Tracker(dev) as tracker:
-            dc = qml.grad(cost)(w)
+        with qp.Tracker(dev) as tracker:
+            dc = qp.grad(cost)(w)
         exec_opt = tracker.totals["executions"]
 
         with tracker:
-            dc2 = qml.grad(cost2)(w)
+            dc2 = qp.grad(cost2)(w)
         exec_no_opt = tracker.totals["executions"]
 
         assert exec_no_opt > exec_opt
@@ -619,22 +619,22 @@ class TestVQE:
         """Test that the gradient of a Hamiltonian cost function is accessible
         and correct when using observable grouping optimization and the
         autograd interface, with a zero Hamiltonian."""
-        dev = qml.device("default.qubit", wires=4)
-        hamiltonian = qml.Hamiltonian([0], [qml.PauliX(0)])
+        dev = qp.device("default.qubit", wires=4)
+        hamiltonian = qp.Hamiltonian([0], [qp.PauliX(0)])
         if opt:
             hamiltonian.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
             diff_method="parameter-shift",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         w = pnp.random.random(shape, requires_grad=True)
 
-        dc = qml.grad(cost)(w)
+        dc = qp.grad(cost)(w)
         assert np.allclose(dc, 0)
 
     @pytest.mark.torch
@@ -645,18 +645,18 @@ class TestVQE:
         interface."""
         import torch
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
         hamiltonian.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers,
+            qp.templates.StronglyEntanglingLayers,
             hamiltonian,
             dev,
             interface="torch",
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         # TODO: This is another case of a magic number in the sense that no other number allows
         #       this test to pass. This is likely because the expected `big_hamiltonian_grad`
         #       was calculated using this exact seed. This test needs to be revisited.
@@ -678,15 +678,15 @@ class TestVQE:
         TensorFlow interface."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         hamiltonian = big_hamiltonian
         hamiltonian.compute_grouping()
 
         cost = generate_cost_fn(
-            qml.templates.StronglyEntanglingLayers, hamiltonian, dev, interface="tf"
+            qp.templates.StronglyEntanglingLayers, hamiltonian, dev, interface="tf"
         )
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
+        shape = qp.templates.StronglyEntanglingLayers.shape(n_layers=2, n_wires=4)
         # TODO: This is another case of a magic number in the sense that no other number allows
         #       this test to pass. This is likely because the expected `big_hamiltonian_grad`
         #       was calculated using this exact seed. This test needs to be revisited.
@@ -704,7 +704,7 @@ class TestVQE:
 
 # Test data
 rng = np.random.default_rng(1967)
-_shape = qml.templates.StronglyEntanglingLayers.shape(2, 4)
+_shape = qp.templates.StronglyEntanglingLayers.shape(2, 4)
 PARAMS = rng.uniform(low=0, high=2 * np.pi, size=_shape)
 
 
@@ -718,24 +718,24 @@ class TestNewVQE:
         """Tests simple VQE evaluations."""
 
         coeffs = [1.0] * len(observables)
-        dev = qml.device("default.qubit", wires=3)
-        H = qml.Hamiltonian(coeffs, observables)
+        dev = qp.device("default.qubit", wires=3)
+        H = qp.Hamiltonian(coeffs, observables)
 
         # pass H directly
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
             ansatz(params, wires=range(3))
-            return qml.expval(H)
+            return qp.expval(H)
 
         res = circuit()
 
         res_expected = []
         for obs in observables:
 
-            @qml.qnode(dev)
+            @qp.qnode(dev)
             def separate_circuit():
                 ansatz(params, wires=range(3))
-                return qml.expval(obs)
+                return qp.expval(obs)
 
             res_expected.append(separate_circuit())
 
@@ -745,26 +745,26 @@ class TestNewVQE:
 
     def test_acting_on_subcircuit(self, tol):
         """Tests a VQE circuit where the observable does not act on all wires."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
         coeffs = [1.0, 1.0, 1.0]
 
-        w = np.random.random(qml.templates.StronglyEntanglingLayers.shape(n_layers=1, n_wires=2))
+        w = np.random.random(qp.templates.StronglyEntanglingLayers.shape(n_layers=1, n_wires=2))
 
-        observables1 = [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)]
-        H1 = qml.Hamiltonian(coeffs, observables1)
+        observables1 = [qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1)]
+        H1 = qp.Hamiltonian(coeffs, observables1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit1():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(2))
-            return qml.expval(H1)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(2))
+            return qp.expval(H1)
 
-        observables2 = [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1) @ qml.Identity(2)]
-        H2 = qml.Hamiltonian(coeffs, observables2)
+        observables2 = [qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1) @ qp.Identity(2)]
+        H2 = qp.Hamiltonian(coeffs, observables2)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit2():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(2))
-            return qml.expval(H2)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(2))
+            return qp.expval(H2)
 
         res1 = circuit1()
         res2 = circuit2()
@@ -779,16 +779,16 @@ class TestNewVQE:
 
         jax.config.update("jax_enable_x64", True)
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
-        @qml.set_shots(shots)
-        @qml.qnode(dev)
+        @qp.set_shots(shots)
+        @qp.qnode(dev)
         def circuit(weights, coeffs):
-            qml.templates.StronglyEntanglingLayers(weights, wires=[0, 1])
-            H = qml.Hamiltonian(coeffs, obs)
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(weights, wires=[0, 1])
+            H = qp.Hamiltonian(coeffs, obs)
+            return qp.expval(H)
 
-        obs = [qml.PauliZ(0), qml.PauliX(0) @ qml.PauliZ(1)]
+        obs = [qp.PauliZ(0), qp.PauliX(0) @ qp.PauliZ(1)]
         coeffs = np.array([0.1, 0.2])
         key = jax.random.PRNGKey(seed)
         weights = jax.random.uniform(key, [2, 2, 3])
@@ -796,21 +796,21 @@ class TestNewVQE:
         res = circuit(weights, coeffs)
         grad = jax.jacobian(circuit, argnums=[1])(weights, coeffs)
         assert len(res) == dim
-        assert qml.math.shape(grad) == (dim, 1, 2)
+        assert qp.math.shape(grad) == (dim, 1, 2)
 
     def test_circuit_drawer(self):
         """Test that the circuit drawer displays Hamiltonians well."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
         coeffs = [1.0, 1.0, 1.0]
-        observables1 = [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(2)]
-        H1 = qml.Hamiltonian(coeffs, observables1)
+        observables1 = [qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(2)]
+        H1 = qp.Hamiltonian(coeffs, observables1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit1():
-            qml.Hadamard(wires=0)
-            return qml.expval(H1)
+            qp.Hadamard(wires=0)
+            return qp.expval(H1)
 
-        res = qml.draw(circuit1)()
+        res = qp.draw(circuit1)()
         expected = "0: ──H─┤ ╭<𝓗(1.00,1.00,1.00)>\n2: ────┤ ╰<𝓗(1.00,1.00,1.00)>"
         assert res == expected
 
@@ -818,27 +818,27 @@ class TestNewVQE:
         """Tests that more than one Hamiltonian expval can be evaluated."""
 
         coeffs = [1.0, 1.0, 1.0]
-        dev = qml.device("default.qubit", wires=4)
-        H1 = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)])
-        H2 = qml.Hamiltonian(coeffs, [qml.PauliZ(2), qml.PauliY(2), qml.PauliZ(3)])
+        dev = qp.device("default.qubit", wires=4)
+        H1 = qp.Hamiltonian(coeffs, [qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1)])
+        H2 = qp.Hamiltonian(coeffs, [qp.PauliZ(2), qp.PauliY(2), qp.PauliZ(3)])
         w = PARAMS
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H1), qml.expval(H2)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H1), qp.expval(H2)
 
         res = circuit()
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit1():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H1)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit2():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H2)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H2)
 
         assert res[0] == circuit1()
         assert res[1] == circuit2()
@@ -847,21 +847,21 @@ class TestNewVQE:
         """Tests that more than one Hamiltonian expval can be evaluated."""
 
         coeffs = [1.0, 1.0, 1.0]
-        dev = qml.device("default.qubit", wires=4)
-        H1 = qml.Hamiltonian(coeffs, [qml.PauliZ(0), qml.PauliY(0), qml.PauliZ(1)])
+        dev = qp.device("default.qubit", wires=4)
+        H1 = qp.Hamiltonian(coeffs, [qp.PauliZ(0), qp.PauliY(0), qp.PauliZ(1)])
         w = PARAMS
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H1), qml.expval(H1)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H1), qp.expval(H1)
 
         res = circuit()
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit1():
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H1)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H1)
 
         assert res[0] == circuit1()
         assert res[1] == circuit1()
@@ -870,31 +870,31 @@ class TestNewVQE:
     @pytest.mark.parametrize("diff_method", ["parameter-shift", "best"])
     def test_grad_autograd(self, diff_method, tol):
         """Tests the VQE gradient in the autograd interface."""
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         H = big_hamiltonian
         w = pnp.array(PARAMS, requires_grad=True)
 
-        @qml.qnode(dev, diff_method=diff_method)
+        @qp.qnode(dev, diff_method=diff_method)
         def circuit(w):
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H)
 
-        dc = qml.grad(circuit)(w)
+        dc = qp.grad(circuit)(w)
         assert np.allclose(dc, big_hamiltonian_grad, atol=tol)
 
     @pytest.mark.autograd
     def test_grad_zero_hamiltonian(self, tol):
         """Tests the VQE gradient for a "zero" Hamiltonian."""
-        dev = qml.device("default.qubit", wires=4)
-        H = qml.Hamiltonian([0], [qml.PauliX(0)])
+        dev = qp.device("default.qubit", wires=4)
+        H = qp.Hamiltonian([0], [qp.PauliX(0)])
         w = pnp.array(PARAMS, requires_grad=True)
 
-        @qml.qnode(dev, diff_method="parameter-shift")
+        @qp.qnode(dev, diff_method="parameter-shift")
         def circuit(w):
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H)
 
-        dc = qml.grad(circuit)(w)
+        dc = qp.grad(circuit)(w)
         assert np.allclose(dc, 0, atol=tol)
 
     @pytest.mark.torch
@@ -903,13 +903,13 @@ class TestNewVQE:
         """Tests VQE gradients in the torch interface."""
         import torch
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         H = big_hamiltonian
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(w):
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H)
 
         w = torch.tensor(PARAMS, requires_grad=True)
 
@@ -924,13 +924,13 @@ class TestNewVQE:
         """Tests VQE gradients in the tf interface."""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         H = big_hamiltonian
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(w):
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H)
 
         w = tf.Variable(PARAMS, dtype=tf.double)
 
@@ -948,33 +948,33 @@ class TestNewVQE:
         import jax
         from jax import numpy as jnp
 
-        dev = qml.device("default.qubit", wires=4)
+        dev = qp.device("default.qubit", wires=4)
         H = big_hamiltonian
 
         w = jnp.array(PARAMS)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit(w):
-            qml.templates.StronglyEntanglingLayers(w, wires=range(4))
-            return qml.expval(H)
+            qp.templates.StronglyEntanglingLayers(w, wires=range(4))
+            return qp.expval(H)
 
         dc = jax.grad(circuit)(w)
         assert np.allclose(dc, big_hamiltonian_grad, atol=tol)
 
     def test_specs(self):
         """Test that the specs of a VQE circuit can be computed"""
-        dev = qml.device("default.qubit", wires=2)
-        H = qml.Hamiltonian([0.1, 0.2], [qml.PauliZ(0), qml.PauliZ(0) @ qml.PauliX(1)])
+        dev = qp.device("default.qubit", wires=2)
+        H = qp.Hamiltonian([0.1, 0.2], [qp.PauliZ(0), qp.PauliZ(0) @ qp.PauliX(1)])
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            qml.Hadamard(wires=0)
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(H)
+            qp.Hadamard(wires=0)
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(H)
 
-        res = qml.specs(circuit)()
+        res = qp.specs(circuit)()
 
-        assert res["resources"] == qml.resource.SpecsResources(
+        assert res["resources"] == qp.resource.SpecsResources(
             num_allocs=2,
             gate_types={"Hadamard": 1, "CNOT": 1},
             gate_sizes={1: 1, 2: 1},
@@ -991,21 +991,21 @@ class TestInterfaces:
     def test_gradient_autograd(self, tol, interface):
         """Tests for the Autograd interface (and the NumPy interface for
         backward compatibility)"""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         def ansatz(params, **kwargs):
-            qml.RX(params[0], wires=0)
-            qml.RY(params[1], wires=0)
+            qp.RX(params[0], wires=0)
+            qp.RY(params[1], wires=0)
 
         coeffs = [0.2, 0.5]
-        observables = [qml.PauliX(0), qml.PauliY(0)]
+        observables = [qp.PauliX(0), qp.PauliY(0)]
 
-        H = qml.Hamiltonian(coeffs, observables)
+        H = qp.Hamiltonian(coeffs, observables)
         a, b = 0.54, 0.123
         params = np.array([a, b])
 
         cost = generate_cost_fn(ansatz, H, dev, interface=interface)
-        dcost = qml.grad(cost, argnums=[0])
+        dcost = qp.grad(cost, argnums=[0])
         res = dcost(params)
 
         expected = [
@@ -1020,16 +1020,16 @@ class TestInterfaces:
         """Tests for the PyTorch interface"""
         import torch
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         def ansatz(params, **kwargs):
-            qml.RX(params[0], wires=0)
-            qml.RY(params[1], wires=0)
+            qp.RX(params[0], wires=0)
+            qp.RY(params[1], wires=0)
 
         coeffs = [0.2, 0.5]
-        observables = [qml.PauliX(0), qml.PauliY(0)]
+        observables = [qp.PauliX(0), qp.PauliY(0)]
 
-        H = qml.Hamiltonian(coeffs, observables)
+        H = qp.Hamiltonian(coeffs, observables)
         a, b = 0.54, 0.123
         params = torch.autograd.Variable(torch.tensor([a, b]), requires_grad=True)
 
@@ -1051,16 +1051,16 @@ class TestInterfaces:
         """Tests for the TF interface"""
         import tensorflow as tf
 
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
         def ansatz(params, **kwargs):
-            qml.RX(params[0], wires=0)
-            qml.RY(params[1], wires=0)
+            qp.RX(params[0], wires=0)
+            qp.RY(params[1], wires=0)
 
         coeffs = [0.2, 0.5]
-        observables = [qml.PauliX(0), qml.PauliY(0)]
+        observables = [qp.PauliX(0), qp.PauliY(0)]
 
-        H = qml.Hamiltonian(coeffs, observables)
+        H = qp.Hamiltonian(coeffs, observables)
         a, b = 0.54, 0.123
         params = tf.Variable([a, b], dtype=tf.float64)
         cost = generate_cost_fn(ansatz, H, dev, interface="tf")
@@ -1082,20 +1082,20 @@ class TestInterfaces:
         """Test the gradient agrees across all interfaces"""
         import torch
 
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         coeffs = [0.2, 0.5]
-        observables = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliY(0)]
+        observables = [qp.PauliX(0) @ qp.PauliZ(1), qp.PauliY(0)]
 
-        H = qml.Hamiltonian(coeffs, observables)
+        H = qp.Hamiltonian(coeffs, observables)
 
-        shape = qml.templates.StronglyEntanglingLayers.shape(3, 2)
+        shape = qp.templates.StronglyEntanglingLayers.shape(3, 2)
         params = np.random.uniform(low=0, high=2 * np.pi, size=shape)
 
         # Torch interface
         w = torch.tensor(params, requires_grad=True)
         w = torch.autograd.Variable(w, requires_grad=True)
-        ansatz = qml.templates.layers.StronglyEntanglingLayers
+        ansatz = qp.templates.layers.StronglyEntanglingLayers
 
         cost = generate_cost_fn(ansatz, H, dev, interface="torch")
         loss = cost(w)
@@ -1104,9 +1104,9 @@ class TestInterfaces:
 
         # NumPy interface
         w = params
-        ansatz = qml.templates.layers.StronglyEntanglingLayers
+        ansatz = qp.templates.layers.StronglyEntanglingLayers
         cost = generate_cost_fn(ansatz, H, dev, interface="autograd")
-        dcost = qml.grad(cost, argnums=[0])
+        dcost = qp.grad(cost, argnums=[0])
         res = dcost(w)
 
         assert np.allclose(res, res_torch, atol=tol, rtol=0)

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -20,7 +20,7 @@ from importlib import import_module, util
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.exceptions import WireError
 from pennylane.wires import Wires
 
@@ -51,12 +51,12 @@ class TestWires:
     @pytest.mark.parametrize(
         "iterable",
         [
-            [qml.RX, qml.RY],
-            [qml.PauliX],
-            (None, qml.expval),
+            [qp.RX, qp.RY],
+            [qp.PauliX],
+            (None, qp.expval),
             (
-                qml.device("default.qubit", wires=range(3)),
-                qml.device("default.gaussian", wires=[qml.RX, 3]),
+                qp.device("default.qubit", wires=range(3)),
+                qp.device("default.gaussian", wires=[qp.RX, 3]),
             ),
         ],
     )


### PR DESCRIPTION
**Context:** We would like to update a number of PennyLane modules to import pennylane as `qp` and to use `qp` instead of `qml` throughout. This is a part of a wider rebrand of the package.

**Description of the Change:** Updates names, imports and references to `qml`.

**Benefits:** Updated to the new branding.

**Possible Drawbacks:** A lot of changes.

**Related GitHub Issues:** [sc-117042]
