### PR TITLE
[part 5] qml->qp in unconventional modules/files

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1018,6 +1018,7 @@ The following classes have been ported over:
   [(#9325)](https://github.com/PennyLaneAI/pennylane/pull/9325)
   [(#9358)](https://github.com/PennyLaneAI/pennylane/pull/9358)
   [(#9281)](https://github.com/PennyLaneAI/pennylane/pull/9281)
+  [(#9360)](https://github.com/PennyLaneAI/pennylane/pull/9360)
 
 * Documentation has been added to :func:`~.transforms.cancel_inverses` and
   :func:`~.transforms.merge_rotations` that details their usage within a ``qjit`` workflow.

--- a/tests/circuit_graph/test_circuit_graph.py
+++ b/tests/circuit_graph/test_circuit_graph.py
@@ -20,7 +20,7 @@ Unit tests for the :mod:`pennylane.circuit_graph` module.
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.ops.mid_measure.measurement_value import MeasurementValue
@@ -35,13 +35,13 @@ from pennylane.wires import Wires
 def ops_fixture():
     """A fixture of a complex example of operations that depend on previous operations."""
     return [
-        qml.RX(0.43, wires=0),
-        qml.RY(0.35, wires=1),
-        qml.RZ(0.35, wires=2),
-        qml.CNOT(wires=[0, 1]),
-        qml.Hadamard(wires=2),
-        qml.CNOT(wires=[2, 0]),
-        qml.PauliX(wires=1),
+        qp.RX(0.43, wires=0),
+        qp.RY(0.35, wires=1),
+        qp.RZ(0.35, wires=2),
+        qp.CNOT(wires=[0, 1]),
+        qp.Hadamard(wires=2),
+        qp.CNOT(wires=[2, 0]),
+        qp.PauliX(wires=1),
     ]
 
 
@@ -49,8 +49,8 @@ def ops_fixture():
 def obs_fixture():
     """A fixture of observables to go after the queue fixture."""
     return [
-        qml.expval(qml.PauliX(wires=0)),
-        qml.expval(qml.Hermitian(np.identity(4), wires=[1, 2])),
+        qp.expval(qp.PauliX(wires=0)),
+        qp.expval(qp.Hermitian(np.identity(4), wires=[1, 2])),
     ]
 
 
@@ -63,35 +63,35 @@ def circuit_fixture(ops, obs):
 @pytest.fixture(name="parametrized_circuit_gaussian")
 def parametrized_circuit_gaussian_fixture(wires):
     def qfunc(a, b, c, d, e, f):
-        qml.Rotation(a, wires=wires[0])
-        qml.Rotation(b, wires=wires[1])
-        qml.Rotation(c, wires=wires[2])
-        qml.Beamsplitter(d, 1, wires=[wires[0], wires[1]])
-        qml.Rotation(1, wires=wires[0])
-        qml.Rotation(e, wires=wires[1])
-        qml.Rotation(f, wires=wires[2])
+        qp.Rotation(a, wires=wires[0])
+        qp.Rotation(b, wires=wires[1])
+        qp.Rotation(c, wires=wires[2])
+        qp.Beamsplitter(d, 1, wires=[wires[0], wires[1]])
+        qp.Rotation(1, wires=wires[0])
+        qp.Rotation(e, wires=wires[1])
+        qp.Rotation(f, wires=wires[2])
 
-        return qml.expval(qml.ops.NumberOperator(wires=wires[0]))
+        return qp.expval(qp.ops.NumberOperator(wires=wires[0]))
 
     return qfunc
 
 
 def circuit_measure_max_once():
     """A fixture of a circuit that measures wire 0 once."""
-    return qml.expval(qml.PauliX(wires=0))
+    return qp.expval(qp.PauliX(wires=0))
 
 
 def circuit_measure_max_twice():
     """A fixture of a circuit that measures wire 0 twice."""
-    return qml.expval(qml.PauliZ(wires=0)), qml.probs(wires=0)
+    return qp.expval(qp.PauliZ(wires=0)), qp.probs(wires=0)
 
 
 def circuit_measure_multiple_with_max_twice():
     """A fixture of a circuit that measures wire 0 twice."""
     return (
-        qml.expval(qml.PauliZ(wires=0)),
-        qml.probs(wires=[0, 1, 2]),
-        qml.var(qml.PauliZ(wires=[1]) @ qml.PauliZ([2])),
+        qp.expval(qp.PauliZ(wires=0)),
+        qp.probs(wires=[0, 1, 2]),
+        qp.var(qp.PauliZ(wires=[1]) @ qp.PauliZ([2])),
     )
 
 
@@ -127,7 +127,7 @@ class TestCircuitGraph:
         """Test case where operations do not depend on each other.
         This should result in a graph with no edges."""
 
-        ops = [qml.RX(0.43, wires=0), qml.RY(0.35, wires=1)]
+        ops = [qp.RX(0.43, wires=0), qp.RY(0.35, wires=1)]
 
         res = CircuitGraph(ops, [], Wires([0, 1])).graph
         assert len(res) == 2
@@ -181,9 +181,9 @@ class TestCircuitGraph:
     def test_ancestors_and_descendents_repeated_op(self, sort):
         """Test ancestors and descendents raises a ValueError is the requested operation occurs more than once."""
 
-        op = qml.X(0)
-        ops = [op, qml.Y(0), op, qml.Z(0), op]
-        graph = CircuitGraph(ops, [], qml.wires.Wires([0, 1, 2]))
+        op = qp.X(0)
+        ops = [op, qp.Y(0), op, qp.Z(0), op]
+        graph = CircuitGraph(ops, [], qp.wires.Wires([0, 1, 2]))
 
         with pytest.raises(ValueError, match=r"operator that occurs multiple times."):
             graph.ancestors([op], sort=sort)
@@ -194,7 +194,7 @@ class TestCircuitGraph:
     def test_ancestors_and_descendents_single_op_error(self, sort):
         """Test ancestors and descendents raises a ValueError is the requested operation occurs more than once."""
 
-        op = qml.Z(0)
+        op = qp.Z(0)
         graph = CircuitGraph([op], [], [0, 1, 2])
 
         with pytest.raises(
@@ -210,18 +210,18 @@ class TestCircuitGraph:
         """Changing nodes in the graph."""
 
         circuit = CircuitGraph(ops, obs, Wires([0, 1, 2]))
-        new = qml.RX(0.1, wires=0)
+        new = qp.RX(0.1, wires=0)
         circuit.update_node(ops[0], new)
         assert circuit.operations[0] is new
-        new_mp = qml.var(qml.Y(0))
+        new_mp = qp.var(qp.Y(0))
         circuit.update_node(obs[0], new_mp)
         assert circuit.observables[0] is new_mp
 
     def test_update_node_error(self, ops, obs):
         """Test that changing nodes in the graph may raise an error."""
         circuit = CircuitGraph(ops, obs, Wires([0, 1, 2]))
-        new = qml.RX(0.1, wires=0)
-        new = qml.CNOT(wires=[0, 1])
+        new = qp.RX(0.1, wires=0)
+        new = qp.CNOT(wires=[0, 1])
         with pytest.raises(ValueError):
             circuit.update_node(ops[0], new)
 
@@ -248,9 +248,9 @@ class TestCircuitGraph:
     def test_layers(self, parametrized_circuit_gaussian, wires):
         """A test of a simple circuit with 3 layers and 6 trainable parameters"""
 
-        dev = qml.device("default.gaussian", wires=wires)
-        qnode = qml.QNode(parametrized_circuit_gaussian, dev)
-        tape = qml.workflow.construct_tape(qnode)(
+        dev = qp.device("default.gaussian", wires=wires)
+        qnode = qp.QNode(parametrized_circuit_gaussian, dev)
+        tape = qp.workflow.construct_tape(qnode)(
             *pnp.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], requires_grad=True)
         )
         circuit = tape.graph
@@ -267,10 +267,10 @@ class TestCircuitGraph:
 
     def test_iterate_layers_repeat_op(self):
         """Test iterate_parametrized_layers can work when the operation is repeated."""
-        op = qml.RX(0.5, 0)
+        op = qp.RX(0.5, 0)
         par_info = [{"op": op, "op_idx": 0, "p_idx": 0}, {"op": op, "op_idx": 2, "p_idx": 0}]
-        graph = qml.CircuitGraph(
-            [op, qml.X(0), op], [], wires=op.wires, trainable_params={0, 1}, par_info=par_info
+        graph = qp.CircuitGraph(
+            [op, qp.X(0), op], [], wires=op.wires, trainable_params={0, 1}, par_info=par_info
         )
         layers = list(graph.iterate_parametrized_layers())
 
@@ -279,20 +279,20 @@ class TestCircuitGraph:
         assert layers[0].pre_ops == []
         assert layers[0].ops == [op]
         assert layers[0].param_inds == (0,)
-        assert layers[0].post_ops == [qml.X(0), op]
+        assert layers[0].post_ops == [qp.X(0), op]
 
         assert layers[1].ops == [op]
         assert layers[1].param_inds == (1,)
-        assert layers[1].pre_ops == [op, qml.X(0)]
+        assert layers[1].pre_ops == [op, qp.X(0)]
         assert layers[1].post_ops == []
 
     @pytest.mark.parametrize("wires", [["a", "q1", 3]])
     def test_iterate_layers(self, parametrized_circuit_gaussian, wires):
         """A test of the different layers, their successors and ancestors using a simple circuit"""
 
-        dev = qml.device("default.gaussian", wires=wires)
-        qnode = qml.QNode(parametrized_circuit_gaussian, dev)
-        tape = qml.workflow.construct_tape(qnode)(
+        dev = qp.device("default.gaussian", wires=wires)
+        qnode = qp.QNode(parametrized_circuit_gaussian, dev)
+        tape = qp.workflow.construct_tape(qnode)(
             *pnp.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], requires_grad=True)
         )
         circuit = tape.graph
@@ -326,41 +326,41 @@ class TestCircuitGraph:
         """A test for getting the maximum number of measurements on any wire in
         the circuit graph."""
 
-        dev = qml.device("default.qubit", wires=3)
-        qnode = qml.QNode(circ, dev)
-        tape = qml.workflow.construct_tape(qnode)()
+        dev = qp.device("default.qubit", wires=3)
+        qnode = qp.QNode(circ, dev)
+        tape = qp.workflow.construct_tape(qnode)()
         circuit = tape.graph
         assert circuit.max_simultaneous_measurements == expected
 
     def test_str_print(self):
         """Tests if the circuit prints correct."""
-        ops = [qml.Hadamard(wires=0), qml.CNOT(wires=[0, 1])]
-        obs_w_wires = [qml.measurements.sample(op=None, wires=[0, 1, 2])]
+        ops = [qp.Hadamard(wires=0), qp.CNOT(wires=[0, 1])]
+        obs_w_wires = [qp.measurements.sample(op=None, wires=[0, 1, 2])]
 
         circuit_w_wires = CircuitGraph(ops, obs_w_wires, wires=Wires([0, 1, 2]))
         expected = """Operations\n==========\nH(0)\nCNOT(wires=[0, 1])\n\nObservables\n===========\nsample(wires=[0, 1, 2])\n"""
         assert str(circuit_w_wires) == expected
 
     tape_depth = (
-        ([qml.PauliZ(0), qml.CNOT([0, 1]), qml.RX(1.23, 2)], 2),
-        ([qml.X(0)] * 4, 4),
-        ([qml.Hadamard(0), qml.CNOT([0, 1]), CustomOpDepth3(wires=[1, 0])], 5),
+        ([qp.PauliZ(0), qp.CNOT([0, 1]), qp.RX(1.23, 2)], 2),
+        ([qp.X(0)] * 4, 4),
+        ([qp.Hadamard(0), qp.CNOT([0, 1]), CustomOpDepth3(wires=[1, 0])], 5),
         (
             [
-                qml.RX(1.23, 0),
-                qml.RZ(-0.45, 0),
+                qp.RX(1.23, 0),
+                qp.RZ(-0.45, 0),
                 CustomOpDepth3(wires=[3, 4]),
-                qml.Hadamard(0),
-                qml.Hadamard(1),
-                qml.Hadamard(2),
-                qml.Hadamard(3),
-                qml.Hadamard(4),
+                qp.Hadamard(0),
+                qp.Hadamard(1),
+                qp.Hadamard(2),
+                qp.Hadamard(3),
+                qp.Hadamard(4),
                 CustomOpDepth2(wires=[1, 2, 3]),
-                qml.RZ(-1, 4),
-                qml.RX(0.5, 4),
-                qml.RX(0.5, 3),
+                qp.RZ(-1, 4),
+                qp.RX(0.5, 4),
+                qp.RX(0.5, 3),
                 CustomOpDepth4(wires=[0, 1]),
-                qml.CNOT(wires=[3, 4]),
+                qp.CNOT(wires=[3, 4]),
             ],
             10,
         ),
@@ -376,7 +376,7 @@ class TestCircuitGraph:
 def test_has_path():
     """Test has_path and has_path_idx."""
 
-    ops = [qml.X(0), qml.X(3), qml.CNOT((0, 1)), qml.X(1), qml.X(3)]
+    ops = [qp.X(0), qp.X(3), qp.CNOT((0, 1)), qp.X(1), qp.X(3)]
     graph = CircuitGraph(ops, [], wires=[0, 1, 2, 3, 4, 5])
 
     assert graph.has_path(ops[0], ops[2])
@@ -389,7 +389,7 @@ def test_path_from_mcm_to_conditional():
     mcm = MidMeasure(wires=Wires([0]))
     ppm = PauliMeasure("XY", wires=Wires([0, 1]))
     m0 = MeasurementValue([mcm, ppm])
-    ops = [mcm, ppm, Conditional(m0, qml.Z(0))]
+    ops = [mcm, ppm, Conditional(m0, qp.Z(0))]
     graph = CircuitGraph(ops, [], wires=Wires([0, 1, 2]))
     assert graph.has_path(mcm, ops[2])
     assert graph.has_path(ppm, ops[2])
@@ -398,8 +398,8 @@ def test_path_from_mcm_to_conditional():
 def test_has_path_repeated_ops():
     """Test has_path and has_path_idx when an operation is repeated."""
 
-    op = qml.X(0)
-    ops = [op, qml.CNOT((0, 1)), op, qml.Y(1)]
+    op = qp.X(0)
+    ops = [op, qp.CNOT((0, 1)), op, qp.Y(1)]
 
     graph = CircuitGraph(ops, [], [0, 1, 2, 3])
 

--- a/tests/circuit_graph/test_circuit_graph_hash.py
+++ b/tests/circuit_graph/test_circuit_graph_hash.py
@@ -18,7 +18,7 @@ Unit and integration tests for creating the :mod:`pennylane` :attr:`tape.graph.h
 import numpy as np
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.wires import Wires
 
@@ -27,12 +27,12 @@ class TestCircuitGraphHash:
     """Test the creation of a hash on a CircuitGraph"""
 
     numeric_queues = [
-        ([qml.RX(0.3, wires=[0])], [], "RX!0.3![0]|||"),
+        ([qp.RX(0.3, wires=[0])], [], "RX!0.3![0]|||"),
         (
             [
-                qml.RX(0.3, wires=[0]),
-                qml.RX(0.4, wires=[1]),
-                qml.RX(0.5, wires=[2]),
+                qp.RX(0.3, wires=[0]),
+                qp.RX(0.4, wires=[1]),
+                qp.RX(0.5, wires=[2]),
             ],
             [],
             "RX!0.3![0]RX!0.4![1]RX!0.5![2]|||",
@@ -48,12 +48,12 @@ class TestCircuitGraphHash:
         assert circuit_graph_1.serialize() == circuit_graph_2.serialize()
         assert expected_string == circuit_graph_1.serialize()
 
-    returntype1 = qml.expval
-    returntype2 = qml.var
+    returntype1 = qp.expval
+    returntype2 = qp.var
 
-    observable1 = qml.PauliZ(wires=[0])
-    observable2 = qml.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0])
-    observable3 = qml.prod(qml.PauliZ(0), qml.PauliZ(1))
+    observable1 = qp.PauliZ(wires=[0])
+    observable2 = qp.Hermitian(np.array([[1, 0], [0, -1]]), wires=[0])
+    observable3 = qp.prod(qp.PauliZ(0), qp.PauliZ(1))
 
     numeric_observable_queue = [
         (returntype1, observable1, "|||ExpectationMP!PauliZ[0]"),
@@ -83,19 +83,19 @@ class TestCircuitGraphHash:
     @pytest.mark.parametrize("obs, op, expected_string", numeric_observable_queue)
     def test_serialize_numeric_arguments_observables_expval_var(self, obs, op, expected_string):
         """Tests the hashes for expval and var return types"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit1():
             return obs(op)
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)()
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.serialize()
 
         assert circuit_hash_1 == expected_string
 
-    returntype4 = qml.probs
-    returntype5 = qml.sample
+    returntype4 = qp.probs
+    returntype5 = qp.sample
 
     numeric_observable_queue = [
         (returntype4, "|||ProbabilityMP!Identity[0]"),
@@ -105,18 +105,18 @@ class TestCircuitGraphHash:
     @pytest.mark.parametrize("obs, expected_string", numeric_observable_queue)
     def test_serialize_numeric_arguments_observables_probs_sample(self, obs, expected_string):
         """Tests the hashes for probs and sample return types"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit1():
             return obs(wires=0)
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)()
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.serialize()
 
         assert circuit_hash_1 == expected_string
 
-    returntype6 = qml.state
+    returntype6 = qp.state
 
     numeric_observable_queue = [
         (returntype6, "PauliX[0]|||StateMP!Identity[]"),
@@ -125,20 +125,20 @@ class TestCircuitGraphHash:
     @pytest.mark.parametrize("obs, expected_string", numeric_observable_queue)
     def test_serialize_numeric_arguments_observables_state(self, obs, expected_string):
         """Tests the hashes for state return types"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit1():
-            qml.PauliX(wires=0)
+            qp.PauliX(wires=0)
             return obs()
 
-        node1 = qml.QNode(circuit1, dev)
+        node1 = qp.QNode(circuit1, dev)
 
-        tape = qml.workflow.construct_tape(node1)()
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.serialize()
 
         assert circuit_hash_1 == expected_string
 
-    returntype7 = qml.density_matrix
+    returntype7 = qp.density_matrix
 
     numeric_observable_queue = [
         (returntype7, "|||DensityMatrixMP!Identity[0, 1]"),
@@ -147,14 +147,14 @@ class TestCircuitGraphHash:
     @pytest.mark.parametrize("obs, expected_string", numeric_observable_queue)
     def test_serialize_numeric_arguments_observables_density_mat(self, obs, expected_string):
         """Tests the hashes density matrix (state) return types"""
-        dev = qml.device("default.mixed", wires=2)
+        dev = qp.device("default.mixed", wires=2)
 
         def circuit1():
             return obs(wires=[0, 1])
 
-        node1 = qml.QNode(circuit1, dev)
+        node1 = qp.QNode(circuit1, dev)
 
-        tape = qml.workflow.construct_tape(node1)()
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.serialize()
 
         assert circuit_hash_1 == expected_string
@@ -165,29 +165,29 @@ class TestQNodeCircuitHashIntegration:
 
     def test_evaluate_circuit_hash_numeric(self):
         """Tests that the circuit hash of identical circuits containing only numeric parameters are equal"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         a = 0.3
         b = 0.2
 
         def circuit1():
-            qml.RX(a, wires=[0])
-            qml.RY(b, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(a, wires=[0])
+            qp.RY(b, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)()
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.hash
 
         def circuit2():
-            qml.RX(a, wires=[0])
-            qml.RY(b, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(a, wires=[0])
+            qp.RY(b, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)()
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)()
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -198,26 +198,26 @@ class TestQNodeCircuitHashIntegration:
     )
     def test_evaluate_circuit_hash_symbolic(self, x, y):
         """Tests that the circuit hash of identical circuits containing only symbolic parameters are equal"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -228,28 +228,28 @@ class TestQNodeCircuitHashIntegration:
     )
     def test_evaluate_circuit_hash_numeric_and_symbolic(self, x, y):
         """Tests that the circuit hash of identical circuits containing numeric and symbolic parameters are equal"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -261,28 +261,28 @@ class TestQNodeCircuitHashIntegration:
     def test_evaluate_circuit_hash_numeric_and_symbolic_tensor_return(self, x, y):
         """Tests that the circuit hashes of identical circuits having a tensor product in the return
         statement are equal"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -294,24 +294,24 @@ class TestQNodeCircuitHashIntegration:
     def test_evaluate_circuit_hash_same_operation_has_numeric_and_symbolic(self, x, y):
         """Tests that the circuit hashes of identical circuits where one operation has both numeric
         and symbolic arguments are equal"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -322,24 +322,24 @@ class TestQNodeCircuitHashIntegration:
     )
     def test_evaluate_circuit_hash_numeric_and_symbolic_return_type_does_matter(self, x, y):
         """Tests that the circuit hashes of identical circuits only differing on their return types are not equal"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.var(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.var(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -350,26 +350,26 @@ class TestQNodeCircuitHashIntegration:
     )
     def test_evaluate_circuit_hash_hermitian(self, x, y):
         """Tests that the circuit hashes of identical circuits containing a Hermitian observable are equal"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         matrix = np.array([[1, 0], [0, 1]])
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.Hermitian(matrix, wires=[0]) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.Hermitian(matrix, wires=[0]) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.Hermitian(matrix, wires=[0]) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.Hermitian(matrix, wires=[0]) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 == circuit_hash_2
@@ -380,55 +380,55 @@ class TestQNodeCircuitHashDifferentHashIntegration:
 
     def test_evaluate_circuit_hash_numeric_different(self):
         """Tests that the circuit hashes of identical circuits except for one numeric value are different"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         a = 0.3
         b = 0.2
 
         def circuit1():
-            qml.RX(a, wires=[0])
-            qml.RY(b, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(a, wires=[0])
+            qp.RY(b, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)()
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.hash
 
         c = 0.6
 
         def circuit2():
-            qml.RX(c, wires=[0])
-            qml.RY(b, wires=[1])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(c, wires=[0])
+            qp.RY(b, wires=[1])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)()
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)()
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
 
     def test_evaluate_circuit_hash_numeric_different_operation(self):
         """Tests that the circuit hashes of identical circuits except for one of the operations are different"""
-        dev = qml.device("default.qubit", wires=2)
+        dev = qp.device("default.qubit", wires=2)
 
         a = 0.3
 
         def circuit1():
-            qml.RX(a, wires=[0])
-            return qml.expval(qml.PauliZ(0))
+            qp.RX(a, wires=[0])
+            return qp.expval(qp.PauliZ(0))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)()
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)()
         circuit_hash_1 = tape.graph.hash
 
         def circuit2():
-            qml.RY(a, wires=[0])
-            return qml.expval(qml.PauliZ(0))
+            qp.RY(a, wires=[0])
+            return qp.expval(qp.PauliZ(0))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)()
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)()
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -440,28 +440,28 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     def test_evaluate_circuit_hash_numeric_and_symbolic_operation_differs(self, x, y):
         """Tests that the circuit hashes of identical circuits that have numeric and symbolic arguments
         except for one of the operations are different"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RZ(y, wires=[1])  # <-------------------------------------- RZ
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RZ(y, wires=[1])  # <-------------------------------------- RZ
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])  # <-------------------------------------- RY
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])  # <-------------------------------------- RY
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -472,30 +472,30 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     )
     def test_evaluate_circuit_hash_different_return_observable_vs_tensor(self, x, y):
         """Tests that the circuit hashes of identical circuits except for the return statement are different"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0))  # <------------- qml.PauliZ(0)
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0))  # <------------- qp.PauliZ(0)
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(
-                qml.PauliZ(0) @ qml.PauliX(1)
-            )  # <------------- qml.PauliZ(0) @ qml.PauliX(1)
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(
+                qp.PauliZ(0) @ qp.PauliX(1)
+            )  # <------------- qp.PauliZ(0) @ qp.PauliX(1)
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -509,24 +509,24 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     ):
         """Tests that the circuit hashes of identical circuits except for the order of numeric and symbolic arguments
         in one of the operations are different."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, 0.3, y, wires=[0])  # <------------- x, 0.3, y
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, 0.3, y, wires=[0])  # <------------- x, 0.3, y
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])  # <------------- x, y, 0.3
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])  # <------------- x, y, 0.3
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -540,24 +540,24 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     ):
         """Tests that the circuit hashes of identical circuits except for the numeric value
         in one of the operations are different."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])  # <------------- 0.3
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])  # <------------- 0.3
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.5, wires=[0])  # <------------- 0.5
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.5, wires=[0])  # <------------- 0.5
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -571,24 +571,24 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     ):
         """Tests that the circuit hashes of identical circuits except for the wires
         in one of the operations are different."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])  # <------ wires = [0, 1]
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])  # <------ wires = [0, 1]
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[1, 0])  # <------ wires = [1, 0]
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[1, 0])  # <------ wires = [1, 0]
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -602,24 +602,24 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     ):
         """Tests that the circuit hashes of identical circuits except for the wires
         in the return statement are different."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))  # <----- (0) @ (1)
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))  # <----- (0) @ (1)
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(2))  # <----- (0) @ (2)
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(2))  # <----- (0) @ (2)
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -631,28 +631,28 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     def test_evaluate_circuit_hash_numeric_and_symbolic_different_parameter(self, x, y):
         """Tests that the circuit hashes of identical circuits except for the numeric argument of a signle operation
         in the circuits are different"""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         def circuit1(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.3, wires=[2])  # <------------- 0.3
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.3, wires=[2])  # <------------- 0.3
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.RX(x, wires=[0])
-            qml.RY(y, wires=[1])
-            qml.RZ(0.5, wires=[2])  # <------------- 0.5
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.PauliZ(0) @ qml.PauliX(1))
+            qp.RX(x, wires=[0])
+            qp.RY(y, wires=[1])
+            qp.RZ(0.5, wires=[2])  # <------------- 0.5
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2
@@ -664,27 +664,27 @@ class TestQNodeCircuitHashDifferentHashIntegration:
     def test_evaluate_circuit_hash_hermitian_different_matrices(self, x, y):
         """Tests that the circuit hashes of identical circuits except for the matrix argument of the Hermitian observable
         in the return statement are different."""
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
         matrix_1 = np.array([[1, 0], [0, 1]])
         matrix_2 = np.array([[1, 0], [0, -1]])
 
         def circuit1(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.Hermitian(matrix_1, wires=[0]) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.Hermitian(matrix_1, wires=[0]) @ qp.PauliX(1))
 
-        node1 = qml.QNode(circuit1, dev)
-        tape = qml.workflow.construct_tape(node1)(x, y)
+        node1 = qp.QNode(circuit1, dev)
+        tape = qp.workflow.construct_tape(node1)(x, y)
         circuit_hash_1 = tape.graph.hash
 
         def circuit2(x, y):
-            qml.Rot(x, y, 0.3, wires=[0])
-            qml.CNOT(wires=[0, 1])
-            return qml.expval(qml.Hermitian(matrix_2, wires=[0]) @ qml.PauliX(1))
+            qp.Rot(x, y, 0.3, wires=[0])
+            qp.CNOT(wires=[0, 1])
+            return qp.expval(qp.Hermitian(matrix_2, wires=[0]) @ qp.PauliX(1))
 
-        node2 = qml.QNode(circuit2, dev)
-        tape = qml.workflow.construct_tape(node2)(x, y)
+        node2 = qp.QNode(circuit2, dev)
+        tape = qp.workflow.construct_tape(node2)(x, y)
         circuit_hash_2 = tape.graph.hash
 
         assert circuit_hash_1 != circuit_hash_2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 from packaging.version import Version
 
-import pennylane as qml
+import pennylane as qp
 from pennylane.devices import DefaultGaussian
 from pennylane.exceptions import PennyLaneDeprecationWarning
 
@@ -89,7 +89,7 @@ def n_subsystems_fixture(request):
 
 @pytest.fixture(scope="session")
 def qubit_device(n_subsystems):
-    return qml.device("default.qubit", wires=n_subsystems)
+    return qp.device("default.qubit", wires=n_subsystems)
 
 
 # The following 3 fixtures are for default.qutrit devices to be used
@@ -98,17 +98,17 @@ def qubit_device(n_subsystems):
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qutrit_device_1_wire(request):
-    return qml.device("default.qutrit", wires=1, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qp.device("default.qutrit", wires=1, r_dtype=request.param[0], c_dtype=request.param[1])
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qutrit_device_2_wires(request):
-    return qml.device("default.qutrit", wires=2, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qp.device("default.qutrit", wires=2, r_dtype=request.param[0], c_dtype=request.param[1])
 
 
 @pytest.fixture(scope="function", params=[(np.float32, np.complex64), (np.float64, np.complex128)])
 def qutrit_device_3_wires(request):
-    return qml.device("default.qutrit", wires=3, r_dtype=request.param[0], c_dtype=request.param[1])
+    return qp.device("default.qutrit", wires=3, r_dtype=request.param[0], c_dtype=request.param[1])
 
 
 #######################################################################
@@ -119,26 +119,26 @@ def mock_device(monkeypatch):
     """A mock instance of the abstract Device class"""
 
     with monkeypatch.context() as m:
-        dev = qml.devices.LegacyDevice
+        dev = qp.devices.LegacyDevice
         m.setattr(dev, "__abstractmethods__", frozenset())
         m.setattr(dev, "short_name", "mock_device")
         m.setattr(dev, "capabilities", lambda cls: {"model": "qubit"})
         m.setattr(dev, "operations", {"RX", "RY", "RZ", "CNOT", "SWAP"})
-        yield qml.devices.LegacyDevice(wires=2)  # pylint:disable=abstract-class-instantiated
+        yield qp.devices.LegacyDevice(wires=2)  # pylint:disable=abstract-class-instantiated
 
 
 # pylint: disable=protected-access
 @pytest.fixture
 def tear_down_hermitian():
     yield None
-    qml.Hermitian._eigs = {}
+    qp.Hermitian._eigs = {}
 
 
 # pylint: disable=protected-access
 @pytest.fixture
 def tear_down_thermitian():
     yield None
-    qml.THermitian._eigs = {}
+    qp.THermitian._eigs = {}
 
 
 @pytest.fixture(autouse=True)
@@ -179,11 +179,11 @@ def seed(request):
 @pytest.fixture(scope="function")
 def enable_disable_plxpr():
     """enable and disable capture around each test."""
-    qml.capture.enable()
+    qp.capture.enable()
     try:
         yield
     finally:
-        qml.capture.disable()
+        qp.capture.disable()
 
 
 @pytest.fixture(scope="function")
@@ -210,14 +210,14 @@ def enable_disable_dynamic_shapes():
 @pytest.fixture(scope="function")
 def enable_graph_decomposition():
     """enable and disable graph-decomposition around each test."""
-    with qml.decomposition.toggle_graph_ctx(True):
+    with qp.decomposition.toggle_graph_ctx(True):
         yield
 
 
 @pytest.fixture(scope="function")
 def disable_graph_decomposition():
     """disable graph-decomposition."""
-    with qml.decomposition.toggle_graph_ctx(False):
+    with qp.decomposition.toggle_graph_ctx(False):
         yield
 
 
@@ -232,7 +232,7 @@ def enable_and_disable_graph_decomp(request):
 
     """
     use_graph_decomp = request.param
-    with qml.decomposition.toggle_graph_ctx(use_graph_decomp):
+    with qp.decomposition.toggle_graph_ctx(use_graph_decomp):
         yield
 
 

--- a/tests/docs/test_supported_confs.py
+++ b/tests/docs/test_supported_confs.py
@@ -18,7 +18,7 @@ A configuration is specified by:
     1. The quantum device, e.g. "default.qubit"
     2. The interface, e.g. "jax"
     3. The differentiation method, e.g. "parameter-shift"
-    4. The return value of the QNode, e.g. qml.expval() or qml.probs()
+    4. The return value of the QNode, e.g. qp.expval() or qp.probs()
     5. The number of shots, either None or an integer > 0
 
 A configuration is supported if gradients can be computed for the
@@ -27,7 +27,7 @@ QNode without an exception being raised."""
 # pylint: disable=too-many-arguments
 import pytest
 
-import pennylane as qml
+import pennylane as qp
 from pennylane import numpy as np
 from pennylane.exceptions import DeviceError, QuantumFunctionError
 
@@ -43,7 +43,7 @@ diff_interfaces = ["autograd", "jax", "torch"]
 shots_list = [None, 100]
 
 # Each of these tuples contain:
-#   1. The argument 'wires' to pass to qml.device()
+#   1. The argument 'wires' to pass to qp.device()
 #   2. A list of the wire labels
 #   3. The wire to measure in a single-qubit measurement process
 #   4. The wires(s) to measure in a multi-qubit measurement process
@@ -104,43 +104,43 @@ def get_qnode(interface, diff_method, return_type, shots, wire_specs, gradient_k
     """
     device_wires, wire_labels, single_meas_wire, multi_meas_wire = wire_specs
 
-    dev = qml.device("default.qubit", wires=device_wires)
+    dev = qp.device("default.qubit", wires=device_wires)
 
     # pylint: disable=too-many-return-statements
-    @qml.set_shots(shots)
-    @qml.qnode(dev, interface=interface, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+    @qp.set_shots(shots)
+    @qp.qnode(dev, interface=interface, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
     def circuit(x):
         for i, wire_label in enumerate(wire_labels[:-1]):
-            qml.Hadamard(wires=wire_label)
-            qml.RX(x[i], wires=wire_label)
+            qp.Hadamard(wires=wire_label)
+            qp.RX(x[i], wires=wire_label)
 
         if return_type == "StateCost":
-            return qml.state()
+            return qp.state()
         if return_type == "StateVector":
-            return qml.state()
+            return qp.state()
         if return_type == "DensityMatrix":
-            return qml.density_matrix(wires=single_meas_wire)
+            return qp.density_matrix(wires=single_meas_wire)
         if return_type == "Probability":
-            return qml.probs(wires=multi_meas_wire)
+            return qp.probs(wires=multi_meas_wire)
         if return_type == "Sample":
-            return qml.sample(wires=multi_meas_wire)
+            return qp.sample(wires=multi_meas_wire)
         if return_type == "Expectation":
-            return qml.expval(qml.PauliZ(wires=single_meas_wire))
+            return qp.expval(qp.PauliZ(wires=single_meas_wire))
         if return_type == "Hermitian":
-            return qml.expval(
-                qml.Hermitian(
+            return qp.expval(
+                qp.Hermitian(
                     np.array([[1.0, 0.0], [0.0, -1.0]], requires_grad=False), wires=single_meas_wire
                 )
             )
         if return_type == "Projector":
-            return qml.expval(qml.Projector(np.array([1]), wires=single_meas_wire))
+            return qp.expval(qp.Projector(np.array([1]), wires=single_meas_wire))
         if return_type == "Variance":
-            return qml.var(qml.PauliZ(wires=single_meas_wire))
+            return qp.var(qp.PauliZ(wires=single_meas_wire))
         if return_type == "VnEntropy":
-            return qml.vn_entropy(wires=single_meas_wire)
+            return qp.vn_entropy(wires=single_meas_wire)
         if return_type == "MutualInfo":
             wires1 = [w for w in wire_labels if w != single_meas_wire]
-            return qml.mutual_info(wires0=[single_meas_wire], wires1=wires1)
+            return qp.mutual_info(wires0=[single_meas_wire], wires1=wires1)
         return None
 
     return circuit
@@ -171,7 +171,7 @@ def get_state_cost_fn(circuit):
 
     def cost_fn(x):
         res = circuit(x)
-        probs = qml.math.abs(res) ** 2
+        probs = qp.math.abs(res) ** 2
         return probs[0]
 
     return cost_fn
@@ -182,7 +182,7 @@ def get_density_matrix_cost_fn(circuit):
 
     def cost_fn(x):
         res = circuit(x)
-        probs = qml.math.abs(res) ** 2
+        probs = qp.math.abs(res) ** 2
         return probs[0][0]
 
     return cost_fn
@@ -213,8 +213,8 @@ def compute_gradient(x, interface, circuit, return_type, complex=False):
 
     if interface == "autograd":
         if return_type in grad_return_cases:
-            return qml.grad(cost_fn)(x)
-        return qml.jacobian(cost_fn)(x)
+            return qp.grad(cost_fn)(x)
+        return qp.jacobian(cost_fn)(x)
     if interface == "jax":
         if return_type in grad_return_cases:
             return jax.grad(cost_fn)(x)

--- a/tests/helpers/mcm_utils.py
+++ b/tests/helpers/mcm_utils.py
@@ -20,7 +20,7 @@ from functools import reduce
 
 import numpy as np
 
-import pennylane as qml
+import pennylane as qp
 
 
 def validate_counts(shots, results1, results2, batch_size=None):
@@ -84,7 +84,7 @@ def validate_samples(shots, results1, results2, batch_size=None):
     assert results1.ndim == results2.ndim
     if results2.ndim > 1:
         assert results1.shape[1] == results2.shape[1]
-    np.allclose(qml.math.sum(results1), qml.math.sum(results2), atol=20, rtol=0.2)
+    np.allclose(qp.math.sum(results1), qp.math.sum(results2), atol=20, rtol=0.2)
 
 
 def validate_expval(shots, results1, results2, batch_size=None):
@@ -118,11 +118,11 @@ def validate_expval(shots, results1, results2, batch_size=None):
 
 def validate_measurements(func, shots, results1, results2, batch_size=None):
     """Calls the correct validation function based on measurement type."""
-    if func is qml.counts:
+    if func is qp.counts:
         validate_counts(shots, results1, results2, batch_size=batch_size)
         return
 
-    if func is qml.sample:
+    if func is qp.sample:
         validate_samples(shots, results1, results2, batch_size=batch_size)
         return
 


### PR DESCRIPTION
**Context:** We would like to update this module to import pennylane as `qp` and to use `qp` instead of `qml` throughout. This is a part of a wider rebrand of the package.

**Description of the Change:** Updates filenames, imports and references to `qml` in the module.

**Benefits:** Updated to the new branding.

**Possible Drawbacks:** A lot of changes.

-------

Updates qml alias with two commands,

```
find ./pennylane/<module> -name "*.py" -type f -exec sed -i '' 's/as qml/as qp/g' {} +;
find ./pennylane/<module> -name "*.py" -type f -exec sed -i '' 's/qml\./qp./g' {} +;
find ./tests/<module> -name "*.py" -type f -exec sed -i '' 's/as qml/as qp/g' {} +;
find ./tests/<module> -name "*.py" -type f -exec sed -i '' 's/qml\./qp./g' {} +;
```

[sc-117825]