### PR TITLE
fix: improve warning message for lack of TensorFlow maintenance support

### DIFF
--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -182,9 +182,8 @@ TensorFlow
 
 .. warning::
 
-    Support for using TensorFlow with PennyLane has been deprecated and will be dropped in Pennylane v0.44.
-    Future versions of PennyLane are not guaranteed to work with TensorFlow.
-    Instead, we recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
+    Maintenance support for using TensorFlow with PennyLane has been terminated as of Pennylane v0.44.
+    We recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
     machine learning applications to benefit from enhanced support and features. Please consult the following demos for 
     a comprehensive guide on JAX and PyTorch: 
     `Turning quantum nodes into Torch Layers <https://pennylane.ai/qml/demos/tutorial_qnn_module_torch>`_ and 

--- a/doc/introduction/interfaces.rst
+++ b/doc/introduction/interfaces.rst
@@ -182,7 +182,7 @@ TensorFlow
 
 .. warning::
 
-    Maintenance support for using TensorFlow with PennyLane has been terminated as of Pennylane v0.44.
+    As of PennyLane v0.44, TensorFlow support is no longer maintained.
     We recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
     machine learning applications to benefit from enhanced support and features. Please consult the following demos for 
     a comprehensive guide on JAX and PyTorch: 

--- a/doc/introduction/interfaces/tf.rst
+++ b/doc/introduction/interfaces/tf.rst
@@ -5,9 +5,8 @@ TensorFlow interface
 
 .. warning::
 
-    Support for using TensorFlow with PennyLane has been deprecated and will be dropped in Pennylane v0.44.
-    Future versions of PennyLane are not guaranteed to work with TensorFlow.
-    Instead, we recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
+    Maintenance support for using TensorFlow with PennyLane has been terminated as of Pennylane v0.44.
+    We recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
     machine learning applications to benefit from enhanced support and features. Please consult the following demos for 
     a comprehensive guide on JAX and PyTorch: 
     `Turning quantum nodes into Torch Layers <https://pennylane.ai/qml/demos/tutorial_qnn_module_torch>`_ and 

--- a/doc/introduction/interfaces/tf.rst
+++ b/doc/introduction/interfaces/tf.rst
@@ -5,7 +5,7 @@ TensorFlow interface
 
 .. warning::
 
-    Maintenance support for using TensorFlow with PennyLane has been terminated as of Pennylane v0.44.
+    As of PennyLane v0.44, TensorFlow support is no longer maintained.
     We recommend using the :doc:`/introduction/interfaces/jax` or :doc:`/introduction/interfaces/torch` for
     machine learning applications to benefit from enhanced support and features. Please consult the following demos for 
     a comprehensive guide on JAX and PyTorch: 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1000,6 +1000,10 @@ The following classes have been ported over:
 
 <h3>Documentation 📝</h3>
 
+* Update TensorFlow related documentation to clarify that maintenance support has been dropped since
+  PennyLane v0.44.
+  [(#9362)](https://github.com/PennyLaneAI/pennylane/pull/9362)
+
 * The `qml` alias as in `import pennylane as qml` has been updated to `qp` in our source code and documentation.
   [(#9310)](https://github.com/PennyLaneAI/pennylane/pull/9310)
   [(#9317)](https://github.com/PennyLaneAI/pennylane/pull/9317)


### PR DESCRIPTION
**Context:**

We've already dropped maintenance support for this interface since v0.44. The warning message should properly reflect that change.

**Description of the Change:**

Update messaging to be more clear that it's already been dropped.

**Benefits:** Clearer messaging.

**Possible Drawbacks:** None identified.

[sc-118153]


