### PR TITLE
Fix qml.trotterize list reversal

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1219,6 +1219,9 @@ The following classes have been ported over:
   when it has decomposition rules with a lower work wire budget but is unrecheable from the provided gate set.
   [(#9298)](https://github.com/PennyLaneAI/pennylane/pull/9298)
 
+* Fixes a bug where :func:`~.trotterize` incorrectly reversed the sequence of operations within a ``qfunc``
+  [(#9369)](https://github.com/PennyLaneAI/pennylane/pull/9369)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/templates/subroutines/time_evolution/trotter.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter.py
@@ -833,16 +833,19 @@ def _recursive_qfunc(time, order, qfunc, wires, reverse, *qfunc_args, **qfunc_kw
         list: the approximation as a product of exponentials of the Hamiltonian terms
     """
     if order == 1:
+        if reverse:
+            tape_inv = make_qscript(qfunc)(-time, *qfunc_args, wires=wires, **qfunc_kwargs)
+            return [qp_ops.adjoint(op) for op in tape_inv.operations[::-1]]
+
         tape = make_qscript(qfunc)(time, *qfunc_args, wires=wires, **qfunc_kwargs)
-        return tape.operations[::-1] if reverse else tape.operations
+        return tape.operations
 
     if order == 2:
         tape = make_qscript(qfunc)(time / 2, *qfunc_args, wires=wires, **qfunc_kwargs)
-        return (
-            tape.operations[::-1] + tape.operations
-            if reverse
-            else tape.operations + tape.operations[::-1]
-        )
+        tape_inv = make_qscript(qfunc)(-time / 2, *qfunc_args, wires=wires, **qfunc_kwargs)
+        inv_ops = [qp_ops.adjoint(op) for op in tape_inv.operations[::-1]]
+
+        return inv_ops + tape.operations if reverse else tape.operations + inv_ops
 
     scalar_1 = _scalar(order)
     scalar_2 = 1 - 4 * scalar_1

--- a/tests/templates/subroutines/time_evolution/test_trotter.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter.py
@@ -1706,72 +1706,37 @@ class TestTrotterizedQfuncIntegration:
     def _generate_simple_decomp_trotterize(self, time, order, reverse, args, wires):
         arg1, arg2 = args
 
-        if order == 1:
-            expected_decomp = [
-                qp.RX(time * arg1, wires=wires[0]),
-                qp.RY(time * arg2, wires=wires[0]),
+        def get_ops(t):
+            return [
+                qp.RX(t * arg1, wires=wires[0]),
+                qp.RY(t * arg2, wires=wires[0]),
                 qp.MultiRZ(arg1, wires=wires),
                 qp.CNOT([wires[0], wires[1]]),
-                qp.ControlledPhaseShift(time * arg2, wires=[wires[1], wires[0]]),
+                qp.ControlledPhaseShift(t * arg2, wires=[wires[1], wires[0]]),
                 qp.CNOT([wires[0], wires[1]]),
                 qp.QFT(wires=wires[1:-1]),
             ]
 
+        if order == 1:
             if reverse:
-                expected_decomp = expected_decomp[::-1]
+                return [qp.adjoint(op) for op in get_ops(-time)[::-1]]
+            return get_ops(time)
 
         if order == 2:
-            expected_decomp = [
-                qp.RX((time / 2) * arg1, wires=wires[0]),
-                qp.RY((time / 2) * arg2, wires=wires[0]),
-                qp.MultiRZ(arg1, wires=wires),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.ControlledPhaseShift((time / 2) * arg2, wires=[wires[1], wires[0]]),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.QFT(wires=wires[1:-1]),
-            ]
-
-            if reverse:
-                expected_decomp = expected_decomp[::-1]
-
-            expected_decomp = expected_decomp + expected_decomp[::-1]
+            ops = get_ops(time / 2)
+            inv_ops = [qp.adjoint(op) for op in get_ops(-time / 2)[::-1]]
+            return (inv_ops + ops) if reverse else (ops + inv_ops)
 
         if order == 4:
-            expected_decomp1 = [
-                qp.RX((p_4 * time / 2) * arg1, wires=wires[0]),
-                qp.RY((p_4 * time / 2) * arg2, wires=wires[0]),
-                qp.MultiRZ(arg1, wires=wires),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.ControlledPhaseShift((p_4 * time / 2) * arg2, wires=[wires[1], wires[0]]),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.QFT(wires=wires[1:-1]),
-            ]
+            ops1 = get_ops(p_4 * time / 2)
+            inv_ops1 = [qp.adjoint(op) for op in get_ops(-p_4 * time / 2)[::-1]]
+            decomp1 = (inv_ops1 + ops1) if reverse else (ops1 + inv_ops1)
 
-            expected_decomp1 = (
-                expected_decomp1[::-1] + expected_decomp1
-                if reverse
-                else expected_decomp1 + expected_decomp1[::-1]
-            )
+            ops2 = get_ops(p4_comp * time / 2)
+            inv_ops2 = [qp.adjoint(op) for op in get_ops(-p4_comp * time / 2)[::-1]]
+            decomp2 = (inv_ops2 + ops2) if reverse else (ops2 + inv_ops2)
 
-            expected_decomp2 = [
-                qp.RX((p4_comp * time / 2) * arg1, wires=wires[0]),
-                qp.RY((p4_comp * time / 2) * arg2, wires=wires[0]),
-                qp.MultiRZ(arg1, wires=wires),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.ControlledPhaseShift((p4_comp * time / 2) * arg2, wires=[wires[1], wires[0]]),
-                qp.CNOT([wires[0], wires[1]]),
-                qp.QFT(wires=wires[1:-1]),
-            ]
-
-            expected_decomp2 = (
-                expected_decomp2[::-1] + expected_decomp2
-                if reverse
-                else expected_decomp2 + expected_decomp2[::-1]
-            )
-
-            expected_decomp = expected_decomp1 * 2 + expected_decomp2 + expected_decomp1 * 2
-
-        return expected_decomp
+            return decomp1 * 2 + decomp2 + decomp1 * 2
 
     #   Circuit execution tests:
     @pytest.mark.parametrize("n", (1, 2, 3))


### PR DESCRIPTION
**Context:**
Fixes #9203
When using qml.trotterize without qml.prod gives incorrect op

**Description of the Change:**

Replaced the list slicing in the qml.trotterize 2nd-order expansion with a proper time-reversal using qml.adjoint

Output: 

```
[7.96326711e-04-5.40302135e-01j 8.41470718e-01+6.54316011e-17j]
[ 7.96326711e-04-0.54030213j -8.41470718e-01+0.j        ]
[ 7.96326711e-04-0.54030213j -8.41470718e-01+0.j        ]
[7.96326711e-04-0.54030213j 8.41470718e-01+0.j        ]
```