### PR TITLE
[WIP] Add decomposition for C(Prod) instances with borrowed/dirty work wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -501,7 +501,7 @@ The following classes have been ported over:
 
 * The `QROM` decompositions now has a smarter allocation of the work wires achieving better decompositions.
   [(#9131)](https://github.com/PennyLaneAI/pennylane/pull/9131)
-  
+
 * The inspectibility of general symbolic decomposition rules is improved. The string representation of a decomposition rule
   is by default its source code. Now for symbolic decomposition rules that wrap a base decomposition rule, the source code
   for the base decomposition rule is also displayed when printing this rule.
@@ -589,12 +589,12 @@ The following classes have been ported over:
 * ``num_x_wires`` and ``num_work_wires`` were added to the ``resource_keys`` and ``resource_params`` of
   :class:`~.SemiAdder`.
   [(#9293)](https://github.com/PennyLaneAI/pennylane/pull/9293)
-  
+
   With this breaking change, please note the following:
-  
+
    - Decomposition rules for ``SemiAdder`` now require those arguments.
    - When registering a resource function (:func:`qp.register_resources <pennylane.register_resources>`) to a decomposition rule of an operator that contains ``SemiAdder``, the resource representation of ``SemiAdder`` must also receive these new arguments.
-   
+
    These changes are relevant only with :func:`~decomposition.enable_graph`.
 
 * All operator classes are now queued by default, unless they implement a custom ``queue``
@@ -857,7 +857,7 @@ The following classes have been ported over:
 
 <h3>Internal changes ⚙️</h3>
 
-* Largely unused PLxPR was recently removed in lightning. Removed tests from PennyLane that are no longer relevant 
+* Largely unused PLxPR was recently removed in lightning. Removed tests from PennyLane that are no longer relevant
   as a result.
   [(#9345)](https://github.com/PennyLaneAI/pennylane/pull/9345)
 
@@ -1087,7 +1087,7 @@ The following classes have been ported over:
   enabling `qml.QROM` to be used with `qjit` when wires are passed as dynamic arguments.
   [(#9282)](https://github.com/PennyLaneAI/pennylane/pull/9282)
 
-* Global phases are now supported in `from_qasm3` so that QASM including the `gphase` instruction 
+* Global phases are now supported in `from_qasm3` so that QASM including the `gphase` instruction
   can be interpreted.
   [(#9247)](https://github.com/PennyLaneAI/pennylane/pull/9247)
 
@@ -1218,6 +1218,9 @@ The following classes have been ported over:
 * Fixes a bug where the `DecompositionGraph` underestimates the minimum number of work wires required to solve for a particular operator
   when it has decomposition rules with a lower work wire budget but is unrecheable from the provided gate set.
   [(#9298)](https://github.com/PennyLaneAI/pennylane/pull/9298)
+
+* Made ``base`` argument optional in ``Controlled.__new__``, which fixes the bug that ``Controlled(CompositeOp)`` cannot be unpickled.
+  [(#9366)](https://github.com/PennyLaneAI/pennylane/pull/9366)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -566,8 +566,9 @@ class Controlled(SymbolicOp):
         return new_sig
 
     # pylint: disable=unused-argument
-    def __new__(cls, *_, base=None, **__):
+    def __new__(cls, *args, **kwargs):
         """If base is an ``Operation``, then a ``ControlledOp`` should be used instead."""
+        base = args[0] if args else kwargs.get("base")
         if base is None:
             return object.__new__(cls)
         if isinstance(base, Operation):

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -566,8 +566,10 @@ class Controlled(SymbolicOp):
         return new_sig
 
     # pylint: disable=unused-argument
-    def __new__(cls, base, *_, **__):
+    def __new__(cls, *_, base=None, **__):
         """If base is an ``Operation``, then a ``ControlledOp`` should be used instead."""
+        if base is None:
+            return object.__new__(cls)
         if isinstance(base, Operation):
             return object.__new__(ControlledOp)
         return object.__new__(Controlled)

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -28,6 +28,11 @@ from scipy.sparse import kron as sparse_kron
 import pennylane as qp
 from pennylane import math
 from pennylane.capture.autograph import wraps
+from pennylane.decomposition import (
+    adjoint_resource_rep,
+    controlled_resource_rep,
+    resource_rep,
+)
 from pennylane.operation import Operator
 from pennylane.ops.op_math.pow import Pow
 from pennylane.ops.op_math.sprod import SProd
@@ -499,6 +504,76 @@ def _prod_decomp(*_, wires=None, operands, **__):
 
 
 qp.add_decomps(Prod, _prod_decomp)
+
+
+def _ctrl_prod_resources(
+    *_,
+    num_control_wires,
+    base_params,
+    **__,
+):
+    factor_reps = base_params["resources"]  # {rep: count} from Prod
+    tand_rep = resource_rep(qp.TemporaryAND)  # resource_keys == set()
+
+    resources = {
+        tand_rep: num_control_wires - 1,
+        adjoint_resource_rep(qp.TemporaryAND, tand_rep.params): num_control_wires - 1,
+    }
+
+    # Per-factor single-control fan-out from the last ancilla.
+    for rep, count in factor_reps.items():
+        resources[
+            controlled_resource_rep(
+                base_class=rep.op_type,
+                base_params=rep.params,
+                num_control_wires=1,
+                num_zero_control_values=0,
+                num_work_wires=0,
+            )
+        ] += count
+
+    return resources
+
+
+@qp.register_condition(
+    lambda *_, num_control_wires, num_work_wires, **__: num_control_wires >= 2
+    and num_work_wires >= num_control_wires - 1
+)
+@qp.register_resources(_ctrl_prod_resources)
+def _controlled_product_with_work_wires(*_, control_wires, control_values, work_wires, base, **__):
+    target_wire = _multi_temporary_and(control_wires, control_values, work_wires)
+    for op in base.operands:
+        qp.ctrl(op, control=[target_wire])  # was: qp.ctrl(base, ...)
+    qp.adjoint(_multi_temporary_and)(control_wires, control_values, work_wires)
+
+
+qp.add_decomps(
+    "C(Prod)",
+    _controlled_product_with_work_wires,
+)
+
+
+def _multi_temporary_and(
+    control,
+    control_values,
+    work_wires,
+):
+    """Controlled decomposition using TemporaryAND ladder (needs work wires)."""
+
+    c = len(control)
+    num_needed = c - 1
+    qp.TemporaryAND(
+        wires=[control[0], control[1], work_wires[0]],
+        control_values=(control_values[0], control_values[1]),
+    )
+
+    for i in range(1, num_needed):
+        qp.TemporaryAND(
+            wires=[work_wires[i - 1], control[i + 1], work_wires[i]],
+            control_values=(True, control_values[i + 1]),
+        )
+
+    return work_wires[i]
 
 
 def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -546,9 +546,89 @@ def _controlled_product_with_work_wires(*_, control_wires, control_values, work_
     qp.adjoint(_multi_temporary_and)(control_wires, control_values, work_wires)
 
 
+def _ctrl_prod_resources_dirty_work_wires(
+    *_,
+    num_control_wires,
+    num_zero_control_values,
+    base_params,
+    **__,
+):
+    factor_reps = base_params["resources"]  # {rep: count} from Prod
+
+    resources = Counter()
+    if num_zero_control_values > 0:
+        resources[qp.X] = 2 * num_zero_control_values
+    resources[
+        resource_rep(
+            qp.MultiControlledX,
+            num_work_wires=0,
+            num_control_wires=2,
+            num_zero_control_values=0,
+            work_wire_type="borrowed",
+        )
+    ] += 4 * (num_control_wires - 1)
+
+    # Per-factor single-control fan-out from the last ancilla.
+    for rep, count in factor_reps.items():
+        resources[
+            controlled_resource_rep(
+                base_class=rep.op_type,
+                base_params=rep.params,
+                num_control_wires=1,
+                num_zero_control_values=0,
+                num_work_wires=0,
+            )
+        ] += (
+            2 * count
+        )
+
+    return dict(resources)
+
+
+@qp.register_condition(
+    lambda *_, num_control_wires, num_work_wires, **__: num_control_wires >= 2
+    and num_work_wires >= num_control_wires - 1
+)
+@qp.register_resources(_ctrl_prod_resources_dirty_work_wires)
+def _controlled_product_with_dirty_work_wires(
+    *_, control_wires, control_values, work_wires, base, **__
+):
+    # Control logical, exemplarily for a fanout operation with second control on 0 state
+    #  0: ───────────────╭X───────────────────────────────╭X─────────┤  State
+    #  1: ────────────╭X─│─────────────────────────────╭X─│──────────┤  State
+    #  2: ─────────╭X─│──│──────────────────────────╭X─│──│──────────┤  State
+    #  3: ──────╭X─│──│──│───────────────────────╭X─│──│──│──────────┤  State
+    # c1: ──────│──│──│──│─────╭●───────╭●───────│──│──│──│─────╭●───────╭●─┤  State
+    # c2: ───X──│──│──│──│─────├●───────├●───────│──│──│──│─────├●───────├●──X──┤  State
+    # c3: ──────│──│──│──│──╭●─│──╭●────│────────│──│──│──│──╭●─│──╭●────│──┤  State
+    # w1: ──────│──│──│──│──├●─╰⊕─├●────╰⊕───────│──│──│──│──├●─╰⊕─├●────╰⊕─┤  State
+    # w2: ──────╰●─╰●─╰●─╰●─╰⊕────╰⊕─────────────╰●─╰●─╰●─╰●─╰⊕────╰⊕───────┤  State
+    c = len(control_wires)
+    num_needed = c - 1
+    target_wire = work_wires[num_needed - 1]
+
+    @qp.for_loop(len(control_wires))
+    def X_loop(i):
+        qp.cond(qp.math.allclose(control_values[i], 0), qp.X)(
+            control_wires[i]
+        )  # apply X on 0-controlled wires before and after main body (see example circit above)
+
+    X_loop()  # pylint: disable=no-value-for-parameter
+
+    for op in base.operands[::-1]:
+        qp.ctrl(op, control=[target_wire])
+    _multi_toffoli_ladder(control_wires, control_values, work_wires)
+    _multi_toffoli_ladder(control_wires, control_values, work_wires)
+    for op in base.operands[::-1]:
+        qp.ctrl(op, control=[target_wire])
+    _multi_toffoli_ladder(control_wires, control_values, work_wires)
+    _multi_toffoli_ladder(control_wires, control_values, work_wires)
+
+    X_loop()  # pylint: disable=no-value-for-parameter
+
+
 qp.add_decomps(
-    "C(Prod)",
-    _controlled_product_with_work_wires,
+    "C(Prod)", _controlled_product_with_work_wires, _controlled_product_with_dirty_work_wires
 )
 
 
@@ -568,6 +648,29 @@ def _multi_temporary_and(
 
     for i in range(1, num_needed):
         qp.TemporaryAND(
+            wires=[work_wires[i - 1], control[i + 1], work_wires[i]],
+            control_values=(True, control_values[i + 1]),
+        )
+
+    return work_wires[num_needed - 1]
+
+
+def _multi_toffoli_ladder(
+    control,
+    control_values,
+    work_wires,
+):
+    """Controlled decomposition using TemporaryAND ladder (needs work wires)."""
+
+    c = len(control)
+    num_needed = c - 1
+    qp.MultiControlledX(
+        wires=[control[0], control[1], work_wires[0]],
+        control_values=(control_values[0], control_values[1]),
+    )
+
+    for i in range(1, num_needed):
+        qp.MultiControlledX(
             wires=[work_wires[i - 1], control[i + 1], work_wires[i]],
             control_values=(True, control_values[i + 1]),
         )

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -515,10 +515,9 @@ def _ctrl_prod_resources(
     factor_reps = base_params["resources"]  # {rep: count} from Prod
     tand_rep = resource_rep(qp.TemporaryAND)  # resource_keys == set()
 
-    resources = {
-        tand_rep: num_control_wires - 1,
-        adjoint_resource_rep(qp.TemporaryAND, tand_rep.params): num_control_wires - 1,
-    }
+    resources = Counter()
+    resources[tand_rep] += num_control_wires - 1
+    resources[adjoint_resource_rep(qp.TemporaryAND, tand_rep.params)] += num_control_wires - 1
 
     # Per-factor single-control fan-out from the last ancilla.
     for rep, count in factor_reps.items():
@@ -532,7 +531,7 @@ def _ctrl_prod_resources(
             )
         ] += count
 
-    return resources
+    return dict(resources)
 
 
 @qp.register_condition(
@@ -542,7 +541,7 @@ def _ctrl_prod_resources(
 @qp.register_resources(_ctrl_prod_resources)
 def _controlled_product_with_work_wires(*_, control_wires, control_values, work_wires, base, **__):
     target_wire = _multi_temporary_and(control_wires, control_values, work_wires)
-    for op in base.operands:
+    for op in base.operands[::-1]:
         qp.ctrl(op, control=[target_wire])  # was: qp.ctrl(base, ...)
     qp.adjoint(_multi_temporary_and)(control_wires, control_values, work_wires)
 
@@ -573,7 +572,7 @@ def _multi_temporary_and(
             control_values=(True, control_values[i + 1]),
         )
 
-    return work_wires[i]
+    return work_wires[num_needed - 1]
 
 
 def _swappable_ops(op1, op2, wire_map: dict = None) -> bool:

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -553,7 +553,7 @@ def _ctrl_prod_resources_dirty_work_wires(
     base_params,
     **__,
 ):
-    factor_reps = base_params["resources"]  # {rep: count} from Prod
+    factor_reps = base_params["resources"]
 
     resources = Counter()
     if num_zero_control_values > 0:
@@ -578,16 +578,36 @@ def _ctrl_prod_resources_dirty_work_wires(
                 num_zero_control_values=0,
                 num_work_wires=0,
             )
-        ] += (
-            2 * count
-        )
+        ] += count
+
+        adj_rep = adjoint_resource_rep(base_class=rep.op_type, base_params=rep.params)
+        resources[
+            controlled_resource_rep(
+                base_class=adj_rep.op_type,
+                base_params=adj_rep.params,
+                num_control_wires=1,
+                num_zero_control_values=0,
+                num_work_wires=0,
+            )
+        ] += count
 
     return dict(resources)
 
 
+def _target_ops_commute(
+    *_, base_params, **__
+):  # control_wires, num_control_wires, num_work_wires, work_wire_type
+    factor_reps = base_params["resources"]
+    print(factor_reps)
+    # TODO: check if resources in the Prod commute, is this possible?
+    return True
+
+
+@qp.register_condition(_target_ops_commute)
 @qp.register_condition(
-    lambda *_, num_control_wires, num_work_wires, **__: num_control_wires >= 2
+    lambda *_, num_control_wires, num_work_wires, work_wire_type, **__: num_control_wires >= 2
     and num_work_wires >= num_control_wires - 1
+    and work_wire_type == "borrowed"
 )
 @qp.register_resources(_ctrl_prod_resources_dirty_work_wires)
 def _controlled_product_with_dirty_work_wires(
@@ -619,8 +639,8 @@ def _controlled_product_with_dirty_work_wires(
         qp.ctrl(op, control=[target_wire])
     _multi_toffoli_ladder(control_wires, control_values, work_wires)
     _multi_toffoli_ladder(control_wires, control_values, work_wires)
-    for op in base.operands[::-1]:
-        qp.ctrl(op, control=[target_wire])
+    for op in base.operands:
+        qp.ctrl(qp.adjoint(op), control=[target_wire])
     _multi_toffoli_ladder(control_wires, control_values, work_wires)
     _multi_toffoli_ladder(control_wires, control_values, work_wires)
 
@@ -666,13 +686,13 @@ def _multi_toffoli_ladder(
     num_needed = c - 1
     qp.MultiControlledX(
         wires=[control[0], control[1], work_wires[0]],
-        control_values=(control_values[0], control_values[1]),
+        # control_values=(control_values[0], control_values[1]),
     )
 
     for i in range(1, num_needed):
         qp.MultiControlledX(
             wires=[work_wires[i - 1], control[i + 1], work_wires[i]],
-            control_values=(True, control_values[i + 1]),
+            # control_values=(True, control_values[i + 1]),
         )
 
     return work_wires[num_needed - 1]

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Unit tests for Controlled"""
 
+import pickle
 from copy import copy
 from functools import partial
 
@@ -120,6 +121,29 @@ class TestControlledInheritance:
 
         assert type(op) is ControlledOp  # pylint: disable=unidiomatic-typecheck
 
+    @pytest.mark.parametrize(
+        "base",
+        [
+            qp.prod(qp.X(0), qp.X(1)),  # Prod -> CompositeOp
+            qp.X(0) + qp.Y(1),  # Sum  -> CompositeOp
+            2.0 * qp.X(0),  # SProd
+        ],
+    )
+    def test_pickle_roundtrip_composite_base(self, base):
+        """
+        Plain ``Controlled`` (i.e. with a non-Operation base like Prod/Sum/SProd)
+        used to fail to unpickle because ``Controlled.__new__`` required ``base``
+        positionally, but the default pickle protocol reconstructs via
+        ``cls.__new__(cls)`` with no arguments. The ``ControlledOp`` branch already
+        had a no-required-arg ``__new__``; this test guards parity on the
+        ``Controlled`` branch.
+        """
+        op = Controlled(base, control_wires=[2], work_wires=[3])
+        assert isinstance(op, Controlled)  # check that we're on the non-Operation branch
+
+        roundtripped = pickle.loads(pickle.dumps(op))
+        qp.assert_equal(op, roundtripped)
+
 
 class TestControlledInit:
     """Test the initialization process and standard properties."""
@@ -199,6 +223,18 @@ class TestControlledInit:
         """Test checking work wires are not in contorl wires."""
         with pytest.raises(ValueError, match="Work wires must be different."):
             Controlled(self.temp_op, control_wires="b", work_wires="b")
+
+    @pytest.mark.parametrize(
+        "base",
+        [
+            qp.prod(qp.X(0), qp.X(1), qp.X(2)),
+            qp.X(0) + qp.Y(1),
+        ],
+    )
+    def test_standard_validity_composite_base(self, base):
+        """``assert_valid`` should pass for ``Controlled`` wrapping a CompositeOp."""
+        op = Controlled(base, control_wires=[3, 4, 5], work_wires=[6, 7, 8])
+        qp.ops.functions.assert_valid(op, skip_decomp_matrix_check=True)
 
 
 class TestControlledProperties:

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1724,3 +1724,26 @@ class TestDecomposition:
             solution.decomposition(op)(**op.hyperparameters)
 
         assert q.queue == list(op[::-1])
+
+    def test_controlled_prod_basic_validity(self):
+        """Check that Controlled(Prod) is valid, in particular its custom decomp rule"""
+        op = qp.ctrl(
+            qp.prod(qp.X(0), qp.X(1), qp.X(2)),
+            control=[4, 5, 6],
+            work_wires=[7, 8, 9],
+        )
+        qp.ops.functions.assert_valid(op, skip_decomp_matrix_check=True)
+
+    @pytest.mark.usefixtures("enable_graph_decomposition")
+    def test_controlled_prod_decomposition_new(self):
+        """The registered ``C(Prod)`` rule decomposes controlled products."""
+        from pennylane.ops.functions.assert_valid import _test_decomposition_rule
+
+        op = qp.ops.Controlled(
+            qp.prod(qp.X(0), qp.X(1), qp.X(2)),
+            control_wires=[4, 5, 6],
+            control_values=[1, 1, 1],
+            work_wires=[7, 8, 9],
+        )
+        for rule in qp.list_decomps("C(Prod)"):
+            _test_decomposition_rule(op, rule)


### PR DESCRIPTION

**Context:**

Addition to https://github.com/PennyLaneAI/pennylane/pull/9368 when no clean work wires are available

However, this only works when the operands in the Prod either commute or self-cancel. Currently not sure how to check that as a condition of the decomposition.

**Description of the Change:**

Add decomposition for C(Prod) instances with borrowed/dirty work wires

**Benefits:**

More efficient decomposition

**Possible Drawbacks:**

**Related GitHub Issues:**
