### PR TITLE
`qml.` -> `qp.` for multiple rst files

### DIFF
--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -27,8 +27,8 @@ serves as the main abstraction of such objects, and all operators (such as gates
 inherit from it.
 
 >>> from jax import numpy as jnp
->>> op = qml.Rot(jnp.array(0.1), jnp.array(0.2), jnp.array(0.3), wires=["a"])
->>> isinstance(op, qml.operation.Operator)
+>>> op = qp.Rot(jnp.array(0.1), jnp.array(0.2), jnp.array(0.3), wires=["a"])
+>>> isinstance(op, qp.operation.Operator)
 True
 
 The basic components of operators are the following:
@@ -64,20 +64,20 @@ The basic components of operators are the following:
 
    * Representation as a **product of operators** (:meth:`.Operator.decomposition`):
 
-     >>> op = qml.Rot(0.1, 0.2, 0.3, wires=["a"])
+     >>> op = qp.Rot(0.1, 0.2, 0.3, wires=["a"])
      >>> op.decomposition()
      [RZ(0.1, wires=['a']), RY(0.2, wires=['a']), RZ(0.3, wires=['a'])]
 
    * Representation as a **linear combination of operators** (:meth:`.Operator.terms`):
 
-     >>> op = qml.Hamiltonian([1., 2.], [qml.PauliX(0), qml.PauliZ(0)])
+     >>> op = qp.Hamiltonian([1., 2.], [qp.PauliX(0), qp.PauliZ(0)])
      >>> op.terms()
      ((1.0, 2.0), [PauliX(wires=[0]), PauliZ(wires=[0])])
 
    * Representation via the **eigenvalue decomposition** specified by eigenvalues (for the diagonal matrix, :meth:`.Operator.eigvals`)
      and diagonalizing gates (for the unitaries :meth:`.Operator.diagonalizing_gates`):
 
-     >>> op = qml.PauliX(0)
+     >>> op = qp.PauliX(0)
      >>> op.diagonalizing_gates()
      [H(0)]
      >>> op.eigvals()
@@ -86,7 +86,7 @@ The basic components of operators are the following:
    * Representation as a **matrix** (:meth:`.Operator.matrix`), as specified by a global wire order that tells us where the
      wires are found on a register:
 
-     >>> op = qml.PauliRot(0.2, "X", wires=["b"])
+     >>> op = qp.PauliRot(0.2, "X", wires=["b"])
      >>> op.matrix(wire_order=["a", "b"])
      [[9.95e-01-2.26e-18j 2.72e-17-9.98e-02j, 0+0j, 0+0j]
       [2.72e-17-9.98e-02j 9.95e-01-2.26e-18j, 0+0j, 0+0j]
@@ -100,7 +100,7 @@ The basic components of operators are the following:
      >>> col = np.array([1, 0])
      >>> data = np.array([1, -1])
      >>> mat = coo_matrix((data, (row, col)), shape=(4, 4))
-     >>> op = qml.SparseHamiltonian(mat, wires=["a"])
+     >>> op = qp.SparseHamiltonian(mat, wires=["a"])
      >>> op.sparse_matrix(wire_order=["a"])
      (0, 1)   1
      (1, 0) - 1
@@ -111,7 +111,7 @@ specific subclasses.
 
 * Operators inheriting from :class:`~.Operator` support addition and scalar multiplication:
 
-  >>> op = qml.PauliX(0) + 0.1 * qml.PauliZ(0)
+  >>> op = qp.PauliX(0) + 0.1 * qp.PauliZ(0)
   >>> op.name
   Hamiltonian
   >>> op
@@ -120,7 +120,7 @@ specific subclasses.
 
 * Operators may define a hermitian conjugate:
 
-  >>> qml.RX(1., wires=0).adjoint()
+  >>> qp.RX(1., wires=0).adjoint()
   RX(-1.0, wires=[0])
 
 Creating custom operators
@@ -137,7 +137,7 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
     import pennylane as qp
 
 
-    class FlipAndRotate(qml.operation.Operation):
+    class FlipAndRotate(qp.operation.Operation):
 
         # This attribute tells PennyLane what differentiation method to use. Here
         # we request parameter-shift (or "analytic") differentiation.
@@ -152,7 +152,7 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
 
             # note: we use the framework-agnostic math library since
             # trainable inputs could be tensors of different types
-            shape = qml.math.shape(angle)
+            shape = qp.math.shape(angle)
             if len(shape) > 1:
                 raise ValueError(f"Expected a scalar angle; got angle of shape {shape}.")
 
@@ -166,7 +166,7 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
 
             # we extract all wires that the operator acts on,
             # relying on the Wire class arithmetic
-            all_wires = qml.wires.Wires(wire_rot) + qml.wires.Wires(wire_flip)
+            all_wires = qp.wires.Wires(wire_rot) + qp.wires.Wires(wire_flip)
 
             # The parent class expects all trainable parameters to be fed as positional
             # arguments, and all wires acted on fed as a keyword argument.
@@ -186,8 +186,8 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
             # The general signature of this function is (*parameters, wires, **hyperparameters).
             op_list = []
             if do_flip:
-                op_list.append(qml.PauliX(wires=wires[1]))
-            op_list.append(qml.RX(angle, wires=wires[0]))
+                op_list.append(qp.PauliX(wires=wires[1]))
+            op_list.append(qp.RX(angle, wires=wires[0]))
             return op_list
 
         def adjoint(self):
@@ -219,7 +219,7 @@ FlipAndRotate(-0.1, wires=['q3', 'q1'])
 Once the class has been created, you can run a suite of validation checks using :func:`.ops.functions.assert_valid`.
 This function will warn you of some common errors in custom operators.
 
->>> qml.ops.functions.assert_valid(op)
+>>> qp.ops.functions.assert_valid(op)
 
 If the above operator omitted the ``_unflatten`` custom definition, it would raise:
 
@@ -253,12 +253,12 @@ The new gate can be used with PennyLane devices.
 
     from pennylane import numpy as np
 
-    dev = qml.device("default.qubit", wires=["q1", "q2", "q3"])
+    dev = qp.device("default.qubit", wires=["q1", "q2", "q3"])
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(angle):
         FlipAndRotate(angle, wire_rot="q1", wire_flip="q1")
-        return qml.expval(qml.PauliZ("q1"))
+        return qp.expval(qp.PauliZ("q1"))
 
 >>> a = np.array(3.14)
 >>> circuit(a)
@@ -267,7 +267,7 @@ The new gate can be used with PennyLane devices.
 If all gates used in the decomposition have gradient recipes defined,
 we can even compute gradients of circuits that use the new gate without any extra effort.
 
->>> qml.grad(circuit)(a)
+>>> qp.grad(circuit)(a)
 -0.0015926529164868282
 
 .. note::
@@ -278,8 +278,8 @@ we can even compute gradients of circuits that use the new gate without any extr
 
         def FlipAndRotate(angle, wire_rot, wire_flip=None, do_flip=False):
             if do_flip:
-                qml.PauliX(wires=wire_flip)
-            qml.RX(angle, wires=wire_rot)
+                qp.PauliX(wires=wire_flip)
+            qp.RX(angle, wires=wire_rot)
 
     and call it in the quantum function *as if it was a gate*.
     However, classes allow much more functionality, such as defining the adjoint gate above,
@@ -308,7 +308,7 @@ For example, we can create a new attribute, ``pauli_ops``, like so:
 
 We can check either a string or an Operation for inclusion in this set:
 
->>> qml.PauliX(0) in pauli_ops
+>>> qp.PauliX(0) in pauli_ops
 True
 >>> "Hadamard" in pauli_ops
 False

--- a/doc/development/guide/architecture.rst
+++ b/doc/development/guide/architecture.rst
@@ -62,7 +62,7 @@ trainable parameters can be tensors of any supported autodifferentiation framewo
 These four defining properties are accessible for all :class:`~.Operator` instances:
 
 >>> from jax import numpy as jnp
->>> op = qml.Rot(jnp.array(0.1), jnp.array(0.2), jnp.array(0.3), wires=["a"])
+>>> op = qp.Rot(jnp.array(0.1), jnp.array(0.2), jnp.array(0.3), wires=["a"])
 
 >>> op.name
 Rot
@@ -81,13 +81,13 @@ details in the documentation on :doc:`adding operations </development/adding_ope
 
 * Representation as a product of operators
 
-  >>> op = qml.Rot(0.1, 0.2, 0.3, wires=["a"])
+  >>> op = qp.Rot(0.1, 0.2, 0.3, wires=["a"])
   >>> op.decomposition()
   [RZ(0.1, wires=['a']), RY(0.2, wires=['a']), RZ(0.3, wires=['a'])]
 
 * Representation as a matrix
 
-  >>> op = qml.PauliRot(0.2, "X", wires=["b"])
+  >>> op = qp.PauliRot(0.2, "X", wires=["b"])
   >>> op.matrix()
   [[9.95004177e-01-2.25761781e-18j 2.72169462e-17-9.98334214e-02j]
    [2.72169462e-17-9.98334214e-02j 9.95004177e-01-2.25761781e-18j]]
@@ -104,7 +104,7 @@ Each measurement in pennylane has a specific class that inherits from :class:`pe
 The measurement functions such as :func:`~pennylane.expval` create an instance of its corresponding
 class (:class:`pennylane.measurements.ExpectationMP`). 
 
->>> m = qml.expval(qml.PauliZ("a"))
+>>> m = qp.expval(qp.PauliZ("a"))
 >>> type(m)
 <class 'pennylane.measurements.expval.ExpectationMP'>
 
@@ -125,10 +125,10 @@ The user defines the circuit by constructing a quantum function, such as:
 .. code-block:: python
 
     def qfunc(params):
-        qml.RX(params[0], wires='b')
-        qml.CNOT(wires=['a', 'b'])
-        qml.RY(params[1], wires='a')
-        return qml.expval(qml.PauliZ(wires='b'))
+        qp.RX(params[0], wires='b')
+        qp.CNOT(wires=['a', 'b'])
+        qp.RY(params[1], wires='a')
+        return qp.expval(qp.PauliZ(wires='b'))
 
 Internally, a quantum function is translated to a quantum tape, which is
 the central representation of a quantum circuit. The tape is a context manager that stores lists
@@ -139,7 +139,7 @@ gates are stored in the tape's ``operation`` property, while the
 measurement functions such as :func:`~pennylane.expval` are responsible for adding measurement processes
 to the tape's ``measurement`` property.
 
->>> with qml.tape.QuantumTape() as tape:
+>>> with qp.tape.QuantumTape() as tape:
 ...     qfunc(params)
 
 >>> tape.operations
@@ -166,7 +166,7 @@ within the :class:`pennylane.devices.Device` class. The main job of devices is t
 interpret and execute tapes. The most important method is ``batch_execute``,
 which executes a list of tapes, such as a list of the single tape created above:
 
->>> device = qml.device("default.qubit", wires=['a', 'b'], shots=None)
+>>> device = qp.device("default.qubit", wires=['a', 'b'], shots=None)
 >>> device.batch_execute([tape])
 [array([0.87758256])]
 
@@ -193,11 +193,11 @@ information processing on a quantum device. It is created by a quantum function 
 >>> from jax import numpy as jnp
 >>> params = jnp.array([0.5, 0.2])
 
->>> qnode = qml.QNode(qfunc, device, interface='jax')
+>>> qnode = qp.QNode(qfunc, device, interface='jax')
 >>> qnode(params)
 0.8776
 
->>> qnode_drawer = qml.draw(qnode)
+>>> qnode_drawer = qp.draw(qnode)
 >>> print(qnode_drawer(params))
 a: ───────────╭●──RY(0.20)─┤     
 b: ──RX(0.50)─╰X───────────┤  <Z>

--- a/doc/development/guide/deprecations_removals.rst
+++ b/doc/development/guide/deprecations_removals.rst
@@ -25,7 +25,7 @@ a feature:
        warnings.warn(
            "<name-of-feature> is deprecated and will be removed in version <target-version>. "
            "Instead, please use <name-of-preferred-way-to-achieve-functionality>.",
-           qml.exceptions.PennyLaneDeprecationWarning,
+           qp.exceptions.PennyLaneDeprecationWarning,
        )
 
    If the feature is being relocated, consider rephrasing the warning to discuss relocation as
@@ -48,7 +48,7 @@ a feature:
 
        def test_my_feature_is_deprecated():
            """Test that my_feature is deprecated."""
-           with pytest.warns(qml.exceptions.PennyLaneDeprecationWarning, match="my_feature is deprecated"):
+           with pytest.warns(qp.exceptions.PennyLaneDeprecationWarning, match="my_feature is deprecated"):
                _ = my_feature()
 
 6. Update any tests that specifically cover the deprecated feature to call it inside a

--- a/doc/development/guide/documentation.rst
+++ b/doc/development/guide/documentation.rst
@@ -349,11 +349,11 @@ When writing code examples for docstrings, use the following guidelines:
 
   .. code-block:: pycon
 
-      >>> dev = qml.device("default.qubit", wires=1)
-      >>> @qml.qnode(dev)
+      >>> dev = qp.device("default.qubit", wires=1)
+      >>> @qp.qnode(dev)
       >>> def circuit(x):
-      ...     qml.RX(x, wires=0)
-      ...     return qml.expval(qml.PauliZ(0))
+      ...     qp.RX(x, wires=0)
+      ...     return qp.expval(qp.PauliZ(0))
       >>> circuit(0.5)
       0.8775825618903726
 
@@ -364,11 +364,11 @@ When writing code examples for docstrings, use the following guidelines:
 
       .. code-block:: python3
 
-          dev = qml.device("default.qubit", wires=1)
-          @qml.qnode(dev)
+          dev = qp.device("default.qubit", wires=1)
+          @qp.qnode(dev)
           def circuit(x):
-              qml.RX(x, wires=0)
-              return qml.expval(qml.PauliZ(0))
+              qp.RX(x, wires=0)
+              return qp.expval(qp.PauliZ(0))
 
       Executing this circuit:
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -30,14 +30,14 @@ be installed alongside PennyLane:
 
 The following Python packages are optional:
 
-* `openfermionpyscf <https://github.com/quantumlib/OpenFermion-PySCF>`_, for the non-differentiable backend of the ``qml.qchem`` module
-* ``matplotlib``: for ``qml.draw_mpl`` and associated code
+* `openfermionpyscf <https://github.com/quantumlib/OpenFermion-PySCF>`_, for the non-differentiable backend of the ``qp.qchem`` module
+* ``matplotlib``: for ``qp.draw_mpl`` and associated code
 * ``quimb``: for the ``default.tensor`` device
-* ``pyzx``: for ``qml.transforms.to_zx`` and ``qml.transforms.from_zx``
+* ``pyzx``: for ``qp.transforms.to_zx`` and ``qp.transforms.from_zx``
 * ``stim``: for ``default.clifford``
-* ``openqasm3`` and ``antlr3_python3_runtime``: for ``qml.from_qasm3``
+* ``openqasm3`` and ``antlr3_python3_runtime``: for ``qp.from_qasm3``
 * ``kahypar`` and ``opt_einsum`` for ``qcut``
-* ``cvxopt``for ``qml.kernels.closest_psd_matrix``
+* ``cvxopt``for ``qp.kernels.closest_psd_matrix``
 
 .. _install_interfaces:
 

--- a/doc/development/guide/logging.rst
+++ b/doc/development/guide/logging.rst
@@ -9,7 +9,7 @@ To enable logging support in your PennyLane work-flow simply run the following l
 .. code:: python
 
    import pennylane as qp
-   qml.logging.enable_logging()
+   qp.logging.enable_logging()
 
 
 This will ensure all levels of the execution pipeline log function entries and
@@ -83,7 +83,7 @@ level.
 
 PennyLane logging defaults are contained in a configuration file in the logging module titled 
 ``log_config.toml``, which is imported when logging is enabled. 
-The file path can be accessed with :func:`qml.logging.config_path()`. To change log-levels that are 
+The file path can be accessed with :func:`qp.logging.config_path()`. To change log-levels that are 
 reporting on a package or module-wide basis, it is possible to do so by 
 modifying the entries in the ``log_config.toml`` file, under the ``[loggers]``
 section. In addition, if we want to send the logs elsewhere, we can
@@ -294,7 +294,7 @@ process, and surrounding operations:
     import logging
 
     # Enable logging
-    qml.logging.enable_logging()
+    qp.logging.enable_logging()
 
     # Get logger for use by this script only.
     logger = logging.getLogger(__name__)
@@ -305,14 +305,14 @@ process, and surrounding operations:
     @jax.jit
     def circuit(key, param):
        logger.info(f"Creating {dev_name} device with {num_wires} wires with {key} PNRG")
-       dev = qml.device(dev_name, wires=num_wires, prng_key=key)
+       dev = qp.device(dev_name, wires=num_wires, prng_key=key)
 
-       @qml.set_shots(shots=num_shots)
-       @qml.qnode(dev, interface="jax", diff_method="backprop")
+       @qp.set_shots(shots=num_shots)
+       @qp.qnode(dev, interface="jax", diff_method="backprop")
        def my_circuit():
-           qml.RX(param, wires=0)
-           qml.CNOT(wires=[0, 1])
-           return qml.expval(qml.PauliZ(0))
+           qp.RX(param, wires=0)
+           qp.CNOT(wires=[0, 1])
+           return qp.expval(qp.PauliZ(0))
 
        logger.info(f"Created QNODE={my_circuit}")
        res =  my_circuit()
@@ -357,7 +357,7 @@ tie-into the execution pipeline for devices without backprop supports:
     import pennylane as qp
     import logging
 
-    qml.logging.enable_logging()
+    qp.logging.enable_logging()
 
     logger = logging.getLogger(__name__)
     dev_name = "lightning.qubit"
@@ -366,14 +366,14 @@ tie-into the execution pipeline for devices without backprop supports:
 
     def circuit(param):
        logger.info(f"Creating {dev_name} device with {num_wires} wires")
-       dev = qml.device(dev_name, wires=num_wires)
+       dev = qp.device(dev_name, wires=num_wires)
 
-       @qml.set_shots(shots=num_shots)
-       @qml.qnode(dev, diff_method="adjoint")
+       @qp.set_shots(shots=num_shots)
+       @qp.qnode(dev, diff_method="adjoint")
        def my_circuit(param):
-           qml.RX(param, wires=0)
-           qml.CNOT(wires=[0, 1])
-           return qml.expval(qml.PauliZ(0))
+           qp.RX(param, wires=0)
+           qp.CNOT(wires=[0, 1])
+           return qp.expval(qp.PauliZ(0))
 
        logger.info(f"Created QNODE={my_circuit}")
        res =  my_circuit(param)
@@ -381,14 +381,14 @@ tie-into the execution pipeline for devices without backprop supports:
 
        return res
 
-    par = qml.numpy.array([0.1,0.2])
+    par = qp.numpy.array([0.1,0.2])
 
     logger.info(f"Running circuit with par={par[0]}")
     circuit(par[0])
     logger.info(f"Running circuit with par={par[1]}")
     circuit(par[1])
     logger.info(f"Calculating jacobian circuit with par={par}")
-    logger.info(f"Jacobian={qml.jacobian(circuit)(par[0])}")
+    logger.info(f"Jacobian={qp.jacobian(circuit)(par[0])}")
 
 By using ``lightning.qubit`` we can now treat the execution environment
 as a black-box, and see the log-level messages as they hit the custom

--- a/doc/development/guide/tests.rst
+++ b/doc/development/guide/tests.rst
@@ -30,11 +30,11 @@ where it is recommended that you follow general `pytest guidelines <https://docs
 
     def test_circuit_expval(self):
         """ Test that the circuit expectation value for PauliX is 0."""
-        dev = qml.device("default.qubit", wires=1)
+        dev = qp.device("default.qubit", wires=1)
 
-        @qml.qnode(dev)
+        @qp.qnode(dev)
         def circuit():
-            return qml.expval(qml.PauliX(0))
+            return qp.expval(qp.PauliX(0))
 
         expval = circuit()
 
@@ -69,14 +69,14 @@ Below you can find an example for testing a PennyLane template with Jax:
 .. code-block:: python
 
     def circuit_template(features):
-        qml.AngleEmbedding(features, range(3))
-        return qml.expval(qml.PauliZ(0))
+        qp.AngleEmbedding(features, range(3))
+        return qp.expval(qp.PauliZ(0))
 
     def circuit_decomposed(features):
-        qml.RX(features[0], wires=0)
-        qml.RX(features[1], wires=1)
-        qml.RX(features[2], wires=2)
-        return qml.expval(qml.PauliZ(0))
+        qp.RX(features[0], wires=0)
+        qp.RX(features[1], wires=1)
+        qp.RX(features[2], wires=2)
+        return qp.expval(qp.PauliZ(0))
 
     @pytest.mark.jax
     def test_jax(self, tol):
@@ -87,22 +87,22 @@ Below you can find an example for testing a PennyLane template with Jax:
 
         features = jnp.array([1.0, 1.0, 1.0])
 
-        dev = qml.device("default.qubit", wires=3)
+        dev = qp.device("default.qubit", wires=3)
 
-        circuit = qml.QNode(circuit_template, dev, interface="jax")
-        circuit2 = qml.QNode(circuit_decomposed, dev, interface="jax")
+        circuit = qp.QNode(circuit_template, dev, interface="jax")
+        circuit2 = qp.QNode(circuit_decomposed, dev, interface="jax")
 
         res = circuit(features)
         res2 = circuit2(features)
-        assert qml.math.allclose(res, res2, atol=tol, rtol=0)
+        assert qp.math.allclose(res, res2, atol=tol, rtol=0)
 
 Another example of a test involving multiple interfaces is shown below:
 
 .. code-block:: python
 
         def circuit(features):
-            qml.AngleEmbedding(features, range(3))
-            return qml.expval(qml.PauliZ(0))
+            qp.AngleEmbedding(features, range(3))
+            return qp.expval(qp.PauliZ(0))
 
         @pytest.mark.parametrize("interface",[
             pytest.param("jax", marks=pytest.mark.jax),
@@ -113,13 +113,13 @@ Another example of a test involving multiple interfaces is shown below:
             import torch
             import jax.numpy as jnp
 
-            dev = qml.device("default.qubit", wires=3)
+            dev = qp.device("default.qubit", wires=3)
 
             features_torch = torch.Tensor([1.0, 1.0, 1.0])
             features_jax = jnp.array([1.0, 1.0, 1.0])
 
-            circuit_torch = qml.QNode(circuit, dev, interface="torch")
-            circuit_jax = qml.QNode(circuit, dev, interface="jax")
+            circuit_torch = qp.QNode(circuit, dev, interface="torch")
+            circuit_jax = qp.QNode(circuit, dev, interface="jax")
 
             res_torch = circuit_torch(features_torch)
             res_jax = circuit_jax(features_torch)

--- a/doc/development/legacy_plugins.rst
+++ b/doc/development/legacy_plugins.rst
@@ -105,7 +105,7 @@ as well as potential further capabilities, by providing the following class attr
       def stopping_condition(self):
           def accepts_obj(obj):
               return obj.name in {'CNOT', 'PauliX', 'PauliY', 'PauliZ'}
-          return qml.BooleanFn(accepts_obj)
+          return qp.BooleanFn(accepts_obj)
 
   Supported operations can also be determined by the :attr:`pennylane.devices.LegacyDevice.operations` property.
   This property is a list of string names for supported operations.
@@ -153,7 +153,7 @@ as well as potential further capabilities, by providing the following class attr
   Some capabilities are queried by PennyLane core to make decisions on how to best run computations, while others are used
   by external apps built on top of the device ecosystem.
 
-  To find out which capabilities are (possibly automatically) defined for your device, ``dev = qml.device('my.device', *args, **kwargs)``,
+  To find out which capabilities are (possibly automatically) defined for your device, ``dev = qp.device('my.device', *args, **kwargs)``,
   check the output of ``dev.capabilities()``.
 
 Adding arguments to your device
@@ -206,7 +206,7 @@ Note that we have also overridden the default shot number.
 
 The user can now pass any of these arguments to the PennyLane device loader:
 
->>> dev = qml.device("example.mydevice", hardware_options={"t2": 0.1})
+>>> dev = qp.device("example.mydevice", hardware_options={"t2": 0.1})
 >>> dev.hardware_options
 {"t2": 0.1}
 
@@ -449,7 +449,7 @@ which allows the device to be initialized in the following way:
 .. code-block:: python
 
     import pennylane as qp
-    dev1 = qml.device(short_name, wires=2)
+    dev1 = qp.device(short_name, wires=2)
 
 where ``short_name`` is a string that uniquely identifies the device. The ``short_name``
 should have the form ``pluginname.devicename``, using periods for delimitation.
@@ -513,9 +513,9 @@ Users can then import this operator directly from your plugin, and use it when d
 
     @qnode(dev1)
     def my_qfunc(phi):
-        qml.Hadamard(wires=0)
+        qp.Hadamard(wires=0)
         CustomGate(phi, theta, wires=0)
-        return qml.expval(qml.PauliZ(0))
+        return qp.expval(qp.PauliZ(0))
 
 .. warning::
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1023,6 +1023,7 @@
   [(#9358)](https://github.com/PennyLaneAI/pennylane/pull/9358)
   [(#9281)](https://github.com/PennyLaneAI/pennylane/pull/9281)
   [(#9360)](https://github.com/PennyLaneAI/pennylane/pull/9360)
+  [(#9375)](https://github.com/PennyLaneAI/pennylane/pull/9375)
 
 * A new AI policy document is now applied across the PennyLaneAI organization for all AI contributions.
   [(#9079)](https://github.com/PennyLaneAI/pennylane/pull/9079)


### PR DESCRIPTION
**Context:**
I was QAing (in advance) the qml->qp migration, and came across multiple places in public pages (see https://pennylane.ai/search?contentType=DOC&q=qml&version=latest&projects=pennylane but ignore those WIP e.g. data, pytree, etc.) where we already `import pennylane as qp` but still use `qml.`. After searching within the on-going PR I don't think any others targeting these pages, so had this PR to help fix in advance.

**Description of the Change:**
Manually applied the replacement from `qml.` to `qp.` within all `rst` files with the following list of exclusion:
```
*.py, *.json, *.svg, deprecations.rst, changelog*
```

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-118082]