### PR TITLE
Make `assert_valid` compatible with MCMs in legacy decompositions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -463,7 +463,7 @@
 <h4>Other improvements</h4>
 
 * Added support to `assert_valid` for decompositions that include mid-circuit measurements and
-  added a cross-verification for the length of returned and queued decompositions.
+  added a verification for the length of various compared iterables.
   [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
   
 * Enhanced capture support of `StatePrep` and `BasisState` to accept `state` arguments of
@@ -1145,6 +1145,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the Pytree structure of `GQSP` and `QPE` were inconsistent with the strcture
+  of their data.
+  [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
+  
 * Fixed a bug where `Reflection` did not queue all operators of its decomposition.
   [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1145,8 +1145,14 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where the Pytree structure of `GQSP` and `QPE` were inconsistent with the strcture
-  of their data.
+* Fixed a bug where the Pytree structure of the following operators were inconsistent with the 
+  structure of their data:
+  
+  - `Pow`
+  - `QPE`
+  - `GQSP`
+  - `estimator.qpe_resources.FirstQuantization`
+  - `estimator.qpe_resources.DoubleFactorization`
   [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
   
 * Fixed a bug where `Reflection` did not queue all operators of its decomposition.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -462,6 +462,10 @@
 
 <h4>Other improvements</h4>
 
+* Added support to `assert_valid` for decompositions that include mid-circuit measurements and
+  added a cross-verification for the length of returned and queued decompositions.
+  [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
+  
 * Enhanced capture support of `StatePrep` and `BasisState` to accept `state` arguments of
   `list` or `tuple` types.
   [(#9338)](https://github.com/PennyLaneAI/pennylane/pull/9338)
@@ -1140,6 +1144,12 @@
   [(#9373)](https://github.com/PennyLaneAI/pennylane/pull/9373)
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed a bug where `Reflection` did not queue all operators of its decomposition.
+  [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
+
+* Fixed a bug where `Hermitian` did not queue its decomposition.
+  [(#9378)](https://github.com/PennyLaneAI/pennylane/pull/9378)
 
 * Fixed a bug in the decomposition of `Adjoint(TemporaryAND)` where control values were ignored.
   [(#9303)](https://github.com/PennyLaneAI/pennylane/pull/9303)

--- a/pennylane/estimator/qpe_resources/first_quantization.py
+++ b/pennylane/estimator/qpe_resources/first_quantization.py
@@ -137,7 +137,7 @@ class FirstQuantization(Operation):
             self.n, self.eta, self.omega, self.error, self.br, self.charge, self.cubic, self.vectors
         )
 
-        super().__init__(wires=range(self._qubits))
+        super().__init__(self.n, self.eta, wires=range(self._qubits))
 
     def _flatten(self):
         return (self.n, self.eta), (

--- a/pennylane/estimator/qpe_resources/second_quantization.py
+++ b/pennylane/estimator/qpe_resources/second_quantization.py
@@ -165,7 +165,7 @@ class DoubleFactorization(Operation):
             self.beta,
         )
 
-        super().__init__(wires=range(self._qubits))
+        super().__init__(self.one_electron, self.two_electron, wires=range(self._qubits))
 
     def _flatten(self):
         return (self.one_electron, self.two_electron), (

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -60,7 +60,6 @@ def _select_pauli_rot_phase_gradient(
             clean=False,
         )
     ] + cnots
-    print(work_wires[len(angle_wires) - 1 :])
 
     pg_op = qp.change_op_basis(
         qp.prod(*ops[::-1]),

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -60,6 +60,7 @@ def _select_pauli_rot_phase_gradient(
             clean=False,
         )
     ] + cnots
+    print(work_wires[len(angle_wires) - 1 :])
 
     pg_op = qp.change_op_basis(
         qp.prod(*ops[::-1]),

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -65,11 +65,22 @@ def _check_decomposition(op, skip_wire_mapping):
         assert isinstance(decomp, list), "decomposition must be a list"
         assert isinstance(compute_decomp, list), "decomposition must be a list"
         assert op not in decomp, "an operator should not be included in its own decomposition"
+        compute_decomp_msg = "decomposition must match compute_decomposition"
+        queue_msg = "decomposition must match queued operations"
+        assert len(decomp) == len(compute_decomp), compute_decomp_msg
+        assert len(decomp) == len(processed_queue), queue_msg
 
         for o1, o2, o3 in zip(decomp, compute_decomp, processed_queue):
-            assert o1 == o2, "decomposition must match compute_decomposition"
-            assert o1 == o3, "decomposition must match queued operations"
-            assert isinstance(o1, qp.operation.Operator), "decomposition must contain operators"
+            if isinstance(o1, qp.ops.MidMeasure):
+                for other_op, msg in [(o2, compute_decomp_msg), (o3, queue_msg)]:
+                    assert isinstance(other_op, qp.ops.MidMeasure), msg
+                    assert o1.wires == other_op.wires, msg
+                    assert o1.reset == other_op.reset, msg
+                    assert o1.postselect == other_op.postselect, msg
+            else:
+                assert o1 == o2, compute_decomp_msg
+                assert o1 == o3, queue_msg
+                assert isinstance(o1, qp.operation.Operator), "decomposition must contain operators"
 
         if skip_wire_mapping:
             return
@@ -198,10 +209,34 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         isinstance(op, qp.templates.SubroutineOp) and not op.subroutine.exact_resources
     ):
         non_zero_gate_counts = {k: v for k, v in gate_counts.items() if v > 0}
-        assert non_zero_gate_counts == actual_gate_counts, (
-            f"\nGate counts expected from resource function:\n{non_zero_gate_counts}"
-            f"\nActual gate counts:\n{dict(actual_gate_counts)}"
-        )
+        if non_zero_gate_counts != actual_gate_counts:
+            miscounts = [
+                (op, val, gate_counts[op])
+                for op, val in actual_gate_counts.items()
+                if op in gate_counts and val != gate_counts[op]
+            ]
+            if miscounts:
+                op_len = max([8] + [len(str(op)) for op, *_ in miscounts])
+                miscounts_str = (
+                    f"\nThe numbers are off for following ops:"
+                    f"\n{'Operator'.rjust(op_len)} : Actual  !=  Resource function\n"
+                )
+                miscounts_str += "\n".join(
+                    f"{str(op).rjust(op_len)} : {str(val0).rjust(6)}  !=  {val1}"
+                    for op, val0, val1 in miscounts
+                )
+            else:
+                miscounts_str = ""
+            assertion_error_string = (
+                f"\nGate counts expected from resource function:\n{non_zero_gate_counts}"
+                f"\nActual gate counts:\n{dict(actual_gate_counts)}"
+                f"{miscounts_str}"
+                "\nMissing entirely in gate counts from resource function:\n"
+                f"{[op for op in actual_gate_counts if op not in gate_counts]}\n"
+                "Missing entirely in actual gate counts:\n"
+                f"{[op for op in gate_counts if op not in actual_gate_counts]}"
+            )
+            raise AssertionError(assertion_error_string)
     else:
         # If the resource estimate is not expected to match exactly to the actual
         # decomposition, at least make sure that all gates are accounted for.

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -70,7 +70,7 @@ def _check_decomposition(op, skip_wire_mapping):
         assert len(decomp) == len(compute_decomp), compute_decomp_msg
         assert len(decomp) == len(processed_queue), queue_msg
 
-        for o1, o2, o3 in zip(decomp, compute_decomp, processed_queue):
+        for o1, o2, o3 in zip(decomp, compute_decomp, processed_queue, strict=True):
             if isinstance(o1, qp.ops.MidMeasure):
                 for other_op, msg in [(o2, compute_decomp_msg), (o3, queue_msg)]:
                     assert isinstance(other_op, qp.ops.MidMeasure), msg
@@ -78,9 +78,12 @@ def _check_decomposition(op, skip_wire_mapping):
                     assert o1.reset == other_op.reset, msg
                     assert o1.postselect == other_op.postselect, msg
             else:
-                assert o1 == o2, compute_decomp_msg
-                assert o1 == o3, queue_msg
                 assert isinstance(o1, qp.operation.Operator), "decomposition must contain operators"
+                for other_op, msg in [(o2, compute_decomp_msg), (o3, queue_msg)]:
+                    try:
+                        assert_equal(o1, other_op)
+                    except AssertionError as e:
+                        raise AssertionError(msg) from e
 
         if skip_wire_mapping:
             return
@@ -94,7 +97,7 @@ def _check_decomposition(op, skip_wire_mapping):
         if mapped_op.has_decomposition:
             mapped_decomp = mapped_op.decomposition()
             orig_decomp = op.decomposition()
-            for mapped_op, orig_op in zip(mapped_decomp, orig_decomp):
+            for mapped_op, orig_op in zip(mapped_decomp, orig_decomp, strict=True):
                 assert (
                     mapped_op.wires
                     == qp.map_wires(orig_op, wire_map).wires  # pylint: disable=no-member
@@ -177,6 +180,39 @@ def _check_reconstructor(op):
     qp.assert_equal(reconstructed_op, pow_op)
 
 
+def _assert_counts_match(counts_0, counts_1):
+    if counts_0 == counts_1:
+        return
+
+    miscounts = [
+        (op, val, counts_0[op])
+        for op, val in counts_1.items()
+        if op in counts_0 and val != counts_0[op]
+    ]
+    if miscounts:
+        op_len = max([8] + [len(str(op)) for op, *_ in miscounts])
+        miscounts_str = (
+            f"\nThe numbers are off for following ops:"
+            f"\n{'Operator'.rjust(op_len)} : Actual  !=  Resource function\n"
+        )
+        miscounts_str += "\n".join(
+            f"{str(op).rjust(op_len)} : {str(val0).rjust(6)}  !=  {val1}"
+            for op, val0, val1 in miscounts
+        )
+    else:
+        miscounts_str = ""
+    assertion_error_string = (
+        f"\nGate counts expected from resource function:\n{counts_0}"
+        f"\nActual gate counts:\n{dict(counts_1)}"
+        f"{miscounts_str}"
+        "\nMissing entirely in gate counts from resource function:\n"
+        f"{[op for op in counts_1 if op not in counts_0]}\n"
+        "Missing entirely in actual gate counts:\n"
+        f"{[op for op in counts_0 if op not in counts_1]}"
+    )
+    raise AssertionError(assertion_error_string)
+
+
 def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_check: bool = False):
     """Tests that a decomposition rule is consistent with the operator."""
 
@@ -209,34 +245,7 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         isinstance(op, qp.templates.SubroutineOp) and not op.subroutine.exact_resources
     ):
         non_zero_gate_counts = {k: v for k, v in gate_counts.items() if v > 0}
-        if non_zero_gate_counts != actual_gate_counts:
-            miscounts = [
-                (op, val, gate_counts[op])
-                for op, val in actual_gate_counts.items()
-                if op in gate_counts and val != gate_counts[op]
-            ]
-            if miscounts:
-                op_len = max([8] + [len(str(op)) for op, *_ in miscounts])
-                miscounts_str = (
-                    f"\nThe numbers are off for following ops:"
-                    f"\n{'Operator'.rjust(op_len)} : Actual  !=  Resource function\n"
-                )
-                miscounts_str += "\n".join(
-                    f"{str(op).rjust(op_len)} : {str(val0).rjust(6)}  !=  {val1}"
-                    for op, val0, val1 in miscounts
-                )
-            else:
-                miscounts_str = ""
-            assertion_error_string = (
-                f"\nGate counts expected from resource function:\n{non_zero_gate_counts}"
-                f"\nActual gate counts:\n{dict(actual_gate_counts)}"
-                f"{miscounts_str}"
-                "\nMissing entirely in gate counts from resource function:\n"
-                f"{[op for op in actual_gate_counts if op not in gate_counts]}\n"
-                "Missing entirely in actual gate counts:\n"
-                f"{[op for op in gate_counts if op not in actual_gate_counts]}"
-            )
-            raise AssertionError(assertion_error_string)
+        _assert_counts_match(non_zero_gate_counts, actual_gate_counts)
     else:
         # If the resource estimate is not expected to match exactly to the actual
         # decomposition, at least make sure that all gates are accounted for.
@@ -334,7 +343,7 @@ def _check_eigendecomposition(op):
             # compute_diagonalizing_gates might also have a different call signature
             compute_dg = dg
 
-        for op1, op2 in zip(dg, compute_dg):
+        for op1, op2 in zip(dg, compute_dg, strict=True):
             assert op1 == op2, "diagonalizing_gates and compute_diagonalizing_gates must match"
     else:
         failure_comment = "If has_diagonalizing_gates is False, diagonalizing_gates must raise a DiagGatesUndefinedError"
@@ -432,7 +441,7 @@ def _check_pytree(op):
     unflattened_op = jax.tree_util.tree_unflatten(struct, leaves)
     assert unflattened_op == op, f"op must be a valid pytree. Got {unflattened_op} instead of {op}."
 
-    for d1, d2 in zip(op.data, leaves):
+    for d1, d2 in zip(op.data, leaves, strict=True):
         assert qp.math.allclose(
             d1, d2
         ), f"data must be the terminal leaves of the pytree. Got {d1}, {d2}"
@@ -487,7 +496,7 @@ def _check_bind_new_parameters(op):
     new_data = [d * 0.0 for d in op.data]
     new_data_op = qp.ops.functions.bind_new_parameters(op, new_data)
     failure_comment = "bind_new_parameters must be able to update the operator with new data."
-    for d1, d2 in zip(new_data_op.data, new_data):
+    for d1, d2 in zip(new_data_op.data, new_data, strict=True):
         assert qp.math.allclose(d1, d2), failure_comment
 
 
@@ -518,7 +527,7 @@ def _check_differentiation(op):
     )
 
     if isinstance(ps, tuple):
-        for actual, expected in zip(ps, expected_bp):
+        for actual, expected in zip(ps, expected_bp, strict=True):
             assert qp.math.allclose(actual, expected), error_msg
     else:
         assert qp.math.allclose(ps, expected_bp), error_msg
@@ -603,7 +612,7 @@ def assert_valid(
 
     assert isinstance(op.data, tuple), "op.data must be a tuple"
     assert isinstance(op.parameters, list), "op.parameters must be a list"
-    for d, p in zip(op.data, op.parameters):
+    for d, p in zip(op.data, op.parameters, strict=True):
         assert isinstance(d, qp.typing.TensorLike), "each data element must be tensorlike"
         assert qp.math.allclose(d, p), "data and parameters must match."
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -136,11 +136,11 @@ class Pow(ScalarSymbolicOp):
     resource_keys = {"base_class", "base_params", "z"}
 
     def _flatten(self):
-        return (self.base, self.z), tuple()
+        return (self.base,), (self.z,)
 
     @classmethod
-    def _unflatten(cls, data, _):
-        return pow(data[0], z=data[1])
+    def _unflatten(cls, data, metadata):
+        return pow(data[0], z=metadata[0])
 
     def __new__(cls, base=None, z=1, id=None):
         """Mixes in parents based on inheritance structure of base.

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -222,7 +222,11 @@ class Hermitian(Operator):
                 UserWarning,
             )
 
-        return [qp.pauli.conversion.pauli_decompose(A, wire_order=wires, pauli=False)]
+        lincomb = qp.pauli.conversion.pauli_decompose(A, wire_order=wires, pauli=False)
+        if qp.QueuingManager.recording():
+            qp.apply(lincomb)
+
+        return [lincomb]
 
     @staticmethod
     def compute_diagonalizing_gates(  # pylint: disable=arguments-differ

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -105,12 +105,12 @@ class GQSP(Operation):
         }
 
     def _flatten(self):
-        return (*self.data, self.hyperparameters["unitary"]), (self.hyperparameters["control"],)
+        return (self.data[0], self.hyperparameters["unitary"]), (self.hyperparameters["control"],)
 
     @classmethod
     def _unflatten(cls, data, metadata):
         # Data contains (angles, derived_data_from_unitary, unitary)
-        return cls(unitary=data[-1], angles=data[0], control=metadata[0])
+        return cls(angles=data[0], unitary=data[-1], control=metadata[0])
 
     # pylint: disable=arguments-differ
     @classmethod

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -216,7 +216,7 @@ class QuantumPhaseEstimation(ErrorOperation):
             "estimation_wires": estimation_wires,
         }
 
-        super().__init__(wires=wires, id=id)
+        super().__init__(*unitary.data, wires=wires, id=id)
 
     @property
     def target_wires(self):
@@ -278,9 +278,7 @@ class QuantumPhaseEstimation(ErrorOperation):
         return self
 
     @staticmethod
-    def compute_decomposition(
-        wires, unitary, target_wires, estimation_wires
-    ):  # pylint: disable=arguments-differ,unused-argument
+    def compute_decomposition(*_, unitary, estimation_wires, **__):
         r"""Representation of the QPE circuit as a product of other operators.
 
         .. math:: O = O_1 O_2 \dots O_n.
@@ -297,7 +295,7 @@ class QuantumPhaseEstimation(ErrorOperation):
         Returns:
             list[.Operator]: decomposition of the operator
         """
-
+        # pylint: disable=arguments-differ
         op_list = [ops.Hadamard(w) for w in estimation_wires]
         pow_ops = (pow(unitary, 2**i) for i in range(len(estimation_wires) - 1, -1, -1))
         op_list.extend(ops.ctrl(op, w) for op, w in zip(pow_ops, estimation_wires))
@@ -327,7 +325,7 @@ def _qpe_decomp_resource(base_resource_rep, num_estimation_wires):
 
 
 @register_resources(_qpe_decomp_resource)
-def _qpe_decomp(wires, unitary, estimation_wires, **_):  # pylint: disable=unused-argument
+def _qpe_decomp(*_, unitary, estimation_wires, **__):  # pylint: disable=unused-argument
     for w in estimation_wires:
         ops.Hadamard(w)
     for i, w in enumerate(estimation_wires):

--- a/pennylane/templates/subroutines/reflection.py
+++ b/pennylane/templates/subroutines/reflection.py
@@ -29,7 +29,7 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.operation import Operation
-from pennylane.queuing import QueuingManager
+from pennylane.queuing import QueuingManager, apply
 from pennylane.wires import Wires
 
 
@@ -210,6 +210,9 @@ class Reflection(Operation):
             decomp_ops.append(ops.X(wires=wires))
             decomp_ops.append(ops.PhaseShift(alpha, wires=wires))
             decomp_ops.append(ops.X(wires=wires))
+
+        if QueuingManager.recording():
+            apply(U)
 
         decomp_ops.append(U)
 

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -511,10 +511,14 @@ def decompose(
             )
 
     >>> print(qp.draw(qp.decompose(circuit, max_expansion=0))())
-    0: ──H─╭QuantumPhaseEstimation─┤
-    1: ────├QuantumPhaseEstimation─┤
-    2: ────├QuantumPhaseEstimation─┤
-    3: ────╰QuantumPhaseEstimation─┤
+    0: ──H─╭QuantumPhaseEstimation(M0)─┤
+    1: ────├QuantumPhaseEstimation(M0)─┤
+    2: ────├QuantumPhaseEstimation(M0)─┤
+    3: ────╰QuantumPhaseEstimation(M0)─┤
+    <BLANKLINE>
+    M0 =
+    [[0.877...+0.j         0.        -0.479...j]
+     [0.        -0.479...j 0.877...+0.j        ]]
 
     >>> print(qp.draw(qp.decompose(circuit, max_expansion=1))())
     0: ──H─╭U(M0)⁴─╭U(M0)²─╭U(M0)¹───────┤

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -33,7 +33,7 @@ class TestDecompositionErrors:
     """Test assertions involving decompositions."""
 
     def test_bad_decomposition_output(self):
-        """Test decomposition output must be a list of operators."""
+        """Test that an error is raised if decomposition output is not a list."""
 
         class BadDecomp(Operator):
             @staticmethod
@@ -43,8 +43,32 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match=r"decomposition must be a list"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
+    def test_bad_decomposition_lengths(self):
+        """Test that an error is raised if decomposition, compute_decomposition and queuing
+        do not have the same number of ops."""
+
+        class BadDecompLength(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                return [qp.X(wires[0]), qp.Y(wires[1])]
+
+            def decomposition(self):
+                return [qp.X(self.wires[0])]
+
+        with pytest.raises(AssertionError, match="decomposition must match compute_decomposition"):
+            assert_valid(BadDecompLength(wires=[0, 1]), skip_pickle=True)
+
+        class BadDecompQueueLength(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                qp.X(wires[0])
+                return [qp.Y(wires[1])]
+
+        with pytest.raises(AssertionError, match="decomposition must match queued operations"):
+            assert_valid(BadDecompQueueLength(wires=[0, 1]), skip_pickle=True)
+
     def test_bad_decomposition_queuing(self):
-        """Test that output must match queued contents."""
+        """Test that an error is raised if decomposition and queuing do not have the same ops."""
 
         class BadDecomp(Operator):
             @staticmethod
@@ -55,8 +79,41 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="decomposition must match queued operations"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
+    def test_bad_decomposition_with_mcm(self):
+        """Test that an error is raised if decomposition and compute_decomposition involve
+        mid-circuit measurements and return different ops."""
+
+        class BadDecomp(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                mcm0 = qp.measure(wires[0])
+                mcm1 = qp.measure(wires[1])
+                return mcm0.measurements + mcm1.measurements
+
+            def decomposition(self):
+                mcm0 = qp.measure(self.wires[0])
+                mcm1 = qp.measure(self.wires[1])
+                return mcm1.measurements + mcm0.measurements
+
+        with pytest.raises(AssertionError, match="decomposition must match compute_decomposition"):
+            assert_valid(BadDecomp(wires=[0, 1]), skip_pickle=True)
+
+        class BadDecompQueue(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                """Return other ops than are queued, but the same number of ops."""
+                meas0 = qp.ops.MidMeasure(wires[0], meas_uid=251)
+                qp.ops.MidMeasure(wires[1], meas_uid=252)
+                with qp.QueuingManager.stop_recording():
+                    meas2 = qp.ops.MidMeasure(wires[0], meas_uid=253)
+                return [meas0, meas2]
+
+        with pytest.raises(AssertionError, match="decomposition must match queued operations"):
+            assert_valid(BadDecompQueue(wires=[0, 1]), skip_pickle=True)
+
     def test_decomposition_wires_must_be_mapped(self):
-        """Test that the operators in decomposition have mapped wires after mapping the op."""
+        """Test that an error is raised if the operators in decomposition do not have mapped
+        wires after mapping the op."""
 
         class BadDecompositionWireMap(Operator):
 
@@ -70,8 +127,9 @@ class TestDecompositionErrors:
             assert_valid(BadDecompositionWireMap(wires=0), skip_pickle=True)
         assert_valid(BadDecompositionWireMap(wires=0), skip_pickle=True, skip_wire_mapping=True)
 
-    def test_error_not_raised(self):
-        """Test if has_decomposition is False but decomposition defined."""
+    def test_error_has_decomposition_but_claims_not_to(self):
+        """Test that an error is raised if has_decomposition is False but a decomposition is
+        defined."""
 
         class BadDecomp(Operator):
             @staticmethod
@@ -84,7 +142,8 @@ class TestDecompositionErrors:
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
     def test_decomposition_must_not_contain_op(self):
-        """Test that the decomposition of an operator doesn't include the operator itself"""
+        """Test that an error is raised if the decomposition of an operator includes
+        the operator itself"""
 
         class BadDecomp(Operator):
             @staticmethod
@@ -93,6 +152,17 @@ class TestDecompositionErrors:
 
         with pytest.raises(AssertionError, match="should not be included in its own decomposition"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
+
+    def test_mcms_can_be_compared(self):
+        """Tests that decompositions with mid-circuit measurements can be compared correctly."""
+
+        class ValidMCMDecomp(Operator):
+            @staticmethod
+            def compute_decomposition(wires):
+                mcm = qp.measure(wires[0])
+                return mcm.measurements
+
+        assert_valid(ValidMCMDecomp(wires=0), skip_pickle=True)
 
 
 class TestBadMatrix:

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -26,7 +26,7 @@ import pytest
 import pennylane as qp
 from pennylane.operation import Operator
 from pennylane.ops.functions import assert_valid
-from pennylane.ops.functions.assert_valid import _check_capture
+from pennylane.ops.functions.assert_valid import _check_capture, _test_decomposition_rule
 
 
 class TestDecompositionErrors:
@@ -163,6 +163,47 @@ class TestDecompositionErrors:
                 return mcm.measurements
 
         assert_valid(ValidMCMDecomp(wires=0), skip_pickle=True)
+
+    def test_bad_new_decomposition_rule_exact(self):
+        """Test that an informative error is raised if the
+        claimed-to-be-exact resources of a decomposition rule are not correct."""
+
+        class MyOp(Operator):
+            num_wires = 2
+
+        op = MyOp([0, 1])
+
+        def rule(wires):
+            qp.X(wires[0])
+            qp.X(wires[1])
+            qp.Y(wires[0])
+            qp.Y(wires[1])
+
+        rule_wrong_numbers = qp.register_resources({qp.X: 2, qp.Y: 3})(rule)
+        with pytest.raises(AssertionError, match="The numbers are off"):
+            _test_decomposition_rule(op, rule_wrong_numbers)
+
+        rule_wrong_ops = qp.register_resources({qp.X: 2, qp.Z: 2})(rule)
+        with pytest.raises(AssertionError, match="Missing entirely in gate counts"):
+            _test_decomposition_rule(op, rule_wrong_ops)
+
+    def test_bad_new_decomposition_rule_inexact(self):
+        """Test that an informative error is raised if the
+        inexact resources of a decomposition rule are not correct."""
+
+        class MyOp(Operator):
+            num_wires = 2
+
+        def rule(wires):
+            qp.X(wires[0])
+            qp.X(wires[1])
+            qp.Y(wires[0])
+            qp.Y(wires[1])
+
+        rule_wrong_ops = qp.register_resources({qp.X: 2, qp.Z: 2}, exact=False)(rule)
+        op = MyOp([0, 1])
+        with pytest.raises(AssertionError, match="Gate counts expected from"):
+            _test_decomposition_rule(op, rule_wrong_ops)
 
 
 class TestBadMatrix:

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -68,13 +68,15 @@ class TestDecompositionErrors:
             assert_valid(BadDecompQueueLength(wires=[0, 1]), skip_pickle=True)
 
     def test_bad_decomposition_queuing(self):
-        """Test that an error is raised if decomposition and queuing do not have the same ops."""
+        """Test that an error is raised if decomposition and queuing do not have the same op."""
 
         class BadDecomp(Operator):
             @staticmethod
             def compute_decomposition(wires):
                 qp.RX(1.2, wires=0)
-                return [qp.RY(2.3, 0)]
+                with qp.QueuingManager.stop_recording():
+                    other_op = qp.RY(2.3, 0)
+                return [other_op]
 
         with pytest.raises(AssertionError, match="decomposition must match queued operations"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -512,13 +512,10 @@ class TestMiscMethods:
         op = Pow(target, z)
         data, metadata = op._flatten()
 
-        assert len(data) == 2
-        assert data[0] is target
-        assert data[1] == z
+        assert data == (target,)
+        assert metadata == (z,)
 
-        assert metadata == tuple()
-
-        new_op = type(op)._unflatten(*op._flatten())
+        new_op = type(op)._unflatten(data, metadata)
         assert new_op is not op
         qp.assert_equal(new_op, op)
 

--- a/tests/templates/subroutines/test_qpe.py
+++ b/tests/templates/subroutines/test_qpe.py
@@ -28,7 +28,7 @@ def test_standard_validity():
     """Test standard validity criteria using assert_valid."""
     op = qp.QuantumPhaseEstimation(np.eye(4), target_wires=(0, 1), estimation_wires=[2, 5])
     assert op.target_wires == qp.wires.Wires([0, 1])
-    qp.ops.functions.assert_valid(op)
+    qp.ops.functions.assert_valid(op, skip_differentiation=True)
 
 
 class TestError:


### PR DESCRIPTION
**Context:**
`assert_valid` compares three lists of operators created with the legacy decomposition system: That returned by `compute_decomposition`, that returned by `decomposition` and the list of queued ops during `decomposition`.
To compare the operators, equality checking is done via `==`, i.e `__eq__`.
For `MidMeasure`, the `meas_uid` needs to be equal in order to evaluate `__eq__` to `True`. However, in the above context of comparing decompositions, this is not actually required/desired, so we should not query `==` but rather use a comparison of the ops' wires, `reset` and `postselect` values.

**Description of the Change:**
- Do what's suggested above
- Add a check for the length of the operator lists that was previously missing.
- Fix`compute_decomposition` of `Hermitian` to queue the same op as it returns (currently does not queue anything)
- Fix `compute_decomposition` of `Reflection` to queue the same ops as it returns (currently forgets the last op of the decomposition in the queue, see #9382)
- Independently, add some more elaborate analysis of the actual and predicted resources in `_test_decomposition_rule`.

**Benefits:**
`assert_valid` is more versatile, bug fix for `Hermitian`, QoL improvement for `test_decomposition_rule` users.

**Possible Drawbacks:**

**Related GitHub Issues:**
Solves #9382 
[sc-118209]
[sc-117978]