### PR TITLE
Improve docstrings for several transforms

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1063,6 +1063,10 @@
   [(#9376)](https://github.com/PennyLaneAI/pennylane/pull/9376)
   [(#9375)](https://github.com/PennyLaneAI/pennylane/pull/9375)
 
+* Docstrings for several optimization transforms have been improved by showing the drawing of the circuit
+  after the transform has been applied as opposed to just the numeric simulation result.
+  [(#9381)](https://github.com/PennyLaneAI/pennylane/pull/9381)
+
 * A new AI policy document is now applied across the PennyLaneAI organization for all AI contributions.
   [(#9079)](https://github.com/PennyLaneAI/pennylane/pull/9079)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1072,7 +1072,7 @@
   [(#9375)](https://github.com/PennyLaneAI/pennylane/pull/9375)
 
 * Docstrings for several optimization transforms have been improved by showing the drawing of the circuit
-  after the transform has been applied as opposed to just the numeric simulation result.
+  after the transform has been applied as opposed to just the numeric simulation result. The improved transform docstrings include ``cancel_inverses``, ``commute_controlled``, ``merge_amplitude_embedding``, ``merge_rotations``, ``pattern_matching_optimization``, ``remove_barrier``, ``single_qubit_fusion``, and ``undo_swaps``.
   [(#9381)](https://github.com/PennyLaneAI/pennylane/pull/9381)
 
 * A new AI policy document is now applied across the PennyLaneAI organization for all AI contributions.

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -346,9 +346,12 @@ def cancel_inverses(
 
     You can apply the cancel inverses transform directly on :class:`~.QNode`.
 
-    >>> dev = qp.device('default.qubit', wires=3)
 
     .. code-block:: python
+
+        import pennylane as qp
+
+        dev = qp.device('default.qubit', wires=3)
 
         @qp.transforms.cancel_inverses
         @qp.qnode(device=dev)
@@ -365,8 +368,10 @@ def cancel_inverses(
             qp.X(1)
             return qp.expval(qp.Z(0))
 
-    >>> print(circuit(0.1, 0.2, 0.3))
-    1.0
+    >>> print(qp.draw(circuit)(0.1, 0.2, 0.3))
+    0: ──RZ(0.30)───────────╭●─┤  <Z>
+    1: ──H─────────RY(0.20)─│──┤
+    2: ──RX(0.10)──RX(0.20)─╰X─┤
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/commute_controlled.py
+++ b/pennylane/transforms/optimization/commute_controlled.py
@@ -438,7 +438,7 @@ def commute_controlled(
     .. details::
         :title: Usage Details
 
-        You can also apply it on quantum function.
+        You can also apply this transform to quantum functions.
 
         .. code-block:: python
 

--- a/pennylane/transforms/optimization/commute_controlled.py
+++ b/pennylane/transforms/optimization/commute_controlled.py
@@ -403,13 +403,15 @@ def commute_controlled(
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=3)
-
     You can apply the transform directly on :class:`QNode`:
 
     .. code-block:: python
 
-        @commute_controlled(direction="right")
+        import pennylane as qp
+
+        dev = qp.device('default.qubit')
+
+        @qp.transforms.commute_controlled(direction="right")
         @qp.qnode(device=dev)
         def circuit(theta):
             qp.CZ(wires=[0, 2])
@@ -428,8 +430,10 @@ def commute_controlled(
 
             return qp.expval(qp.Z(0))
 
-    >>> circuit(0.5)
-    np.float64(0.999...)
+    >>> print(qp.draw(circuit)(0.5))
+    0: ─╭●─╭●─╭●───────────╭●──S─────────Rϕ(0.25)──T─┤  <Z>
+    1: ─│──╰X─╰RY(0.50)──Y─├●──RZ(0.25)──────────────┤
+    2: ─╰Z─────────────────╰X──X─────────────────────┤
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -384,26 +384,27 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
         0: ─╭●───┤  State
         1: ─╰X───┤  State
         2: ─╭|Ψ⟩─┤  State
-       You can also apply this transform on quantum functions:
 
-       .. code-block:: python
+        You can also apply this transform on quantum functions:
 
-           def qfunc():
-               qp.CNOT(wires = [0,1])
-               qp.AmplitudeEmbedding([0,1], wires = 2)
-               qp.AmplitudeEmbedding([0,1], wires = 3)
-               return qp.state()
+        .. code-block:: python
 
-       This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``.
-       Using the transformation we can join the different instances into a single one:
+            def qfunc():
+                qp.CNOT(wires = [0,1])
+                qp.AmplitudeEmbedding([0,1], wires = 2)
+                qp.AmplitudeEmbedding([0,1], wires = 3)
+                return qp.state()
 
-       >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)
-       >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-       >>> print(qp.draw(optimized_qnode)())
-       0: ─╭●───┤  State
-       1: ─╰X───┤  State
-       2: ─╭|Ψ⟩─┤  State
-       3: ─╰|Ψ⟩─┤  State
+        This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``.
+        Using the transformation we can join the different instances into a single one:
+
+        >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)
+        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+        >>> print(qp.draw(optimized_qnode)())
+        0: ─╭●───┤  State
+        1: ─╰X───┤  State
+        2: ─╭|Ψ⟩─┤  State
+        3: ─╰|Ψ⟩─┤  State
 
     """
     new_operations = []

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -384,6 +384,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
         0: ─╭●───┤  State
         1: ─╰X───┤  State
         2: ─╭|Ψ⟩─┤  State
+        3: ─╰|Ψ⟩─┤  State
 
         You can also apply this transform on quantum functions:
 

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -336,20 +336,27 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=4)
-
     You can apply the transform directly on :class:`QNode`:
 
     .. code-block:: python
+
+        import pennylane as qp
+
+        dev = qp.device('default.qubit', wires=4)
 
         @qp.transforms.merge_amplitude_embedding
         @qp.qnode(device=dev)
         def circuit():
             qp.CNOT(wires = [0,1])
-            qp.AmplitudeEmbedding([0,1], wires = 2)
-            qp.AmplitudeEmbedding([0,1], wires = 3)
+            qp.AmplitudeEmbedding([0, 1], wires = 2)
+            qp.AmplitudeEmbedding([0, 1], wires = 3)
             return qp.state()
 
+    >>> print(qp.draw(circuit)())
+    0: ─╭●───┤  State
+    1: ─╰X───┤  State
+    2: ─╭|Ψ⟩─┤  State
+    3: ─╰|Ψ⟩─┤  State
     >>> circuit()
     array([0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j,
            0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j])

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -384,7 +384,26 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
         0: ─╭●───┤  State
         1: ─╰X───┤  State
         2: ─╭|Ψ⟩─┤  State
-        3: ─╰|Ψ⟩─┤  State
+       You can also apply this transform on quantum functions:
+
+       .. code-block:: python
+
+           def qfunc():
+               qp.CNOT(wires = [0,1])
+               qp.AmplitudeEmbedding([0,1], wires = 2)
+               qp.AmplitudeEmbedding([0,1], wires = 3)
+               return qp.state()
+
+       This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``. 
+       Using the transformation we can join the different instances into a single one:
+
+       >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)
+       >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+       >>> print(qp.draw(optimized_qnode)())
+       0: ─╭●───┤  State
+       1: ─╰X───┤  State
+       2: ─╭|Ψ⟩─┤  State
+       3: ─╰|Ψ⟩─┤  State
 
     """
     new_operations = []

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -336,7 +336,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
 
     **Example**
 
-    You can apply the transform directly on :class:`QNode`:
+    You can apply the transform directly on a :class:`QNode`:
 
     .. code-block:: python
 
@@ -364,7 +364,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
     .. details::
         :title: Usage Details
 
-        You can also apply it on quantum function.
+        You can also apply the transform on a quantum function:
 
         .. code-block:: python
 
@@ -394,7 +394,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
                qp.AmplitudeEmbedding([0,1], wires = 3)
                return qp.state()
 
-       This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``. 
+       This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``.
        Using the transformation we can join the different instances into a single one:
 
        >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -279,13 +279,15 @@ def merge_rotations(
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=3)
-
     You can apply the transform directly on :class:`QNode`
 
     .. code-block:: python
 
-        @merge_rotations
+        import pennylane as qp
+
+        dev = qp.device('default.qubit', wires=3)
+
+        @qp.transforms.merge_rotations
         @qp.qnode(device=dev)
         def circuit(x, y, z):
             qp.RX(x, wires=0)
@@ -297,8 +299,10 @@ def merge_rotations(
             qp.RY(-y, wires=1)
             return qp.expval(qp.Z(0))
 
-    >>> circuit(0.1, 0.2, 0.3)
-    np.float64(0.955...)
+    >>> print(qp.draw(circuit)(0.1, 0.2, 0.3))
+    0: ──RX(0.30)────╭RZ(0.30)─┤  <Z>
+    1: ─╭●───────────│─────────┤
+    2: ─╰X─────────H─╰●────────┤
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -69,23 +69,24 @@ def pattern_matching_optimization(
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=5)
-
     You can apply the transform directly on a :class:`QNode`. For that, you need first to define a pattern that is to be
     found in the circuit. We use the following pattern that implements the identity:
 
     .. code-block:: python
 
+        import pennylane as qp
+
         ops = [qp.S(0), qp.S(0), qp.Z(0)]
         pattern = qp.tape.QuantumTape(ops)
-
 
     Let's consider the following circuit where we want to replace a sequence of two ``pennylane.S`` gates with a
     ``pennylane.PauliZ`` gate.
 
     .. code-block:: python
 
-        @pattern_matching_optimization(pattern_tapes = [pattern])
+        dev = qp.device('default.qubit', wires=5)
+
+        @qp.transforms.pattern_matching_optimization(pattern_tapes = [pattern])
         @qp.qnode(device=dev)
         def circuit():
             qp.S(wires=0)
@@ -100,8 +101,10 @@ def pattern_matching_optimization(
 
     During the call of the circuit, it is first optimized (if possible) and then executed.
 
-    >>> circuit()
-    np.float64(0.0)
+    >>> print(qp.draw(circuit)())
+    0: ──S†─╭●────┤  <X>
+    1: ──Z──╰Z─╭●─┤
+    2: ──Z─────╰Z─┤
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/remove_barrier.py
+++ b/pennylane/transforms/optimization/remove_barrier.py
@@ -49,7 +49,7 @@ def remove_barrier(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
     0: ──H──X─┤  <Z>
     1: ──H────┤
 
-    The barrier is then removed before execution.
+    The barrier is removed before execution.
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/remove_barrier.py
+++ b/pennylane/transforms/optimization/remove_barrier.py
@@ -34,6 +34,8 @@ def remove_barrier(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
 
     .. code-block:: python
 
+        import pennylane as qp
+
         @remove_barrier
         @qp.qnode(qp.device('default.qubit'))
         def circuit(x, y):
@@ -42,6 +44,10 @@ def remove_barrier(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
             qp.Barrier(wires=[0,1])
             qp.X(0)
             return qp.expval(qp.Z(0))
+
+    >>> print(qp.draw(circuit)(0.1, 0.2))
+    0: ──H──X─┤  <Z>
+    1: ──H────┤
 
     The barrier is then removed before execution.
 

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -287,11 +287,14 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=1)
 
     You can apply the transform directly on :class:`QNode`:
 
     .. code-block:: python
+
+        import pennylane as qp
+
+        dev = qp.device('default.qubit', wires=1)
 
         @qp.transforms.single_qubit_fusion
         @qp.qnode(device=dev)
@@ -302,6 +305,9 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
             qp.RZ(r1[0], wires=0)
             qp.RZ(r2[0], wires=0)
             return qp.expval(qp.X(0))
+
+    >>> print(qp.draw(qfunc)([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]))
+    0: ──Rot(3.57,2.09,2.05)──GlobalPhase(-1.57)─┤  <X>
 
     The single qubit gates are fused before execution.
 

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -287,8 +287,7 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
 
     **Example**
 
-
-    You can apply the transform directly on :class:`QNode`:
+    You can apply the transform directly on :class:`QNode`.
 
     .. code-block:: python
 
@@ -311,35 +310,15 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
 
     The single qubit gates are fused before execution.
 
-    .. note::
-
-        The fused angles between two sets of rotation angles are not always defined uniquely
-        because Euler angles are not unique for some rotations. ``single_qubit_fusion``
-        makes a particular choice in this case.
-
-    .. note::
-
-        The order of the gates resulting from the fusion may be different depending
-        on whether program capture is enabled or not. This only impacts the order of
-        operations that do not share any wires, so the correctness of the circuit is not affected.
    .. note::
 
-       - The fused angles between two sets of rotation angles are not always defined uniquely because Euler angles are not unique for some rotations. ``single_qubit_fusion`` makes a particular choice in this case.
+        - The fused angles between two sets of rotation angles are not always defined uniquely because Euler angles are not unique for some rotations. ``single_qubit_fusion`` makes a particular choice in this case.
+        - The order of the gates resulting from the fusion may be different depending on whether program capture is enabled or not. This only impacts the order of operations that do not share any wires, so the correctness of the circuit is not affected.
 
-       - The order of the gates resulting from the fusion may be different depending on whether program capture is enabled or not. This only impacts the order of operations that do not share any wires, so the correctness of the circuit is not affected.
-
-    .. warning::
-
-        This function is not differentiable everywhere. It has singularities for specific
-        input rotation angles, where the derivative will be NaN.
-
-    .. warning::
-
-        This function is numerically unstable at its singular points. It is recommended to use
    .. warning::
 
-       - This function is not differentiable everywhere. It has singularities for specific input rotation angles, where the derivative will be ``NaN``.
-       - This function is numerically unstable at its singular points. It is recommended to use it with 64-bit floating point precision.
+        - This function is not differentiable everywhere. It has singularities for specific input rotation angles, where the derivative will be ``NaN``.
+        - This function is numerically unstable at its singular points. It is recommended to use it with 64-bit floating point precision.
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -310,12 +310,12 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
 
     The single qubit gates are fused before execution.
 
-   .. note::
+    .. note::
 
         - The fused angles between two sets of rotation angles are not always defined uniquely because Euler angles are not unique for some rotations. ``single_qubit_fusion`` makes a particular choice in this case.
         - The order of the gates resulting from the fusion may be different depending on whether program capture is enabled or not. This only impacts the order of operations that do not share any wires, so the correctness of the circuit is not affected.
 
-   .. warning::
+    .. warning::
 
         - This function is not differentiable everywhere. It has singularities for specific input rotation angles, where the derivative will be ``NaN``.
         - This function is numerically unstable at its singular points. It is recommended to use it with 64-bit floating point precision.

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -322,6 +322,11 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
         The order of the gates resulting from the fusion may be different depending
         on whether program capture is enabled or not. This only impacts the order of
         operations that do not share any wires, so the correctness of the circuit is not affected.
+   .. note::
+
+       - The fused angles between two sets of rotation angles are not always defined uniquely because Euler angles are not unique for some rotations. ``single_qubit_fusion`` makes a particular choice in this case.
+
+       - The order of the gates resulting from the fusion may be different depending on whether program capture is enabled or not. This only impacts the order of operations that do not share any wires, so the correctness of the circuit is not affected.
 
     .. warning::
 
@@ -331,7 +336,10 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
     .. warning::
 
         This function is numerically unstable at its singular points. It is recommended to use
-        it with 64-bit floating point precision.
+   .. warning::
+
+       - This function is not differentiable everywhere. It has singularities for specific input rotation angles, where the derivative will be ``NaN``.
+       - This function is numerically unstable at its singular points. It is recommended to use it with 64-bit floating point precision.
 
     .. details::
         :title: Usage Details

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -28,8 +28,8 @@ def null_postprocessing(results):
 
 @transform
 def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-    """Quantum function transform to remove SWAP gates by running from right
-    to left through the circuit changing the position of the qubits accordingly.
+    """Quantum function transform to remove SWAP gates by running from right to left through the
+    circuit changing the position of the qubits accordingly.
 
     Args:
         tape (QNode or QuantumTape or Callable): A quantum circuit.
@@ -39,7 +39,7 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
 
     **Example**
 
-    You can apply the transform directly on a :class:`QNode`:
+    You can apply the transform directly on a :class:`QNode`.
 
     .. code-block:: python
 
@@ -91,9 +91,9 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
         We can remove the SWAP gates by running the ``undo_swap`` transform, where the wires
         involved in the SWAP gates are interchanged:
 
-        >>> optimized_qfunc = undo_swaps(qfunc)
-        >>> print(qp.draw(optimized_qfunc)())
-        0: ──Y─┤
+        >>> optimized_qnode = undo_swaps(qnode)
+        >>> print(qp.draw(optimized_qnode)())
+        0: ──Y─┤ <Z>
         1: ──H─┤
         2: ──X─┤
 
@@ -108,6 +108,7 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
         - wire ``0`` :math:`\rightarrow` ``2`` :math:`\rightarrow` ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
         - wire ``2`` :math:`\rightarrow` ``0``.
         - wire ``1`` :math:`\rightarrow` ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
+
     """
 
     wire_map = {wire: wire for wire in tape.wires}

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -39,13 +39,15 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
 
     **Example**
 
-    >>> dev = qp.device('default.qubit', wires=3)
-
-    You can apply the transform directly on a :class:`QNode`
+    You can apply the transform directly on a :class:`QNode`:
 
     .. code-block:: python
 
-        @undo_swaps
+        import pennylane as qp
+
+        dev = qp.device('default.qubit', wires=3)
+
+        @qp.transforms.undo_swaps
         @qp.qnode(device=dev)
         def circuit():
             qp.Hadamard(wires=0)
@@ -54,6 +56,11 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
             qp.SWAP(wires=[0,2])
             qp.Y(0)
             return qp.expval(qp.Z(0))
+
+    >>> print(qp.draw(circuit)())
+    0: ──Y─┤  <Z>
+    1: ──H─┤
+    2: ──X─┤
 
     The SWAP gates are removed before execution.
 

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -97,7 +97,22 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
         0: ──Y─┤  <Z>
         1: ──H─┤
         2: ──X─┤
+       We can remove the SWAP gates by running the ``undo_swap`` transform, where the wires involved in the SWAP gates are interchanged:
 
+       >>> optimized_qfunc = undo_swaps(qfunc)
+       >>> print(qp.draw(optimized_qfunc)())
+       0: ──Y─┤
+       1: ──H─┤
+       2: ──X─┤
+       
+       Gates are iterated through from right to left, where non-SWAP gates are ignored. The first gate is a ``Y`` gate, which is left to act on wire ``0``.
+       Next, the right-most SWAP gate acting on wires ``(0, 2)`` is removed, and the wires are manually 
+       swapped; wire ``2`` now becomes wire ``0``, and vice versa. Next, the SWAP gate acting on wires 
+       ``(0, 1)`` is removed and the wires are interchanged. Altogether, this affects the wire labels as follows, where the operations to the left of both SWAP gates have their wire labels changed accordingly:
+       
+       - wire ``0`` :math:`\rightarrow` ``2`` :math:`\rightarrow` ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
+       - wire ``2`` :math:`\rightarrow` ``0``.
+       - wire ``1`` :math:`\rightarrow` ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
     """
 
     wire_map = {wire: wire for wire in tape.wires}

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -79,8 +79,6 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
                 qp.Y(0)
                 return qp.expval(qp.Z(0))
 
-        The circuit before optimization:
-
         >>> dev = qp.device('default.qubit', wires=3)
         >>> qnode = qp.QNode(qfunc, dev)
         >>> print(qp.draw(qnode)())
@@ -101,13 +99,16 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
         gate is a ``Y`` gate, which is left to act on wire ``0``. Next, the right-most SWAP gate
         acting on wires ``(0, 2)`` is removed, and the wires are manually swapped; wire ``2`` now
         becomes wire ``0``, and vice versa. Next, the SWAP gate acting on wires ``(0, 1)`` is
-        removed and the wires are interchanged. Altogether, this affects the wire labels as follows,
-        where the operations to the left of both SWAP gates have their wire labels changed
-        accordingly:
+        removed and the wires are interchanged.
 
-        - wire ``0`` :math:`\rightarrow` ``2`` :math:`\rightarrow` ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
-        - wire ``2`` :math:`\rightarrow` ``0``.
-        - wire ``1`` :math:`\rightarrow` ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
+        Altogether, this affects the wire labels as follows, where the operations to the left of
+        both SWAP gates have their wire labels changed accordingly.
+
+        * wire ``0`` changes to wire ``2`` which changes to wire ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
+
+        * wire ``2`` changes to wire ``0``.
+
+        * wire ``1`` changes to wire ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
 
     """
 

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -88,31 +88,26 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
         1: ──X─╰SWAP─│────────┤
         2: ──────────╰SWAP────┤
 
-
-        We can remove the SWAP gates by running the ``undo_swap`` transform:
+        We can remove the SWAP gates by running the ``undo_swap`` transform, where the wires
+        involved in the SWAP gates are interchanged:
 
         >>> optimized_qfunc = undo_swaps(qfunc)
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)())
-        0: ──Y─┤  <Z>
+        >>> print(qp.draw(optimized_qfunc)())
+        0: ──Y─┤
         1: ──H─┤
         2: ──X─┤
-       We can remove the SWAP gates by running the ``undo_swap`` transform, where the wires involved in the SWAP gates are interchanged:
 
-       >>> optimized_qfunc = undo_swaps(qfunc)
-       >>> print(qp.draw(optimized_qfunc)())
-       0: ──Y─┤
-       1: ──H─┤
-       2: ──X─┤
-       
-       Gates are iterated through from right to left, where non-SWAP gates are ignored. The first gate is a ``Y`` gate, which is left to act on wire ``0``.
-       Next, the right-most SWAP gate acting on wires ``(0, 2)`` is removed, and the wires are manually 
-       swapped; wire ``2`` now becomes wire ``0``, and vice versa. Next, the SWAP gate acting on wires 
-       ``(0, 1)`` is removed and the wires are interchanged. Altogether, this affects the wire labels as follows, where the operations to the left of both SWAP gates have their wire labels changed accordingly:
-       
-       - wire ``0`` :math:`\rightarrow` ``2`` :math:`\rightarrow` ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
-       - wire ``2`` :math:`\rightarrow` ``0``.
-       - wire ``1`` :math:`\rightarrow` ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
+        Gates are iterated through from right to left, where non-SWAP gates are ignored. The first
+        gate is a ``Y`` gate, which is left to act on wire ``0``. Next, the right-most SWAP gate
+        acting on wires ``(0, 2)`` is removed, and the wires are manually swapped; wire ``2`` now
+        becomes wire ``0``, and vice versa. Next, the SWAP gate acting on wires ``(0, 1)`` is
+        removed and the wires are interchanged. Altogether, this affects the wire labels as follows,
+        where the operations to the left of both SWAP gates have their wire labels changed
+        accordingly:
+
+        - wire ``0`` :math:`\rightarrow` ``2`` :math:`\rightarrow` ``1``. This moves the ``H`` gate from wire ``0`` to wire ``1``.
+        - wire ``2`` :math:`\rightarrow` ``0``.
+        - wire ``1`` :math:`\rightarrow` ``2``. This moves the ``X`` gate from wire ``1`` to wire ``2``.
     """
 
     wire_map = {wire: wire for wire in tape.wires}


### PR DESCRIPTION
**Context:**

**Description of the Change:** Docs upgrades to several optimization transforms.

**Benefits:** Better docs

**Possible Drawbacks:**

**Related GitHub Issues:** [sc-115885](https://app.shortcut.com/xanaduai/story/115885/better-code-examples-in-docstrings-for-various-transforms)
