### PR TITLE
Update qml -> qp in logging, documentation guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ benchmark/revisions/
 *venv*/
 config.toml
 .envrc
-qml_debug.log
+qp_debug.log
 datasets/*
 .benchmarks/*
 *.h5

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ benchmark/revisions/
 *venv*/
 config.toml
 .envrc
+qml_debug.log
 qp_debug.log
 datasets/*
 .benchmarks/*

--- a/doc/development/guide/documentation.rst
+++ b/doc/development/guide/documentation.rst
@@ -335,7 +335,7 @@ Code examples
 Code examples are very important; they *show* readers how the function or class should be used.
 When writing code examples for docstrings, use the following guidelines:
 
-- You may assume that PennyLane is imported as ``qml`` and NumPy is imported as ``np`` in the code examples.
+- You may assume that PennyLane is imported as ``qp`` and NumPy is imported as ``np`` in the code examples.
   All other imports must be specified explicitly.
 
 - For single line statements and associated output, use Python console syntax (``pycon``):

--- a/doc/development/guide/example_module_rst.txt
+++ b/doc/development/guide/example_module_rst.txt
@@ -1,4 +1,4 @@
-qml.module_name
+qp.module_name
 ===============
 
 .. currentmodule:: pennylane.module_name

--- a/doc/development/guide/example_package_rst.txt
+++ b/doc/development/guide/example_package_rst.txt
@@ -1,4 +1,4 @@
-qml.package_name
+qp.package_name
 ================
 
 .. rubric:: Modules

--- a/doc/development/guide/logging.rst
+++ b/doc/development/guide/logging.rst
@@ -121,10 +121,10 @@ sections to discuss how these can be adjusted to suit needs:
    ###############################################################################
 
    [formatters]
-   [formatters.qml_default_formatter]
+   [formatters.qp_default_formatter]
    "()" = "pennylane.logging.formatters.formatter.DefaultFormatter"
 
-   [formatters.qml_alt_formatter]
+   [formatters.qp_alt_formatter]
    "()" = "pennylane.logging.formatters.formatter.AnotherLogFormatter"
 
    [formatters.local_detailed]
@@ -148,11 +148,11 @@ as ``false`` unless required otherwise.
 
    [filters]
    # Filter to show messages from the same local process as the Python script
-   [filters.qml_LocalProcessFilter]
+   [filters.qp_LocalProcessFilter]
    "()" = "pennylane.logging.filter.LocalProcessFilter"
 
    # Filter to show debug level messages only
-   [filters.qml_DebugOnlyFilter]
+   [filters.qp_DebugOnlyFilter]
    "()" = "pennylane.logging.filter.DebugOnlyFilter"
 
 The above section defines how to filter log messages (known as
@@ -168,32 +168,32 @@ can be used in the next section.
    ###############################################################################
 
    [handlers]
-   [handlers.qml_debug_stream]
+   [handlers.qp_debug_stream]
    class = "logging.StreamHandler"
-   formatter = "qml_default_formatter"
+   formatter = "qp_default_formatter"
    level = "DEBUG"
    stream = "ext://sys.stdout"
 
-   [handlers.qml_debug_stream_alt]
+   [handlers.qp_debug_stream_alt]
    class = "logging.StreamHandler"
-   formatter = "qml_alt_formatter"
+   formatter = "qp_alt_formatter"
    level = "DEBUG"
    stream = "ext://sys.stdout"
 
-   [handlers.qml_debug_file]
+   [handlers.qp_debug_file]
    class = "logging.handlers.RotatingFileHandler"
    formatter = "local_standard"
    level = "DEBUG"
-   filename ='qml_debug.log' # use `/tmp/filename.log` on Linux machines to avoid long-term persistence
+   filename ='qp_debug.log' # use `/tmp/filename.log` on Linux machines to avoid long-term persistence
    maxBytes = 16777216 # 16MB per file before splitting
-   backupCount = 10 # Create 'qml_debug.log.1', ... 'qml_debug.log.backupCount' files and rollover when maxBytes is reached
+   backupCount = 10 # Create 'qp_debug.log.1', ... 'qp_debug.log.backupCount' files and rollover when maxBytes is reached
 
    [handlers.local_filtered_detailed_stdout]
    class = "logging.StreamHandler"
    formatter = "local_standard"
    level = "DEBUG"
    stream = "ext://sys.stdout"
-   filters = ["qml_LocalProcessFilter", "qml_DebugOnlyFilter"]
+   filters = ["qp_LocalProcessFilter", "qp_DebugOnlyFilter"]
 
 The above defines how ``LogRecord`` messages are handled, and directs
 them to the appropriate sink. The logging framework supports many such
@@ -214,20 +214,20 @@ formatters so that the consumed message fits the needs of the user.
 
    # Control JAX logging 
    [loggers.jax]
-   handlers = ["qml_debug_stream",]
+   handlers = ["qp_debug_stream",]
    level = "WARN"
    propagate = false
 
    # Control logging across pennylane
    [loggers.pennylane]
-   handlers = ["qml_debug_stream",]
+   handlers = ["qp_debug_stream",]
    level = "DEBUG" # Set to TRACE for highest verbosity
    propagate = false
 
    # Control logging specifically in the pennylane.qnode module
    # Note the required quotes to overcome TOML nesting issues
    [loggers."pennylane.qnode"]
-   handlers = ["qml_debug_stream_alt",]
+   handlers = ["qp_debug_stream_alt",]
    level = "DEBUG" # Set to TRACE for highest verbosity
    propagate = false
 
@@ -238,13 +238,13 @@ across the packages we are using. Python’s logging framework follows a
 parent-child hierarchy, where a logging configuration set at a parent
 level will set all child levels with the same features. In this
 instance, we have configured JAX, PennyLane and our script to all log
-into the ``qml_debug_stream`` handler we defined earlier, and modified
+into the ``qp_debug_stream`` handler we defined earlier, and modified
 the child logger ``"pennylane.qnode"`` (quotes needed due to TOML
 parsing limitations) to use a different logger, in this case
-``qml_debug_stream_alt``. We are free to define the module/package
+``qp_debug_stream_alt``. We are free to define the module/package
 log-level here (we opt for ``DEBUG`` for all), and to also use multiple
 handlers per logger (such as for logging to the standard output and
-files through ``qml_debug_stream`` and ``qml_debug_file``
+files through ``qp_debug_stream`` and ``qp_debug_file``
 simultaneously). Given the complexity explosion with configuring these
 options, the default features in ``log_config.toml`` all use the same
 log-level, and handler, which can be adjusted based on developer needs.
@@ -263,7 +263,7 @@ file as:
 .. code:: toml
 
    [loggers.jax]
-   handlers = ["qml_debug_stream"]
+   handlers = ["qp_debug_stream"]
    level = "DEBUG"
    propagate = false
 
@@ -279,7 +279,7 @@ warnings and more severe, by making the following change:
 .. code:: toml
 
    [loggers.pennylane]
-   handlers = ["qml_debug_stream"]
+   handlers = ["qp_debug_stream"]
    level = "WARN"
    propagate = false
 
@@ -337,7 +337,7 @@ messages from JAX, and info-level messages for the given script. To modify the l
 
    # Control logging in the executing Python script
    [loggers.__main__]
-   handlers = ["qml_debug_stream",]
+   handlers = ["qp_debug_stream",]
    level = "INFO"
    propagate = false
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1067,6 +1067,7 @@
   [(#9360)](https://github.com/PennyLaneAI/pennylane/pull/9360)
   [(#9376)](https://github.com/PennyLaneAI/pennylane/pull/9376)
   [(#9375)](https://github.com/PennyLaneAI/pennylane/pull/9375)
+  [(#9384)](https://github.com/PennyLaneAI/pennylane/pull/9384)
 
 * A new AI policy document is now applied across the PennyLaneAI organization for all AI contributions.
   [(#9079)](https://github.com/PennyLaneAI/pennylane/pull/9079)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -289,8 +289,8 @@
   [(#9260)](https://github.com/PennyLaneAI/pennylane/pull/9260)
 
   ```pycon
-  >>> import pennylane as qml
-  >>> collection = qml.list_decomps(qml.CRX)
+  >>> import pennylane as qp
+  >>> collection = qp.list_decomps(qp.CRX)
   >>> print(collection)
   Available Decomposition Rules:
   0: _crx_to_rx_cz
@@ -301,7 +301,7 @@
   DecompositionRule(name=_crx_to_rx_cz)
   >>> collection['_crx_to_ppr']
   DecompositionRule(name=_crx_to_ppr)
-  >>> print(qml.draw(collection[0])(0.5, wires=[0, 1]))
+  >>> print(qp.draw(collection[0])(0.5, wires=[0, 1]))
   0: ───────────╭●────────────╭●─┤
   1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
 
@@ -414,11 +414,11 @@
   QNode when program capture is turned on.
   [(#9072)](https://github.com/PennyLaneAI/pennylane/pull/9072)
 
-* During program capture, `qml.cond` converts non-boolean predicates to boolean immediately
+* During program capture, `qp.cond` converts non-boolean predicates to boolean immediately
   during capture time.
   [(#9336)](https://github.com/PennyLaneAI/pennylane/pull/9336)
 
-* During program capture, `qml.for_loop` with negative step sizes is now handled immediately during capture time.
+* During program capture, `qp.for_loop` with negative step sizes is now handled immediately during capture time.
   [(#9299)](https://github.com/PennyLaneAI/pennylane/pull/9299)
 
 * With program capture, arrays dynamic shapes with `qp.for_loop` and `qp.while_loop` can now be combined
@@ -1157,11 +1157,11 @@
   [(#9155)](https://github.com/PennyLaneAI/pennylane/pull/9155)
 
 * Fixed a bug with program capture when a transform is applied to a qnode with a dynamic number of shots
-  and return `qml.sample`.
+  and return `qp.sample`.
   [(#9342)](https://github.com/PennyLaneAI/pennylane/pull/9342)
 
 * Fixed wire overlap validation in :class:`~.QROM` and :class:`~.Select` to support JAX-traced wires,
-  enabling `qml.QROM` to be used with `qjit` when wires are passed as dynamic arguments.
+  enabling `qp.QROM` to be used with `qjit` when wires are passed as dynamic arguments.
   [(#9282)](https://github.com/PennyLaneAI/pennylane/pull/9282)
 
 * Fixed an issue with Catalyst and `qp.for_loop` and `qp.while_loop`, where it was defaulting

--- a/pennylane/logging/log_config.toml
+++ b/pennylane/logging/log_config.toml
@@ -10,13 +10,13 @@ version = 1
 ###############################################################################
 
 [formatters]
-[formatters.qml_default_formatter]
+[formatters.qp_default_formatter]
 "()" = "pennylane.logging.formatters.formatter.DefaultFormatter"
 
-[formatters.qml_dynamic_formatter]
+[formatters.qp_dynamic_formatter]
 "()" = "pennylane.logging.formatters.formatter.DynamicFormatter"
 
-[formatters.qml_alt_formatter]
+[formatters.qp_alt_formatter]
 "()" = "pennylane.logging.formatters.formatter.SimpleFormatter"
 
 [formatters.local_detailed]
@@ -31,11 +31,11 @@ format = "[%(asctime)s] - %(name)s - %(levelname)s - %(message)s"
 
 [filters]
 # Filter to show messages from the same local process as the Python script
-[filters.qml_LocalProcessFilter]
+[filters.qp_LocalProcessFilter]
 "()" = "pennylane.logging.filter.LocalProcessFilter"
 
 # Filter to show debug level messages only
-[filters.qml_DebugOnlyFilter]
+[filters.qp_DebugOnlyFilter]
 "()" = "pennylane.logging.filter.DebugOnlyFilter"
 
 ###############################################################################
@@ -43,37 +43,37 @@ format = "[%(asctime)s] - %(name)s - %(levelname)s - %(message)s"
 ###############################################################################
 
 [handlers]
-[handlers.qml_debug_stream]
+[handlers.qp_debug_stream]
 class = "logging.StreamHandler"
-formatter = "qml_default_formatter"
+formatter = "qp_default_formatter"
 level = "DEBUG"
 stream = "ext://sys.stdout"
 
-[handlers.qml_debug_stream_dyn]
+[handlers.qp_debug_stream_dyn]
 class = "logging.StreamHandler"
-formatter = "qml_dynamic_formatter"
+formatter = "qp_dynamic_formatter"
 level = "DEBUG"
 stream = "ext://sys.stdout"
 
-[handlers.qml_debug_stream_alt]
+[handlers.qp_debug_stream_alt]
 class = "logging.StreamHandler"
-formatter = "qml_alt_formatter"
+formatter = "qp_alt_formatter"
 level = "DEBUG"
 stream = "ext://sys.stdout"
 
-[handlers.qml_debug_syslog]
+[handlers.qp_debug_syslog]
 class = "logging.handlers.SysLogHandler"
 formatter = "local_standard"
 level = "DEBUG"
 address = "/dev/log"
 
-[handlers.qml_debug_file]
+[handlers.qp_debug_file]
 class = "logging.handlers.RotatingFileHandler"
 formatter = "local_standard"
 level = "DEBUG"
-filename = "qml_debug.log" # use `/tmp/filename.log` on Linux machines to avoid long-term persistence
+filename = "qp_debug.log" # use `/tmp/filename.log` on Linux machines to avoid long-term persistence
 maxBytes = 16777216 # 16MB per file before splitting
-backupCount = 10 # Create 'qml_debug.log.1', ... 'qml_debug.log.backupCount' files and rollover when maxBytes is reached
+backupCount = 10 # Create 'qp_debug.log.1', ... 'qp_debug.log.backupCount' files and rollover when maxBytes is reached
 delay = true # Avoid file-creation unless used
 
 [handlers.local_filtered_detailed_stdout]
@@ -81,7 +81,7 @@ class = "logging.StreamHandler"
 formatter = "local_standard"
 level = "DEBUG"
 stream = "ext://sys.stdout"
-filters = ["qml_LocalProcessFilter", "qml_DebugOnlyFilter"]
+filters = ["qp_LocalProcessFilter", "qp_DebugOnlyFilter"]
 
 ###############################################################################
 # Define logger controls for internal and external packages
@@ -91,32 +91,32 @@ filters = ["qml_LocalProcessFilter", "qml_DebugOnlyFilter"]
 
 # Control JAX logging
 [loggers.jax]
-handlers = ["qml_debug_stream",]
+handlers = ["qp_debug_stream",]
 level = "WARN"
 propagate = false
 
 # Control JAXlib logging
 [loggers.jaxlib]
-handlers = ["qml_debug_stream",]
+handlers = ["qp_debug_stream",]
 level = "WARN"
 propagate = false
 
 # Control logging across pennylane
 [loggers.pennylane]
-handlers = ["qml_debug_stream",]
+handlers = ["qp_debug_stream",]
 level = "DEBUG" # Set to TRACE for highest verbosity
 propagate = false
 
 # Control logging specifically in the pennylane.qnode module
 # Note the required quotes to overcome TOML nesting issues
 [loggers."pennylane.qnode"]
-handlers = ["qml_debug_stream",]
+handlers = ["qp_debug_stream",]
 level = "DEBUG" # Set to TRACE for highest verbosity
 propagate = false
 
 # Control logging across catalyst
 [loggers.catalyst]
-handlers = ["qml_debug_stream",]
+handlers = ["qp_debug_stream",]
 level = "DEBUG" # Set to TRACE for highest verbosity
 propagate = false
 


### PR DESCRIPTION
**Context:** We want to make sure we caught all instances of qml when changing to qp.

**Description of the Change:** Catches a few instances in the guides.

**Benefits:** New marketing.

**Possible Drawbacks:** N/A

**Related GitHub Issues:** [sc-116757]
