### PR TITLE
[chore] `zip(.., strict)` in bose, capture, drawer, gradients, transforms

### DIFF
--- a/pennylane/bose/bosonic.py
+++ b/pennylane/bose/bosonic.py
@@ -124,7 +124,9 @@ class BoseWord(dict):
             [
                 "b" + symbol_map[j] + "(" + i + ")"
                 for i, j in zip(
-                    [str(i[1]) for i in self.sorted_dic.keys()], self.sorted_dic.values()
+                    [str(i[1]) for i in self.sorted_dic.keys()],
+                    self.sorted_dic.values(),
+                    strict=True,
                 )
             ]
         )
@@ -177,7 +179,9 @@ class BoseWord(dict):
             return self_bs + BoseSentence({other: -1.0})
 
         if isinstance(other, BoseSentence):
-            other_bs = BoseSentence(dict(zip(other.keys(), [-v for v in other.values()])))
+            other_bs = BoseSentence(
+                dict(zip(other.keys(), [-v for v in other.values()], strict=True))
+            )
             return self_bs + other_bs
 
         if not isinstance(other, TensorLike):
@@ -227,9 +231,10 @@ class BoseWord(dict):
                 zip(
                     [(order_idx, other_wires[i]) for i, order_idx in enumerate(order_final)],
                     other.values(),
+                    strict=True,
                 )
             )
-            dict_self = dict(zip(self.keys(), self.values()))
+            dict_self = dict(zip(self.keys(), self.values(), strict=True))
 
             dict_self.update(dict_other)
 
@@ -502,7 +507,9 @@ class BoseSentence(dict):
             return self.__add__(other)
 
         if isinstance(other, BoseSentence):
-            other = BoseSentence(dict(zip(other.keys(), [-1 * v for v in other.values()])))
+            other = BoseSentence(
+                dict(zip(other.keys(), [-1 * v for v in other.values()], strict=True))
+            )
             return self.__add__(other)
 
         if not isinstance(other, TensorLike):
@@ -529,7 +536,7 @@ class BoseSentence(dict):
                 f"but received {other} of length {len(other)}"
             )
 
-        self_bs = BoseSentence(dict(zip(self.keys(), [-1 * v for v in self.values()])))
+        self_bs = BoseSentence(dict(zip(self.keys(), [-1 * v for v in self.values()], strict=True)))
         other_bs = BoseSentence({BoseWord({}): other})  # constant * I
         return self_bs + other_bs
 
@@ -561,7 +568,7 @@ class BoseSentence(dict):
                 f"but received {other} of length {len(other)}"
             )
         vals = [i * other for i in self.values()]
-        return BoseSentence(dict(zip(self.keys(), vals)))
+        return BoseSentence(dict(zip(self.keys(), vals, strict=True)))
 
     def __rmul__(self, other):
         r"""Reverse multiply a BoseSentence
@@ -581,7 +588,7 @@ class BoseSentence(dict):
             )
 
         vals = [i * other for i in self.values()]
-        return BoseSentence(dict(zip(self.keys(), vals)))
+        return BoseSentence(dict(zip(self.keys(), vals, strict=True)))
 
     def __pow__(self, value):
         r"""Exponentiate a Bose sentence to an integer power."""

--- a/pennylane/bose/bosonic_mapping.py
+++ b/pennylane/bose/bosonic_mapping.py
@@ -116,7 +116,7 @@ def _(bose_operator: BoseWord, n_states, tol=None):
     for (_, b_idx), sign in bose_operator.items():
         op = PauliSentence()
         sparse_coeffmat = np.nonzero(coeff_mat[sign])
-        for i, j in zip(*sparse_coeffmat):
+        for i, j in zip(*sparse_coeffmat, strict=True):
             coeff = coeff_mat[sign][i][j]
 
             binary_row = list(map(int, bin(i)[2:]))[::-1]
@@ -255,7 +255,7 @@ def _(bose_operator: BoseWord, n_states, tol=None):
 
         op = PauliSentence()
         sparse_coeffmat = np.nonzero(coeff_mat_prod)
-        for i, j in zip(*sparse_coeffmat):
+        for i, j in zip(*sparse_coeffmat, strict=True):
             coeff = coeff_mat_prod[i][j]
 
             row = np.zeros(n_states)

--- a/pennylane/capture/autograph/ag_primitives.py
+++ b/pennylane/capture/autograph/ag_primitives.py
@@ -105,7 +105,7 @@ def _assert_results(results, var_names):
 
     assert len(results) == len(var_names)
 
-    for r, v in zip(results, var_names):
+    for r, v in zip(results, var_names, strict=True):
         if isinstance(r, Undefined):
             raise AutoGraphError(f"Some branches did not define a value for variable '{v}'")
 
@@ -196,7 +196,7 @@ def _assert_iteration_results(inputs, outputs, symbol_names):
     variable was initialized with the wrong type.
     """
 
-    for i, (inp, out) in enumerate(zip(inputs, outputs)):
+    for i, (inp, out) in enumerate(zip(inputs, outputs, strict=True)):
         inp_t, out_t = jax.api_util.shaped_abstractify(inp), jax.api_util.shaped_abstractify(out)
         if inp_t.dtype != out_t.dtype or inp_t.shape != out_t.shape:
             raise AutoGraphError(

--- a/pennylane/capture/base_interpreter.py
+++ b/pennylane/capture/base_interpreter.py
@@ -541,7 +541,7 @@ def handle_cond(self, *invals, jaxpr_branches, consts_slices, args_slice):
     new_consts_slices = []
     end_const_ind = len(jaxpr_branches)
 
-    for const_slice, jaxpr in zip(consts_slices, jaxpr_branches):
+    for const_slice, jaxpr in zip(consts_slices, jaxpr_branches, strict=True):
         consts = invals[const_slice]
         new_jaxpr = jaxpr_to_jaxpr(copy(self), jaxpr, consts, *args)
         new_jaxprs.append(new_jaxpr.jaxpr)
@@ -761,7 +761,7 @@ def flattened_cond(self, *invals, jaxpr_branches, consts_slices, args_slice):
     conditions = invals[:n_branches]
     args = invals[args_slice]
 
-    for pred, jaxpr, const_slice in zip(conditions, jaxpr_branches, consts_slices):
+    for pred, jaxpr, const_slice in zip(conditions, jaxpr_branches, consts_slices, strict=True):
         consts = invals[const_slice]
         if math.is_abstract(pred):
             raise NotImplementedError(

--- a/pennylane/capture/jax_patches.py
+++ b/pennylane/capture/jax_patches.py
@@ -149,7 +149,7 @@ def _add_make_eqn_helper():
         # We pass the equation as the parent parameter (4th argument to __init__)
         out_tracers = [
             DynamicJaxprTracer(self, aval, v, source_info, eqn)
-            for aval, v in zip(out_avals, outvars)
+            for aval, v in zip(out_avals, outvars, strict=True)
         ]
 
         return eqn, out_tracers

--- a/pennylane/drawer/_add_obj.py
+++ b/pennylane/drawer/_add_obj.py
@@ -178,7 +178,7 @@ def _add_controlled(
         return _add_controlled_global_op(obj, layer_str, config)
 
     layer_str = _add_grouping_symbols(obj.wires, layer_str, config)
-    for w, val in zip(obj.control_wires, obj.control_values):
+    for w, val in zip(obj.control_wires, obj.control_values, strict=True):
         layer_str[config.wire_map[w]] += "●" if val else "○"
     return _add_obj(obj.base, layer_str, config, skip_grouping_symbols=True)
 
@@ -188,7 +188,7 @@ def _add_controlled_global_op(obj, layer_str, config):
     but a manually managed dispatch."""
     layer_str = _add_grouping_symbols(list(config.wire_map.keys()), layer_str, config)
 
-    for w, val in zip(obj.control_wires, obj.control_values):
+    for w, val in zip(obj.control_wires, obj.control_values, strict=True):
         layer_str[config.wire_map[w]] += "●" if val else "○"
 
     label = obj.base.label(decimals=config.decimals, cache=config.cache).replace("\n", "")

--- a/pennylane/drawer/mpldrawer.py
+++ b/pennylane/drawer/mpldrawer.py
@@ -684,7 +684,7 @@ class MPLDrawer:
         else:
             if len(control_values) != len(wires_ctrl):
                 raise ValueError("`control_values` must be the same length as `wires`")
-            for wire, control_on in zip(wires_ctrl, control_values):
+            for wire, control_on in zip(wires_ctrl, control_values, strict=True):
                 if control_on:
                     self._ctrl_circ(layer, wire, options=options)
                 else:
@@ -1001,7 +1001,7 @@ class MPLDrawer:
         }
         text_options.update(user_text_options)
         text_x = main_box_x + main_box_width / 2
-        for symbol, wire in zip(pauli_word, wires):
+        for symbol, wire in zip(pauli_word, wires, strict=True):
             self._ax.text(text_x, wire, symbol, **text_options)
 
         measure_icon_x, measure_icon_y = notch_x + notch_width / 2 + self._notch_pad, box_center

--- a/pennylane/drawer/tape_text.py
+++ b/pennylane/drawer/tape_text.py
@@ -189,12 +189,16 @@ def _add_layer_str_to_totals(totals: _CurrentTotals, layer_str, config) -> _Curr
     # Process quantum wires - join accumulated wire strings with current layer strings
     totals.wire_totals = [
         config.wire_filler.join([t, s])
-        for t, s in zip(totals.wire_totals, layer_str[: config.n_wires])
+        for t, s in zip(totals.wire_totals, layer_str[: config.n_wires], strict=True)
     ]
 
     # Process classical bits - join accumulated bit strings with current layer strings
     for j, (bt, s) in enumerate(
-        zip(totals.bit_totals, layer_str[config.n_wires : config.n_wires + config.n_bits])
+        zip(
+            totals.bit_totals,
+            layer_str[config.n_wires : config.n_wires + config.n_bits],
+            strict=True,
+        )
     ):
         totals.bit_totals[j] = config.bit_filler(j).join([bt, s])
 

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -246,7 +246,7 @@ def finite_diff_jvp(
                 continue
 
             ti_over_h = ti / h
-            for coeff, shift in zip(coeffs, shifts):
+            for coeff, shift in zip(coeffs, shifts, strict=True):
                 if shift == 0:
                     res = flat_initial_res
                 else:

--- a/pennylane/gradients/general_shift_rules.py
+++ b/pennylane/gradients/general_shift_rules.py
@@ -198,7 +198,7 @@ def _iterate_shift_rule_with_multipliers(rule, order, period):
     for partial_rules in itertools.product(rule, repeat=order):
         c, m, s = np.stack(partial_rules).T
         cumul_shift = 0.0
-        for _m, _s in zip(m, s):
+        for _m, _s in zip(m, s, strict=True):
             cumul_shift *= _m
             cumul_shift += _s
         if period is not None:
@@ -383,7 +383,7 @@ def generate_multi_shift_rule(frequencies, shifts=None, orders=None):
     shifts = shifts or [None] * len(frequencies)
     orders = orders or [1] * len(frequencies)
 
-    for f, s, o in zip(frequencies, shifts, orders):
+    for f, s, o in zip(frequencies, shifts, orders, strict=True):
         rule = generate_shift_rule(f, shifts=s, order=o)
         rules.append(process_shifts(rule))
 
@@ -395,7 +395,7 @@ def _copy_and_shift_params(tape, indices, shifts, multipliers, cast=False):
     rescaled and shifted as indicated by ``indices``, ``multipliers`` and ``shifts``."""
     all_ops = tape.circuit
 
-    for idx, shift, multiplier in zip(indices, shifts, multipliers):
+    for idx, shift, multiplier in zip(indices, shifts, multipliers, strict=True):
         _, op_idx, p_idx = tape.get_operation(idx)
         op = (
             all_ops[op_idx].obs
@@ -465,7 +465,7 @@ def generate_shifted_tapes(tape, index, shifts, multipliers=None, broadcast=Fals
 
     return tuple(
         _copy_and_shift_params(tape, [index], [shift], [multiplier])
-        for shift, multiplier in zip(shifts, multipliers)
+        for shift, multiplier in zip(shifts, multipliers, strict=True)
     )
 
 
@@ -496,7 +496,7 @@ def generate_multishifted_tapes(tape, indices, shifts, multipliers=None):
 
     tapes = [
         _copy_and_shift_params(tape, indices, _shifts, _multipliers, cast=True)
-        for _shifts, _multipliers in zip(shifts, multipliers)
+        for _shifts, _multipliers in zip(shifts, multipliers, strict=True)
     ]
 
     return tapes

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -449,7 +449,7 @@ def hadamard_grad(
     if mode in ["standard", "reversed"] and aux_wire is None:
         warnings.warn(
             """
-            Providing a value of None to aux_wire in reversed or standard mode has been deprecated and will 
+            Providing a value of None to aux_wire in reversed or standard mode has been deprecated and will
             no longer be supported in v0.46. An aux_wire will no longer be automatically assigned.
             """,
             PennyLaneDeprecationWarning,
@@ -721,7 +721,7 @@ def processing_fn(results: ResultBatch, tape, coeffs, generators_per_parameter):
     """Post processing function for computing a hadamard gradient."""
 
     final_res = []
-    for coeff, res in zip(coeffs, results):
+    for coeff, res in zip(coeffs, results, strict=True):
         if not isinstance(res, (tuple, list)):
             res = [res]  # add singleton dimension back in for one measurement
         final_res.append([math.convert_like(2 * coeff * r, r) for r in res])
@@ -747,7 +747,7 @@ def processing_fn(results: ResultBatch, tape, coeffs, generators_per_parameter):
     results = iter(final_res)
     for num_generators in generators_per_parameter:
         if num_generators == 0:
-            for g_for_parameter, mp in zip(grads, mps):
+            for g_for_parameter, mp in zip(grads, mps, strict=True):
                 zeros_like_mp = np.zeros(
                     mp.shape(num_device_wires=len(tape.wires)), dtype=mp.numeric_type
                 )
@@ -755,7 +755,7 @@ def processing_fn(results: ResultBatch, tape, coeffs, generators_per_parameter):
         else:
             sub_results = islice(results, num_generators)  # take the next number of results
             # sum over batch, iterate over measurements
-            summed_sub_results = (sum(r) for r in zip(*sub_results))
+            summed_sub_results = (sum(r) for r in zip(*sub_results, strict=True))
 
             for g_for_parameter, r in zip(grads, summed_sub_results, strict=True):
                 g_for_parameter.append(r)

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -193,9 +193,11 @@ def compute_jvp_single(tangent, jac):
     jac_shapes = [j.shape for j in jac]
     new_shapes = [
         shape[: len(shape) - t_ndim] + (tsize,)
-        for shape, t_ndim, tsize in zip(jac_shapes, tangent_ndims, tangent_sizes)
+        for shape, t_ndim, tsize in zip(jac_shapes, tangent_ndims, tangent_sizes, strict=True)
     ]
-    jac = math.concatenate([math.reshape(j, s) for j, s in zip(jac, new_shapes)], axis=-1)
+    jac = math.concatenate(
+        [math.reshape(j, s) for j, s in zip(jac, new_shapes, strict=True)], axis=-1
+    )
     jac = math.cast(math.convert_like(jac, tangent), tangent.dtype)
     return math.tensordot(jac, tangent, [[-1], [0]])
 
@@ -425,7 +427,7 @@ def batch_jvp(tapes, tangents, gradient_fn, reduction="append", gradient_kwargs=
     processing_fns = []
 
     # Loop through the tapes and dys vector
-    for tape, tangent in zip(tapes, tangents):
+    for tape, tangent in zip(tapes, tangents, strict=True):
         g_tapes, fn = jvp(tape, tangent, gradient_fn, gradient_kwargs)
 
         reshape_info.append(len(g_tapes))

--- a/pennylane/gradients/metric_tensor.py
+++ b/pennylane/gradients/metric_tensor.py
@@ -513,7 +513,7 @@ def _metric_tensor_cov_matrix(tape, argnum, diag_approx):  # pylint: disable=too
 
         # for each operation in the layer, get the generator
         j = 0
-        for p, op in zip(param_idx, curr_ops):
+        for p, op in zip(param_idx, curr_ops, strict=True):
             layers_ids.append(i)
             if p in argnum:
                 obs, s = generator(op)
@@ -534,9 +534,8 @@ def _metric_tensor_cov_matrix(tape, argnum, diag_approx):  # pylint: disable=too
         # TODO: Maybe there are gates that do not affect the
         # generators of interest and thus need not be applied.
 
-        for o, param_in_argnum in zip(layer_obs, in_argnum_list[-1]):
-            if param_in_argnum:
-                queue.extend(o.diagonalizing_gates())
+        for o in layer_obs:
+            queue.extend(o.diagonalizing_gates())
 
         layer_tape = QuantumScript(queue, [probs(wires=tape.wires)], shots=tape.shots)
         metric_tensor_tapes.append(layer_tape)
@@ -658,12 +657,12 @@ def _get_first_term_tapes(layer_i, layer_j, allow_nonunitary, aux_wire, shots):
     ]
 
     # Iterate over differentiated operation in first layer
-    for diffed_op_i, par_idx_i in zip(layer_i.ops, layer_i.param_inds):
+    for diffed_op_i, par_idx_i in zip(layer_i.ops, layer_i.param_inds, strict=True):
         gen_op_i = _get_gen_op(WrappedObj(diffed_op_i), allow_nonunitary, aux_wire)
 
         # Iterate over differentiated operation in second layer
         # There will be one tape per pair of differentiated operations
-        for diffed_op_j, par_idx_j in zip(layer_j.ops, layer_j.param_inds):
+        for diffed_op_j, par_idx_j in zip(layer_j.ops, layer_j.param_inds, strict=True):
             gen_op_j = _get_gen_op(WrappedObj(diffed_op_j), allow_nonunitary, aux_wire)
 
             ops = [
@@ -725,7 +724,7 @@ def _metric_tensor_hadamard(
     par_idx_to_trainable_idx = {idx: i for i, idx in enumerate(sorted(tape.trainable_params))}
     layers = []
 
-    for layer, in_argnum in zip(graph.iterate_parametrized_layers(), in_argnum_list):
+    for layer, in_argnum in zip(graph.iterate_parametrized_layers(), in_argnum_list, strict=True):
         if not any(in_argnum):
             # no tapes need to be constructed for this layer
             continue
@@ -734,7 +733,7 @@ def _metric_tensor_hadamard(
         new_ops = []
         new_param_idx = []
 
-        for o, idx, param_in_argnum in zip(ops, param_idx, in_argnum):
+        for o, idx, param_in_argnum in zip(ops, param_idx, in_argnum, strict=True):
             if param_in_argnum:
                 new_ops.append(o)
                 new_param_idx.append(par_idx_to_trainable_idx[idx])
@@ -793,7 +792,7 @@ def _metric_tensor_hadamard(
         if ids:
             off_diag_res = math.stack(off_diag_res, 1)[0]
 
-            for loc, r in zip(ids, off_diag_res):
+            for loc, r in zip(ids, off_diag_res, strict=True):
                 # not sure if we can promise ordering of locations
                 # so need to loop over indices for compatibility with catalyst
                 first_term = math.scatter_element_add(first_term, loc, r)
@@ -802,7 +801,7 @@ def _metric_tensor_hadamard(
         # Second terms of off block-diagonal metric tensor
         expvals = math.zeros_like(first_term[0])
 
-        for i, (layer_i, obs_i) in enumerate(zip(layer_ids, obs_ids)):
+        for i, (layer_i, obs_i) in enumerate(zip(layer_ids, obs_ids, strict=True)):
             if layer_i is not None and obs_i is not None:
                 prob = diag_res[layer_i]
                 o = obs_list[layer_i][obs_i]

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -178,7 +178,9 @@ def _multi_meas_grad(res, coeffs, r0, unshifted_coeff, num_measurements):
         r0 = [None] * num_measurements
     if res == ():
         res = tuple(() for _ in range(num_measurements))
-    return tuple(_single_meas_grad(r, coeffs, unshifted_coeff, r0_) for r, r0_ in zip(res, r0))
+    return tuple(
+        _single_meas_grad(r, coeffs, unshifted_coeff, r0_) for r, r0_ in zip(res, r0, strict=True)
+    )
 
 
 def _evaluate_gradient(tape_specs, res, data, r0, batch_size):
@@ -208,7 +210,10 @@ def _evaluate_gradient(tape_specs, res, data, r0, batch_size):
             # Move shots to first position
             res = _swap_first_two_axes(res, len(res), len_shot_vec, squeeze=False)
         # _single_meas_grad expects axis (parameters,), iterate over shot vector
-        return tuple(_single_meas_grad(r, coeffs, unshifted_coeff, r0_) for r, r0_ in zip(res, r0))
+        return tuple(
+            _single_meas_grad(r, coeffs, unshifted_coeff, r0_)
+            for r, r0_ in zip(res, r0, strict=True)
+        )
 
     if scalar_shots:
         # Res has axes (parameters, measurements) or with broadcasting (measurements, parameters)
@@ -231,7 +236,7 @@ def _evaluate_gradient(tape_specs, res, data, r0, batch_size):
     # _multi_meas_grad expects (measurements, parameters), so we iterate over shot vector
     return tuple(
         _multi_meas_grad(r, coeffs, r0_, unshifted_coeff, num_measurements)
-        for r, r0_ in zip(res, r0)
+        for r, r0_ in zip(res, r0, strict=True)
     )
 
 
@@ -1182,15 +1187,15 @@ def param_shift(
             multi_measure = len(tape.measurements) > 1
             if not multi_measure:
                 res = []
-                for i, j in zip(unsupported_grads, supported_grads):
+                for i, j in zip(unsupported_grads, supported_grads, strict=True):
                     component = math.array(i + j)
                     res.append(component)
                 return tuple(res)
 
             combined_grad = []
-            for meas_res1, meas_res2 in zip(unsupported_grads, supported_grads):
+            for meas_res1, meas_res2 in zip(unsupported_grads, supported_grads, strict=True):
                 meas_grad = []
-                for param_res1, param_res2 in zip(meas_res1, meas_res2):
+                for param_res1, param_res2 in zip(meas_res1, meas_res2, strict=True):
                     component = math.array(param_res1 + param_res2)
                     meas_grad.append(component)
 

--- a/pennylane/gradients/parameter_shift_cv.py
+++ b/pennylane/gradients/parameter_shift_cv.py
@@ -458,7 +458,7 @@ def second_order_param_shift(tape, dev_wires, argnum=None, shifts=None, gradient
             results = [np.array(0.0)]
 
         interface = math.get_interface(results[0])
-        iterator = enumerate(zip(shapes, gradient_values, obs_indices))
+        iterator = enumerate(zip(shapes, gradient_values, obs_indices, strict=True))
 
         for i, (shape, grad_value, obs_ind) in iterator:
             if shape == 0:
@@ -817,7 +817,7 @@ def param_shift_cv(
         start = 0
         grads = []
 
-        for s, f in zip(shapes, fns):
+        for s, f in zip(shapes, fns, strict=True):
             grads.append(f(results[start : start + s]))
             start += s
 

--- a/pennylane/gradients/parameter_shift_hessian.py
+++ b/pennylane/gradients/parameter_shift_hessian.py
@@ -144,7 +144,7 @@ def _collect_recipes(tape, argnum, method_map, diagonal_shifts, off_diagonal_shi
     diag_recipes = []
     partial_offdiag_recipes = []
     diag_shifts_idx = offdiag_shifts_idx = 0
-    for i, (d, od) in enumerate(zip(diag_argnum, offdiag_argnum)):
+    for i, (d, od) in enumerate(zip(diag_argnum, offdiag_argnum, strict=True)):
         if not d or method_map[i] == "0":
             # hessian will be set to 0 for this row/column
             diag_recipes.append(None)

--- a/pennylane/gradients/pulse_gradient.py
+++ b/pennylane/gradients/pulse_gradient.py
@@ -123,7 +123,9 @@ def _split_evol_ops(op, ob, tau):
                     "ignore", ".*the eigenvalues will be computed numerically.*"
                 )
             eigenvalues = eigvals(ob)
-        coeffs, shifts = zip(*generate_shift_rule(eigvals_to_frequencies(tuple(eigenvalues))))
+        coeffs, shifts = zip(
+            *generate_shift_rule(eigvals_to_frequencies(tuple(eigenvalues))), strict=True
+        )
         insert_ops = [exp(dot([-1j * shift], [ob])) for shift in shifts]
 
     # Create Pauli rotations to be inserted at tau
@@ -238,7 +240,7 @@ def _parshift_and_integrate(
             # and include the rescaling factor from the Monte Carlo integral and from global
             # prefactors of Pauli word generators.
             diff_per_term = jnp.array(
-                [_contract(c, r, cjac) for c, r, cjac in zip(psr_coeffs, res, cjacs)]
+                [_contract(c, r, cjac) for c, r, cjac in zip(psr_coeffs, res, cjacs, strict=True)]
             )
             return math.sum(diff_per_term, axis=0) * int_prefactor
 
@@ -271,13 +273,14 @@ def _parshift_and_integrate(
 
     nesting_layers = (not single_measure) + has_partitioned_shots
     if nesting_layers == 1:
-        return tuple(_psr_and_contract(r, cjacs, int_prefactor) for r in zip(*results))
+        return tuple(_psr_and_contract(r, cjacs, int_prefactor) for r in zip(*results, strict=True))
     if nesting_layers == 0:
         # Single measurement without shot vector
         return _psr_and_contract(results, cjacs, int_prefactor)
 
     return tuple(
-        tuple(_psr_and_contract(_r, cjacs, int_prefactor) for _r in zip(*r)) for r in zip(*results)
+        tuple(_psr_and_contract(_r, cjacs, int_prefactor) for _r in zip(*r, strict=True))
+        for r in zip(*results, strict=True)
     )
 
 

--- a/pennylane/gradients/pulse_gradient_odegen.py
+++ b/pennylane/gradients/pulse_gradient_odegen.py
@@ -105,7 +105,7 @@ def _one_parameter_generators(op):
     moveax = partial(math.moveaxis, source=(0, 1), destination=(-2, -1))
     return tuple(
         moveax(math.tensordot(U_dagger, j_r + 1j * j_i, axes=[[0], [0]]))
-        for j_r, j_i in zip(jac_real, jac_imag)
+        for j_r, j_i in zip(jac_real, jac_imag, strict=True)
     )
 
 
@@ -152,11 +152,11 @@ def _nonzero_coeffs_and_words(coefficients, num_wires, atol=1e-8):
     words = pauli_basis_strings(num_wires)
     new_coefficients = [[] for _ in coefficients]
     new_words = []
-    for word, *coeffs in zip(words, *coefficients):
+    for word, *coeffs in zip(words, *coefficients, strict=True):
         if all(math.allclose(c, 0.0, atol=atol, rtol=0.0) for c in coeffs):
             continue
         new_words.append(word)
-        for new_coeffs, c in zip(new_coefficients, coeffs):
+        for new_coeffs, c in zip(new_coefficients, coeffs, strict=True):
             new_coeffs.append(c)
     return new_coefficients, new_words
 
@@ -273,11 +273,13 @@ def _parshift_and_contract(results, coeffs, single_measure, single_shot_entry):
         return _parshift_and_contract_single(results, math.stack(coeffs))
     if single_measure or single_shot_entry:
         # single measurement or single shot entry, but not both
-        return tuple(_parshift_and_contract_single(r, math.stack(coeffs)) for r in zip(*results))
+        return tuple(
+            _parshift_and_contract_single(r, math.stack(coeffs)) for r in zip(*results, strict=True)
+        )
 
     return tuple(
-        tuple(_parshift_and_contract_single(_r, math.stack(coeffs)) for _r in zip(*r))
-        for r in zip(*results)
+        tuple(_parshift_and_contract_single(_r, math.stack(coeffs)) for _r in zip(*r, strict=True))
+        for r in zip(*results, strict=True)
     )
 
 

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -209,7 +209,7 @@ def compute_vjp_multi(dy, jac, num=None):
     # Single parameter
     if not isinstance(jac[0], (tuple, autograd.builtins.SequenceBox)):
         res = []
-        for d, j_ in zip(dy, jac):
+        for d, j_ in zip(dy, jac, strict=True):
             res.append(compute_vjp_single(d, j_, num=num))
         res = math.sum(math.stack(res), axis=0)
     # Multiple parameters
@@ -237,7 +237,7 @@ def compute_vjp_multi(dy, jac, num=None):
         # TODO: Catalogue and update for expected exception types
         except Exception:  # pylint: disable=broad-except
             res = []
-            for d, j_ in zip(dy, jac):
+            for d, j_ in zip(dy, jac, strict=True):
                 sub_res = []
                 for j in j_:
                     sub_res.append(math.squeeze(compute_vjp_single(d, j, num=num)))
@@ -381,7 +381,7 @@ def vjp(tape, dy, gradient_fn, gradient_kwargs=None):
         if not tape.shots.has_partitioned_shots:
             return comp_vjp_fn(dy, jac, num=num)
 
-        vjp_ = [comp_vjp_fn(dy_, jac_, num=num) for dy_, jac_ in zip(dy, jac)]
+        vjp_ = [comp_vjp_fn(dy_, jac_, num=num) for dy_, jac_ in zip(dy, jac, strict=True)]
         return math.sum(math.stack(vjp_), 0)
 
     return gradient_tapes, processing_fn
@@ -506,7 +506,7 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None)
     processing_fns = []
 
     # Loop through the tapes and dys vector
-    for tape, dy in zip(tapes, dys):
+    for tape, dy in zip(tapes, dys, strict=True):
         g_tapes, fn = vjp(tape, dy, gradient_fn, gradient_kwargs=gradient_kwargs)
         reshape_info.append(len(g_tapes))
         processing_fns.append(fn)

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -61,7 +61,7 @@ def _create_transform_primitive():
     def setup_env(tracers, params):
         args_tracers = tracers[slice(*params["args_slice"])]
         args_vars = params["inner_jaxpr"].invars
-        env = dict(zip(args_vars, args_tracers), strict=True)
+        env = dict(zip(args_vars, args_tracers, strict=True))
 
         consts_tracers = tracers[slice(*params["consts_slice"])]
         consts_vars = params["inner_jaxpr"].constvars
@@ -1196,7 +1196,7 @@ def _apply_to_sequence(obj: Sequence, transform, *targs, **tkwargs):
         count = 0
         final_results = []
 
-        for f, s in zip(batch_fns, tape_counts):
+        for f, s in zip(batch_fns, tape_counts, strict=True):
             # apply any batch transform post-processing
             new_res = f(res[count : count + s])
             final_results.append(new_res)

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -574,7 +574,7 @@ class TestMetricTensor:
             qp.RY(weights[1], wires=0)
             qp.CNOT(wires=[0, 1])
             qp.RZ(weights[2], wires=1)
-            qp.RZ(weights[3], wires=0)
+            qp.RX(weights[3], wires=0)
 
         weights = getattr(mod, array_cls)([0.1, 0.2, 0.3, 0.5])
 


### PR DESCRIPTION
**Context:**

We are not using `strict` with `zip` consistently in the codebase

**Description of the Change:**
Adding `strict=True` to all `zip`s without `strict` argument in modules:

- bose
- capture
- drawer
- gradients
- transforms

(used ruff to detect, then fixed)
There is exactly one thing that is not just adding `strict=True`, I left a comment there (a hidden bug, actually).

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
