### PR TITLE
remove: `qml` alias from documentation testing namespace

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,6 @@ except ImportError:
 
 namespace = {
     "qp": qp,
-    "qml": qp,
     "np": base_numpy,
     "sp": base_scipy,
     "pnp": qp.numpy,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1126,6 +1126,7 @@
   [(#9376)](https://github.com/PennyLaneAI/pennylane/pull/9376)
   [(#9375)](https://github.com/PennyLaneAI/pennylane/pull/9375)
   [(#9384)](https://github.com/PennyLaneAI/pennylane/pull/9384)
+  [(#9397)](https://github.com/PennyLaneAI/pennylane/pull/9397)
 
 * A new AI policy document is now applied across the PennyLaneAI organization for all AI contributions.
   [(#9079)](https://github.com/PennyLaneAI/pennylane/pull/9079)


### PR DESCRIPTION
**Context:**

With the migration complete, we can remove the `qml` alias from this file.

**Benefits:** If someone tries to use `qml` as an alias in a docstring it'll fail.

**Possible Drawbacks:** None identified.

[sc-117034]
