### PR TITLE
fix: suppress `pytest` exit code 5 for changelog doctesting

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -144,4 +144,10 @@ jobs:
       - name: Test `changelog-dev.md` file
         if: always()
         run: |
-          pytest doc/releases/changelog-dev.md
+          pytest doc/releases/changelog-dev.md 
+          ret=$?
+          if [ "$ret" = 5 ]; then
+              echo "No tests collected in changelog-dev.md. Exiting with 0."
+              exit 0
+          fi 
+          exit "$ret"

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -141,8 +141,9 @@ jobs:
 
           pytest doc ${IGNORE}
 
-        # NOTE: If no tests are found (say after a fresh changelog-dev.md is created after RCs are cut)
-        # then 'pytest' raises an exit code 5, which fails on CI.
+        # NOTE: Suppress pytest exit code 5 (No Tests Collected).
+        # This avoids CI breakage when the changelog is reset after a RC
+        # branch is cut and hasn't yet accumulated any code snippets to test.
       - name: Test `changelog-dev.md` file
         if: always()
         run: |

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -141,13 +141,9 @@ jobs:
 
           pytest doc ${IGNORE}
 
+        # NOTE: If no tests are found (say after a fresh changelog-dev.md is created after RCs are cut)
+        # then 'pytest' raises an exit code 5, which fails on CI.
       - name: Test `changelog-dev.md` file
         if: always()
         run: |
-          pytest doc/releases/changelog-dev.md 
-          ret=$?
-          if [ "$ret" = 5 ]; then
-              echo "No tests collected in changelog-dev.md. Exiting with 0."
-              exit 0
-          fi 
-          exit "$ret"
+          pytest doc/releases/changelog-dev.md || [ $? -eq 5 ] 


### PR DESCRIPTION
**Context:**

If the `changelog-dev.md` is empty (say after a RC branch is cut), `pytest` will fail as it exits with a code 5. However, CI only passes if an exit code is 0. This creates a false failure in CI.

**Description of the Change:**

Update the shell command to return exit code 0 even if it gets an exit code 5. Other people found this frustrating too [[source](https://github.com/pytest-dev/pytest/issues/2393)].

**Benefits:**

CI won't fail.

**Possible Drawbacks:** None identified.

[sc-118551]
