### PR TITLE
fix: update doctesting to not fail when `changelog-dev.md` is missing

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -141,10 +141,11 @@ jobs:
 
           pytest doc ${IGNORE}
 
+        # NOTE: Only run if the file exists. RC branches won't have the 'changelog-dev.md' file.
         # NOTE: Suppress pytest exit code 5 (No Tests Collected).
         # This avoids CI breakage when the changelog is reset after a RC
         # branch is cut and hasn't yet accumulated any code snippets to test.
       - name: Test `changelog-dev.md` file
         if: always()
         run: |
-          [ -f "doc/releases/changelog-dev.md" ] && pytest doc/releases/changelog-dev.md || [ $? -eq 5 ] 
+          ! [ -f "doc/releases/changelog-dev.md" ] || pytest doc/releases/changelog-dev.md || [ $? -eq 5 ] 

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -141,7 +141,10 @@ jobs:
 
           pytest doc ${IGNORE}
 
+        # NOTE: Suppress pytest exit code 5 (No Tests Collected).
+        # This avoids CI breakage when the changelog is reset after a RC
+        # branch is cut and hasn't yet accumulated any code snippets to test.
       - name: Test `changelog-dev.md` file
         if: always()
         run: |
-          pytest doc/releases/changelog-dev.md
+          [ -f "doc/releases/changelog-dev.md" ] && pytest doc/releases/changelog-dev.md || [ $? -eq 5 ] 

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -141,7 +141,8 @@ jobs:
 
           pytest doc ${IGNORE}
 
-        # NOTE: Only run if the file exists. RC branches won't have the 'changelog-dev.md' file.
+        # NOTE: Only run if the file exists (invert result to ensure exit code 0). 
+        # This avoids CI breakage when RC wranches don't have the 'changelog-dev.md' file.
         # NOTE: Suppress pytest exit code 5 (No Tests Collected).
         # This avoids CI breakage when the changelog is reset after a RC
         # branch is cut and hasn't yet accumulated any code snippets to test.


### PR DESCRIPTION
**Context:**

`changelog-dev.md` doesn't exist on RC branches.

**Description of the Change:**

Update CI logic to only run `pytest` if the file is there.

**Benefits:** CI doesn't fail for no reason.

**Possible Drawbacks:** None identified

[sc-118551]


