### PR TITLE
Fix pulse queue

### DIFF
--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -711,6 +711,9 @@
   - :class:`~.Projector`
   - :class:`~.BasisStateProjector`
 
+  as well as the operator-like objects `ParametrizedHamiltonian`, `HardwareHamiltonian`, and
+  `ParametrizedEvolution` in the `pulse` module.
+
   All operators are de-queued when used to construct new operators, so the following example
   does *not* show changed behaviour (creating ``B`` removes ``A`` from the queue):
 

--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -764,6 +764,7 @@
   outside of the quantum circuit.
   [(#8131)](https://github.com/PennyLaneAI/pennylane/pull/8131)
   [(#9029)](https://github.com/PennyLaneAI/pennylane/pull/9029)
+  [(#9423)](https://github.com/PennyLaneAI/pennylane/pull/9423)
 
 * Dropped support for NumPy 1.x following its end-of-life. NumPy 2.0 or higher is now required.
   [(#8914)](https://github.com/PennyLaneAI/pennylane/pull/8914)
@@ -1227,6 +1228,11 @@
   [(#9356)](https://github.com/PennyLaneAI/pennylane/pull/9356)
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed a bug where `ParametrizedHamiltonian`, `HardwareHamiltonian`, and `ParametrizedEvolution`
+  did not follow PennyLane's queuing convention. They have been updated to de-queue their input
+  operators and queue themselves like other PennyLane gate objects (that derive from `Operator`).
+  [(#9423)](https://github.com/PennyLaneAI/pennylane/pull/9423)
 
 * Fixed a bug where the Pytree structure of the following operators were inconsistent with the
   structure of their data:

--- a/pennylane/pulse/hardware_hamiltonian.py
+++ b/pennylane/pulse/hardware_hamiltonian.py
@@ -333,6 +333,9 @@ class HardwareHamiltonian(ParametrizedHamiltonian):
         return f"HardwareHamiltonian: terms={math.shape(self.coeffs)[0]}"
 
     def __add__(self, other):  # pylint: disable=too-many-return-statements
+        if QueuingManager.recording():
+            QueuingManager.remove(self)
+            QueuingManager.remove(other)
         if isinstance(other, HardwareHamiltonian):
             if not self.reorder_fn == other.reorder_fn:
                 raise ValueError(
@@ -390,8 +393,7 @@ class HardwareHamiltonian(ParametrizedHamiltonian):
                     coeffs, ops, reorder_fn=self.reorder_fn, settings=settings, pulses=pulses
                 )
             new_coeffs = coeffs + [other]
-            with QueuingManager.stop_recording():
-                new_ops = ops + [Identity(self.wires[0])]
+            new_ops = ops + [Identity(self.wires[0])]
 
             return HardwareHamiltonian(
                 new_coeffs, new_ops, reorder_fn=self.reorder_fn, settings=settings, pulses=pulses
@@ -408,6 +410,9 @@ class HardwareHamiltonian(ParametrizedHamiltonian):
         returns a HardwareHamiltonian where the call expects params = [params_PH] + [params_RH]
         """
         if isinstance(other, ParametrizedHamiltonian):
+            if QueuingManager.recording():
+                QueuingManager.remove(self)
+                QueuingManager.remove(other)
             ops = self.ops.copy()
             coeffs = self.coeffs.copy()
 

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -411,6 +411,8 @@ class ParametrizedEvolution(Operation):
         self.hyperparameters["complementary"] = complementary
         self._check_time_batching()
         self.dense = len(self.wires) < 3 if dense is None else dense
+        if QueuingManager.recording():
+            QueuingManager.remove(H)
 
     def __call__(
         self, params, t, return_intermediate=None, complementary=None, dense=None, **odeint_kwargs

--- a/pennylane/pulse/parametrized_hamiltonian.py
+++ b/pennylane/pulse/parametrized_hamiltonian.py
@@ -246,6 +246,7 @@ class ParametrizedHamiltonian:
         self.wires = Wires.all_wires(
             [op.wires for op in self.ops_fixed] + [op.wires for op in self.ops_parametrized]
         )
+        self.queue()
 
     def __call__(self, params, t):
         if len(params) != len(self.coeffs_parametrized):
@@ -277,6 +278,13 @@ class ParametrizedHamiltonian:
 
         res = "\n  + ".join(terms)
         return f"(\n    {res}\n)"
+
+    def queue(self, context=QueuingManager):
+        """Append the parametrized Hamiltonian to the queue."""
+        for op in self.ops:
+            context.remove(op)
+        context.append(self)
+        return self
 
     def map_wires(self, wire_map):
         """Returns a copy of the current ParametrizedHamiltonian with its wires changed according
@@ -344,6 +352,9 @@ class ParametrizedHamiltonian:
     def __add__(self, H):
         r"""The addition operation between a ``ParametrizedHamiltonian`` and an ``Operator``
         or ``ParametrizedHamiltonian``."""
+        if QueuingManager.recording():
+            QueuingManager.remove(self)
+            QueuingManager.remove(H)
         ops = self.ops.copy()
         coeffs = self.coeffs.copy()
 
@@ -369,6 +380,9 @@ class ParametrizedHamiltonian:
     def __radd__(self, H):
         r"""The addition operation between a ``ParametrizedHamiltonian`` and an ``Operator``
         or ``ParametrizedHamiltonian``."""
+        if QueuingManager.recording():
+            QueuingManager.remove(self)
+            QueuingManager.remove(H)
         ops = self.ops.copy()
         coeffs = self.coeffs.copy()
 
@@ -392,6 +406,8 @@ class ParametrizedHamiltonian:
         return NotImplemented
 
     def __mul__(self, other):
+        if QueuingManager.recording():
+            QueuingManager.remove(self)
         ops = self.ops.copy()
         coeffs_fixed = self.coeffs_fixed.copy()
         coeffs_parametrized = self.coeffs_parametrized.copy()

--- a/tests/pulse/test_hardware_hamiltonian.py
+++ b/tests/pulse/test_hardware_hamiltonian.py
@@ -93,21 +93,25 @@ class TestHardwareHamiltonian:
     )
     def test_add_hardware_hamiltonian(self, settings):
         """Test that the __add__ dunder method works correctly."""
-        rm1 = HardwareHamiltonian(
-            coeffs=[1, 2],
-            observables=[qp.PauliX(4), qp.PauliZ(8)],
-            pulses=[HardwarePulse(1, 2, 3, [4, 8])],
-            settings=settings,
-            reorder_fn=_reorder_parameters,
-        )
-        rm2 = HardwareHamiltonian(
-            coeffs=[2],
-            observables=[qp.PauliY(8)],
-            pulses=[HardwarePulse(5, 6, 7, 8)],
-            reorder_fn=_reorder_parameters,
-        )
+        with qp.queuing.AnnotatedQueue() as q:
+            rm1 = HardwareHamiltonian(
+                coeffs=[1, 2],
+                observables=[qp.PauliX(4), qp.PauliZ(8)],
+                pulses=[HardwarePulse(1, 2, 3, [4, 8])],
+                settings=settings,
+                reorder_fn=_reorder_parameters,
+            )
+            rm2 = HardwareHamiltonian(
+                coeffs=[2],
+                observables=[qp.PauliY(8)],
+                pulses=[HardwarePulse(5, 6, 7, 8)],
+                reorder_fn=_reorder_parameters,
+            )
 
-        sum_rm = rm1 + rm2
+            sum_rm = rm1 + rm2
+
+        assert len(q.queue) == 1
+        assert q.queue[0] == sum_rm
 
         assert isinstance(sum_rm, HardwareHamiltonian)
         assert qp.math.allequal(sum_rm.coeffs, [1, 2, 2])
@@ -137,15 +141,19 @@ class TestHardwareHamiltonian:
         ops = [qp.PauliZ(0), qp.PauliX(2)]
         h_wires = [0, 2]
 
-        rh = HardwareHamiltonian(
-            coeffs=[coeffs[0]],
-            observables=[ops[0]],
-            pulses=[HardwarePulse(5, 6, 7, 8)],
-        )
-        ph = qp.pulse.ParametrizedHamiltonian(coeffs=[coeffs[1]], observables=[ops[1]])
+        with qp.queuing.AnnotatedQueue() as q:
+            rh = HardwareHamiltonian(
+                coeffs=[coeffs[0]],
+                observables=[ops[0]],
+                pulses=[HardwarePulse(5, 6, 7, 8)],
+            )
+            ph = qp.pulse.ParametrizedHamiltonian(coeffs=[coeffs[1]], observables=[ops[1]])
 
-        res1 = rh + ph
-        res2 = ph + rh
+            res1 = rh + ph
+            res2 = ph + rh
+
+        assert len(q.queue) == 2
+        assert q.queue == [res1, res2]
 
         assert isinstance(res1, HardwareHamiltonian)
         assert res1.coeffs_fixed == coeffs
@@ -351,7 +359,8 @@ class TestInteractionWithOperators:
         R = drive(amplitude=f1, phase=0, wires=[0, 1])
         with qp.queuing.AnnotatedQueue() as q:
             R += 3
-        assert len(q) == 0
+        assert len(q) == 1
+        assert q.queue[0] == R
 
     def test_unknown_type_raises_error(self):
         """Test that adding an invalid object to a HardwareHamiltonian raises an error."""

--- a/tests/pulse/test_parametrized_evolution.py
+++ b/tests/pulse/test_parametrized_evolution.py
@@ -147,8 +147,11 @@ class TestInitialization:
     def test_init(self, params, coeffs):
         """Test the initialization."""
         ops = [qp.PauliX(0), qp.PauliY(1)]
-        H = ParametrizedHamiltonian(coeffs, ops)
-        ev = ParametrizedEvolution(H=H, params=params, t=2, dense=True)
+        with qp.queuing.AnnotatedQueue() as q:
+            H = ParametrizedHamiltonian(coeffs, ops)
+            ev = ParametrizedEvolution(H=H, params=params, t=2, dense=True)
+        assert len(q.queue) == 1
+        assert q.queue[0] == ev
 
         assert ev.H is H
         assert qp.math.allequal(ev.t, [0, 2])
@@ -291,9 +294,9 @@ class TestInitialization:
         operator is removed from the queue."""
         ops = [qp.PauliX(0), qp.PauliY(1)]
         coeffs = [1, 2]
-        H = ParametrizedHamiltonian(coeffs, ops)
 
         with QuantumTape() as tape:
+            H = ParametrizedHamiltonian(coeffs, ops)
             op = qp.evolve(H)
             op2 = op(params=[], t=6)
 

--- a/tests/pulse/test_parametrized_hamiltonian.py
+++ b/tests/pulse/test_parametrized_hamiltonian.py
@@ -64,11 +64,15 @@ class TestInitialization:
         """Test that adding combinations of operators and numbers/callables initializes
         a ParametrizedHamiltonian"""
 
-        XX = qp.PauliX(0) @ qp.PauliX(1)
-        YY = qp.PauliY(0) @ qp.PauliY(1)
-        ZZ = qp.PauliZ(0) @ qp.PauliZ(1)
+        with qp.queuing.AnnotatedQueue() as q:
+            XX = qp.PauliX(0) @ qp.PauliX(1)
+            YY = qp.PauliY(0) @ qp.PauliY(1)
+            ZZ = qp.PauliZ(0) @ qp.PauliZ(1)
 
-        H = 2 * XX + f1 * YY + f2 * ZZ
+            H = 2 * XX + f1 * YY + f2 * ZZ
+
+        assert len(q.queue) == 1
+        assert q.queue[0] == H
 
         coeffs = [2, f1, f2]
         ops = [XX, YY, ZZ]
@@ -284,11 +288,15 @@ class TestInteractionWithOperators:
         """Test that a Hamiltonian and SProd can be added to a ParametrizedHamiltonian, and
         will be incorporated in the H_fixed term, with their coefficients included in H_coeffs_fixed
         """
-        pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
+        with qp.queuing.AnnotatedQueue() as q:
+            pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
+            # Adding on the right
+            new_pH = pH + H
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_pH
+
         pH_fixed = qp.s_prod(2, qp.PauliZ(2))
         params = [1, 2]
-        # Adding on the right
-        new_pH = pH + H
         qp.assert_equal(pH.H_fixed(), pH_fixed)
         qp.assert_equal(new_pH.H_fixed(), sum((pH_fixed, qp.s_prod(coeff, qp.PauliZ(0)))))
         assert new_pH.coeffs_fixed == [2, coeff]
@@ -296,8 +304,14 @@ class TestInteractionWithOperators:
             new_pH(params, t=0.5).matrix(),
             qp.matrix(pH(params, t=0.5) + H, wire_order=new_pH.wires),
         )
-        # Adding on the left
-        new_pH = H + pH
+
+        with qp.queuing.AnnotatedQueue() as q:
+            pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
+            # Adding on the left
+            new_pH = H + pH
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_pH
+
         qp.assert_equal(pH.H_fixed(), pH_fixed)
         qp.assert_equal(new_pH.H_fixed(), sum((qp.s_prod(coeff, qp.PauliZ(0)), pH_fixed)))
         assert new_pH.coeffs_fixed == [coeff, 2]
@@ -310,16 +324,24 @@ class TestInteractionWithOperators:
     def test_add_other_operators(self, op):
         """Test that a Hamiltonian, SProd, Tensor or Operator can be added to a
         ParametrizedHamiltonian, and will be incorporated in the H_fixed term"""
-        pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
-        pH_fixed = qp.s_prod(2, qp.PauliZ(2))
+        with qp.queuing.AnnotatedQueue() as q:
+            pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
 
-        # Adding on the right
-        new_pH = pH + op
+            # Adding on the right
+            new_pH = pH + op
+
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_pH
+        pH_fixed = qp.s_prod(2, qp.PauliZ(2))
         qp.assert_equal(pH.H_fixed(), pH_fixed)
         qp.assert_equal(new_pH.H_fixed(), sum((pH_fixed, qp.s_prod(1, op))))
 
-        # Adding on the left
-        new_pH = op + pH
+        with qp.queuing.AnnotatedQueue() as q:
+            pH = ParametrizedHamiltonian([f1, f2, 2], [qp.PauliX(0), qp.PauliY(1), qp.PauliZ(2)])
+            # Adding on the left
+            new_pH = op + pH
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_pH
         qp.assert_equal(pH.H_fixed(), pH_fixed)
         qp.assert_equal(new_pH.H_fixed(), sum((qp.s_prod(1, op), pH_fixed)))
 
@@ -336,8 +358,12 @@ class TestInteractionWithOperators:
 
     def test_multiply_with_scalar(self):
         """Test the __mul__ dunder method with a scalar."""
-        H = ParametrizedHamiltonian([f1, f2], [qp.PauliX(0), qp.PauliY(1)])
-        new_H = 3 * H
+        with qp.queuing.AnnotatedQueue() as q:
+            H = ParametrizedHamiltonian([f1, f2], [qp.PauliX(0), qp.PauliY(1)])
+            new_H = 3 * H
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_H
+
         expected_H = ParametrizedHamiltonian(
             [lambda p, t: 3 * f1(p, t), lambda p, t: 3 * f2(p, t)], [qp.PauliX(0), qp.PauliY(1)]
         )
@@ -358,11 +384,15 @@ class TestInteractionWithOperators:
     def test_adding_two_parametrized_hamiltonians(self):
         """Test that two ParametrizedHamiltonians can be added together and
         the H_fixed and H_parametrized terms are correctly combined."""
-        pH1 = ParametrizedHamiltonian([1.2, f2], [qp.PauliX(0), qp.PauliY(1)])
-        pH2 = ParametrizedHamiltonian([2.3, f1], [qp.Hadamard(2), qp.PauliZ(3)])
+        with qp.queuing.AnnotatedQueue() as q:
+            pH1 = ParametrizedHamiltonian([1.2, f2], [qp.PauliX(0), qp.PauliY(1)])
+            pH2 = ParametrizedHamiltonian([2.3, f1], [qp.Hadamard(2), qp.PauliZ(3)])
+            new_pH = pH1 + pH2
+
+        assert len(q.queue) == 1
+        assert q.queue[0] == new_pH
 
         # H_fixed now contains the fixed terms from both pH1 and pH2
-        new_pH = pH1 + pH2
         qp.assert_equal(new_pH.H_fixed()[0], pH1.H_fixed())
         qp.assert_equal(new_pH.H_fixed()[1], pH2.H_fixed())
 
@@ -374,7 +404,10 @@ class TestInteractionWithOperators:
     def test_fn_times_observable_creates_parametrized_hamiltonian(self):
         """Test a ParametrizedHamiltonian can be created by multiplying a
         function and an Observable"""
-        pH = f1 * qp.PauliX(0)
+        with qp.queuing.AnnotatedQueue() as q:
+            pH = f1 * qp.PauliX(0)
+        assert len(q.queue) == 1
+        assert q.queue[0] == pH
         assert isinstance(pH, ParametrizedHamiltonian)
         assert len(pH.coeffs_fixed) == 0
         assert isinstance(pH.H_parametrized(param, 0.5), qp.ops.SProd)

--- a/tests/pulse/test_rydberg.py
+++ b/tests/pulse/test_rydberg.py
@@ -38,11 +38,12 @@ class TestRydbergInteraction:
     """Unit tests for the ``rydberg_interaction`` function."""
 
     def test_queuing(self):
-        """Test that the function does not queue any objects."""
+        """Test that the function only queues one Hamiltonian object."""
         with qp.queuing.AnnotatedQueue() as q:
-            rydberg_interaction(register=atom_coordinates, wires=wires, interaction_coeff=1)
+            H = rydberg_interaction(register=atom_coordinates, wires=wires, interaction_coeff=1)
 
-        assert len(q) == 0
+        assert len(q) == 1
+        assert q.queue[0] == H
 
     def test_attributes_and_number_of_terms(self):
         """Test that the attributes and the number of terms of the ``ParametrizedHamiltonian`` returned by
@@ -104,6 +105,14 @@ class TestRydbergInteraction:
 
 class TestRydbergDrive:
     """Unit tests for the ``rydberg_drive`` function"""
+
+    def test_queuing(self):
+        """Test that the function only queues one Hamiltonian object."""
+        with qp.queuing.AnnotatedQueue() as q:
+            Hd = rydberg_drive(amplitude=1, phase=2, detuning=3, wires=[1, 2])
+
+        assert len(q) == 1
+        assert q.queue[0] == Hd
 
     def test_attributes_and_number_of_terms(self):
         """Test that the attributes and the number of terms of the ``ParametrizedHamiltonian`` returned by


### PR DESCRIPTION
**Context:**
The `pulse` module contains `Operator`-like objects that do not follow the by-now-mostly-consistent convention of queuing of `Operator` objects in PennyLane.

**Description of the Change:**
Update them to adhere to the convention. In particular, `ParametrizedHamiltonian` and `HardwareHamiltonian` now de-queue their input operators and queue themselves, just like `LinearCombination`, for example. This also holds for their `__add__` and `__radd__` dunder methods.
`ParametrizedEvolution` now correctly de-queues its input Hamiltonian.

**Benefits:**
Consistent behaviour and effectively bug fix.

**Possible Drawbacks:**
Propagates breaking change from #8131 into `pulse` module.

**Related GitHub Issues:**
