### PR TITLE
fix: `get_compile_pipeline` works with QJIT'd QNodes

### DIFF
--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -606,6 +606,7 @@
 * Added a `qp.workflow.get_compile_pipeline(qnode, level)(*args, **kwargs)` function to extract the
   compile pipeline of a given QNode at a specific level.
   [(#8979)](https://github.com/PennyLaneAI/pennylane/pull/8979)
+  [(#9425)](https://github.com/PennyLaneAI/pennylane/pull/9425)
 
 * No unnecessary classical registers will be created now when using `qp.to_openqasm` with `measure_all=False`.
   [(#9033)](https://github.com/PennyLaneAI/pennylane/pull/9033)

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -140,7 +140,7 @@ def add_noise(tape, noise_model, level="user"):
             noisy_circuit = qp.noise.add_noise(circuit, noise_model)
 
         >>> from pennylane.workflow import get_compile_pipeline
-        >>> print(get_compile_pipeline(circuit)(1,2,3,4))
+        >>> print(get_compile_pipeline(circuit, level="device")(1,2,3,4))
          CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),
@@ -155,7 +155,7 @@ def add_noise(tape, noise_model, level="user"):
           [11] validate_observables(stopping_condition=..., name=default.mixed)
         )
 
-        >>> print(get_compile_pipeline(noisy_circuit)(1,2,3,4))
+        >>> print(get_compile_pipeline(noisy_circuit, level="device")(1,2,3,4))
         CompilePipeline(
           [1] cancel_inverses(),
           [2] merge_rotations(),

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -174,7 +174,8 @@ class CompilePipeline:
             qp.RX(y, wires=0)
             return qp.expval(qp.Z(1))
 
-    >>> print(circuit.compile_pipeline)
+    >>> from pennylane.workflow import get_compile_pipeline
+    >>> print(get_compile_pipeline(circuit)(0.1, 0.2))
     CompilePipeline(
        ├─▶ no-transforms
       [1] commute_controlled(),

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -79,6 +79,11 @@ def get_compile_pipeline(
 ) -> Callable[P, CompilePipeline]:
     """Create a function that produces the compilation pipeline at the designated level.
 
+    .. note::
+
+        If used on a QJIT'd QNode, only user applied transforms are accessible.
+        Consequently, ``level="gradient"`` and ``level="device"`` are not supported.
+
     Args:
         qnode (:class:`~.QNode`): The QNode to get the compilation pipeline for.
         level (str, int, slice): Specifies the stage at which to retrieve the compile pipeline. Defaults to ``"user"``.

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -130,7 +130,7 @@ def get_compile_pipeline(
     >>> print(get_compile_pipeline(circuit)(*args)) # or level="user"
     CompilePipeline(
       [1] cancel_inverses(),
-      [2] merge_rotations(),
+      [2] merge_rotations()
     )
 
     .. details::
@@ -156,10 +156,9 @@ def get_compile_pipeline(
                 qp.RX(x, wires=0)
                 return qp.expval(qp.Z(0))
 
-        By default, without specifying a ``level`` we will get the full compile pipeline that is used
-        during execution on this device. Note that this can also be retrieved by manually specifying ``level="device"``,
+        To get the full compile pipeline that is used during execution on this device we can specify ``level="device"``,
 
-        >>> print(get_compile_pipeline(circuit)(3.14)) # or level="device"
+        >>> print(get_compile_pipeline(circuit, level="device")(3.14))
         CompilePipeline(
           [1] cancel_inverses(),
            ├─▶ checkpoint

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -63,25 +63,16 @@ def _resolve_level(
         level = slice(0, num_user)
     elif level == "gradient":
         if is_qjit_qnode:
-            raise NotImplementedError("This level is not valid for QJIT'd QNodes.")
+            raise NotImplementedError(f"'level={level}' is not supported for QJIT'd QNodes.")
         level = slice(0, num_user + int(hasattr(config.gradient_method, "expand_transform")))
     elif level == "device":
         if is_qjit_qnode:
-            raise NotImplementedError("This level is not valid for QJIT'd QNodes.")
+            raise NotImplementedError(f"'level={level}' is not supported for QJIT'd QNodes.")
         # Captures everything: user + gradient + device
         level = slice(0, None)
     elif isinstance(level, str):
-        stop = _find_level(full_pipeline, level)
-        if is_qjit_qnode and stop > num_user:
-            raise NotImplementedError(
-                "This level is higher than the number of transforms available."
-            )
-        level = slice(0, stop)
+        level = slice(0, _find_level(full_pipeline, level))
     elif isinstance(level, int):
-        if is_qjit_qnode and level > num_user:
-            raise NotImplementedError(
-                "This level is higher than the number of transforms available."
-            )
         level = slice(0, level)
 
     return level

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -259,11 +259,18 @@ def get_compile_pipeline(
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> CompilePipeline:
         full_compile_pipeline = CompilePipeline()
         full_compile_pipeline += qnode.compile_pipeline
-        # NOTE: Gradient + device transforms are *not* applied to qnodes that contain informative transforms
-        resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
-        if not qnode.compile_pipeline.is_informative:
-            outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
-            full_compile_pipeline += outer_pipeline + inner_pipeline
+
+        # NOTE: Anything past user applied transforms
+        # doesn't make sense for a QJIT'd QNode.
+        resolved_config = None
+        if not is_qjit_qnode:
+            # NOTE: Gradient + device transforms are *not* applied to qnodes that contain informative transforms
+            resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
+            if not qnode.compile_pipeline.is_informative:
+                outer_pipeline, inner_pipeline = _setup_transform_program(
+                    qnode.device, resolved_config
+                )
+                full_compile_pipeline += outer_pipeline + inner_pipeline
 
         num_user = len(qnode.compile_pipeline)
         level_slice: slice = _resolve_level(

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -265,6 +265,8 @@ def get_compile_pipeline(
 
         num_user = len(qnode.compile_pipeline)
         level_slice: slice = _resolve_level(level, full_compile_pipeline, num_user, resolved_config)
-        return full_compile_pipeline[level_slice]
+        resolved_pipeline = full_compile_pipeline[level_slice]
+
+        return resolved_pipeline
 
     return wrapper

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 
 
-def catalyst_qjit(qnode):
-    """A method checking whether a qnode is compiled by catalyst.qjit"""
-    return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
+def _is_qjit(obj):
+    """A method checking whether the object is compiled by catalyst.qjit"""
+    return obj.__class__.__name__ == "QJIT" and hasattr(obj, "user_function")
 
 
 def _find_level(program: CompilePipeline, level: str) -> int:
@@ -52,8 +52,7 @@ def _resolve_level(
     level: str | int | slice,
     full_pipeline: CompilePipeline,
     num_user: int,
-    config: ExecutionConfig,
-    is_qjit_qnode: bool,
+    config: ExecutionConfig | None,
 ) -> slice:
     """Resolve level to a slice."""
 
@@ -62,12 +61,8 @@ def _resolve_level(
     elif level == "user":
         level = slice(0, num_user)
     elif level == "gradient":
-        if is_qjit_qnode:
-            raise NotImplementedError(f"'level={level}' is not supported for QJIT'd QNodes.")
         level = slice(0, num_user + int(hasattr(config.gradient_method, "expand_transform")))
     elif level == "device":
-        if is_qjit_qnode:
-            raise NotImplementedError(f"'level={level}' is not supported for QJIT'd QNodes.")
         # Captures everything: user + gradient + device
         level = slice(0, None)
     elif isinstance(level, str):
@@ -242,8 +237,10 @@ def get_compile_pipeline(
         )
 
     is_qjit_qnode = False
-    if catalyst_qjit(qnode):
+    if _is_qjit(qnode):
         qnode = qnode.user_function
+        if not hasattr(qnode, "compile_pipeline"):
+            raise ValueError("Can only retrieve the compilation pipeline of a QJIT'd QNode object.")
         is_qjit_qnode = True
 
     @wraps(qnode)
@@ -263,12 +260,11 @@ def get_compile_pipeline(
                 )
                 full_compile_pipeline += outer_pipeline + inner_pipeline
 
-        num_user = len(qnode.compile_pipeline)
-        level_slice: slice = _resolve_level(
-            level, full_compile_pipeline, num_user, resolved_config, is_qjit_qnode
-        )
-        resolved_pipeline = full_compile_pipeline[level_slice]
+        if is_qjit_qnode and isinstance(level, str) and level in ("gradient", "device"):
+            raise NotImplementedError(f"'level={level}' is not supported for QJIT'd QNodes.")
 
-        return resolved_pipeline
+        num_user = len(qnode.compile_pipeline)
+        level_slice: slice = _resolve_level(level, full_compile_pipeline, num_user, resolved_config)
+        return full_compile_pipeline[level_slice]
 
     return wrapper

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -31,6 +31,11 @@ if TYPE_CHECKING:
 P = ParamSpec("P")
 
 
+def catalyst_qjit(qnode):
+    """A method checking whether a qnode is compiled by catalyst.qjit"""
+    return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
+
+
 def _find_level(program: CompilePipeline, level: str) -> int:
     """Retrieve the numerical level associated to a marker."""
     found_level = program.get_marker_level(level)
@@ -48,6 +53,7 @@ def _resolve_level(
     full_pipeline: CompilePipeline,
     num_user: int,
     config: ExecutionConfig,
+    is_qjit_qnode: bool,
 ) -> slice:
     """Resolve level to a slice."""
 
@@ -56,13 +62,26 @@ def _resolve_level(
     elif level == "user":
         level = slice(0, num_user)
     elif level == "gradient":
+        if is_qjit_qnode:
+            raise NotImplementedError("This level is not valid for QJIT'd QNodes.")
         level = slice(0, num_user + int(hasattr(config.gradient_method, "expand_transform")))
     elif level == "device":
+        if is_qjit_qnode:
+            raise NotImplementedError("This level is not valid for QJIT'd QNodes.")
         # Captures everything: user + gradient + device
         level = slice(0, None)
     elif isinstance(level, str):
-        level = slice(0, _find_level(full_pipeline, level))
+        stop = _find_level(full_pipeline, level)
+        if is_qjit_qnode and stop > num_user:
+            raise NotImplementedError(
+                "This level is higher than the number of transforms available."
+            )
+        level = slice(0, stop)
     elif isinstance(level, int):
+        if is_qjit_qnode and level > num_user:
+            raise NotImplementedError(
+                "This level is higher than the number of transforms available."
+            )
         level = slice(0, level)
 
     return level
@@ -70,13 +89,13 @@ def _resolve_level(
 
 def get_compile_pipeline(
     qnode: QNode,
-    level: str | int | slice = "device",
+    level: str | int | slice = "user",
 ) -> Callable[P, CompilePipeline]:
     """Create a function that produces the compilation pipeline at the designated level.
 
     Args:
         qnode (:class:`~.QNode`): The QNode to get the compilation pipeline for.
-        level (str, int, slice): Specifies the stage at which to retrieve the compile pipeline. Defaults to ``"device"``.
+        level (str, int, slice): Specifies the stage at which to retrieve the compile pipeline. Defaults to ``"user"``.
 
             - ``"top"``: Returns an empty pipeline representing the initial stage before any transformations are applied.
             - ``"user"``: Only includes transformations that are manually applied by the user.
@@ -108,17 +127,10 @@ def get_compile_pipeline(
             return qp.expval(qp.Z(0))
 
     >>> args = (3.14,)
-    >>> print(get_compile_pipeline(circuit)(*args)) # or level="device"
+    >>> print(get_compile_pipeline(circuit)(*args)) # or level="user"
     CompilePipeline(
       [1] cancel_inverses(),
       [2] merge_rotations(),
-      [3] defer_measurements(allow_postselect=True),
-      [4] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-      [5] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-      [6] validate_device_wires(None, name=default.qubit),
-      [7] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-      [8] _conditional_broadcast_expand(),
-      [9] no_sampling(name=backprop + default.qubit)
     )
 
     .. details::
@@ -239,19 +251,25 @@ def get_compile_pipeline(
             f"'level={level}' of type '{type(level)}' is not supported. Please provide an integer, slice or a string as input."
         )
 
+    is_qjit_qnode = False
+    if catalyst_qjit(qnode):
+        qnode = qnode.user_function
+        is_qjit_qnode = True
+
     @wraps(qnode)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> CompilePipeline:
-        resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
-
         full_compile_pipeline = CompilePipeline()
         full_compile_pipeline += qnode.compile_pipeline
         # NOTE: Gradient + device transforms are *not* applied to qnodes that contain informative transforms
+        resolved_config = construct_execution_config(qnode, resolve=True)(*args, **kwargs)
         if not qnode.compile_pipeline.is_informative:
             outer_pipeline, inner_pipeline = _setup_transform_program(qnode.device, resolved_config)
             full_compile_pipeline += outer_pipeline + inner_pipeline
 
         num_user = len(qnode.compile_pipeline)
-        level_slice: slice = _resolve_level(level, full_compile_pipeline, num_user, resolved_config)
+        level_slice: slice = _resolve_level(
+            level, full_compile_pipeline, num_user, resolved_config, is_qjit_qnode
+        )
         resolved_pipeline = full_compile_pipeline[level_slice]
 
         return resolved_pipeline

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -245,7 +245,7 @@ def get_compile_pipeline(
     if _is_qjit(qnode):
         qnode = qnode.user_function
         if not hasattr(qnode, "compile_pipeline"):
-            raise ValueError("Can only retrieve the compilation pipeline of a QJIT'd QNode object.")
+            raise ValueError("Can only retrieve the compilation pipeline if the QJIT'd object is a QNode.")
         is_qjit_qnode = True
 
     @wraps(qnode)

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -253,6 +253,9 @@ def get_compile_pipeline(
         full_compile_pipeline = CompilePipeline()
         full_compile_pipeline += qnode.compile_pipeline
 
+        if level == "user":
+            return full_compile_pipeline
+
         # NOTE: Anything past user applied transforms
         # doesn't make sense for a QJIT'd QNode.
         resolved_config = None

--- a/pennylane/workflow/get_compile_pipeline.py
+++ b/pennylane/workflow/get_compile_pipeline.py
@@ -245,7 +245,9 @@ def get_compile_pipeline(
     if _is_qjit(qnode):
         qnode = qnode.user_function
         if not hasattr(qnode, "compile_pipeline"):
-            raise ValueError("Can only retrieve the compilation pipeline if the QJIT'd object is a QNode.")
+            raise ValueError(
+                "Can only retrieve the compilation pipeline if the QJIT'd object is a QNode."
+            )
         is_qjit_qnode = True
 
     @wraps(qnode)

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -30,6 +30,27 @@ class TestValidation:
     @pytest.mark.parametrize(
         "unsupported_level",
         (
+            "device",
+            "gradient",
+        ),
+    )
+    def test_unsupported_levels_qjit(self, unsupported_level):
+        """Tests unsupported levels when the input is QJIT'd QNode."""
+
+        @qp.qjit
+        @qp.qnode(qp.device("null.qubit", wires=2))
+        def circuit():
+            return qp.expval(qp.Z(0))
+
+        with pytest.raises(
+            NotImplementedError,
+            match=re.escape(f"'level={unsupported_level}' is not supported for QJIT'd QNodes."),
+        ):
+            _ = get_compile_pipeline(circuit, level=unsupported_level)()
+
+    @pytest.mark.parametrize(
+        "unsupported_level",
+        (
             [0],
             [0, 1],
             (0,),

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -375,6 +375,32 @@ def test_level_is_integer(level, use_qjit):
         assert cp == CompilePipeline(qp.transforms.cancel_inverses, qp.transforms.merge_rotations)
 
 
+@pytest.mark.external
+@pytest.mark.catalyst
+@pytest.mark.parametrize("level_slice", [slice(2, 5), slice(2, None), slice(None, 3)])
+def test_level_is_slice_qjit(level_slice):
+    """Tests level is slice when using qjit."""
+
+    user_pipeline = CompilePipeline(
+        qp.decompose,
+        qp.transforms.cancel_inverses,
+        qp.transforms.merge_rotations,
+    )
+
+    @qp.qjit
+    @user_pipeline
+    @qp.qnode(
+        qp.device("null.qubit"),
+    )
+    def circuit():
+        qp.X(0)
+        return qp.expval(qp.Z(0))
+
+    sliced_cp = get_compile_pipeline(circuit, level=level_slice)()
+    full_cp = user_pipeline
+    assert full_cp[level_slice] == sliced_cp
+
+
 @pytest.mark.parametrize("level_slice", [slice(2, 5), slice(2, None), slice(None, 3)])
 def test_level_is_slice(level_slice):
     """Tests that slice levels are correctly handled."""

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -27,6 +27,8 @@ from pennylane.workflow import get_compile_pipeline
 class TestValidation:
     """Tests for validation errors."""
 
+    @pytest.mark.external
+    @pytest.mark.catalyst
     @pytest.mark.parametrize(
         "unsupported_level",
         (
@@ -86,7 +88,9 @@ class TestValidation:
             _ = get_compile_pipeline(circuit, level="my_marker")()
 
 
-@pytest.mark.parametrize("use_qjit", [False, True])
+@pytest.mark.parametrize(
+    "use_qjit", [False, pytest.param(True, marks=[pytest.mark.external, pytest.mark.catalyst])]
+)
 class TestUserLevel:
     """Tests 'user' level transforms."""
 

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -65,29 +65,33 @@ class TestValidation:
             _ = get_compile_pipeline(circuit, level="my_marker")()
 
 
+@pytest.mark.parametrize("use_qjit", [False, True])
 class TestUserLevel:
     """Tests 'user' level transforms."""
 
-    def test_user_level_pipeline(self):
+    def test_user_level_pipeline(self, use_qjit):
         """Tests the contents of a user level pipeline."""
 
-        dev = qp.device("reference.qubit")
+        dev = qp.device("null.qubit")
 
-        @qp.transforms.merge_rotations(atol=1e-5)
+        @qp.transforms.merge_rotations
         @qp.transforms.cancel_inverses
         @qp.qnode(dev)
         def circuit():
             return qp.expval(qp.Z(0))
+
+        if use_qjit:
+            circuit = qp.qjit(circuit)
 
         cp = get_compile_pipeline(circuit, level="user")()
         assert len(cp) == 2
         assert cp[0].tape_transform == qp.transforms.cancel_inverses.tape_transform
         assert cp[1].tape_transform == qp.transforms.merge_rotations.tape_transform
 
-    def test_user_level_with_final_transform(self):
+    def test_user_level_with_final_transform(self, use_qjit):
         """Tests that a final transform is correctly re-appended."""
 
-        dev = qp.device("reference.qubit")
+        dev = qp.device("null.qubit")
 
         @qp.gradients.metric_tensor
         @qp.transforms.merge_rotations(atol=1e-5)
@@ -95,6 +99,9 @@ class TestUserLevel:
         @qp.qnode(dev)
         def circuit():
             return qp.expval(qp.Z(0))
+
+        if use_qjit:
+            circuit = qp.qjit(circuit)
 
         cp = get_compile_pipeline(circuit, level="user")()
 
@@ -104,13 +111,16 @@ class TestUserLevel:
         assert cp[2].tape_transform == qp.gradients.metric_tensor.expand_transform
         assert cp[3].tape_transform == qp.gradients.metric_tensor.tape_transform
 
-    def test_no_user_levels(self):
+    def test_no_user_levels(self, use_qjit):
         """Ensures an empty compile pipeline if no user transforms."""
-        dev = qp.device("reference.qubit")
+        dev = qp.device("null.qubit")
 
         @qp.qnode(dev)
         def circuit():
             return qp.expval(qp.Z(0))
+
+        if use_qjit:
+            circuit = qp.qjit(circuit)
 
         cp = get_compile_pipeline(circuit, level="user")()
 

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -302,50 +302,68 @@ class TestDeviceLevel:
         assert cp[2:] == expected_cp[2:]
 
 
-def test_marker_level():
+@pytest.mark.parametrize(
+    "use_qjit", [False, pytest.param(True, marks=[pytest.mark.external, pytest.mark.catalyst])]
+)
+def test_marker_level(use_qjit):
     """Tests that a string corresponding to a marker level can be used."""
 
-    dev = qp.device("reference.qubit")
+    dev = qp.device("null.qubit")
 
     @qp.transforms.merge_rotations
     @qp.marker("blah")
     @qp.transforms.cancel_inverses
-    @qp.qnode(dev, diff_method="parameter-shift")
+    @qp.qnode(dev)
     def circuit():
         return qp.expval(qp.Z(0))
+
+    if use_qjit:
+        circuit = qp.qjit(circuit)
 
     cp = get_compile_pipeline(circuit, level="blah")()
     assert len(cp) == 1
     assert cp[0].tape_transform == qp.transforms.cancel_inverses.tape_transform
 
 
-def test_level_is_top():
+@pytest.mark.parametrize(
+    "use_qjit", [False, pytest.param(True, marks=[pytest.mark.external, pytest.mark.catalyst])]
+)
+def test_level_is_top(use_qjit):
     """Tests that level is top returns an empty pipeline."""
 
-    dev = qp.device("reference.qubit")
-
-    @qp.transforms.merge_rotations(atol=1e-5)
-    @qp.transforms.cancel_inverses
-    @qp.qnode(dev)
-    def circuit():
-        return qp.expval(qp.Z(0))
-
-    cp = get_compile_pipeline(circuit, level="top")()
-    assert cp == CompilePipeline()
-
-
-@pytest.mark.parametrize("level", [0, 1, 2])
-def test_level_is_integer(level):
-    """Tests that levels can be integers corresponding to their position
-    in the compile pipeline."""
-
-    dev = qp.device("reference.qubit")
+    dev = qp.device("null.qubit")
 
     @qp.transforms.merge_rotations
     @qp.transforms.cancel_inverses
     @qp.qnode(dev)
     def circuit():
         return qp.expval(qp.Z(0))
+
+    if use_qjit:
+        circuit = qp.qjit(circuit)
+
+    cp = get_compile_pipeline(circuit, level="top")()
+    assert cp == CompilePipeline()
+
+
+@pytest.mark.parametrize(
+    "use_qjit", [False, pytest.param(True, marks=[pytest.mark.external, pytest.mark.catalyst])]
+)
+@pytest.mark.parametrize("level", [0, 1, 2])
+def test_level_is_integer(level, use_qjit):
+    """Tests that levels can be integers corresponding to their position
+    in the compile pipeline."""
+
+    dev = qp.device("null.qubit")
+
+    @qp.transforms.merge_rotations
+    @qp.transforms.cancel_inverses
+    @qp.qnode(dev)
+    def circuit():
+        return qp.expval(qp.Z(0))
+
+    if use_qjit:
+        circuit = qp.qjit(circuit)
 
     cp = get_compile_pipeline(circuit, level=level)()
 

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -29,6 +29,21 @@ class TestValidation:
 
     @pytest.mark.external
     @pytest.mark.catalyst
+    def test_input_is_not_qjit_qnode(self):
+        """Tests when the input is QJIT'd but not a qnode."""
+
+        @qp.qjit
+        def inc(x):
+            return x + 1
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Can only retrieve the compilation pipeline of a QJIT'd QNode object."),
+        ):
+            _ = get_compile_pipeline(inc)()
+
+    @pytest.mark.external
+    @pytest.mark.catalyst
     @pytest.mark.parametrize(
         "unsupported_level",
         (

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -109,6 +109,28 @@ class TestValidation:
 class TestUserLevel:
     """Tests 'user' level transforms."""
 
+    def test_user_level_pipeline_with_markers(self, use_qjit):
+        """Tests that markers are properly retained."""
+
+        dev = qp.device("null.qubit")
+
+        pipeline = CompilePipeline()
+        pipeline += qp.transforms.merge_rotations
+        pipeline.add_marker("after-merge-rotations")
+        pipeline += qp.transforms.cancel_inverses
+        pipeline.add_marker("after-cancel-inverses")
+
+        @pipeline
+        @qp.qnode(dev)
+        def circuit():
+            return qp.expval(qp.Z(0))
+
+        if use_qjit:
+            circuit = qp.qjit(circuit)
+
+        cp = get_compile_pipeline(circuit, level="user")()
+        assert cp == pipeline
+
     def test_user_level_pipeline(self, use_qjit):
         """Tests the contents of a user level pipeline."""
 

--- a/tests/workflow/test_get_compile_pipeline.py
+++ b/tests/workflow/test_get_compile_pipeline.py
@@ -38,7 +38,9 @@ class TestValidation:
 
         with pytest.raises(
             ValueError,
-            match=re.escape("Can only retrieve the compilation pipeline of a QJIT'd QNode object."),
+            match=re.escape(
+                "Can only retrieve the compilation pipeline if the QJIT'd object is a QNode."
+            ),
         ):
             _ = get_compile_pipeline(inc)()
 


### PR DESCRIPTION
**Context:**

`get_compile_pipeline` should work on QNodes that have been wrapped with `qp.qjit`. 

**Description of the Change:**

- `get_compile_pipeline` is modified as follows:
   - Update default to `level="user"` rather than `level="device"`
       - Not a user breaking change as this feature was added in this development cycle and we don't use this functionality anywhere else
       - This ensures it supports both QNodes and QJIT'd QNodes by default
       - Aligns with other tools like `construct_tape`
   - Add support for QJIT'd QNode as input
       - Will only be able to return the compile pipeline representing user applied transforms/passes
       - Will raise `NotImplementedError` when `level="gradient"` and `"device"` as it is not supported ATM
- Adjust any doc-string using `.compile_pipeline` to use our more "user-facing" `get_compile_pipeline` 
   - Ensures there is no confusion if a user tries to run the example with `qp.qjit`

**Benefits:**

Clearer API usage and less confusion for the reader.

**Possible Drawbacks:**

None identified.

[sc-118635]
