### PR TITLE
`DecompCollection` related documentation fix

### DIFF
--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -100,7 +100,7 @@
   of how many markers are present.
   Additionally, markers can now be added directly to a :class:`~.CompilePipeline` with the `add_marker` method, and the
   pipeline's string representation now shows both transforms and markers.
-  The `CompilePipeline` object also now has an improved `__str__`, `__repr__` and `_ipython_display_` allowing improved inspectibility.
+  The `CompilePipeline` object also now has an improved `__str__`, `__repr__` and `_ipython_display_` allowing improved inspectability.
   [(#8990)](https://github.com/PennyLaneAI/pennylane/pull/8990)
   [(#9007)](https://github.com/PennyLaneAI/pennylane/pull/9007)
   [(#9076)](https://github.com/PennyLaneAI/pennylane/pull/9076)
@@ -281,7 +281,7 @@
   new graph-based decomposition system.
   [(#9056)](https://github.com/PennyLaneAI/pennylane/pull/9056)
 
-* The inspectibility of general symbolic decomposition rules is improved. The string representation of a decomposition rule
+* The inspectability of general symbolic decomposition rules is improved. The string representation of a decomposition rule
   is by default its source code. Now for symbolic decomposition rules that wrap a base decomposition rule, the source code
   for the base decomposition rule is also displayed when printing this rule.
   [(#9305)](https://github.com/PennyLaneAI/pennylane/pull/9305)

--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -362,6 +362,7 @@
   for a concrete operator instance.
   [(#9322)](https://github.com/PennyLaneAI/pennylane/pull/9322)
   [(#9359)](https://github.com/PennyLaneAI/pennylane/pull/9359)
+  [(#9427)](https://github.com/PennyLaneAI/pennylane/pull/9427)
 
   ```pycon
   >>> qp.inspect_decomps(qp.CRX(0.5, wires=[0, 1]))

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -493,7 +493,7 @@ class DecompositionRule:
 class DecompCollection:
     """An ordered, name-addressable collection of :class:`~.DecompositionRule` objects.
 
-    A ``DecompCollection`` is most commonly returned by :func:`~pennylane.list_decomps`, which
+    A ``DecompCollection`` is exclusively returned by :func:`~pennylane.list_decomps`, which
     retrieves all registered decomposition rules for a given operator. Each rule in the collection
     has a unique name (derived from the decorated function name by default, or explicitly set via
     :func:`~pennylane.register_resources` with ``name="..."``).

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -491,13 +491,64 @@ class DecompositionRule:
 
 
 class DecompCollection:
-    """A collection of decomposition rules.
+    """An ordered, name-addressable collection of :class:`~pennylane.DecompositionRule` objects.
 
-    The :func:`~pennylane.list_decomps` function returns a ``DecompCollection`` for an operator,
-    which is an ordered sequence of decomposition rules. Individual decomposition rules within a
-    collection can be accessed by index or by name.
+    A ``DecompCollection`` is most commonly returned by :func:`~pennylane.list_decomps`, which
+    retrieves all registered decomposition rules for a given operator. Each rule in the collection
+    has a unique name (derived from the decorated function name by default, or explicitly set via
+    :func:`~pennylane.register_resources` with ``name="..."``).
 
-    .. seealso:: :func:`~pennylane.list_decomps`
+    Individual rules can be accessed by integer index or by string name. The collection supports
+    :func:`len`, iteration, membership checks (by name or by :class:`~pennylane.DecompositionRule`
+    instance), :meth:`copy`, :meth:`append`, :meth:`extend`, ``+``, and ``+=``.  Duplicate names
+    within a collection are rejected with a ``ValueError``.
+
+    .. important::
+
+        A ``DecompCollection`` returned by :func:`~pennylane.list_decomps` is a **copy** of the
+        internally registered rules.  Mutating it (e.g. with :meth:`append` or :meth:`extend`)
+        does **not** update the global decomposition registry.  Use :func:`~pennylane.add_decomps`
+        to register new decomposition rules globally.
+
+    .. seealso::
+
+        :class:`~pennylane.DecompositionRule`,
+        :func:`~pennylane.register_resources`,
+        :func:`~pennylane.list_decomps`,
+        :func:`~pennylane.add_decomps`,
+        :func:`~pennylane.inspect_decomps`
+
+    **Examples**
+
+    Retrieve and explore decomposition rules for an operator:
+
+    >>> import pennylane as qp
+    >>> decomps = qp.list_decomps(qp.CRX)
+    >>> len(decomps)
+    4
+    >>> print(decomps)
+    Available Decomposition Rules:
+    0: _crx_to_rx_cz
+    1: _crx_to_rz_ry
+    2: _crx_to_h_crz
+    3: _crx_to_ppr
+
+    Access rules by index or by name:
+
+    >>> decomps[0]
+    DecompositionRule(name=_crx_to_rx_cz)
+    >>> decomps["_crx_to_ppr"]
+    DecompositionRule(name=_crx_to_ppr)
+
+    Check membership:
+
+    >>> "_crx_to_ppr" in decomps
+    True
+
+    Iterate through rule names:
+
+    >>> [rule.name for rule in decomps]
+    ['_crx_to_rx_cz', '_crx_to_rz_ry', '_crx_to_h_crz', '_crx_to_ppr']
 
     """
 
@@ -673,6 +724,9 @@ def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
 
     Returns:
         DecompCollection: a collection of decomposition rules registered for the given operator.
+            The returned :class:`~pennylane.DecompCollection` is a **copy** of the registered
+            rules.  Mutating it does not update the global decomposition registry; use
+            :func:`~pennylane.add_decomps` to register rules globally.
 
     **Example**
 

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -522,7 +522,6 @@ class DecompCollection:
 
     Retrieve and explore decomposition rules for an operator:
 
-    >>> import pennylane as qp
     >>> decomps = qp.list_decomps(qp.CRX)
     >>> len(decomps)
     4

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -922,7 +922,7 @@ def inspect_decomps(
             which puts no constraint on the maximum number of work wires.
 
     Returns:
-        _DecompInfoCollection: a displayable object with information about decomposition rules.
+        a displayable object with information about decomposition rules.
 
     **Example**
 

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -491,7 +491,7 @@ class DecompositionRule:
 
 
 class DecompCollection:
-    """An ordered, name-addressable collection of :class:`~pennylane.DecompositionRule` objects.
+    """An ordered, name-addressable collection of :class:`~.DecompositionRule` objects.
 
     A ``DecompCollection`` is most commonly returned by :func:`~pennylane.list_decomps`, which
     retrieves all registered decomposition rules for a given operator. Each rule in the collection
@@ -499,7 +499,7 @@ class DecompCollection:
     :func:`~pennylane.register_resources` with ``name="..."``).
 
     Individual rules can be accessed by integer index or by string name. The collection supports
-    :func:`len`, iteration, membership checks (by name or by :class:`~pennylane.DecompositionRule`
+    :func:`len`, iteration, membership checks (by name or by :class:`~.DecompositionRule`
     instance), :meth:`copy`, :meth:`append`, :meth:`extend`, ``+``, and ``+=``.  Duplicate names
     within a collection are rejected with a ``ValueError``.
 

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -512,7 +512,7 @@ class DecompCollection:
 
     .. seealso::
 
-        :class:`~pennylane.DecompositionRule`,
+        :class:`~.DecompositionRule`,
         :func:`~pennylane.register_resources`,
         :func:`~pennylane.list_decomps`,
         :func:`~pennylane.add_decomps`,
@@ -723,9 +723,12 @@ def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
 
     Returns:
         DecompCollection: a collection of decomposition rules registered for the given operator.
-            The returned :class:`~pennylane.DecompCollection` is a **copy** of the registered
-            rules.  Mutating it does not update the global decomposition registry; use
-            :func:`~pennylane.add_decomps` to register rules globally.
+
+    .. important::
+
+        The returned :class:`~.DecompCollection` is a **copy** of the registered
+        rules.  Mutating it does not update the global decomposition registry; use
+        :func:`~pennylane.add_decomps` to register rules globally.
 
     **Example**
 

--- a/pennylane/transforms/core/compile_pipeline.py
+++ b/pennylane/transforms/core/compile_pipeline.py
@@ -158,7 +158,7 @@ class CompilePipeline:
             qp.transforms.cancel_inverses(recursive=True),
             qp.transforms.merge_rotations,
         )
-        # Add a marker for inspectibility
+        # Add a marker for inspectability
         pipeline.add_marker("no-transforms", 0)
 
         @pipeline

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -226,7 +226,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     fixed_decomps: dict | None = None,
     alt_decomps: dict | None = None,
 ) -> tuple[QuantumScriptBatch, PostprocessingFn]:
-    """Inspect the decomposition graph solved with a given circuit.
+    """Returns a :class:`DecompGraphInspector` for querying the decomposition decisions made
+    for a given circuit and target gate set.
 
     .. note::
 


### PR DESCRIPTION
This PR I'll focus on improving the documentation for the epic Improved Decomposition Accessibility, which primarily focused on improving user's experience with `list_decomps`, `show_decomp`, and new classes `DecompCollection` as public API.

Todo list:
 - [x] Documentation of `DecompCollection` directs to `DecompositionRule` instead of merely re-directing back to `list_decomps`
 - [x] `decomp_inspector` self-states as a decorator instead of a typical method/function
 - [x] `inspectibility` -> `inspectability`
