### PR TITLE
DecompInspector: informative error message with gate set

### DIFF
--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -394,6 +394,7 @@
 * A new function :func:`~.transforms.decomp_inspector` that allows users to inspect how the decomposition
   graph is choosing decomposition rules for each operator in the circuit has been added.
   [(#9359)](https://github.com/PennyLaneAI/pennylane/pull/9359)
+  [(#9436)](https://github.com/PennyLaneAI/pennylane/pull/9436)
 
   ```python
   qp.decomposition.enable_graph()

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -163,6 +163,9 @@ class DecompGraphInspector:
 
         op_node_idx = self._decomp_graph._all_op_indices[op_node]
         decomp_indices = self._raw_graph.predecessor_indices(op_node_idx)
+        if decomp_indices == [0]:
+            msg = "The operator does not have decompositions as it is in the target gate set."
+            return _DecompInGraphInfoCollection([], override_txt=msg)
 
         chosen_idx = None
         rule_infos = []

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -163,6 +163,7 @@ class DecompGraphInspector:
 
         op_node_idx = self._decomp_graph._all_op_indices[op_node]
         decomp_indices = self._raw_graph.predecessor_indices(op_node_idx)
+        # 0 is the index of the dummy starter node that connects to all ops in the gate set.
         if decomp_indices == [0]:
             msg = "The operator does not have decompositions as it is in the target gate set."
             return _DecompInGraphInfoCollection([], override_txt=msg)

--- a/pennylane/workflow/_capture_qnode.py
+++ b/pennylane/workflow/_capture_qnode.py
@@ -497,7 +497,6 @@ def capture_qnode(qnode: "qp.QNode", *args, **kwargs) -> "qp.typing.Result":
             return 2 * expval_z + probs
 
         jaxpr = jax.make_jaxpr(f)(0.1)
-        res = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.7)
 
     >>> print(jaxpr)
     { lambda ; a:f64[]. let
@@ -518,9 +517,6 @@ def capture_qnode(qnode: "qp.QNode", *args, **kwargs) -> "qp.typing.Result":
         i:f64[] = mul 2.0:f64[] c
         j:f64[2] = add i d
       in (j,) }
-
-    >>> print(res)
-    [Array([-0.956..., -0.365...], dtype=float64)]
 
 
     """

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -306,3 +306,17 @@ class TestInspectDecompGraph:
             Full Expansion Gates: {GlobalPhase: 1, RZ: 4, RX: 1}
             Weighted Cost: 6.0
             """).strip()
+
+    def test_gate_set(self):
+        """Tests that the output is correct when querying an op in the gate set."""
+
+        @decomp_inspector(gate_set={"RZ", "RX", "CNOT", "GlobalPhase"})
+        @qp.qnode(qp.device("default.qubit"))
+        def circuit():
+            qp.CNOT([0, 1])
+            return qp.probs()
+
+        inspector = circuit()
+
+        msg = "The operator does not have decompositions as it is in the target gate set."
+        assert str(inspector.inspect_decomps(qp.CNOT([0, 1]))) == msg


### PR DESCRIPTION
**Context:**
The ``decomp_inspector`` raises an error when the op being inspected is in the target gate set, because it doesn't have a decomposition in the graph.

**Description of the Change:**
Add special handling for this case to display a meaningful message.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
