### PR TITLE
Clarifications in transforms docstrings

### DIFF
--- a/pennylane/transforms/combine_global_phases.py
+++ b/pennylane/transforms/combine_global_phases.py
@@ -66,9 +66,13 @@ def combine_global_phases(tape: QuantumScript) -> tuple[QuantumScriptBatch, Post
     .. details::
         :title: Usage with qjit
 
-        When used with ``qjit``, the ``combine_global_phases`` compilation pass will merge
-        operations surrounding control flow together, while those within the control flow are merged
-        together separately (i.e., no formal loop-boundary optimizations).
+        There are two key differences to note when using ``combine_global_phases`` with ``qjit``:
+
+        * ``combine_global_phases`` must be applied to a QNode. Quantum functions are not supported as input.
+
+        * When used with ``qjit``, the ``combine_global_phases`` compilation pass will merge
+          operations surrounding control flow together, while those within the control flow are merged
+          together separately (i.e., no formal loop-boundary optimizations).
 
         Consider the following example:
 

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -57,7 +57,7 @@ def compile(
       (:func:`~pennylane.transforms.merge_rotations`)
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
         pipeline (Sequence[transform]): A list of
             tape and/or quantum function transforms to apply.
             The default ``pipeline`` applies the following transforms:

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -381,7 +381,7 @@ def decompose(
         :doc:`Compiling Circuits page </introduction/compiling_circuits>`.
 
     Args:
-        tape (QuantumScript or QNode or Callable): a quantum circuit.
+        tape (QuantumScript or QNode or Callable): A quantum circuit (QNode or quantum function).
         gate_set (Iterable[str or type], Dict[type or str, float], optional): The
             target gate set specified as either (1) a sequence of operator types and/or names,
             (2) a dictionary mapping operator types and/or names to their respective costs, in
@@ -615,7 +615,6 @@ def decompose(
         0: ────╭●───────────╭●─┤  <Z>
         1: ──H─╰RZ(0.10)──H─├●─┤
         2: ─────────────────╰X─┤
-
 
         Here, when the Hadamard and ``CRZ`` have relatively high weights, a decomposition involving them is considered
         *less* efficient. When they have relatively low weights, a decomposition involving them is considered *more*

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -331,7 +331,7 @@ def cancel_inverses(
     (self-)inverses or adjoint.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
         recursive (bool): Whether or not to recursively cancel inverses after a first pair of mutual inverses has been cancelled. Enabled by default.
 
             .. note::
@@ -374,49 +374,11 @@ def cancel_inverses(
     2: ──RX(0.10)──RX(0.20)─╰X─┤
 
     .. details::
-        :title: Usage Details
-
-        You can also apply it on quantum functions:
-
-        .. code-block:: python
-
-            def qfunc(x, y, z):
-                qp.Hadamard(wires=0)
-                qp.Hadamard(wires=1)
-                qp.Hadamard(wires=0)
-                qp.RX(x, wires=2)
-                qp.RY(y, wires=1)
-                qp.X(1)
-                qp.RZ(z, wires=0)
-                qp.RX(y, wires=2)
-                qp.CNOT(wires=[0, 2])
-                qp.X(1)
-                return qp.expval(qp.Z(0))
-
-        The circuit before optimization:
-
-        >>> qnode = qp.QNode(qfunc, dev)
-        >>> print(qp.draw(qnode)(1, 2, 3))
-        0: ──H─────────H─────────RZ(3.00)─╭●────┤  <Z>
-        1: ──H─────────RY(2.00)──X────────│───X─┤
-        2: ──RX(1.00)──RX(2.00)───────────╰X────┤
-
-        We can see that there are two adjacent Hadamards on the first qubit that
-        should cancel each other out. Similarly, there are two Pauli-X gates on the
-        second qubit that should cancel. We can obtain a simplified circuit by running
-        the ``cancel_inverses`` transform:
-
-        >>> optimized_qfunc = qp.transforms.cancel_inverses(qfunc)
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)(1, 2, 3))
-        0: ──RZ(3.00)───────────╭●─┤  <Z>
-        1: ──H─────────RY(2.00)─│──┤
-        2: ──RX(1.00)──RX(2.00)─╰X─┤
-
-    .. details::
         :title: Usage with qjit
 
-        There are two key differences to note when using ``cancel_inverses`` with ``qjit``:
+        There are three key differences to note when using ``cancel_inverses`` with ``qjit``:
+
+        * ``cancel_inverses`` must be applied to a QNode. Quantum functions are not supported as input.
 
         * The ``recursive`` argument is not supoprted, and an error will be raised if a value for ``recursive`` is specified.
 

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -364,6 +364,7 @@ def cancel_inverses(
 
     The circuit before optimization:
 
+    >>> dev = qp.device("default.qubit")
     >>> qnode = qp.QNode(qfunc, dev)
     >>> print(qp.draw(qnode)(1, 2, 3))
     0: ──H─────────H─────────RZ(3.00)─╭●────┤  <Z>

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -344,18 +344,12 @@ def cancel_inverses(
 
     **Example**
 
-    You can apply the cancel inverses transform directly on :class:`~.QNode`.
 
+    You can also apply it on quantum functions:
 
     .. code-block:: python
 
-        import pennylane as qp
-
-        dev = qp.device('default.qubit', wires=3)
-
-        @qp.transforms.cancel_inverses
-        @qp.qnode(device=dev)
-        def circuit(x, y, z):
+        def qfunc(x, y, z):
             qp.Hadamard(wires=0)
             qp.Hadamard(wires=1)
             qp.Hadamard(wires=0)
@@ -368,10 +362,25 @@ def cancel_inverses(
             qp.X(1)
             return qp.expval(qp.Z(0))
 
-    >>> print(qp.draw(circuit)(0.1, 0.2, 0.3))
-    0: ──RZ(0.30)───────────╭●─┤  <Z>
-    1: ──H─────────RY(0.20)─│──┤
-    2: ──RX(0.10)──RX(0.20)─╰X─┤
+    The circuit before optimization:
+
+    >>> qnode = qp.QNode(qfunc, dev)
+    >>> print(qp.draw(qnode)(1, 2, 3))
+    0: ──H─────────H─────────RZ(3.00)─╭●────┤  <Z>
+    1: ──H─────────RY(2.00)──X────────│───X─┤
+    2: ──RX(1.00)──RX(2.00)───────────╰X────┤
+
+    We can see that there are two adjacent Hadamards on the first qubit that
+    should cancel each other out. Similarly, there are two ``X`` gates on the
+    second qubit that should cancel. We can obtain a simplified circuit by running
+    the ``cancel_inverses`` transform:
+
+    >>> optimized_qfunc = qp.transforms.cancel_inverses(qfunc)
+    >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+    >>> print(qp.draw(optimized_qnode)(1, 2, 3))
+    0: ──RZ(3.00)───────────╭●─┤  <Z>
+    1: ──H─────────RY(2.00)─│──┤
+    2: ──RX(1.00)──RX(2.00)─╰X─┤
 
     .. details::
         :title: Usage with qjit

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -376,8 +376,7 @@ def cancel_inverses(
     second qubit that should cancel. We can obtain a simplified circuit by running
     the ``cancel_inverses`` transform:
 
-    >>> optimized_qfunc = qp.transforms.cancel_inverses(qfunc)
-    >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+    >>> optimized_qnode = qp.transforms.cancel_inverses(qnode)
     >>> print(qp.draw(optimized_qnode)(1, 2, 3))
     0: ──RZ(3.00)───────────╭●─┤  <Z>
     1: ──H─────────RY(2.00)─│──┤

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -345,7 +345,7 @@ def cancel_inverses(
     **Example**
 
 
-    You can also apply it on quantum functions:
+    You can apply it on quantum functions:
 
     .. code-block:: python
 

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -328,7 +328,7 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
     r"""Quantum function transform to combine amplitude embedding templates that act on different qubits.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
 
     Returns:
         qnode (QNode) or quantum function (Callable) or tuple[List[.QuantumTape], function]: The transformed circuit as described in :func:`qp.transform <pennylane.transform>`.
@@ -360,53 +360,6 @@ def merge_amplitude_embedding(tape: QuantumScript) -> tuple[QuantumScriptBatch, 
     >>> circuit()
     array([0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j,
            0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j])
-
-    .. details::
-        :title: Usage Details
-
-        You can also apply the transform on a quantum function:
-
-        .. code-block:: python
-
-            def qfunc():
-                qp.CNOT(wires = [0,1])
-                qp.AmplitudeEmbedding([0,1], wires = 2)
-                qp.AmplitudeEmbedding([0,1], wires = 3)
-                return qp.state()
-
-        The circuit before compilation will not work because of using two amplitude embedding.
-
-        Using the transformation we can join the different amplitude embedding into a single one:
-
-        >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)())
-        0: ─╭●───┤  State
-        1: ─╰X───┤  State
-        2: ─╭|Ψ⟩─┤  State
-        3: ─╰|Ψ⟩─┤  State
-
-        You can also apply this transform on quantum functions:
-
-        .. code-block:: python
-
-            def qfunc():
-                qp.CNOT(wires = [0,1])
-                qp.AmplitudeEmbedding([0,1], wires = 2)
-                qp.AmplitudeEmbedding([0,1], wires = 3)
-                return qp.state()
-
-        This circuit will not run because there are two separate instances of ``AmplitudeEmbedding``.
-        Using the transformation we can join the different instances into a single one:
-
-        >>> optimized_qfunc = qp.transforms.merge_amplitude_embedding(qfunc)
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)())
-        0: ─╭●───┤  State
-        1: ─╰X───┤  State
-        2: ─╭|Ψ⟩─┤  State
-        3: ─╰|Ψ⟩─┤  State
-
     """
     new_operations = []
     visited_wires = set()

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -261,7 +261,7 @@ def merge_rotations(
     neither gate will be applied.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
         atol (float):
             After fusion of gates, if the fused angle :math:`\theta` is such that
             :math:`|\theta|\leq \text{atol}`, no rotation gate will be applied.
@@ -372,7 +372,9 @@ def merge_rotations(
     .. details::
         :title: Usage with qjit
 
-        There are two key differences to note when using ``merge_rotations`` with ``qjit``:
+        There are three key differences to note when using ``merge_rotations`` with ``qjit``:
+
+        * ``merge_rotations`` must be applied to a QNode. Quantum functions are not supported as input.
 
         * The ``atol`` and ``include_gates`` arguments are not available with ``merge_rotations``
           when used with ``qjit``, and an error will be raised if either arguments are specified.

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -295,6 +295,7 @@ def merge_rotations(
 
     The circuit before optimization:
 
+    >>> dev = qp.device("default.qubit")
     >>> qnode = qp.QNode(qfunc, dev)
     >>> print(qp.draw(qnode)(1, 2, 3))
     0: ──RX(1.00)──RX(2.00)─╭RZ(3.00)────────────┤  <Z>

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -279,7 +279,7 @@ def merge_rotations(
 
     **Example**
 
-    You can also apply ``merge_rotations`` to a quantum function.
+    You can apply ``merge_rotations`` to a quantum function.
 
     .. code-block:: python
 

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -305,8 +305,7 @@ def merge_rotations(
     By inspection, we can combine the two ``RX`` rotations on the first qubit.
     On the second qubit, we have a cumulative angle of 0, and the gates will cancel.
 
-    >>> optimized_qfunc = merge_rotations(qfunc)
-    >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+    >>> optimized_qnode = merge_rotations(qnode)
     >>> print(qp.draw(optimized_qnode)(1, 2, 3))
     0: ──RX(3.00)────╭RZ(3.00)─┤  <Z>
     1: ─╭●───────────│─────────┤

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -279,17 +279,11 @@ def merge_rotations(
 
     **Example**
 
-    You can apply the transform directly on :class:`QNode`
+    You can also apply ``merge_rotations`` to a quantum function.
 
     .. code-block:: python
 
-        import pennylane as qp
-
-        dev = qp.device('default.qubit', wires=3)
-
-        @qp.transforms.merge_rotations
-        @qp.qnode(device=dev)
-        def circuit(x, y, z):
+        def qfunc(x, y, z):
             qp.RX(x, wires=0)
             qp.RX(y, wires=0)
             qp.CNOT(wires=[1, 2])
@@ -299,15 +293,38 @@ def merge_rotations(
             qp.RY(-y, wires=1)
             return qp.expval(qp.Z(0))
 
-    >>> print(qp.draw(circuit)(0.1, 0.2, 0.3))
-    0: ──RX(0.30)────╭RZ(0.30)─┤  <Z>
+    The circuit before optimization:
+
+    >>> qnode = qp.QNode(qfunc, dev)
+    >>> print(qp.draw(qnode)(1, 2, 3))
+    0: ──RX(1.00)──RX(2.00)─╭RZ(3.00)────────────┤  <Z>
+    1: ─╭●─────────RY(2.00)─│──────────RY(-2.00)─┤
+    2: ─╰X─────────H────────╰●───────────────────┤
+
+    By inspection, we can combine the two ``RX`` rotations on the first qubit.
+    On the second qubit, we have a cumulative angle of 0, and the gates will cancel.
+
+    >>> optimized_qfunc = merge_rotations(qfunc)
+    >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+    >>> print(qp.draw(optimized_qnode)(1, 2, 3))
+    0: ──RX(3.00)────╭RZ(3.00)─┤  <Z>
     1: ─╭●───────────│─────────┤
     2: ─╰X─────────H─╰●────────┤
 
+    It is also possible to explicitly specify which rotations ``merge_rotations`` should
+    merge using the ``include_gates`` argument. For example, if in the above
+    circuit we wanted only to merge the "RX" gates, we could do so as follows:
+
+    >>> optimized_qfunc = merge_rotations(qfunc, include_gates=["RX"])
+    >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
+    >>> print(qp.draw(optimized_qnode)(1, 2, 3))
+    0: ──RX(3.00)───────────╭RZ(3.00)────────────┤  <Z>
+    1: ─╭●─────────RY(2.00)─│──────────RY(-2.00)─┤
+    2: ─╰X─────────H────────╰●───────────────────┤
+
+
     .. details::
         :title: Usage Details
-
-        **Merging ``Rot`` gates**
 
         When merging two :class:`~.pennylane.Rot` gates, there are a number of details to consider:
 
@@ -323,51 +340,6 @@ def merge_rotations(
 
         For a mathematical derivation of the fusion of two ``Rot`` gates, see the documentation
         of :func:`~.pennylane.transforms.single_qubit_fusion`.
-
-        **Usage on quantum functions**
-
-        You can also apply ``merge_rotations`` to a quantum function.
-
-        .. code-block:: python
-
-            def qfunc(x, y, z):
-                qp.RX(x, wires=0)
-                qp.RX(y, wires=0)
-                qp.CNOT(wires=[1, 2])
-                qp.RY(y, wires=1)
-                qp.Hadamard(wires=2)
-                qp.CRZ(z, wires=[2, 0])
-                qp.RY(-y, wires=1)
-                return qp.expval(qp.Z(0))
-
-        The circuit before optimization:
-
-        >>> qnode = qp.QNode(qfunc, dev)
-        >>> print(qp.draw(qnode)(1, 2, 3))
-        0: ──RX(1.00)──RX(2.00)─╭RZ(3.00)────────────┤  <Z>
-        1: ─╭●─────────RY(2.00)─│──────────RY(-2.00)─┤
-        2: ─╰X─────────H────────╰●───────────────────┤
-
-        By inspection, we can combine the two ``RX`` rotations on the first qubit.
-        On the second qubit, we have a cumulative angle of 0, and the gates will cancel.
-
-        >>> optimized_qfunc = merge_rotations(qfunc)
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)(1, 2, 3))
-        0: ──RX(3.00)────╭RZ(3.00)─┤  <Z>
-        1: ─╭●───────────│─────────┤
-        2: ─╰X─────────H─╰●────────┤
-
-        It is also possible to explicitly specify which rotations ``merge_rotations`` should
-        merge using the ``include_gates`` argument. For example, if in the above
-        circuit we wanted only to merge the "RX" gates, we could do so as follows:
-
-        >>> optimized_qfunc = merge_rotations(qfunc, include_gates=["RX"])
-        >>> optimized_qnode = qp.QNode(optimized_qfunc, dev)
-        >>> print(qp.draw(optimized_qnode)(1, 2, 3))
-        0: ──RX(3.00)───────────╭RZ(3.00)────────────┤  <Z>
-        1: ─╭●─────────RY(2.00)─│──────────RY(-2.00)─┤
-        2: ─╰X─────────H────────╰●───────────────────┤
 
     .. details::
         :title: Usage with qjit

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -56,7 +56,7 @@ def pattern_matching_optimization(
     r"""Quantum function transform to optimize a circuit given a list of patterns (templates).
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit to be optimized.
+        tape (QNode or QuantumTape or Callable): A quantum circuit to be optimized (QNode or quantum function).
         pattern_tapes(list(.QuantumTape)): List of quantum tapes that implement the identity.
         custom_quantum_cost (dict): Optional, quantum cost that overrides the default cost dictionary.
 

--- a/pennylane/transforms/optimization/remove_barrier.py
+++ b/pennylane/transforms/optimization/remove_barrier.py
@@ -23,7 +23,7 @@ def remove_barrier(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
     """Quantum transform to remove Barrier gates.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
 
     Returns:
         qnode (QNode) or quantum function (Callable) or tuple[List[.QuantumTape], function]: The transformed circuit as described in :func:`qp.transform <pennylane.transform>`.
@@ -72,7 +72,6 @@ def remove_barrier(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
         >>> print(qp.draw(qnode)(1, 2))
         0: ──H─╭||──X─┤  <Z>
         1: ──H─╰||────┤
-
 
         We can remove the Barrier by running the ``remove_barrier`` transform:
 

--- a/pennylane/transforms/optimization/single_qubit_fusion.py
+++ b/pennylane/transforms/optimization/single_qubit_fusion.py
@@ -273,7 +273,7 @@ def single_qubit_fusion(  # pylint: disable=too-many-branches
     (on the same qubit) with that property defined will be fused into one ``Rot``.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
         atol (float): An absolute tolerance for which to apply a rotation after
             fusion. After fusion of gates, if the fused angles :math:`\theta` are such that
             :math:`|\theta|\leq \text{atol}`, no rotation gate will be applied.

--- a/pennylane/transforms/optimization/undo_swaps.py
+++ b/pennylane/transforms/optimization/undo_swaps.py
@@ -32,7 +32,7 @@ def undo_swaps(tape: QuantumScript) -> tuple[QuantumScriptBatch, PostprocessingF
     circuit changing the position of the qubits accordingly.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
 
     Returns:
         qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape], function]: The transformed circuit as described in :func:`qp.transform <pennylane.transform>`.

--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -69,7 +69,7 @@ def transpile(
         is passed which contains these types of measurements, a ``NotImplementedError`` will be raised.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum tape (QNode or quantum function).
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
         coupling_map: Data specifying the couplings between different qubits. This data can be any format accepted by ``nx.to_networkx_graph()``,
             currently including edge list, dict of dicts, dict of lists, NetworkX graph, 2D NumPy array, SciPy sparse matrix, or PyGraphviz graph.
 

--- a/pennylane/transforms/transpile.py
+++ b/pennylane/transforms/transpile.py
@@ -69,7 +69,7 @@ def transpile(
         is passed which contains these types of measurements, a ``NotImplementedError`` will be raised.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum tape.
+        tape (QNode or QuantumTape or Callable): A quantum tape (QNode or quantum function).
         coupling_map: Data specifying the couplings between different qubits. This data can be any format accepted by ``nx.to_networkx_graph()``,
             currently including edge list, dict of dicts, dict of lists, NetworkX graph, 2D NumPy array, SciPy sparse matrix, or PyGraphviz graph.
 

--- a/pennylane/transforms/unitary_to_rot.py
+++ b/pennylane/transforms/unitary_to_rot.py
@@ -106,7 +106,7 @@ def unitary_to_rot(tape: QuantumScript) -> tuple[QuantumScriptBatch, Postprocess
         operations. See usage details below.
 
     Args:
-        tape (QNode or QuantumTape or Callable): A quantum circuit.
+        tape (QNode or QuantumTape or Callable): A quantum circuit (QNode or quantum function).
 
     Returns:
         qnode (QNode) or quantum function (Callable) or tuple[List[QuantumTape], function]: The transformed circuit as described in :func:`qp.transform <pennylane.transform>`.


### PR DESCRIPTION
**Context:** @albi3ro pointed out that there is some redundancy in some of the transforms docstrings (usage details that just show usage on quantum functions). Additionally, the usage details for using with qjit should include that they only work on QNodes.

**Description of the Change:** Remove redundant usage details and clarify in `args` instead. Where applicable, add verbiage that they only apply to QNodes with Catalyst.

**Benefits:** Clearer docstrings and less extraneous information.

**Possible Drawbacks:**

**Related GitHub Issues:**
