### PR TITLE
Three miscs docfix

### DIFF
--- a/doc/code/qp_concurrency.rst
+++ b/doc/code/qp_concurrency.rst
@@ -6,12 +6,4 @@ qp.concurrency
 .. warning::
     This module is intended for developer use only.
 
-.. autosummary::
-    :toctree: api
-
-    ~executors.get_supported_backends
-    ~executors.create_executor
-    ~executors.get_executor
-    ~executors.ExecBackends
-
 .. automodule:: pennylane.concurrency

--- a/doc/code/qp_concurrency.rst
+++ b/doc/code/qp_concurrency.rst
@@ -6,4 +6,12 @@ qp.concurrency
 .. warning::
     This module is intended for developer use only.
 
+.. autosummary::
+    :toctree: api
+
+    ~executors.get_supported_backends
+    ~executors.create_executor
+    ~executors.get_executor
+    ~executors.ExecBackends
+
 .. automodule:: pennylane.concurrency

--- a/doc/news/program_capture_sharp_bits.rst
+++ b/doc/news/program_capture_sharp_bits.rst
@@ -297,7 +297,6 @@ errors may occur. Currently, this includes:
 * :func:`~.pennylane.transforms.single_qubit_fusion`
 * :func:`~.pennylane.transforms.transpile`
 * :func:`~.pennylane.transforms.unitary_to_rot`
-* :func:`~.pennylane.transforms.transpile`
 * :func:`~.pennylane.transforms.rz_phase_gradient`
 * :func:`~.pennylane.transforms.zx.optimize_t_count`
 * :func:`~.pennylane.transforms.zx.push_hadamards`

--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -1195,7 +1195,7 @@
   a resource decomposition defined and is not in the provided ``gate_set``.
   [(#9230)](https://github.com/PennyLaneAI/pennylane/pull/9230)
 
-* Refined the documentation of :func:~.shadow_expval measurement for clarity and added instructions
+* Refined the documentation of :func:`~.shadow_expval` measurement for clarity and added instructions
   for achieving reproducible results with the seed keyword argument.
   [(#9216)](https://github.com/PennyLaneAI/pennylane/pull/9216)
 

--- a/pennylane/concurrency/__init__.py
+++ b/pennylane/concurrency/__init__.py
@@ -49,7 +49,7 @@ Support functions to query supported backends and initialize them are provided t
 
 .. currentmodule:: pennylane.concurrency.executors
 .. automodule:: pennylane.concurrency.executors
-    :noindex:
+    :members: get_supported_backends, create_executor, get_executor, ExecBackends
 
 
 Supported executors

--- a/pennylane/concurrency/__init__.py
+++ b/pennylane/concurrency/__init__.py
@@ -48,8 +48,14 @@ Local and remote function execution through an instantiated ``executor`` is avai
 Support functions to query supported backends and initialize them are provided through the following functions.
 
 .. currentmodule:: pennylane.concurrency.executors
-.. automodule:: pennylane.concurrency.executors
-    :noindex:
+
+.. autosummary::
+    :toctree: api
+
+    get_supported_backends
+    create_executor
+    get_executor
+    ExecBackends
 
 
 Supported executors

--- a/pennylane/concurrency/__init__.py
+++ b/pennylane/concurrency/__init__.py
@@ -49,7 +49,7 @@ Support functions to query supported backends and initialize them are provided t
 
 .. currentmodule:: pennylane.concurrency.executors
 .. automodule:: pennylane.concurrency.executors
-    :members: get_supported_backends, create_executor, get_executor, ExecBackends
+    :noindex:
 
 
 Supported executors

--- a/pennylane/concurrency/__init__.py
+++ b/pennylane/concurrency/__init__.py
@@ -47,6 +47,10 @@ Local and remote function execution through an instantiated ``executor`` is avai
 
 Support functions to query supported backends and initialize them are provided through the following functions.
 
+.. currentmodule:: pennylane.concurrency.executors
+.. automodule:: pennylane.concurrency.executors
+    :noindex:
+
 
 Supported executors
 ===================

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -307,7 +307,7 @@ class QNode:
         executor_backend (ExecBackends | str): The backend executor for concurrent function execution. This argument
             allows for selective control of how to run data-parallel/task-based parallel functions via a defined execution
             environment. All supported options can be queried using
-            :func:`pennylane.concurrency.executors.get_supported_backends <.concurrency.executors.get_supported_backends>`.
+            :func:`qp.concurrency.executors.get_supported_backends <.concurrency.executors.get_supported_backends>`.
             The default value is :class:`~.concurrency.executors.native.multiproc.MPPoolExec`.
 
     **Example**

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -307,7 +307,7 @@ class QNode:
         executor_backend (ExecBackends | str): The backend executor for concurrent function execution. This argument
             allows for selective control of how to run data-parallel/task-based parallel functions via a defined execution
             environment. All supported options can be queried using
-            ``pennylane.concurrency.executors.get_supported_backends``.
+            :func:`pennylane.concurrency.executors.get_supported_backends`.
             The default value is :class:`~.concurrency.executors.native.multiproc.MPPoolExec`.
 
     **Example**

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -307,7 +307,7 @@ class QNode:
         executor_backend (ExecBackends | str): The backend executor for concurrent function execution. This argument
             allows for selective control of how to run data-parallel/task-based parallel functions via a defined execution
             environment. All supported options can be queried using
-            :func:`~pennylane.concurrency.executors.get_supported_backends`.
+            :func:`pennylane.concurrency.executors.get_supported_backends <.concurrency.executors.get_supported_backends>`.
             The default value is :class:`~.concurrency.executors.native.multiproc.MPPoolExec`.
 
     **Example**

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -307,7 +307,7 @@ class QNode:
         executor_backend (ExecBackends | str): The backend executor for concurrent function execution. This argument
             allows for selective control of how to run data-parallel/task-based parallel functions via a defined execution
             environment. All supported options can be queried using
-            :func:`pennylane.concurrency.executors.get_supported_backends`.
+            :func:`~pennylane.concurrency.executors.get_supported_backends`.
             The default value is :class:`~.concurrency.executors.native.multiproc.MPPoolExec`.
 
     **Example**


### PR DESCRIPTION
1. deleted a redundant ":func:`~.pennylane.transforms.transpile`" from `doc/news/program_capture_sharp_bits.rst`
2. fixed broken `shadow_expval` link in changelog
3. fixed broken `get_supported_backends` link in qnode page