### PR TITLE
fix SProd.is_verified_hermitian with abstract coeffs

### DIFF
--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -1246,6 +1246,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * `SProd.is_verified_hermitian` can now be calculated with abstract (jax tracer) coefficients.
+  [(#9446)](https://github.com/PennyLaneAI/pennylane/pull/9446)
 
 * Fixed a bug where :func:`~.specs` would fail in multi-threaded or multi-processed settings.
   [(#9420)](https://github.com/PennyLaneAI/pennylane/pull/9420)

--- a/doc/releases/changelog-0.45.0.md
+++ b/doc/releases/changelog-0.45.0.md
@@ -1245,6 +1245,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* `SProd.is_verified_hermitian` can now be calculated with abstract (jax tracer) coefficients.
+
 * Fixed a bug where :func:`~.specs` would fail in multi-threaded or multi-processed settings.
   [(#9420)](https://github.com/PennyLaneAI/pennylane/pull/9420)
 

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -204,7 +204,7 @@ class SProd(ScalarSymbolicOp):
         if not self.base.is_verified_hermitian:
             return False
         if math.is_abstract(self.scalar):
-            return "complex" not in math.get_dtype_name(self.scalar)
+            return not math.get_dtype_name(obj).startswith("complex")
         return not math.iscomplex(self.scalar)
 
     # pylint: disable=arguments-renamed,invalid-overridden-method

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -204,7 +204,7 @@ class SProd(ScalarSymbolicOp):
         if not self.base.is_verified_hermitian:
             return False
         if math.is_abstract(self.scalar):
-            return not math.get_dtype_name(obj).startswith("complex")
+            return not math.get_dtype_name(self.scalar).startswith("complex")
         return not math.iscomplex(self.scalar)
 
     # pylint: disable=arguments-renamed,invalid-overridden-method

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -201,7 +201,11 @@ class SProd(ScalarSymbolicOp):
     def is_verified_hermitian(self):
         """If the base operator is hermitian and the scalar is real,
         then the scalar product operator is hermitian."""
-        return self.base.is_verified_hermitian and not math.iscomplex(self.scalar)
+        if not self.base.is_verified_hermitian:
+            return False
+        if math.is_abstract(self.scalar):
+            return "complex" not in math.get_dtype_name(self.scalar)
+        return not math.iscomplex(self.scalar)
 
     # pylint: disable=arguments-renamed,invalid-overridden-method
     @property

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -771,6 +771,24 @@ class TestProperties:
         sprod_op = s_prod(scalar, op)
         assert sprod_op.is_verified_hermitian == hermitian_status
 
+    @pytest.mark.jax
+    def test_is_verified_hermitian_abstract(self):
+        """Test that is_verified_hermitian works with abstract coefficients."""
+
+        import jax  # pylint: disable=import-outside-toplevel
+
+        def float_arg(x):
+            op = x * qp.X(0)
+            assert op.is_verified_hermitian
+
+        jax.jit(float_arg)(0.5)
+
+        def complex_arg(x):
+            op = x * qp.X(0)
+            assert not op.is_verified_hermitian
+
+        jax.jit(complex_arg)(jax.numpy.array(0.5 + 1.2j))
+
     @pytest.mark.tf
     def test_is_verified_hermitian_tf(self):
         """Test that is_verified_hermitian works when a tf type scalar is provided."""


### PR DESCRIPTION

**Context:**

`TrotterProduct` workflow was erroring out because `SProd.is_verified_hermitian` didn't like abstract coefficients.

`check_hermitian` on `TrotterProduct` should also really default to `False`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #9367 
