### PR TITLE
[v0.45 release] strip -rcX suffix from version in preparation for release

### DIFF
--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.45.0-rc7"
+__version__ = "0.45.0"


### PR DESCRIPTION
Ref: https://github.com/PennyLaneAI/pennylane/pull/8473/changes

[sc-119243]