### PR TITLE
BREAKING CHANGE: remove `QNode.transform_program` property

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -96,12 +96,6 @@ Pending deprecations
   - Deprecated in v0.45
   - Will be removed in v0.46
 
-* The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
-  The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
 * The ``qp.transforms.create_expand_fn`` has been deprecated and will be removed in v0.46.
   Instead, please use the :func:`qp.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
 
@@ -167,6 +161,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
+  The deprecated access through ``transform_program`` has been removed.
+
+  - Deprecated in v0.45
+  - Removed in v0.46
 
 * Maintenance support of NumPy<2.0 has been removed. PennyLane v0.45 and beyond are not guaranteed to work with NumPy<2.0.
   We recommend upgrading your version of NumPy to benefit from enhanced support and features.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -76,4 +76,5 @@ This release contains contributions from (in alphabetical order):
 Guillermo Alonso,
 Yushao Chen,
 Marcus Edwards,
+Andrija Paurevic,
 David Wierichs

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,10 @@
   
 <h3>Breaking changes 💔</h3>
 
+* The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
+  The deprecated access through `transform_program` has been removed.
+  [(#)]()
+
 <h3>Deprecations 👋</h3>
 
 <h3>Internal changes ⚙️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,7 +47,7 @@
 
 * The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
   The deprecated access through `transform_program` has been removed.
-  [(#)]()
+  [(#9465)](https://github.com/PennyLaneAI/pennylane/pull/9465)
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -653,23 +653,6 @@ class QNode:
         self._interface = Interface(value)
 
     @property
-    def transform_program(self) -> CompilePipeline:
-        """The transform program used by the QNode.
-
-        .. warning::
-
-            The ``transform_program`` property of the QNode has been renamed to ``compile_pipeline``.
-            Access through ``transform_program`` will be removed in PennyLane v0.46.
-
-        """
-        warnings.warn(
-            "The 'transform_program' property of the QNode has been renamed to 'compile_pipeline'. "
-            "Access through 'transform_program' will be removed in PennyLane v0.46.",
-            PennyLaneDeprecationWarning,
-        )
-        return self.compile_pipeline
-
-    @property
     def compile_pipeline(self) -> CompilePipeline:
         """The compile pipeline used by the QNode."""
         return self._compile_pipeline

--- a/tests/workflow/test_qnode.py
+++ b/tests/workflow/test_qnode.py
@@ -41,20 +41,6 @@ from pennylane.workflow.qnode import _make_execution_config
 from pennylane.workflow.set_shots import set_shots
 
 
-def test_transform_program_prop_is_deprecated():
-    """Tests that the deprecation warning is raised."""
-
-    @qp.qnode(qp.device("reference.qubit"))
-    def circuit():
-        return qp.expval(qp.Z(0))
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning,
-        match="The 'transform_program' property of the QNode has been renamed",
-    ):
-        _ = circuit.transform_program
-
-
 def dummyfunc():
     """dummy func."""
     return None


### PR DESCRIPTION
Standard removal post deprecation.

Deprecation doc render: https://xanaduai-pennylane--9465.com.readthedocs.build/en/9465/development/deprecations.html
Changelog render: https://xanaduai-pennylane--9465.com.readthedocs.build/en/9465/development/release_notes.html

[sc-119276]