### PR TITLE
BREAKING CHANGE: remove `id` as kwarg for various objects

### DIFF
--- a/doc/code/qp_fourier.rst
+++ b/doc/code/qp_fourier.rst
@@ -104,7 +104,7 @@ the potential expressivity of a type of ansatz.
 The theoretically supported frequencies can be computed
 using the :func:`~.pennylane.fourier.circuit_spectrum` function. To mark which gates encode
 inputs (and, for example, which ones are only used for trainable parameters), we
-have to give input-encoding gates an ``id``:
+have to use the :func:`~.pennylane.fourier.mark` helper to mark an operator with a custom tag:
 
 .. code::
 
@@ -114,8 +114,8 @@ have to give input-encoding gates an ``id``:
 
     @qp.qnode(dev)
     def simple_circuit_marked(x):
-        qp.RX(x[0], wires=0, id="x")
-        qp.RY(x[0], wires=1, id="x")
+        qp.fourier.mark(qp.RX(x[0], wires=0), "x")
+        qp.fourier.mark(qp.RY(x[0], wires=1), "x")
         qp.CNOT(wires=[1, 0])
         return qp.expval(qp.PauliZ(0))
 

--- a/doc/development/adding_operators.rst
+++ b/doc/development/adding_operators.rst
@@ -143,7 +143,7 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
         # we request parameter-shift (or "analytic") differentiation.
         grad_method = "A"
 
-        def __init__(self, angle, wire_rot, wire_flip=None, do_flip=False, id=None):
+        def __init__(self, angle, wire_rot, wire_flip=None, do_flip=False):
 
             # checking the inputs --------------
 
@@ -170,8 +170,7 @@ knows a native implementation for ``FlipAndRotate``). It also defines an adjoint
 
             # The parent class expects all trainable parameters to be fed as positional
             # arguments, and all wires acted on fed as a keyword argument.
-            # The id keyword argument allows users to give their instance a custom name.
-            super().__init__(angle, wires=all_wires, id=id)
+            super().__init__(angle, wires=all_wires)
 
         @property
         def num_params(self):

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,58 +9,6 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* The ``id`` keyword argument to :class:`~.qcut.MeasureNode` and :class:`~.qcut.PrepareNode` has been renamed to ``node_uid`` and will be removed in v0.46. 
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
-* The ``id`` keyword argument to :class:`~.ops.MidMeasure` has been renamed to ``meas_uid`` and will be removed in v0.46. 
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
-* The ``id`` keyword argument to :class:`~.measurements.MeasurementProcess` has been deprecated and will be removed in v0.46. 
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
-* The ``id`` keyword argument to :class:`~.Operator` has been deprecated and will be removed in v0.46. 
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
-  The ``id`` argument previously served two purposes: (1) adding custom labels
-  to operator instances which were rendered in circuit drawings and (2)
-  tagging encoding gates for Fourier spectrum analysis.
-
-  These are now handled by dedicated functions:
-
-  .. warning::
-
-    Neither of these functions are currently supported inside :func:`~.qjit`-compiled circuits, as the corresponding ``id`` behaviour didn't work beforehand.
-
-  Use :func:`~.drawer.label` to attach a custom label to an operator instance
-  for circuit drawing:
-
-  .. code-block:: python
-
-    # Legacy method (deprecated):
-    qp.RX(0.5, wires=0, id="my-rx")
-
-    # New method:
-    qp.drawer.label(qp.RX(0.5, wires=0), "my-rx")
-
-  Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
-  for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
-
-  .. code-block:: python
-
-    # Legacy method (deprecated):
-    qp.RX(0.5, wires=0, id="x0")
-
-    # New method:
-    qp.fourier.mark(qp.RX(0.5, wires=0), "x0")
-
 * Deactivating queuing of an ``Operator`` by setting its
   :attr:`~pennylane.operation.Operator._queue_category` to ``None``
   has been deprecated and will be removed in v0.46. If necessary, the
@@ -154,6 +102,58 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``id`` keyword argument to :class:`~.qcut.MeasureNode` and :class:`~.qcut.PrepareNode` has been renamed to ``node_uid``. 
+
+  - Deprecated in v0.45
+  - Removed in v0.46
+
+* The ``id`` keyword argument to :class:`~.ops.MidMeasure` has been renamed to ``meas_uid``. 
+
+  - Deprecated in v0.45
+  - Removed in v0.46
+
+* The ``id`` keyword argument to :class:`~.measurements.MeasurementProcess` has been removed. 
+
+  - Deprecated in v0.45
+  - Will be removed in v0.46
+
+* The ``id`` keyword argument to :class:`~.Operator` has been removed. 
+
+  - Deprecated in v0.45
+  - Removed in v0.46
+
+  The ``id`` argument previously served two purposes: (1) adding custom labels
+  to operator instances which were rendered in circuit drawings and (2)
+  tagging encoding gates for Fourier spectrum analysis.
+
+  These are now handled by dedicated functions:
+
+  .. warning::
+
+    Neither of these functions are currently supported inside :func:`~.qjit`-compiled circuits, as the corresponding ``id`` behaviour didn't work beforehand.
+
+  Use :func:`~.drawer.label` to attach a custom label to an operator instance
+  for circuit drawing:
+
+  .. code-block:: python
+
+    # Legacy method (deprecated):
+    qp.RX(0.5, wires=0, id="my-rx")
+
+    # New method:
+    qp.drawer.label(qp.RX(0.5, wires=0), "my-rx")
+
+  Use :func:`~.fourier.mark` to mark an operator as an input-encoding gate
+  for :func:`~.fourier.circuit_spectrum`, and :func:`~.fourier.qnode_spectrum`:
+
+  .. code-block:: python
+
+    # Legacy method (deprecated):
+    qp.RX(0.5, wires=0, id="x0")
+
+    # New method:
+    qp.fourier.mark(qp.RX(0.5, wires=0), "x0")
 
 * The :func:`~pennylane.workflow.get_transform_program` function has been removed.
   Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -9,13 +9,6 @@ deprecations are listed below.
 Pending deprecations
 --------------------
 
-* The :func:`~pennylane.workflow.get_transform_program` function has been deprecated and will be removed in v0.46.
-  Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
-  of a QNode.
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
- 
 * The ``id`` keyword argument to :class:`~.qcut.MeasureNode` and :class:`~.qcut.PrepareNode` has been renamed to ``node_uid`` and will be removed in v0.46. 
 
   - Deprecated in v0.45
@@ -161,6 +154,13 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* The :func:`~pennylane.workflow.get_transform_program` function has been removed.
+  Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
+  of a QNode.
+
+  - Deprecated in v0.45
+  - Removed in v0.46 
 
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` has been removed.

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -96,12 +96,6 @@ Pending deprecations
   - Deprecated in v0.45
   - Will be removed in v0.46
 
-* The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
-  The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
 * The ``qp.transforms.create_expand_fn`` has been deprecated and will be removed in v0.46.
   Instead, please use the :func:`qp.transforms.decompose <.transforms.decompose>` function for decomposing circuits.
 
@@ -167,6 +161,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
+  The deprecated access through ``transform_program`` has been removed.
+
+  - Deprecated in v0.45
+  - Removed in v0.46
 
 * Maintenance support of NumPy<2.0 has been removed. PennyLane v0.45 and beyond are not guaranteed to work with NumPy<2.0.
   We recommend upgrading your version of NumPy to benefit from enhanced support and features.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -48,7 +48,7 @@
 * The :func:`~pennylane.workflow.get_transform_program` function has been removed.
   Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
   of a QNode.
-  [(#)]()
+  [(#9466)](https://github.com/PennyLaneAI/pennylane/pull/9466)
 
 * The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
   The deprecated access through `transform_program` has been removed.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,11 @@
   
 <h3>Breaking changes 💔</h3>
 
+* The :func:`~pennylane.workflow.get_transform_program` function has been removed.
+  Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
+  of a QNode.
+  [(#)]()
+
 * The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
   The deprecated access through `transform_program` has been removed.
   [(#)]()

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,10 @@
   
 <h3>Breaking changes 💔</h3>
 
+* The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
+  The deprecated access through `transform_program` has been removed.
+  [(#)]()
+
 <h3>Deprecations 👋</h3>
 
 <h3>Internal changes ⚙️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,16 +46,16 @@
 <h3>Breaking changes 💔</h3>
 
 * The `id` keyword argument to :class:`~.qcut.MeasureNode` and :class:`~.qcut.PrepareNode` has been renamed to `node_uid`. 
-  [(#)]()
+  [(#9467)](https://github.com/PennyLaneAI/pennylane/pull/9467)
 
 * The `id` keyword argument to :class:`~.ops.MidMeasure` has been renamed to `meas_uid`. 
-  [(#)]()
+  [(#9467)](https://github.com/PennyLaneAI/pennylane/pull/9467)
 
 * The `id` keyword argument to :class:`~.measurements.MeasurementProcess` has been removed. 
-  [(#)]()
+  [(#9467)](https://github.com/PennyLaneAI/pennylane/pull/9467)
 
 * The `id` keyword argument to :class:`~.Operator` has been removed. 
-  [(#)]()
+  [(#9467)](https://github.com/PennyLaneAI/pennylane/pull/9467)
 
 * The :func:`~pennylane.workflow.get_transform_program` function has been removed.
   Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -45,6 +45,18 @@
   
 <h3>Breaking changes 💔</h3>
 
+* The `id` keyword argument to :class:`~.qcut.MeasureNode` and :class:`~.qcut.PrepareNode` has been renamed to `node_uid`. 
+  [(#)]()
+
+* The `id` keyword argument to :class:`~.ops.MidMeasure` has been renamed to `meas_uid`. 
+  [(#)]()
+
+* The `id` keyword argument to :class:`~.measurements.MeasurementProcess` has been removed. 
+  [(#)]()
+
+* The `id` keyword argument to :class:`~.Operator` has been removed. 
+  [(#)]()
+
 * The :func:`~pennylane.workflow.get_transform_program` function has been removed.
   Instead, please use the improved :func:`~pennylane.workflow.get_compile_pipeline` to retrieve the execution pipeline
   of a QNode.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,7 +47,7 @@
 
 * The `transform_program` property of `QNode` has been renamed to `compile_pipeline`.
   The deprecated access through `transform_program` has been removed.
-  [(#)]()
+  [(#9465)](https://github.com/PennyLaneAI/pennylane/pull/9465)
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -78,13 +78,13 @@ def draw(
         def circuit(a, w):
             qp.Hadamard(0)
             qp.CRX(a, wires=[0, 1])
-            qp.Rot(*w, wires=[1], id="arbitrary")
+            qp.drawer.label(qp.Rot(*w, wires=[1]), "arbitrary")
             qp.CRX(-a, wires=[0, 1])
             return qp.expval(qp.Z(0) @ qp.Z(1))
 
     >>> print(qp.draw(circuit)(a=2.3, w=[1.2, 3.2, 0.7]))
-    0: ──H─╭●─────────────────────────────────────────╭●─────────┤ ╭<Z@Z>
-    1: ────╰RX(2.30)──Rot(1.20,3.20,0.70,"arbitrary")─╰RX(-2.30)─┤ ╰<Z@Z>
+    0: ──H─╭●──────────────────────────────────────────╭●─────────┤ ╭<Z@Z>
+    1: ────╰RX(2.30)──Rot(1.20,3.20,0.70, "arbitrary")─╰RX(-2.30)─┤ ╰<Z@Z>
 
     .. details::
         :title: Usage Details
@@ -92,8 +92,8 @@ def draw(
         By specifying the ``decimals`` keyword, parameters are displayed to the specified precision.
 
         >>> print(qp.draw(circuit, decimals=4)(a=2.3, w=[1.2, 3.2, 0.7]))
-        0: ──H─╭●─────────────────────────────────────────────────╭●───────────┤ ╭<Z@Z>
-        1: ────╰RX(2.3000)──Rot(1.2000,3.2000,0.7000,"arbitrary")─╰RX(-2.3000)─┤ ╰<Z@Z>
+        0: ──H─╭●──────────────────────────────────────────────────╭●───────────┤ ╭<Z@Z>
+        1: ────╰RX(2.3000)──Rot(1.2000,3.2000,0.7000, "arbitrary")─╰RX(-2.3000)─┤ ╰<Z@Z>
 
         Parameters can be omitted by requesting ``decimals=None``:
 
@@ -159,8 +159,8 @@ def draw(
         top to bottom:
 
         >>> print(qp.draw(circuit, wire_order=[1,0])(a=2.3, w=[1.2, 3.2, 0.7]))
-        1: ────╭RX(2.30)──Rot(1.20,3.20,0.70,"arbitrary")─╭RX(-2.30)─┤ ╭<Z@Z>
-        0: ──H─╰●─────────────────────────────────────────╰●─────────┤ ╰<Z@Z>
+        1: ────╭RX(2.30)──Rot(1.20,3.20,0.70, "arbitrary")─╭RX(-2.30)─┤ ╭<Z@Z>
+        0: ──H─╰●──────────────────────────────────────────╰●─────────┤ ╰<Z@Z>
 
         If the device or ``wire_order`` has wires not used by operations, those wires are omitted
         unless requested with ``show_all_wires=True``

--- a/pennylane/fourier/circuit_spectrum.py
+++ b/pennylane/fourier/circuit_spectrum.py
@@ -15,10 +15,8 @@
 of a quantum circuit, that is the frequencies without considering
 preprocessing in the QNode."""
 
-import warnings
 from functools import partial
 
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
@@ -202,16 +200,6 @@ def circuit_spectrum(
         tape = tapes[0]
         freqs = {}
         for op in tape.operations:
-            # NOTE: Here for backwards compatibility remove once 'id' deprecation is complete
-            # pylint: disable=protected-access
-            if (id := op._id) is not None:
-                warnings.warn(
-                    "Using 'id' with 'circuit_spectrum' is deprecated "
-                    "and will be removed in v0.46. Instead, please use 'pennylane.fourier.mark' to "
-                    "add a marker to your operator. ",
-                    PennyLaneDeprecationWarning,
-                )
-                op = MarkedOp(op, id)
 
             # If the operator is not marked, move to the next
             if not isinstance(op, MarkedOp):

--- a/pennylane/fourier/qnode_spectrum.py
+++ b/pennylane/fourier/qnode_spectrum.py
@@ -365,14 +365,16 @@ def qnode_spectrum(qnode, encoding_args=None, argnum=None, decimals=8, validatio
 
         .. code-block:: python
 
+            from pennylane.fourier import mark
+
             dev = qp.device("default.qubit", wires=2)
 
             @qp.qnode(dev)
             def circuit(x, y, z):
-                qp.RX(0.5*x**2, wires=0, id="x")
-                qp.RY(2.3*y, wires=1, id="y0")
+                mark(qp.RX(0.5*x**2, wires=0), "x")
+                mark(qp.RY(2.3*y, wires=1), "y0")
                 qp.CNOT(wires=[1,0])
-                qp.RY(z, wires=0, id="y1")
+                mark(qp.RY(z, wires=0), "y1")
                 return qp.expval(qp.Z(0))
 
         First, note that we assigned ``id`` labels to the gates for which we will use
@@ -399,7 +401,7 @@ def qnode_spectrum(qnode, encoding_args=None, argnum=None, decimals=8, validatio
         Note that the values of the output are dictionaries instead of the spectrum lists, that
         they include the prefactors introduced by classical preprocessing, and
         that we would not be able to compute the advanced spectrum for ``x`` because it is
-        preprocessed non-linearly in the gate ``qp.RX(0.5*x**2, wires=0, id="x")``.
+        preprocessed non-linearly in the gate ``qp.RX(0.5*x**2, wires=0)`` marked with ``"x"``.
 
     """
     # pylint: disable=too-many-branches

--- a/pennylane/ftqc/operations.py
+++ b/pennylane/ftqc/operations.py
@@ -61,8 +61,8 @@ class RotXZX(Operation):
     parameter_frequencies = [(1,), (1,), (1,)]
 
     # pylint: disable = too-many-arguments, too-many-positional-arguments
-    def __init__(self, phi, theta, omega, wires, id=None):
-        super().__init__(phi, theta, omega, wires=wires, id=id)
+    def __init__(self, phi, theta, omega, wires):
+        super().__init__(phi, theta, omega, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -355,7 +355,7 @@ class ParametricMidMeasure(MidMeasure):
         postselect (Optional[int]): Which basis state to postselect after a mid-circuit
             measurement. None by default. If postselection is requested, only the post-measurement
             state that is used for postselection will be considered in the remaining circuit.
-        id (str): Custom label given to a measurement instance.
+        meas_uid (str | None): Custom label given to a measurement instance.
     """
 
     _shortname = "measure"

--- a/pennylane/ftqc/parametric_midmeasure.py
+++ b/pennylane/ftqc/parametric_midmeasure.py
@@ -370,14 +370,9 @@ class ParametricMidMeasure(MidMeasure):
         reset: bool | None = False,
         postselect: int | None = None,
         meas_uid: str | None = None,
-        id: str | None = None,
     ):
         self.batch_size = None
-        # NOTE: The base class handles the deprecation warning of 'id'
-        # and the logic of meas_uid = id if meas_uid is None.
-        super().__init__(
-            wires=Wires(wires), reset=reset, postselect=postselect, id=id, meas_uid=meas_uid
-        )
+        super().__init__(wires=Wires(wires), reset=reset, postselect=postselect, meas_uid=meas_uid)
         self.hyperparameters["plane"] = plane
         self.hyperparameters["angle"] = angle
 
@@ -483,7 +478,6 @@ class XMidMeasure(ParametricMidMeasure):
             ("reset", self.reset),
             ("postselect", self.postselect),
             ("meas_uid", self.meas_uid),
-            ("id", self._id),
         )
         return (), (self.wires, metadata)
 
@@ -494,17 +488,13 @@ class XMidMeasure(ParametricMidMeasure):
         reset: bool | None = False,
         postselect: int | None = None,
         meas_uid: str | None = None,
-        id: str | None = None,
     ):
-        # NOTE: The base class handles the deprecation warning of 'id'
-        # and the logic of meas_uid = id if meas_uid is None.
         super().__init__(
             wires=Wires(wires),
             angle=0,
             plane="XY",
             reset=reset,
             postselect=postselect,
-            id=id,
             meas_uid=meas_uid,
         )
 
@@ -552,7 +542,6 @@ class YMidMeasure(ParametricMidMeasure):
             ("reset", self.reset),
             ("postselect", self.postselect),
             ("meas_uid", self.meas_uid),
-            ("id", self._id),
         )
         return (), (self.wires, metadata)
 
@@ -563,17 +552,13 @@ class YMidMeasure(ParametricMidMeasure):
         reset: bool | None = False,
         postselect: int | None = None,
         meas_uid: str | None = None,
-        id: str | None = None,
     ):
-        # NOTE: The base class handles the deprecation warning of 'id'
-        # and the logic of meas_uid = id if meas_uid is None.
         super().__init__(
             wires=Wires(wires),
             angle=np.pi / 2,
             plane="XY",
             reset=reset,
             postselect=postselect,
-            id=id,
             meas_uid=meas_uid,
         )
 

--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -998,7 +998,7 @@ class FromBloq(Operation):
         if not isinstance(bloq, qt.Bloq):
             raise TypeError(f"bloq must be an instance of {qt.Bloq}.")
         self._hyperparameters = {"bloq": bloq}
-        super().__init__(wires=wires, id=None)
+        super().__init__(wires=wires)
 
     def __repr__(self):
         return f'FromBloq({self.hyperparameters["bloq"]}, wires={self.wires})'

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -41,8 +41,6 @@ class ClassicalShadowMP(MeasurementTransform):
     Args:
         wires (.Wires): The wires the measurement process applies to.
         seed (Union[int, None]): The seed used to generate the random measurements
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "shadow"
@@ -51,10 +49,9 @@ class ClassicalShadowMP(MeasurementTransform):
         self,
         wires: WiresLike | None = None,
         seed: int | None = None,
-        id: str | None = None,
     ):
         self.seed = seed
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     def _flatten(self):
         metadata = (("wires", self.wires), ("seed", self.seed))
@@ -451,17 +448,17 @@ class ShadowExpvalMP(MeasurementTransform):
     def _unflatten(cls, data, metadata):
         return cls(data[0], **dict(metadata))
 
+    # pylint: disable=arguments-renamed
     def __init__(
         self,
         H: Operator | Sequence[Operator],
         seed: int | None = None,
         k: int = 1,
-        id: str | None = None,
     ):
         self.seed = seed
         self.H = H
         self.k = k
-        super().__init__(id=id)
+        super().__init__()
 
     # pylint: disable=arguments-differ
     @classmethod

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -431,8 +431,6 @@ class ShadowExpvalMP(MeasurementTransform):
         seed (Union[int, None]): The seed used to generate the random measurements
         k (int): Number of equal parts to split the shadow's measurements to compute the median of means.
             ``k=1`` corresponds to simply taking the mean over all measurements.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "shadowexpval"

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -60,14 +60,13 @@ class CountsMP(SampleMeasurement):
         obs: Operator | None = None,
         wires=None,
         eigvals=None,
-        id: str | None = None,
         all_outcomes: bool = False,
     ):
         self.all_outcomes = all_outcomes
         self._shortname = "allcounts" if all_outcomes else "counts"
         if wires is not None:
             wires = Wires(wires)
-        super().__init__(obs, wires, eigvals, id)
+        super().__init__(obs, wires, eigvals)
 
     def _flatten(self):
         metadata = (("wires", self.raw_wires), ("all_outcomes", self.all_outcomes))

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -46,8 +46,6 @@ class CountsMP(SampleMeasurement):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
         all_outcomes(bool): determines whether the returned dict will contain only the observed
             outcomes (default), or whether it will display all possible outcomes for the system
     """

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -41,8 +41,6 @@ class ExpectationMP(SampleMeasurement, StateMeasurement):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "expval"

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -18,7 +18,6 @@ and measurement samples using AnnotatedQueues.
 """
 
 import copy
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Optional
@@ -29,7 +28,6 @@ from pennylane.capture import enabled as capture_enabled
 from pennylane.exceptions import (
     DecompositionUndefinedError,
     EigvalsUndefinedError,
-    PennyLaneDeprecationWarning,
     QuantumFunctionError,
 )
 from pennylane.math.utils import is_abstract
@@ -51,10 +49,6 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
     """Represents a measurement process occurring at the end of a
     quantum variational circuit.
 
-    .. warning::
-
-        The ``id`` keyword argument is deprecated and will be removed in v0.46.
-
     Args:
         obs (Union[.Operator, .MeasurementValue, Sequence[.MeasurementValue]]): The observable that
             is to be measured as part of the measurement process. Not all measurement processes
@@ -63,8 +57,6 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): **Deprecated** custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = None
@@ -81,7 +73,7 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         cls._mcm_primitive = create_measurement_mcm_primitive(cls, name=name)
 
     @classmethod
-    def _primitive_bind_call(cls, obs=None, wires=None, eigvals=None, id=None, **kwargs):
+    def _primitive_bind_call(cls, obs=None, wires=None, eigvals=None, **kwargs):
         """Called instead of ``type.__call__`` if ``qp.capture.enabled()``.
 
         Measurements have three "modes":
@@ -96,7 +88,7 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         """
         if cls._obs_primitive is None:
             # safety check if primitives aren't set correctly.
-            return type.__call__(cls, obs=obs, wires=wires, eigvals=eigvals, id=id, **kwargs)
+            return type.__call__(cls, obs=obs, wires=wires, eigvals=eigvals, **kwargs)
         if obs is None:
             wires = () if wires is None else wires
             if eigvals is None:
@@ -173,7 +165,6 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         obs: None | (Operator | MeasurementValue | Sequence[MeasurementValue]) = None,
         wires: Wires | None = None,
         eigvals: TensorLike | None = None,
-        id: str | None = None,
     ):
         if getattr(obs, "name", None) == "MeasurementValue" or isinstance(obs, Sequence):
             # Cast sequence of measurement values to list
@@ -185,14 +176,6 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         else:
             self.obs = obs
             self.mv = None
-
-        if id is not None:
-            warnings.warn(
-                "The 'id' argument is deprecated and will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-                stacklevel=2,
-            )
-        self.id = id
 
         if wires is not None:
             if not capture_enabled() and len(wires) == 0:

--- a/pennylane/measurements/mutual_info.py
+++ b/pennylane/measurements/mutual_info.py
@@ -34,8 +34,6 @@ class MutualInfoMP(StateMeasurement):
 
     Args:
         wires (Sequence[.Wires]): The wires the measurement process applies to.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
         log_base (float): base for the logarithm
 
     """
@@ -52,11 +50,10 @@ class MutualInfoMP(StateMeasurement):
     def __init__(
         self,
         wires: Sequence[Wires] | None = None,
-        id: str | None = None,
         log_base: float | None = None,
     ):
         self.log_base = log_base
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     # pylint: disable=arguments-differ
     @classmethod

--- a/pennylane/measurements/probs.py
+++ b/pennylane/measurements/probs.py
@@ -45,8 +45,6 @@ class ProbabilityMP(SampleMeasurement, StateMeasurement):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "probs"

--- a/pennylane/measurements/purity.py
+++ b/pennylane/measurements/purity.py
@@ -31,8 +31,6 @@ class PurityMP(StateMeasurement):
 
     Args:
         wires (.Wires): The wires the measurement process applies to.
-        id (str): custom label given to a measurement instance, can be useful for some
-            applications where the instance has to be identified
     """
 
     def __str__(self):
@@ -40,8 +38,8 @@ class PurityMP(StateMeasurement):
 
     _shortname = "purity"
 
-    def __init__(self, wires: Wires, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: Wires):
+        super().__init__(wires=wires)
 
     @property
     def numeric_type(self):

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -54,7 +54,7 @@ class SampleMP(SampleMeasurement):
     _shortname = "sample"
 
     # pylint: disable=too-many-arguments
-    def __init__(self, obs=None, wires=None, eigvals=None, id=None, dtype=None):
+    def __init__(self, obs=None, wires=None, eigvals=None, dtype=None):
 
         self._dtype = dtype
 
@@ -83,7 +83,7 @@ class SampleMP(SampleMeasurement):
                 )
             wires = Wires(wires)
 
-        super().__init__(obs=obs, wires=wires, eigvals=eigvals, id=id)
+        super().__init__(obs=obs, wires=wires, eigvals=eigvals)
 
     @classmethod
     def _abstract_eval(

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -46,8 +46,6 @@ class SampleMP(SampleMeasurement):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
         dtype (str or None): The dtype of the samples returned by this measurement process.
     """
 

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -38,8 +38,8 @@ class StateMP(StateMeasurement):
 
     _shortname = "state"
 
-    def __init__(self, wires: Wires | None = None, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: Wires | None = None):
+        super().__init__(wires=wires)
 
     @classmethod
     def _abstract_eval(
@@ -121,8 +121,8 @@ class DensityMatrixMP(StateMP):
             where the instance has to be identified
     """
 
-    def __init__(self, wires: Wires, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: Wires):
+        super().__init__(wires=wires)
 
     @classmethod
     def _abstract_eval(

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -32,8 +32,6 @@ class StateMP(StateMeasurement):
 
     Args:
         wires (.Wires): The wires the measurement process applies to.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "state"

--- a/pennylane/measurements/state.py
+++ b/pennylane/measurements/state.py
@@ -115,8 +115,6 @@ class DensityMatrixMP(StateMP):
 
     Args:
         wires (.Wires): The wires the measurement process applies to.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     def __init__(self, wires: Wires):

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -43,8 +43,6 @@ class VarianceMP(SampleMeasurement, StateMeasurement):
             This can only be specified if an observable was not provided.
         eigvals (array): A flat array representing the eigenvalues of the measurement.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
     """
 
     _shortname = "var"

--- a/pennylane/measurements/vn_entropy.py
+++ b/pennylane/measurements/vn_entropy.py
@@ -31,8 +31,6 @@ class VnEntropyMP(StateMeasurement):
     Args:
         wires (.Wires): The wires the measurement process applies to.
             This can only be specified if an observable was not provided.
-        id (str): custom label given to a measurement instance, can be useful for some applications
-            where the instance has to be identified
         log_base (float): Base for the logarithm.
     """
 
@@ -48,11 +46,10 @@ class VnEntropyMP(StateMeasurement):
     def __init__(
         self,
         wires: Wires | None = None,
-        id: str | None = None,
         log_base: float | None = None,
     ):
         self.log_base = log_base
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @property
     def hash(self):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -201,7 +201,6 @@ from pennylane.exceptions import (
     GeneratorUndefinedError,
     MatrixUndefinedError,
     ParameterFrequenciesUndefinedError,
-    PennyLaneDeprecationWarning,
     PowUndefinedError,
     SparseMatrixUndefinedError,
     TermsUndefinedError,
@@ -419,16 +418,10 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
     to know about wire labels) or ``(*parameters, wires, **hyperparameters)``, where ``parameters``, ``wires``, and
     ``hyperparameters`` are the respective attributes of the operator class.
 
-    .. warning::
-
-        The ``id`` keyword argument is deprecated and will be removed in v0.46.
-
     Args:
         *params (tuple[tensor_like]): trainable parameters
         wires (Iterable[Any] | Any): Wire label(s) that the operator acts on.
             If not given, args[-1] is interpreted as wires.
-        id (str | None): *Deprecated* A custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
 
     **Example**
 
@@ -471,7 +464,6 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
 
                 # The parent class expects all trainable parameters to be fed as positional
                 # arguments, and all wires acted on fed as a keyword argument.
-                # The id keyword argument allows users to give their instance a custom name.
                 super().__init__(angle, wires=all_wires)
 
             @property
@@ -1016,22 +1008,6 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         """String for the name of the operator."""
         return self._name
 
-    @property
-    def id(self) -> str:
-        """Custom string to label a specific operator instance.
-
-        .. warning::
-
-            The ``id`` keyword argument is deprecated and will be removed in v0.46.
-
-        """
-        warnings.warn(
-            "The 'id' argument is deprecated and will be removed in v0.46.",
-            PennyLaneDeprecationWarning,
-            stacklevel=2,
-        )
-        return self._id
-
     @name.setter
     def name(self, value: str):
         self._name = value
@@ -1096,16 +1072,8 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         """
         op_label = base_label or self.__class__.__name__
 
-        if self._id is not None:
-            warnings.warn(
-                "Using 'id' to add a custom label to your operator is deprecated. "
-                "Please use 'pennylane.drawer.label' to add a custom label to "
-                "your operator instead. ",
-                PennyLaneDeprecationWarning,
-            )
-
         if len(self.data) == 0:
-            return op_label if self._id is None else f'{op_label}("{self._id}")'
+            return op_label
 
         def _format(x):
             """Format a scalar parameter or retrieve/store a matrix-valued parameter
@@ -1135,27 +1103,13 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         # Format each parameter individually, excluding those that lead to empty strings
         param_strings = [out for p in self.parameters if (out := _format(p)) != ""]
         inner_string = ",\n".join(param_strings)
-        # Include operation's id in string
-        if self._id is not None:
-            if inner_string == "":
-                inner_string = f'"{self._id}"'
-            else:
-                inner_string = f'{inner_string},"{self._id}"'
         if inner_string == "":
             return f"{op_label}"
         return f"{op_label}\n({inner_string})"
 
-    def __init__(self, *params: TensorLike, wires: WiresLike | None = None, id: str | None = None):
+    def __init__(self, *params: TensorLike, wires: WiresLike | None = None):
         self._name: str = self.__class__.__name__  #: str: name of the operator
 
-        if id is not None:
-            warnings.warn(
-                "The 'id' argument is deprecated and will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-                stacklevel=2,
-            )
-
-        self._id: str = id
         self._pauli_rep: qp.pauli.PauliSentence | None = (
             None  # Union[PauliSentence, None]: Representation of the operator as a pauli sentence, if applicable
         )
@@ -1833,16 +1787,10 @@ class Operation(Operator):
     please see the documentation for :class:`~.gradients.param_shift`,
     :class:`~.metric_tensor`, :func:`~.reconstruct`.
 
-    .. warning::
-
-        The ``id`` argument is deprecated and will be removed in v0.46.
-
     Args:
         *params (tuple[tensor_like]): trainable parameters
         wires (Iterable[Any] or Any): Wire label(s) that the operator acts on.
             If not given, args[-1] is interpreted as wires.
-        id (str | None): *Deprecated* A custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
     """
 
     @property
@@ -1977,9 +1925,8 @@ class Operation(Operator):
         self,
         *params: TensorLike,
         wires: WiresLike | None = None,
-        id: str | None = None,
     ):
-        super().__init__(*params, wires=wires, id=id)
+        super().__init__(*params, wires=wires)
 
         # check the grad_recipe validity
         if self.grad_recipe is None:
@@ -1997,8 +1944,6 @@ class Channel(Operation, abc.ABC):
         params (tuple[tensor_like]): trainable parameters
         wires (Iterable[Any] or Any): Wire label(s) that the operator acts on.
             If not given, args[-1] is interpreted as wires.
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
     """
 
     @staticmethod
@@ -2185,8 +2130,6 @@ class CVOperation(CV, Operation):
         params (tuple[tensor_like]): trainable parameters
         wires (Iterable[Any] or Any): Wire label(s) that the operator acts on.
             If not given, args[-1] is interpreted as wires.
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
     """
 
     @classproperty
@@ -2306,8 +2249,6 @@ class CVObservable(CV, Operator):
        params (tuple[tensor_like]): trainable parameters
        wires (Iterable[Any] or Any): Wire label(s) that the operator acts on.
            If not given, args[-1] is interpreted as wires.
-       id (str): custom label given to an operator instance,
-           can be useful for some applications where the instance has to be identified
     """
 
     is_verified_hermitian = True

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -62,9 +62,9 @@ class AmplitudeDamping(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, gamma, wires: WiresLike, id=None):
+    def __init__(self, gamma, wires: WiresLike):
         wires = Wires(wires)
-        super().__init__(gamma, wires=wires, id=id)
+        super().__init__(gamma, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(gamma):  # pylint:disable=arguments-differ
@@ -145,8 +145,8 @@ class GeneralizedAmplitudeDamping(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, gamma, p, wires, id=None):
-        super().__init__(gamma, p, wires=wires, id=id)
+    def __init__(self, gamma, p, wires):
+        super().__init__(gamma, p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(gamma, p):  # pylint:disable=arguments-differ
@@ -224,8 +224,8 @@ class PhaseDamping(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, gamma, wires, id=None):
-        super().__init__(gamma, wires=wires, id=id)
+    def __init__(self, gamma, wires):
+        super().__init__(gamma, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(gamma):  # pylint:disable=arguments-differ
@@ -311,8 +311,8 @@ class DepolarizingChannel(Channel):
     grad_method = "A"
     grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
-    def __init__(self, p, wires, id=None):
-        super().__init__(p, wires=wires, id=id)
+    def __init__(self, p, wires):
+        super().__init__(p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p):  # pylint:disable=arguments-differ
@@ -391,8 +391,8 @@ class BitFlip(Channel):
     grad_method = "A"
     grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
-    def __init__(self, p, wires, id=None):
-        super().__init__(p, wires=wires, id=id)
+    def __init__(self, p, wires):
+        super().__init__(p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p):  # pylint:disable=arguments-differ
@@ -473,8 +473,8 @@ class ResetError(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, p0, p1, wires, id=None):
-        super().__init__(p0, p1, wires=wires, id=id)
+    def __init__(self, p0, p1, wires):
+        super().__init__(p0, p1, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p_0, p_1):  # pylint:disable=arguments-differ
@@ -577,9 +577,9 @@ class PauliError(Channel):
 
     """int: Number of trainable parameters that the operator depends on."""
 
-    def __init__(self, operators, p, wires: WiresLike, id=None):
+    def __init__(self, operators, p, wires: WiresLike):
         wires = Wires(wires)
-        super().__init__(p, wires=wires, id=id)
+        super().__init__(p, wires=wires)
 
         # check if the specified operators are legal
         if not set(operators).issubset({"X", "Y", "Z", "I"}):
@@ -701,8 +701,8 @@ class PhaseFlip(Channel):
     grad_method = "A"
     grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
-    def __init__(self, p, wires, id=None):
-        super().__init__(p, wires=wires, id=id)
+    def __init__(self, p, wires):
+        super().__init__(p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p):  # pylint:disable=arguments-differ
@@ -749,9 +749,9 @@ class QubitChannel(Channel):
 
     grad_method = None
 
-    def __init__(self, K_list, wires: WiresLike, id=None):
+    def __init__(self, K_list, wires: WiresLike):
         wires = Wires(wires)
-        super().__init__(*K_list, wires=wires, id=id)
+        super().__init__(*K_list, wires=wires)
 
         # check all Kraus matrices are square matrices
         if any(K.shape[0] != K.shape[1] for K in K_list):
@@ -781,7 +781,7 @@ class QubitChannel(Channel):
 
     # pylint: disable=arguments-differ, unused-argument
     @classmethod
-    def _primitive_bind_call(cls, K_list, wires: WiresLike, id=None):
+    def _primitive_bind_call(cls, K_list, wires: WiresLike):
         wires = Wires(wires)
         return super()._primitive_bind_call(*K_list, wires=wires)
 
@@ -900,8 +900,8 @@ class ThermalRelaxationError(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, pe, t1, t2, tg, wires, id=None):
-        super().__init__(pe, t1, t2, tg, wires=wires, id=id)
+    def __init__(self, pe, t1, t2, tg, wires):
+        super().__init__(pe, t1, t2, tg, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(pe, t1, t2, tg):  # pylint:disable=arguments-differ

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -105,8 +105,8 @@ class Rotation(CVOperation):
     grad_method = "A"
     grad_recipe = (_two_term_shift_rule,)
 
-    def __init__(self, phi, wires, id=None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi, wires):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -159,8 +159,8 @@ class Squeezing(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]], _two_term_shift_rule)
 
-    def __init__(self, r, phi, wires, id=None):
-        super().__init__(r, phi, wires=wires, id=id)
+    def __init__(self, r, phi, wires):
+        super().__init__(r, phi, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -215,8 +215,8 @@ class Displacement(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]], _two_term_shift_rule)
 
-    def __init__(self, a, phi, wires, id=None):
-        super().__init__(a, phi, wires=wires, id=id)
+    def __init__(self, a, phi, wires):
+        super().__init__(a, phi, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -273,8 +273,8 @@ class Beamsplitter(CVOperation):
     grad_method = "A"
     grad_recipe = (_two_term_shift_rule, _two_term_shift_rule)
 
-    def __init__(self, theta, phi, wires, id=None):
-        super().__init__(theta, phi, wires=wires, id=id)
+    def __init__(self, theta, phi, wires):
+        super().__init__(theta, phi, wires=wires)
 
     # For the beamsplitter, both parameters are rotation-like
     @staticmethod
@@ -341,8 +341,8 @@ class TwoModeSqueezing(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]], _two_term_shift_rule)
 
-    def __init__(self, r, phi, wires, id=None):
-        super().__init__(r, phi, wires=wires, id=id)
+    def __init__(self, r, phi, wires):
+        super().__init__(r, phi, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -404,8 +404,8 @@ class QuadraticPhase(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]],)
 
-    def __init__(self, s, wires, id=None):
-        super().__init__(s, wires=wires, id=id)
+    def __init__(self, s, wires):
+        super().__init__(s, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -458,8 +458,8 @@ class ControlledAddition(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]],)
 
-    def __init__(self, s, wires, id=None):
-        super().__init__(s, wires=wires, id=id)
+    def __init__(self, s, wires):
+        super().__init__(s, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -516,8 +516,8 @@ class ControlledPhase(CVOperation):
     a = 1
     grad_recipe = ([[multiplier, a, shift], [-multiplier, a, -shift]],)
 
-    def __init__(self, s, wires, id=None):
-        super().__init__(s, wires=wires, id=id)
+    def __init__(self, s, wires):
+        super().__init__(s, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -556,8 +556,8 @@ class Kerr(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, kappa, wires, id=None):
-        super().__init__(kappa, wires=wires, id=id)
+    def __init__(self, kappa, wires):
+        super().__init__(kappa, wires=wires)
 
     def adjoint(self):
         return Kerr(-self.parameters[0], wires=self.wires)
@@ -586,8 +586,8 @@ class CrossKerr(CVOperation):
     num_wires = 2
     grad_method = "F"
 
-    def __init__(self, kappa, wires, id=None):
-        super().__init__(kappa, wires=wires, id=id)
+    def __init__(self, kappa, wires):
+        super().__init__(kappa, wires=wires)
 
     def adjoint(self):
         return CrossKerr(-self.parameters[0], wires=self.wires)
@@ -616,8 +616,8 @@ class CubicPhase(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, gamma, wires, id=None):
-        super().__init__(gamma, wires=wires, id=id)
+    def __init__(self, gamma, wires):
+        super().__init__(gamma, wires=wires)
 
     def adjoint(self):
         return CubicPhase(-self.parameters[0], wires=self.wires)
@@ -666,8 +666,8 @@ class InterferometerUnitary(CVOperation):
     grad_method = None
     grad_recipe = None
 
-    def __init__(self, U, wires, id=None):
-        super().__init__(U, wires=wires, id=id)
+    def __init__(self, U, wires):
+        super().__init__(U, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -718,8 +718,8 @@ class CoherentState(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, a, phi, wires, id=None):
-        super().__init__(a, phi, wires=wires, id=id)
+    def __init__(self, a, phi, wires):
+        super().__init__(a, phi, wires=wires)
 
 
 class SqueezedState(CVOperation):
@@ -743,8 +743,8 @@ class SqueezedState(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, r, phi, wires, id=None):
-        super().__init__(r, phi, wires=wires, id=id)
+    def __init__(self, r, phi, wires):
+        super().__init__(r, phi, wires=wires)
 
 
 class DisplacedSqueezedState(CVOperation):
@@ -778,8 +778,8 @@ class DisplacedSqueezedState(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, a, phi_a, r, phi_r, wires, id=None):
-        super().__init__(a, phi_a, r, phi_r, wires=wires, id=id)
+    def __init__(self, a, phi_a, r, phi_r, wires):
+        super().__init__(a, phi_a, r, phi_r, wires=wires)
 
 
 class ThermalState(CVOperation):
@@ -802,8 +802,8 @@ class ThermalState(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, nbar, wires, id=None):
-        super().__init__(nbar, wires=wires, id=id)
+    def __init__(self, nbar, wires):
+        super().__init__(nbar, wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         return super().label(decimals=decimals, base_label=base_label or "Thermal", cache=cache)
@@ -830,8 +830,8 @@ class GaussianState(CVOperation):
     num_params = 2
     grad_method = "F"
 
-    def __init__(self, V, r, wires, id=None):
-        super().__init__(V, r, wires=wires, id=id)
+    def __init__(self, V, r, wires):
+        super().__init__(V, r, wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         return super().label(decimals=decimals, base_label=base_label or "Gaussian", cache=cache)
@@ -857,8 +857,8 @@ class FockState(CVOperation):
     num_wires = 1
     grad_method = None
 
-    def __init__(self, n, wires, id=None):
-        super().__init__(n, wires=wires, id=id)
+    def __init__(self, n, wires):
+        super().__init__(n, wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         r"""A customizable string representation of the operator.
@@ -948,8 +948,8 @@ class FockStateVector(CVOperation):
     num_params = 1
     grad_method = "F"
 
-    def __init__(self, state, wires, id=None):
-        super().__init__(state, wires=wires, id=id)
+    def __init__(self, state, wires):
+        super().__init__(state, wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         r"""A customizable string representation of the operator.
@@ -996,8 +996,8 @@ class FockDensityMatrix(CVOperation):
     num_params = 1
     grad_method = "F"
 
-    def __init__(self, state, wires, id=None):
-        super().__init__(state, wires=wires, id=id)
+    def __init__(self, state, wires):
+        super().__init__(state, wires=wires)
 
 
 class CatState(CVOperation):
@@ -1032,8 +1032,8 @@ class CatState(CVOperation):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, a, phi, p, wires, id=None):
-        super().__init__(a, phi, p, wires=wires, id=id)
+    def __init__(self, a, phi, p, wires):
+        super().__init__(a, phi, p, wires=wires)
 
 
 # =============================================================================
@@ -1243,8 +1243,8 @@ class QuadOperator(CVObservable):
     grad_method = "A"
     ev_order = 1
 
-    def __init__(self, phi, wires, id=None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi, wires):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -1321,8 +1321,8 @@ class PolyXP(CVObservable):
     grad_method = "F"
     ev_order = 2
 
-    def __init__(self, q, wires, id=None):
-        super().__init__(q, wires=wires, id=id)
+    def __init__(self, q, wires):
+        super().__init__(q, wires=wires)
 
     @staticmethod
     def _heisenberg_rep(p):
@@ -1379,8 +1379,8 @@ class FockStateProjector(CVObservable):
     grad_method = None
     ev_order = None
 
-    def __init__(self, n, wires, id=None):
-        super().__init__(n, wires=wires, id=id)
+    def __init__(self, n, wires):
+        super().__init__(n, wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         r"""A customizable string representation of the operator.

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -46,8 +46,6 @@ class Identity(CVObservable, Operation):
 
     Args:
         wires (Iterable[Any] or Any): Wire label(s) that the identity acts on.
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
 
     Corresponds to the trace of the quantum state, which in exact
     simulators should always be equal to 1.
@@ -237,8 +235,6 @@ The expectation of this observable
 
 Args:
     wires (Iterable[Any] or Any): Wire label(s) that the identity acts on.
-    id (str): custom label given to an operator instance,
-        can be useful for some applications where the instance has to be identified.
 
 Corresponds to the trace of the quantum state, which in exact
 simulators should always be equal to 1.
@@ -263,8 +259,6 @@ class GlobalPhase(Operation):
     Args:
         phi (TensorLike): the global phase
         wires (Iterable[Any] or Any): unused argument - the operator is applied to all wires
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
 
     **Example**
 

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -77,8 +77,8 @@ class Identity(CVObservable, Operation):
     def _flatten(self):
         return tuple(), (self.wires, tuple())
 
-    def __init__(self, wires: WiresLike = (), id=None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: WiresLike = ()):
+        super().__init__(wires=wires)
         self._hyperparameters = {"n_wires": len(self.wires)}
         self._pauli_rep = qp.pauli.PauliSentence({qp.pauli.PauliWord({}): 1.0})
 
@@ -315,8 +315,8 @@ class GlobalPhase(Operation):
     ):  # pylint: disable=arguments-differ
         return super()._primitive_bind_call(phi, wires=wires, **kwargs)
 
-    def __init__(self, phi, wires: WiresLike = (), id=None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi, wires: WiresLike = ()):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/ops/meta.py
+++ b/pennylane/ops/meta.py
@@ -44,11 +44,11 @@ class Barrier(Operation):
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
 
-    def __init__(self, wires: WiresLike = (), only_visual=False, id=None):
+    def __init__(self, wires: WiresLike = (), only_visual=False):
         wires = Wires(wires)
         self.only_visual = only_visual
         self.hyperparameters["only_visual"] = only_visual
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @staticmethod
     def compute_decomposition(wires, only_visual=False):  # pylint: disable=unused-argument
@@ -117,9 +117,9 @@ class WireCut(Operation):
     num_params = 0
     grad_method = None
 
-    def __init__(self, wires: WiresLike = (), id=None):
+    def __init__(self, wires: WiresLike = ()):
         wires = Wires(wires)
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
         if not self._wires:
             raise ValueError(
                 f"{self.name}: wrong number of wires. At least one wire has to be provided."

--- a/pennylane/ops/mid_measure/mid_measure.py
+++ b/pennylane/ops/mid_measure/mid_measure.py
@@ -16,13 +16,12 @@ This module contains the qp.measure measurement.
 """
 
 import uuid
-import warnings
 from collections.abc import Hashable
 from functools import lru_cache
 
 from pennylane.capture import enabled as capture_enabled
 from pennylane.compiler import compiler
-from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import QuantumFunctionError
 from pennylane.operation import Operator
 from pennylane.wires import Wires
 
@@ -113,7 +112,6 @@ class MidMeasure(Operator):
         postselect (Optional[int]): Which basis state to postselect after a mid-circuit
             measurement. None by default. If postselection is requested, only the post-measurement
             state that is used for postselection will be considered in the remaining circuit.
-        id (str | None): *Deprecated* Custom unique id given to a measurement instance.
         meas_uid (str | None): Custom unique id given to a measurement instance.
     """
 
@@ -132,16 +130,7 @@ class MidMeasure(Operator):
         reset: bool = False,
         postselect: int | None = None,
         meas_uid: str | None = None,
-        id: str | None = None,
     ):
-        if id is not None:
-            warnings.warn(
-                "The 'id' argument has been renamed to 'meas_uid'. Access through 'id' will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-            )
-            # Only override if meas_uid wasn't explicitly provided
-            if meas_uid is None:
-                meas_uid = id
         super().__init__(wires=Wires(wires))
         self._hyperparameters = {"reset": reset, "postselect": postselect, "meas_uid": meas_uid}
         self._name = "MidMeasureMP"

--- a/pennylane/ops/mid_measure/pauli_measure.py
+++ b/pennylane/ops/mid_measure/pauli_measure.py
@@ -16,12 +16,10 @@ Implements the pauli measurement.
 """
 
 import uuid
-import warnings
 from functools import lru_cache
 
 from pennylane import math
 from pennylane.capture import enabled as capture_enabled
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import Operator
 from pennylane.wires import Wires, WiresLike
 
@@ -39,17 +37,8 @@ class PauliMeasure(Operator):
         pauli_word: str,
         wires: WiresLike,
         postselect: int | None = None,
-        id: str | None = None,
         meas_uid: str | None = None,
     ):
-        if id is not None:
-            warnings.warn(
-                "The 'id' argument has been renamed to 'meas_uid'. Access through 'id' will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-            )
-            # Only override if meas_uid wasn't explicitly provided
-            if meas_uid is None:
-                meas_uid = id
 
         if not all(c in _VALID_PAULI_CHARS for c in pauli_word):
             raise ValueError(

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -342,7 +342,7 @@ class Adjoint(SymbolicOp):
             base = pytrees.unflatten(*pytrees.flatten(base))
         return cls._primitive.bind(base, **kwargs)
 
-    def __new__(cls, base=None, id=None):
+    def __new__(cls, base=None):
         """Returns an uninitialized type with the necessary mixins.
 
         If the ``base`` is an ``Operation``, this will return an instance of ``AdjointOperation``.
@@ -355,9 +355,9 @@ class Adjoint(SymbolicOp):
 
         return object.__new__(Adjoint)
 
-    def __init__(self, base=None, id=None):
+    def __init__(self, base=None):
         self._name = f"Adjoint({base.name})"
-        super().__init__(base, id=id)
+        super().__init__(base)
         if self.base.pauli_rep:
             pr = {pw: qp.math.conjugate(coeff) for pw, coeff in self.base.pauli_rep.items()}
             self._pauli_rep = qp.pauli.PauliSentence(pr)

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -76,7 +76,7 @@ class CompositeOp(Operator):
     _eigs = {}  # cache eigen vectors and values like in qp.Hermitian
 
     def __init__(
-        self, *operands: Operator, id=None, _pauli_rep=None
+        self, *operands: Operator, _pauli_rep=None
     ):  # pylint: disable=super-init-not-called
         self._id = id
         self._name = self.__class__.__name__

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -78,7 +78,6 @@ class CompositeOp(Operator):
     def __init__(
         self, *operands: Operator, _pauli_rep=None
     ):  # pylint: disable=super-init-not-called
-        self._id = id
         self._name = self.__class__.__name__
         if any(isinstance(op, (qp.ops.MidMeasure, qp.ops.PauliMeasure)) for op in operands):
             raise ValueError("Composite operators of mid-circuit measurements are not supported.")

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -114,7 +114,7 @@ class Conditional(SymbolicOp, Operation):
             can be useful for some applications where the instance has to be identified
     """
 
-    def __init__(self, expr, then_op: Operation, id=None):
+    def __init__(self, expr, then_op: Operation):
         # pylint: disable=super-init-not-called
         self.hyperparameters["meas_val"] = expr
         self._name = f"Conditional({then_op.name})"

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -110,8 +110,6 @@ class Conditional(SymbolicOp, Operation):
     Args:
         expr (qp.ops.MeasurementValue): the measurement outcome value to consider
         then_op (Operation): the PennyLane operation to apply conditionally
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
     """
 
     def __init__(self, expr, then_op: Operation):
@@ -119,7 +117,6 @@ class Conditional(SymbolicOp, Operation):
         self.hyperparameters["meas_val"] = expr
         self._name = f"Conditional({then_op.name})"
         self.hyperparameters["base"] = then_op
-        self._id = id
         self._pauli_rep = None
         self.queue()
         self._wires = then_op.wires

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -593,7 +593,6 @@ class Controlled(SymbolicOp):
         control_values=None,
         work_wires=None,
         work_wire_type="borrowed",
-        id=None,
     ):
         if isinstance(base, Operator):
             qp.QueuingManager.remove(base)
@@ -615,7 +614,6 @@ class Controlled(SymbolicOp):
         control_values=None,
         work_wires: WiresLike = None,
         work_wire_type: Literal["zeroed", "borrowed"] = "borrowed",
-        id=None,
     ):
         control_wires = Wires(control_wires)
         work_wires = Wires(() if work_wires is None else work_wires)
@@ -651,7 +649,7 @@ class Controlled(SymbolicOp):
         self.hyperparameters["work_wire_type"] = work_wire_type
         self._name = f"C({base.name})"
 
-        super().__init__(base, id)
+        super().__init__(base)
 
     @property
     def hash(self):
@@ -1088,9 +1086,8 @@ class ControlledOp(Controlled, Operation):
         control_values=None,
         work_wires=None,
         work_wire_type="borrowed",
-        id=None,
     ):
-        super().__init__(base, control_wires, control_values, work_wires, work_wire_type, id)
+        super().__init__(base, control_wires, control_values, work_wires, work_wire_type)
         # check the grad_recipe validity
         if self.grad_recipe is None:
             # Make sure grad_recipe is an iterable of correct length instead of None
@@ -1147,7 +1144,6 @@ if Controlled._primitive is not None:  # pylint: disable=protected-access
         control_values=None,
         work_wires=None,
         work_wire_type="borrowed",
-        id=None,
     ):
         return type.__call__(
             Controlled,
@@ -1156,7 +1152,6 @@ if Controlled._primitive is not None:  # pylint: disable=protected-access
             control_values=control_values,
             work_wires=work_wires,
             work_wire_type=work_wire_type,
-            id=id,
         )
 
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -451,8 +451,6 @@ class CY(ControlledOp):
 
     Args:
         wires (Sequence[int]): the wires the operation acts on
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
     """
 
     num_wires = 2
@@ -1876,7 +1874,6 @@ class CRX(ControlledOp):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -2093,7 +2090,6 @@ class CRY(ControlledOp):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -2289,7 +2285,6 @@ class CRZ(ControlledOp):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
 
     """
 
@@ -2520,7 +2515,6 @@ class CRot(ControlledOp):
         theta (float): rotation angle :math:`\theta`
         omega (float): rotation angle :math:`\omega`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
 
     """
 
@@ -2730,7 +2724,6 @@ class ControlledPhaseShift(ControlledOp):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
 
     """
 

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -333,17 +333,17 @@ class CH(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=2)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         control_wires = wires[:1]
         target_wires = wires[1:]
 
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.Hadamard, wires=target_wires)
-        super().__init__(base, control_wires, id=id)
+        super().__init__(base, control_wires)
 
     def __repr__(self):
         return f"CH(wires={self.wires.tolist()})"
@@ -476,14 +476,14 @@ class CY(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=2)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.Y, wires=wires[1:])
-        super().__init__(base, wires[:1], id=id)
+        super().__init__(base, wires[:1])
 
     def __repr__(self):
         return f"CY(wires={self.wires.tolist()})"
@@ -626,14 +626,14 @@ class CZ(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=2)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.Z, wires=wires[1:])
-        super().__init__(base, wires[:1], id=id)
+        super().__init__(base, wires[:1])
 
     def __repr__(self):
         return f"CZ(wires={self.wires.tolist()})"
@@ -764,17 +764,17 @@ class CSWAP(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=3)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         control_wires = wires[:1]
         target_wires = wires[1:]
 
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.SWAP, wires=target_wires)
-        super().__init__(base, control_wires, id=id)
+        super().__init__(base, control_wires)
 
     def __repr__(self):
         return f"CSWAP(wires={self.wires.tolist()})"
@@ -921,7 +921,7 @@ class CCZ(ControlledOp):
     """
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=3)
 
     def _flatten(self):
@@ -944,14 +944,14 @@ class CCZ(ControlledOp):
 
     name = "CCZ"
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         control_wires = wires[:2]
         target_wires = wires[2:]
 
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.Z, wires=target_wires)
-        super().__init__(base, control_wires, id=id)
+        super().__init__(base, control_wires)
 
     def __repr__(self):
         return f"CCZ(wires={self.wires.tolist()})"
@@ -1145,14 +1145,14 @@ class CNOT(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=2)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.X, wires=wires[1:])
-        super().__init__(base, wires[:1], id=id)
+        super().__init__(base, wires[:1])
 
     def adjoint(self):
         return CNOT(self.wires)
@@ -1299,16 +1299,16 @@ class Toffoli(ControlledOp):
         return cls(metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, wires, id=None):
+    def _primitive_bind_call(cls, wires):
         return cls._primitive.bind(*wires, n_wires=3)
 
-    def __init__(self, wires, id=None):
+    def __init__(self, wires):
         control_wires = wires[:2]
         target_wires = wires[2:]
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.X, wires=target_wires)
-        super().__init__(base, control_wires, id=id)
+        super().__init__(base, control_wires)
 
     def __repr__(self):
         return f"Toffoli(wires={self.wires.tolist()})"
@@ -1585,7 +1585,7 @@ class MultiControlledX(ControlledOp):
 
     @classmethod
     def _primitive_bind_call(
-        cls, wires, control_values=None, work_wires=None, work_wire_type="borrowed", id=None
+        cls, wires, control_values=None, work_wires=None, work_wire_type="borrowed"
     ):
         return cls._primitive.bind(
             *wires,
@@ -1893,11 +1893,11 @@ class CRX(ControlledOp):
     name = "CRX"
     parameter_frequencies = [(0.5, 1.0)]
 
-    def __init__(self, phi, wires: WiresLike, id=None):
+    def __init__(self, phi, wires: WiresLike):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.RX, phi, wires=wires[1:])
-        super().__init__(base, control_wires=wires[:1], id=id)
+        super().__init__(base, control_wires=wires[:1])
 
     def __repr__(self):
         return f"CRX({self.data[0]}, wires={self.wires.tolist()})"
@@ -1910,7 +1910,7 @@ class CRX(ControlledOp):
         return cls(*data, wires=metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, phi, wires: WiresLike, id=None):
+    def _primitive_bind_call(cls, phi, wires: WiresLike):
         return cls._primitive.bind(phi, *wires, n_wires=len(wires))
 
     @property
@@ -2110,11 +2110,11 @@ class CRY(ControlledOp):
     name = "CRY"
     parameter_frequencies = [(0.5, 1.0)]
 
-    def __init__(self, phi, wires, id=None):
+    def __init__(self, phi, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.RY, phi, wires=wires[1:])
-        super().__init__(base, control_wires=wires[:1], id=id)
+        super().__init__(base, control_wires=wires[:1])
 
     def __repr__(self):
         return f"CRY({self.data[0]}, wires={self.wires.tolist()}))"
@@ -2127,7 +2127,7 @@ class CRY(ControlledOp):
         return cls(*data, wires=metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, phi, wires, id=None):
+    def _primitive_bind_call(cls, phi, wires):
         return cls._primitive.bind(phi, *wires, n_wires=len(wires))
 
     @property
@@ -2307,11 +2307,11 @@ class CRZ(ControlledOp):
     name = "CRZ"
     parameter_frequencies = [(0.5, 1.0)]
 
-    def __init__(self, phi, wires, id=None):
+    def __init__(self, phi, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.RZ, phi, wires=wires[1:])
-        super().__init__(base, control_wires=wires[:1], id=id)
+        super().__init__(base, control_wires=wires[:1])
 
     def __repr__(self):
         return f"CRZ({self.data[0]}, wires={self.wires})"
@@ -2324,7 +2324,7 @@ class CRZ(ControlledOp):
         return cls(*data, wires=metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, phi, wires, id=None):
+    def _primitive_bind_call(cls, phi, wires):
         return cls._primitive.bind(phi, *wires, n_wires=len(wires))
 
     @property
@@ -2539,11 +2539,11 @@ class CRot(ControlledOp):
     parameter_frequencies = [(0.5, 1.0), (0.5, 1.0), (0.5, 1.0)]
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(self, phi, theta, omega, wires, id=None):
+    def __init__(self, phi, theta, omega, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.Rot, phi, theta, omega, wires=wires[1:])
-        super().__init__(base, control_wires=wires[:1], id=id)
+        super().__init__(base, control_wires=wires[:1])
 
     def __repr__(self):
         params = ", ".join([repr(p) for p in self.parameters])
@@ -2558,7 +2558,7 @@ class CRot(ControlledOp):
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     @classmethod
-    def _primitive_bind_call(cls, phi, theta, omega, wires, id=None):
+    def _primitive_bind_call(cls, phi, theta, omega, wires):
         return cls._primitive.bind(phi, theta, omega, *wires, n_wires=len(wires))
 
     @property
@@ -2748,11 +2748,11 @@ class ControlledPhaseShift(ControlledOp):
     name = "ControlledPhaseShift"
     parameter_frequencies = [(1,)]
 
-    def __init__(self, phi, wires, id=None):
+    def __init__(self, phi, wires):
         # We use type.__call__ instead of calling the class directly so that we don't bind the
         # operator primitive when new program capture is enabled
         base = type.__call__(qp.PhaseShift, phi, wires=wires[1:])
-        super().__init__(base, control_wires=wires[:1], id=id)
+        super().__init__(base, control_wires=wires[:1])
 
     def __repr__(self):
         return f"ControlledPhaseShift({self.data[0]}, wires={self.wires})"
@@ -2765,7 +2765,7 @@ class ControlledPhaseShift(ControlledOp):
         return cls(*data, wires=metadata[0])
 
     @classmethod
-    def _primitive_bind_call(cls, phi, wires, id=None):
+    def _primitive_bind_call(cls, phi, wires):
         return cls._primitive.bind(phi, *wires, n_wires=len(wires))
 
     @property

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -32,7 +32,6 @@ class Evolution(Exp):
         base (~.operation.Operator): The operator to be used as a generator, G.
         param (float): The evolution parameter, x. This parameter is expected not to have
             any complex component.
-        id (str): id for the Evolution operator. Default is None.
 
     Returns:
        :class:`Evolution`: A :class:`~.operation.Operator` representing an operator exponential of the form :math:`e^{-ix\hat{G}}`,

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -77,8 +77,8 @@ class Evolution(Exp):
     _name = "Evolution"
     num_params = 1
 
-    def __init__(self, generator, param=1, id=None):
-        super().__init__(generator, coeff=-1j * param, id=id)
+    def __init__(self, generator, param=1):
+        super().__init__(generator, coeff=-1j * param)
         self._data = (param,)
 
     def __repr__(self):

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -81,13 +81,12 @@ def _find_equal_generator(base, coeff):
     return None
 
 
-def exp(op, coeff: float = 1.0, id: str | None = None):
+def exp(op, coeff: float = 1.0):
     """Take the exponential of an Operator times a coefficient.
 
     Args:
         base (~.operation.Operator): The Operator to be exponentiated
         coeff (float): a scalar coefficient of the operator
-        id (str): id for the Exp operator. Default is None.
 
     Returns:
        :class:`Exp`: An :class:`~.operation.Operator` representing an operator exponential.
@@ -153,7 +152,7 @@ def exp(op, coeff: float = 1.0, id: str | None = None):
 
 
     """
-    return Exp(op, coeff, id=id)
+    return Exp(op, coeff)
 
 
 class Exp(ScalarSymbolicOp, Operation):
@@ -162,7 +161,6 @@ class Exp(ScalarSymbolicOp, Operation):
     Args:
         base (~.operation.Operator): The Operator to be exponentiated
         coeff=1 (Number): A scalar coefficient of the operator.
-        id (str): id for the Exp operator. Default is None.
 
     **Example**
 
@@ -216,10 +214,10 @@ class Exp(ScalarSymbolicOp, Operation):
         base, coeff = data
         return cls(base, coeff)
 
-    def __init__(self, base, coeff=1.0, id=None):
+    def __init__(self, base, coeff=1.0):
         if not isinstance(base, Operator):
             raise TypeError(f"base is expected to be of type Operator, but received {type(base)}")
-        super().__init__(base, scalar=coeff, id=id)
+        super().__init__(base, scalar=coeff)
         self.grad_recipe = [None]
 
     def __repr__(self):

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -48,7 +48,6 @@ class LinearCombination(Sum):
         method (str): The graph colouring heuristic to use in solving minimum clique cover for grouping, which
             can be ``'lf'`` (Largest First), ``'rlf'`` (Recursive Largest First), ``'dsatur'`` (Degree of Saturation), or
             ``'gis'`` (IndependentSet). Defaults to ``'lf'``. Ignored if ``grouping_type=None``.
-        id (str): name to be assigned to this ``LinearCombination`` instance
 
     .. seealso:: `rustworkx.ColoringStrategy <https://www.rustworkx.org/apiref/rustworkx.ColoringStrategy.html#coloringstrategy>`_
         for more information on the ``('lf', 'dsatur', 'gis')`` strategies.
@@ -129,7 +128,6 @@ class LinearCombination(Sum):
         *,
         _grouping_indices=None,
         _pauli_rep=None,
-        id=None,
     ):
         if isinstance(observables, Operator):
             raise ValueError(
@@ -157,7 +155,6 @@ class LinearCombination(Sum):
             *operands,
             grouping_type=grouping_type,
             method=method,
-            id=id,
             _grouping_indices=_grouping_indices,
             _pauli_rep=_pauli_rep,
         )
@@ -515,7 +512,6 @@ class Hamiltonian:
         method (str): The graph colouring heuristic to use in solving minimum clique cover for grouping, which
             can be ``'lf'`` (Largest First), ``'rlf'`` (Recursive Largest First), ``'dsatur'`` (Degree of Saturation),
             or ``'gis'`` (Greedy Independent Set). Ignored if ``grouping_type=None``.
-        id (str): name to be assigned to this Hamiltonian instance
 
     **Example:**
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -47,8 +47,6 @@ def pow(base, z=1, lazy=True) -> Operator:
     Keyword Args:
         lazy=True (bool): In lazy mode, all operations are wrapped in a ``Pow`` class
             and handled later. If ``lazy=False``, operation-specific simplifications are first attempted.
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
 
     Returns:
         Operator

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -37,7 +37,7 @@ from .symbolicop import ScalarSymbolicOp
 _superscript = str.maketrans("0123456789.+-", "⁰¹²³⁴⁵⁶⁷⁸⁹⋅⁺⁻")
 
 
-def pow(base, z=1, lazy=True, id=None) -> Operator:
+def pow(base, z=1, lazy=True) -> Operator:
     """Raise an Operator to a power.
 
     Args:
@@ -91,15 +91,15 @@ def pow(base, z=1, lazy=True, id=None) -> Operator:
 
     """
     if lazy:
-        return Pow(base, z, id=id)
+        return Pow(base, z)
     try:
         pow_ops = base.pow(z)
     except PowUndefinedError:
-        return Pow(base, z, id=id)
+        return Pow(base, z)
 
     num_ops = len(pow_ops)
     if num_ops == 0:
-        pow_op = qp.Identity(base.wires, id=id)
+        pow_op = qp.Identity(base.wires)
     elif num_ops == 1:
         pow_op = pow_ops[0]
     else:
@@ -142,7 +142,7 @@ class Pow(ScalarSymbolicOp):
     def _unflatten(cls, data, metadata):
         return pow(data[0], z=metadata[0])
 
-    def __new__(cls, base=None, z=1, id=None):
+    def __new__(cls, base=None, z=1):
         """Mixes in parents based on inheritance structure of base.
 
         Though all the types will be named "Pow", their *identity* and location in memory will be
@@ -168,11 +168,11 @@ class Pow(ScalarSymbolicOp):
 
         return object.__new__(Pow)
 
-    def __init__(self, base=None, z=1, id=None):
+    def __init__(self, base=None, z=1):
         self.hyperparameters["z"] = z
         self._name = f"{base.name}**{z}"
 
-        super().__init__(base, scalar=z, id=id)
+        super().__init__(base, scalar=z)
 
         if isinstance(self.z, int) and self.z > 0:
             if (base_pauli_rep := getattr(self.base, "pauli_rep", None)) and (

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -43,7 +43,7 @@ MAX_NUM_WIRES_KRON_PRODUCT = 9
 computing the sparse matrix representation."""
 
 
-def prod(*ops, id=None, lazy=True):
+def prod(*ops, lazy=True):
     """Construct an operator which represents the generalized product of the
     operators provided.
 
@@ -130,16 +130,15 @@ def prod(*ops, id=None, lazy=True):
                 if qp.QueuingManager.recording():
                     op = qp.apply(op)
                 return op
-            return prod(*qs.operations[::-1], id=id, lazy=lazy)
+            return prod(*qs.operations[::-1], lazy=lazy)
 
         return wrapper
 
     if lazy:
-        return Prod(*ops, id=id)
+        return Prod(*ops)
 
     ops_simp = Prod(
         *itertools.chain.from_iterable([op if isinstance(op, Prod) else [op] for op in ops]),
-        id=id,
     )
 
     for op in ops:

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -38,7 +38,6 @@ def s_prod(scalar, operator, lazy=True):
 
     Keyword Args:
         lazy=True (bool): If ``lazy=False`` and the operator is already a scalar product operator, the scalar provided will simply be combined with the existing scaling factor.
-        id (str or None): id for the scalar product operator. Default is None.
     Returns:
         ~ops.op_math.SProd: The operator representing the scalar product.
 
@@ -84,9 +83,6 @@ class SProd(ScalarSymbolicOp):
     Args:
         scalar (float or complex): the scale factor being multiplied to the operator.
         base (~.operation.Operator): the operator which will get scaled.
-
-    Keyword Args:
-        id (str or None): id for the scalar product operator. Default is None.
 
     .. note::
         Currently this operator can not be queued in a circuit as an operation, only measured terminally.

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -28,7 +28,7 @@ from .composite import handle_recursion_error
 from .symbolicop import ScalarSymbolicOp
 
 
-def s_prod(scalar, operator, lazy=True, id=None):
+def s_prod(scalar, operator, lazy=True):
     r"""Construct an operator which is the scalar product of the
     given scalar and operator provided.
 
@@ -70,9 +70,9 @@ def s_prod(scalar, operator, lazy=True, id=None):
            [2., 0.]])
     """
     if lazy or not isinstance(operator, SProd):
-        return SProd(scalar, operator, id=id)
+        return SProd(scalar, operator)
 
-    sprod_op = SProd(scalar=scalar * operator.scalar, base=operator.base, id=id)
+    sprod_op = SProd(scalar=scalar * operator.scalar, base=operator.base)
     QueuingManager.remove(operator)
     return sprod_op
 
@@ -134,8 +134,8 @@ class SProd(ScalarSymbolicOp):
     def _unflatten(cls, data, _):
         return cls(data[0], data[1])
 
-    def __init__(self, scalar: qp.typing.TensorLike, base: Operator, id=None, _pauli_rep=None):
-        super().__init__(base=base, scalar=scalar, id=id)
+    def __init__(self, scalar: qp.typing.TensorLike, base: Operator, _pauli_rep=None):
+        super().__init__(base=base, scalar=scalar)
 
         if _pauli_rep:
             self._pauli_rep = _pauli_rep

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -29,14 +29,13 @@ from pennylane.queuing import QueuingManager
 from .composite import CompositeOp, handle_recursion_error
 
 
-def sum(*summands, grouping_type=None, method="lf", id=None, lazy=True):
+def sum(*summands, grouping_type=None, method="lf", lazy=True):
     r"""Construct an operator which is the sum of the given operators.
 
     Args:
         *summands (tuple[~.operation.Operator]): the operators we want to sum together.
 
     Keyword Args:
-        id (str or None): id for the Sum operator. Default is None.
         lazy=True (bool): If ``lazy=False``, a simplification will be performed such that when any
             of the operators is already a sum operator, its operands (summands) will be used instead.
         grouping_type (str): The type of binary relation between Pauli words used to compute
@@ -105,13 +104,12 @@ def sum(*summands, grouping_type=None, method="lf", id=None, lazy=True):
         :ref:`Pauli Graph Colouring<graph_colouring>` and :func:`~pennylane.pauli.compute_partition_indices`.
     """
     if lazy:
-        return Sum(*summands, grouping_type=grouping_type, method=method, id=id)
+        return Sum(*summands, grouping_type=grouping_type, method=method)
 
     summands_simp = Sum(
         *itertools.chain.from_iterable([op if isinstance(op, Sum) else [op] for op in summands]),
         grouping_type=grouping_type,
         method=method,
-        id=id,
     )
 
     for op in summands:
@@ -132,7 +130,6 @@ class Sum(CompositeOp):
         method (str): The graph colouring heuristic to use in solving minimum clique cover for
             grouping, which can be ``'lf'`` (Largest First), ``'rlf'`` (Recursive Largest First), ``'dsatur'`` (Degree of Saturation),
             or ``'gis'`` (Greedy Independent Set). This keyword argument is ignored if ``grouping_type`` is ``None``.
-        id (str or None): id for the sum operator. Default is None.
 
     .. note::
         Currently this operator can not be queued in a circuit as an operation, only measured terminally.
@@ -227,11 +224,10 @@ class Sum(CompositeOp):
         *operands: Operator,
         grouping_type=None,
         method="lf",
-        id=None,
         _grouping_indices=None,
         _pauli_rep=None,
     ):
-        super().__init__(*operands, id=id, _pauli_rep=_pauli_rep)
+        super().__init__(*operands, _pauli_rep=_pauli_rep)
 
         self._grouping_indices = _grouping_indices
         if _grouping_indices is not None and grouping_type is not None:

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -15,14 +15,12 @@
 This submodule defines a base class for symbolic operations representing operator math.
 """
 
-import warnings
 from abc import abstractmethod
 from copy import copy
 
 import numpy as np
 
 import pennylane as qp
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import _UNSET_BATCH_SIZE, Operator
 from pennylane.queuing import QueuingManager
 
@@ -34,8 +32,6 @@ class SymbolicOp(Operator):
 
     Args:
         base (~.operation.Operator): the base operation that is modified symbolically
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
 
     This *developer-facing* class can serve as a parent to single base symbolic operators, such as
     :class:`~.ops.op_math.Adjoint`.
@@ -74,17 +70,10 @@ class SymbolicOp(Operator):
         return copied_op
 
     # pylint: disable=super-init-not-called
-    def __init__(self, base, id=None):
+    def __init__(self, base):
         self.hyperparameters["base"] = base
         if isinstance(base, (qp.ops.MidMeasure, qp.ops.PauliMeasure)):
             raise ValueError("Symbolic operators of mid-circuit measurements are not supported.")
-        if id is not None:
-            warnings.warn(
-                "The 'id' argument is deprecated and will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-                stacklevel=2,
-            )
-        self._id = id
         self._pauli_rep = None
         self.queue()
         self._wires = base.wires
@@ -173,8 +162,6 @@ class ScalarSymbolicOp(SymbolicOp):
     Args:
         base (~.operation.Operator): the base operation that is modified symbolically
         scalar (float): the scalar coefficient
-        id (str): custom label given to an operator instance, can be useful for some applications
-            where the instance has to be identified
 
     This *developer-facing* class can serve as a parent to single base symbolic operators, such as
     :class:`~.ops.op_math.SProd` and :class:`~.ops.op_math.Pow`.
@@ -182,9 +169,9 @@ class ScalarSymbolicOp(SymbolicOp):
 
     _name = "ScalarSymbolicOp"
 
-    def __init__(self, base, scalar: float, id=None):
+    def __init__(self, base, scalar: float):
         self.scalar = np.array(scalar) if isinstance(scalar, list) else scalar
-        super().__init__(base, id=id)
+        super().__init__(base)
         self._batch_size = _UNSET_BATCH_SIZE
 
     @property

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -108,8 +108,6 @@ class QubitUnitary(Operation):
     Args:
         U (array[complex] or csr_matrix): square unitary matrix
         wires (Sequence[int] or int): the wire(s) the operation acts on
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
         unitary_check (bool): check for unitarity of the given matrix
 
     Raises:
@@ -142,7 +140,6 @@ class QubitUnitary(Operation):
         self,
         U: TensorLike | csr_matrix,
         wires: WiresLike,
-        id: str | None = None,
         unitary_check: bool = False,
     ):
         wires = Wires(wires)
@@ -171,7 +168,7 @@ class QubitUnitary(Operation):
                 UserWarning,
             )
 
-        super().__init__(U, wires=wires, id=id)
+        super().__init__(U, wires=wires)
 
     @staticmethod
     def _unitary_check(U, dim):
@@ -717,7 +714,6 @@ class BlockEncode(Operation):
     Args:
         A (tensor_like): a general :math:`(n \times m)` matrix to be encoded
         wires (Iterable[int, str], Wires): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     Raises:
         ValueError: if the number of wires doesn't fit the dimensions of the matrix
@@ -774,7 +770,7 @@ class BlockEncode(Operation):
     grad_method = None
     """Gradient computation method."""
 
-    def __init__(self, A: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, A: TensorLike, wires: WiresLike):
         wires = Wires(wires)
         shape_a = qp.math.shape(A)
         if shape_a == () or all(x == 1 for x in shape_a):
@@ -804,7 +800,7 @@ class BlockEncode(Operation):
                 f" Cannot be embedded in a {len(wires)} qubit system."
             )
 
-        super().__init__(A, wires=wires, id=id)
+        super().__init__(A, wires=wires)
         self.hyperparameters["norm"] = normalization
         self.hyperparameters["subspace"] = subspace
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -74,8 +74,8 @@ class Hadamard(Operation):
 
     resource_keys = set()
 
-    def __init__(self, wires: WiresLike, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: WiresLike):
+        super().__init__(wires=wires)
 
     def label(
         self,
@@ -343,8 +343,8 @@ class PauliX(Operation):
             )
         return self._pauli_rep
 
-    def __init__(self, wires: WiresLike, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: WiresLike):
+        super().__init__(wires=wires)
 
     def label(
         self,
@@ -624,8 +624,8 @@ class PauliY(Operation):
             )
         return self._pauli_rep
 
-    def __init__(self, wires: WiresLike, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: WiresLike):
+        super().__init__(wires=wires)
 
     def __repr__(self) -> str:
         """String representation."""
@@ -877,8 +877,8 @@ class PauliZ(Operation):
             )
         return self._pauli_rep
 
-    def __init__(self, wires: WiresLike, id: str | None = None):
-        super().__init__(wires=wires, id=id)
+    def __init__(self, wires: WiresLike):
+        super().__init__(wires=wires)
 
     def __repr__(self) -> str:
         """String representation."""
@@ -1827,7 +1827,6 @@ class ECR(Operation):
 
     Args:
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -54,7 +54,6 @@ class Hermitian(Operator):
     Args:
         A (array or Sequence): square hermitian matrix
         wires (Sequence[int] or int): the wire(s) the operation acts on
-        id (str or None): String representing the operation (optional)
 
     .. warning::
 
@@ -78,7 +77,7 @@ class Hermitian(Operator):
     _num_basis_states = 2
     _eigs = {}
 
-    def __init__(self, A: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, A: TensorLike, wires: WiresLike):
         A = np.array(A) if isinstance(A, list) else A
         if not qp.math.is_abstract(A):
             if isinstance(wires, Sequence) and not isinstance(wires, str):
@@ -93,7 +92,7 @@ class Hermitian(Operator):
 
             Hermitian._validate_input(A, expected_mx_shape)
 
-        super().__init__(A, wires=wires, id=id)
+        super().__init__(A, wires=wires)
 
     @staticmethod
     def _validate_input(A: TensorLike, expected_mx_shape: int | None = None):
@@ -292,7 +291,6 @@ class SparseHamiltonian(Operator):
         H (csr_matrix): a sparse matrix in SciPy Compressed Sparse Row (CSR) format with
             dimension :math:`(2^n, 2^n)`, where :math:`n` is the number of wires.
         wires (Sequence[int]): the wire(s) the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 
@@ -316,10 +314,10 @@ class SparseHamiltonian(Operator):
 
     grad_method = None
 
-    def __init__(self, H: csr_matrix, wires: WiresLike, id: str | None = None):
+    def __init__(self, H: csr_matrix, wires: WiresLike):
         if not isinstance(H, csr_matrix):
             raise TypeError("Observable must be a scipy sparse csr_matrix.")
-        super().__init__(H, wires=wires, id=id)
+        super().__init__(H, wires=wires)
         self.H = H
         mat_len = 2 ** len(self.wires)
         if H.shape != (mat_len, mat_len):
@@ -412,7 +410,7 @@ class SparseHamiltonian(Operator):
 
 
 class Projector(Operator):
-    r"""Projector(state, wires, id=None)
+    r"""Projector(state, wires)
     Observable corresponding to the state projector :math:`P=\ket{\phi}\bra{\phi}`.
 
     The expectation of this observable returns the value
@@ -432,7 +430,6 @@ class Projector(Operator):
         state (tensor-like): Input state of shape ``(n,)`` for a basis-state projector, or ``(2**n,)``
             for a statevector projector.
         wires (Iterable): wires that the projector acts on.
-        id (str or None): String representing the operation (optional).
 
     **Example**
 
@@ -514,7 +511,7 @@ class BasisStateProjector(Projector, Operation):
 
     # The call signature should be the same as Projector.__new__ for the positional
     # arguments, but with free key word arguments.
-    def __init__(self, state: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, state: TensorLike, wires: WiresLike):
         wires = Wires(wires)
 
         if qp.math.get_interface(state) == "jax":
@@ -528,7 +525,7 @@ class BasisStateProjector(Projector, Operation):
             if not set(state).issubset({0, 1}):
                 raise ValueError(f"Basis state must only consist of 0s and 1s; got {state}")
 
-        super().__init__(state, wires=wires, id=id)
+        super().__init__(state, wires=wires)
 
     def __new__(cls, *_, **__):
         return object.__new__(cls)
@@ -696,9 +693,9 @@ class StateVectorProjector(Projector):
 
     # The call signature should be the same as Projector.__new__ for the positional
     # arguments, but with free key word arguments.
-    def __init__(self, state: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, state: TensorLike, wires: WiresLike):
         wires = Wires(wires)
-        super().__init__(state, wires=wires, id=id)
+        super().__init__(state, wires=wires)
 
     def __new__(cls, *_, **__):
         return object.__new__(cls)

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -71,7 +71,6 @@ class MultiRZ(Operation):
     Args:
         theta (TensorLike): rotation angle :math:`\theta`
         wires (Sequence[int] or int): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_params = 1
@@ -88,10 +87,10 @@ class MultiRZ(Operation):
     def _flatten(self) -> FlatPytree:
         return self.data, (self.wires, tuple())
 
-    def __init__(self, theta: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, theta: TensorLike, wires: WiresLike):
         wires = Wires(wires)
         self.hyperparameters["num_wires"] = len(wires)
-        super().__init__(theta, wires=wires, id=id)
+        super().__init__(theta, wires=wires)
         if not self._wires:
             raise ValueError(
                 f"{self.name}: wrong number of wires. At least one wire has to be provided."
@@ -285,7 +284,6 @@ class PauliRot(Operation):
         theta (float): rotation angle :math:`\theta`
         pauli_word (string): the Pauli word defining the rotation
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 
@@ -319,17 +317,16 @@ class PauliRot(Operation):
     }
 
     @classmethod
-    def _primitive_bind_call(cls, theta, pauli_word, wires=None, id=None):
-        return super()._primitive_bind_call(theta, pauli_word=pauli_word, wires=wires, id=id)
+    def _primitive_bind_call(cls, theta, pauli_word, wires=None):
+        return super()._primitive_bind_call(theta, pauli_word=pauli_word, wires=wires)
 
     def __init__(
         self,
         theta: TensorLike,
         pauli_word: str,
         wires: WiresLike,
-        id: str | None = None,
     ):
-        super().__init__(theta, wires=wires, id=id)
+        super().__init__(theta, wires=wires)
 
         if not self._wires:
             raise ValueError(
@@ -653,7 +650,6 @@ class PCPhase(Operation):
         phi (float): rotation angle :math:`\phi`
         dim (int): the dimension of the subspace
         wires (Iterable[int, str], Wires): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example:**
 
@@ -738,7 +734,7 @@ class PCPhase(Operation):
         hyperparameter = (("dim", self.hyperparameters["dimension"][0]),)
         return tuple(self.data), (self.wires, hyperparameter)
 
-    def __init__(self, phi: TensorLike, dim: int, wires: WiresLike, id: str | None = None):
+    def __init__(self, phi: TensorLike, dim: int, wires: WiresLike):
         wires = wires if isinstance(wires, Wires) else Wires(wires)
 
         if not (isinstance(dim, int) and (dim <= 2 ** len(wires))):
@@ -747,7 +743,7 @@ class PCPhase(Operation):
                 f"the max size of the matrix {2 ** len(wires)}. Try adding more wires."
             )
 
-        super().__init__(phi, wires=wires, id=id)
+        super().__init__(phi, wires=wires)
         self.hyperparameters["dimension"] = (dim, 2 ** len(wires))
 
     @property
@@ -1157,7 +1153,6 @@ class IsingXX(Operation):
     Args:
         phi (float): the phase angle
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -1175,8 +1170,8 @@ class IsingXX(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliX(wires=self.wires[0]) @ PauliX(wires=self.wires[1])])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1326,7 +1321,6 @@ class IsingYY(Operation):
     Args:
         phi (float): the phase angle
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -1344,8 +1338,8 @@ class IsingYY(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliY(wires=self.wires[0]) @ PauliY(wires=self.wires[1])])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1503,7 +1497,6 @@ class IsingZZ(Operation):
     Args:
         phi (float): the phase angle
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -1521,8 +1514,8 @@ class IsingZZ(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliZ(wires=self.wires[0]) @ PauliZ(wires=self.wires[1])])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1721,7 +1714,6 @@ class IsingXY(Operation):
     Args:
         phi (float): the phase angle
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -1746,8 +1738,8 @@ class IsingXY(Operation):
             ],
         )
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1933,7 +1925,6 @@ class PSWAP(Operation):
     Args:
         phi (float): the phase angle
         wires (int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -1948,8 +1939,8 @@ class PSWAP(Operation):
     grad_method = "A"
     grad_recipe = ([[0.5, 1, np.pi / 2], [-0.5, 1, -np.pi / 2]],)
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -2142,7 +2133,6 @@ class CPhaseShift00(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -2160,8 +2150,8 @@ class CPhaseShift00(Operation):
 
     resource_keys = set()
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -2366,7 +2356,6 @@ class CPhaseShift01(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -2384,8 +2373,8 @@ class CPhaseShift01(Operation):
 
     resource_keys = set()
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -2580,7 +2569,6 @@ class CPhaseShift10(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Any, Wires): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 2
@@ -2598,8 +2586,8 @@ class CPhaseShift10(Operation):
 
     resource_keys = set()
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -76,7 +76,6 @@ class RX(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -96,8 +95,8 @@ class RX(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliX(wires=self.wires)])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -282,7 +281,6 @@ class RY(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -300,8 +298,8 @@ class RY(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliY(wires=self.wires)])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -498,7 +496,6 @@ class RZ(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -517,8 +514,8 @@ class RZ(Operation):
     def generator(self) -> "qp.Hamiltonian":
         return qp.Hamiltonian([-0.5], [PauliZ(wires=self.wires)])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     has_decomposition = False
 
@@ -765,7 +762,6 @@ class PhaseShift(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -788,8 +784,8 @@ class PhaseShift(Operation):
     def generator(self) -> "qp.Projector":
         return qp.Projector(np.array([1]), wires=self.wires)
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     def label(
         self,
@@ -990,7 +986,6 @@ class Rot(Operation):
         theta (float): rotation angle :math:`\theta`
         omega (float): rotation angle :math:`\omega`
         wires (Any, Wires): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -1014,9 +1009,8 @@ class Rot(Operation):
         theta: TensorLike,
         omega: TensorLike,
         wires: WiresLike,
-        id: str | None = None,
     ):
-        super().__init__(phi, theta, omega, wires=wires, id=id)
+        super().__init__(phi, theta, omega, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1236,7 +1230,6 @@ class U1(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -1254,8 +1247,8 @@ class U1(Operation):
     def generator(self) -> "qp.Projector":
         return qp.Projector(np.array([1]), wires=self.wires)
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1386,7 +1379,6 @@ class U2(Operation):
         phi (float): azimuthal angle :math:`\phi`
         delta (float): quantum phase :math:`\delta`
         wires (Sequence[int] or int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -1401,8 +1393,8 @@ class U2(Operation):
 
     resource_keys = set()
 
-    def __init__(self, phi: TensorLike, delta: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, delta, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, delta: TensorLike, wires: WiresLike):
+        super().__init__(phi, delta, wires=wires)
 
     @property
     def resource_params(self) -> dict:
@@ -1560,7 +1552,6 @@ class U3(Operation):
         phi (float): azimuthal angle :math:`\phi`
         delta (float): quantum phase :math:`\delta`
         wires (Sequence[int] or int): the subsystem the gate acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 1
@@ -1582,9 +1573,8 @@ class U3(Operation):
         phi: TensorLike,
         delta: TensorLike,
         wires: WiresLike,
-        id: str | None = None,
     ):
-        super().__init__(theta, phi, delta, wires=wires, id=id)
+        super().__init__(theta, phi, delta, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -192,8 +192,8 @@ class SingleExcitation(Operation):
         w1, w2 = self.wires
         return qp.Hamiltonian([0.25, -0.25], [qp.X(w1) @ qp.Y(w2), qp.Y(w1) @ qp.X(w2)])
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def compute_matrix(phi: TensorLike) -> TensorLike:  # pylint: disable=arguments-differ
@@ -366,8 +366,8 @@ class SingleExcitationMinus(Operation):
             [qp.Identity(w1), qp.X(w1) @ qp.Y(w2), qp.Y(w1) @ qp.X(w2), qp.Z(w1) @ qp.Z(w2)],
         )
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def compute_matrix(phi: TensorLike) -> TensorLike:  # pylint: disable=arguments-differ
@@ -538,8 +538,8 @@ class SingleExcitationPlus(Operation):
             [qp.Identity(w1), qp.X(w1) @ qp.Y(w2), qp.Y(w1) @ qp.X(w2), qp.Z(w1) @ qp.Z(w2)],
         )
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def compute_matrix(phi: TensorLike) -> TensorLike:  # pylint: disable=arguments-differ
@@ -739,8 +739,8 @@ class DoubleExcitation(Operation):
     def pow(self, z: int | float) -> list["qp.operation.Operator"]:
         return [DoubleExcitation(self.data[0] * z, wires=self.wires)]
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     mask_s = np.zeros((16, 16))
     mask_s[3, 12] = -1
@@ -988,8 +988,8 @@ class DoubleExcitationPlus(Operation):
         H = csr_matrix(-0.5 * G)
         return qp.SparseHamiltonian(H, wires=self.wires)
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def compute_matrix(phi: TensorLike) -> TensorLike:  # pylint: disable=arguments-differ
@@ -1211,8 +1211,8 @@ class OrbitalRotation(Operation):
             ],
         )
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     mask_s = np.zeros((16, 16))
     mask_s[1, 4] = mask_s[2, 8] = mask_s[13, 7] = mask_s[14, 11] = -1
@@ -1426,8 +1426,8 @@ class FermionicSWAP(Operation):
             ],
         )
 
-    def __init__(self, phi: TensorLike, wires: WiresLike, id: str | None = None):
-        super().__init__(phi, wires=wires, id=id)
+    def __init__(self, phi: TensorLike, wires: WiresLike):
+        super().__init__(phi, wires=wires)
 
     @staticmethod
     def compute_matrix(phi: TensorLike) -> TensorLike:  # pylint: disable=arguments-differ

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -147,7 +147,6 @@ class SingleExcitation(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 
@@ -334,7 +333,6 @@ class SingleExcitationMinus(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     """
 
@@ -506,7 +504,6 @@ class SingleExcitationPlus(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int] or int): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     """
 
@@ -678,7 +675,6 @@ class DoubleExcitation(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 
@@ -956,7 +952,6 @@ class DoubleExcitationPlus(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 4
@@ -1053,7 +1048,6 @@ class DoubleExcitationMinus(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
     """
 
     num_wires = 4
@@ -1157,7 +1151,6 @@ class OrbitalRotation(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 
@@ -1372,7 +1365,6 @@ class FermionicSWAP(Operation):
     Args:
         phi (float): rotation angle :math:`\phi`
         wires (Sequence[int]): the wires the operation acts on
-        id (str or None): String representing the operation (optional)
 
     **Example**
 

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -210,7 +210,6 @@ class SpecialUnitary(Operation):
         theta (tensor_like): Pauli coordinates of the exponent :math:`A(\bm{\theta})`.
             See details below for the order of the Pauli words.
         wires (Sequence[int] or int): The wire(s) the operation acts on
-        id (str or None): String representing the operation (optional)
 
     Raises:
         ValueError: If the shape of the input does not match the Lie algebra
@@ -411,7 +410,7 @@ class SpecialUnitary(Operation):
     grad_method = None
     """Gradient computation method."""
 
-    def __init__(self, theta: TensorLike, wires: WiresLike, id: str | None = None):
+    def __init__(self, theta: TensorLike, wires: WiresLike):
         num_wires = 1 if isinstance(wires, int) else len(wires)
         self.hyperparameters["num_wires"] = num_wires
         theta_shape = qp.math.shape(theta)
@@ -429,7 +428,7 @@ class SpecialUnitary(Operation):
                 f"{expected_dim}). The parameters have shape {theta_shape}"
             )
 
-        super().__init__(theta, wires=wires, id=id)
+        super().__init__(theta, wires=wires)
 
     def _flatten(self) -> FlatPytree:
         return self.data, (self.wires, ())

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -70,7 +70,6 @@ class BasisState(StatePrepBase):
         state (tensor_like): Binary input of shape ``(len(wires), )``. For example, if ``state=np.array([0, 1, 0])`` or ``state=2`` (equivalent to 010 in binary), the quantum system will be prepared in the state :math:`|010 \rangle`.
 
         wires (Sequence[int] or int): the wire(s) the operation acts on
-        id (str): Custom label given to an operator instance. Can be useful for some applications where the instance has to be identified.
 
     **Example**
 
@@ -98,7 +97,7 @@ class BasisState(StatePrepBase):
     def resource_params(self) -> dict:
         return {"num_wires": len(self.wires)}
 
-    def __init__(self, state, wires: WiresLike, id=None):
+    def __init__(self, state, wires: WiresLike):
 
         wires = Wires(wires)
         if isinstance(state, list):
@@ -130,7 +129,7 @@ class BasisState(StatePrepBase):
             if not set(state_list).issubset({0, 1}):
                 raise ValueError(f"Basis state must only consist of 0s and 1s; got {state_list}")
         state = qp.math.cast(state, int)
-        super().__init__(state, wires=wires, id=id)
+        super().__init__(state, wires=wires)
 
     def _flatten(self):
         state = self.parameters[0]
@@ -286,8 +285,6 @@ class StatePrep(StatePrepBase):
             :math:`n` is the number of wires.
         normalize (bool): whether to normalize the state vector. To represent a valid quantum state vector, the L2-norm
             of ``state`` must be one. The argument ``normalize`` can be set to ``True`` to normalize the state automatically.
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
         validate_norm (bool): whether to validate the norm of the input state
 
 
@@ -414,7 +411,6 @@ class StatePrep(StatePrepBase):
         wires: WiresLike,
         pad_with=None,
         normalize: bool = False,
-        id: str | None = None,
         validate_norm: bool = False,
     ):
         self.is_sparse = False
@@ -435,7 +431,7 @@ class StatePrep(StatePrepBase):
             "validate_norm": validate_norm,
         }
 
-        super().__init__(state, wires=wires, id=id)
+        super().__init__(state, wires=wires)
 
     def _check_batching(self):
         if self.is_sparse:
@@ -671,8 +667,6 @@ class QubitDensityMatrix(Operation):
     Args:
         state (array[complex]): a density matrix of size ``(2**len(wires), 2**len(wires))``
         wires (Sequence[int] or int): the wire(s) the operation acts on
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
 
     .. details::
         :title: Usage Details

--- a/pennylane/ops/qutrit/channel.py
+++ b/pennylane/ops/qutrit/channel.py
@@ -135,8 +135,8 @@ class QutritDepolarizingChannel(Channel):
     grad_method = "A"
     grad_recipe = ([[1, 0, 1], [-1, 0, 0]],)
 
-    def __init__(self, p, wires, id=None):
-        super().__init__(p, wires=wires, id=id)
+    def __init__(self, p, wires):
+        super().__init__(p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p):  # pylint:disable=arguments-differ
@@ -290,7 +290,7 @@ class QutritAmplitudeDamping(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, gamma_10, gamma_20, gamma_21, wires, id=None):
+    def __init__(self, gamma_10, gamma_20, gamma_21, wires):
         # Verify input
         for gamma in (gamma_10, gamma_20, gamma_21):
             if not math.is_abstract(gamma):
@@ -299,7 +299,7 @@ class QutritAmplitudeDamping(Channel):
         if not (math.is_abstract(gamma_20) or math.is_abstract(gamma_21)):
             if not 0.0 <= gamma_20 + gamma_21 <= 1.0:
                 raise ValueError(r"\gamma_{20}+\gamma_{21} must be in the interval [0,1]")
-        super().__init__(gamma_10, gamma_20, gamma_21, wires=wires, id=id)
+        super().__init__(gamma_10, gamma_20, gamma_21, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(gamma_10, gamma_20, gamma_21):  # pylint:disable=arguments-differ
@@ -405,7 +405,7 @@ class TritFlip(Channel):
     num_wires = 1
     grad_method = "F"
 
-    def __init__(self, p_01, p_02, p_12, wires, id=None):
+    def __init__(self, p_01, p_02, p_12, wires):
         # Verify input
         ps = (p_01, p_02, p_12)
         for p in ps:
@@ -415,7 +415,7 @@ class TritFlip(Channel):
             if not 0.0 <= sum(ps) <= 1.0:
                 raise ValueError("The sum of probabilities must be in the interval [0,1]")
 
-        super().__init__(p_01, p_02, p_12, wires=wires, id=id)
+        super().__init__(p_01, p_02, p_12, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p_01, p_02, p_12):  # pylint:disable=arguments-differ
@@ -482,8 +482,8 @@ class QutritChannel(Channel):
 
     grad_method = None
 
-    def __init__(self, K_list, wires=None, id=None):
-        super().__init__(*K_list, wires=wires, id=id)
+    def __init__(self, K_list, wires=None):
+        super().__init__(*K_list, wires=wires)
 
         # check all Kraus matrices are square matrices
         if any(K.shape[0] != K.shape[1] for K in K_list):

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -37,8 +37,6 @@ class QutritUnitary(Operation):
     Args:
         U (array[complex]): square unitary matrix
         wires(Sequence[int] or int): the wire(s) the operation acts on
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
 
     **Example**
 

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -209,7 +209,7 @@ class GellMann(Operator):
         """Append the operator to the Operator queue."""
         return self
 
-    def __init__(self, wires, index=1, id=None):
+    def __init__(self, wires, index=1):
         if not isinstance(index, int) or index < 1 or index > 8:
             raise ValueError(
                 "The index of a Gell-Mann observable must be an integer between 1 and 8 inclusive."
@@ -217,7 +217,7 @@ class GellMann(Operator):
 
         self.hyperparameters["index"] = index
 
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     def label(self, decimals=None, base_label=None, cache=None):
         return base_label or f"GellMann({self.hyperparameters['index']})"

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -121,12 +121,12 @@ class TRX(Operation):
         # to qudit operators (for example, they do not have a matrix defined as a Hamiltonian)
         return qp.s_prod(-0.5, qp.GellMann(self.wires, index=self._index_dict[self.subspace]))
 
-    def __init__(self, phi, wires, subspace=(0, 1), id=None):
+    def __init__(self, phi, wires, subspace=(0, 1)):
         self._subspace = validate_subspace(subspace)
         self._hyperparameters = {
             "subspace": self._subspace,
         }
-        super().__init__(phi, wires=wires, id=id)
+        super().__init__(phi, wires=wires)
 
     @property
     def subspace(self):
@@ -271,12 +271,12 @@ class TRY(Operation):
         # to qudit operators (for example, they do not have a matrix defined as a Hamiltonian)
         return qp.s_prod(-0.5, qp.GellMann(self.wires, index=self._index_dict[self.subspace]))
 
-    def __init__(self, phi, wires, subspace=(0, 1), id=None):
+    def __init__(self, phi, wires, subspace=(0, 1)):
         self._subspace = validate_subspace(subspace)
         self._hyperparameters = {
             "subspace": self._subspace,
         }
-        super().__init__(phi, wires=wires, id=id)
+        super().__init__(phi, wires=wires)
 
     @property
     def subspace(self):
@@ -426,12 +426,12 @@ class TRZ(Operation):
         obs = [qp.GellMann(wires=self.wires, index=3), qp.GellMann(wires=self.wires, index=8)]
         return qp.dot(coeffs, obs)
 
-    def __init__(self, phi, wires, subspace=(0, 1), id=None):
+    def __init__(self, phi, wires, subspace=(0, 1)):
         self._subspace = validate_subspace(subspace)
         self._hyperparameters = {
             "subspace": self._subspace,
         }
-        super().__init__(phi, wires=wires, id=id)
+        super().__init__(phi, wires=wires)
 
     @property
     def subspace(self):

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -42,7 +42,7 @@ except ImportError as e:
 
 class ParametrizedEvolution(Operation):
     r"""
-    ParametrizedEvolution(H, params=None, t=None, return_intermediate=False, complementary=False, id=None, **odeint_kwargs)
+    ParametrizedEvolution(H, params=None, t=None, return_intermediate=False, complementary=False, **odeint_kwargs)
 
     Parametrized evolution gate, created by passing a :class:`~.ParametrizedHamiltonian` to
     the :func:`~.pennylane.evolve` function
@@ -376,7 +376,6 @@ class ParametrizedEvolution(Operation):
         return_intermediate: bool = False,
         complementary: bool = False,
         dense: bool = None,
-        id=None,
         **odeint_kwargs,
     ):
         if not all(op.has_matrix for op in H.ops):
@@ -406,7 +405,7 @@ class ParametrizedEvolution(Operation):
                     f"in the Hamiltonian must be the same. Received {len(params)=} parameters but "
                     f"expected {len(H.coeffs_parametrized)} parameters."
                 )
-        super().__init__(*params, wires=H.wires, id=id)
+        super().__init__(*params, wires=H.wires)
         self.hyperparameters["return_intermediate"] = return_intermediate
         self.hyperparameters["complementary"] = complementary
         self._check_time_batching()
@@ -443,7 +442,6 @@ class ParametrizedEvolution(Operation):
             return_intermediate=return_intermediate,
             complementary=complementary,
             dense=dense,
-            id=self._id,
             **odeint_kwargs,
         )
 

--- a/pennylane/qcut/ops.py
+++ b/pennylane/qcut/ops.py
@@ -16,9 +16,7 @@ Nodes for use in qcut.
 """
 
 import uuid
-import warnings
 
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import Operation
 
 
@@ -29,15 +27,7 @@ class PrepareNode(Operation):
     grad_method = None
     num_params = 0
 
-    def __init__(self, wires=None, id: str | None = None, node_uid: str | None = None):
-        if id is not None:
-            warnings.warn(
-                "The 'id' kwarg has been renamed to 'node_uid'. Access through 'id' will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-            )
-            # Only override if meas_uid wasn't explicitly provided
-            if node_uid is None:
-                node_uid = id
+    def __init__(self, wires=None, node_uid: str | None = None):
         self._node_uid: str = node_uid or str(uuid.uuid4())
 
         super().__init__(wires=wires)
@@ -59,15 +49,7 @@ class MeasureNode(Operation):
     grad_method = None
     num_params = 0
 
-    def __init__(self, wires=None, id: str | None = None, node_uid: str | None = None):
-        if id is not None:
-            warnings.warn(
-                "The 'id' kwarg has been renamed to 'node_uid'. Access through 'id' will be removed in v0.46.",
-                PennyLaneDeprecationWarning,
-            )
-            # Only override if meas_uid wasn't explicitly provided
-            if node_uid is None:
-                node_uid = id
+    def __init__(self, wires=None, node_uid: str | None = None):
         self._node_uid: str = node_uid or str(uuid.uuid4())
 
         super().__init__(wires=wires)

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -367,7 +367,6 @@ class SubroutineOp(Operation):
         bound_args: BoundArguments,
         decomposition: list[Operation],
         output: Any = None,
-        id: None | str = None,
     ):
         self._subroutine = subroutine
         self._bound_args = bound_args
@@ -383,7 +382,7 @@ class SubroutineOp(Operation):
 
         dynamic_args = [self._bound_args.arguments[arg] for arg in self.subroutine.dynamic_argnames]
         data = flatten(dynamic_args)[0]
-        super().__init__(*data, wires=wires, id=id)
+        super().__init__(*data, wires=wires)
 
         self._hyperparameters = {
             "decomposition": tuple(decomposition),
@@ -852,18 +851,18 @@ class Subroutine:
 
         return tuple(name for name in self._signature.parameters if not is_static(name))
 
-    def operator(self, *args, id: str | None = None, **kwargs) -> SubroutineOp:
+    def operator(self, *args, **kwargs) -> SubroutineOp:
         """Create a ``SubroutineOp`` from the template."""
         bound_args = self._full_setup_inputs(*args, **kwargs)
         with queuing.AnnotatedQueue() as decomposition:
             output = self.definition(*bound_args.args, **bound_args.kwargs)
-        return SubroutineOp(self, bound_args, decomposition.queue, output, id=id)
+        return SubroutineOp(self, bound_args, decomposition.queue, output)
 
-    def __call__(self, *args, id: str | None = None, **kwargs):
+    def __call__(self, *args, **kwargs):
         if capture.enabled():
             bound_args = self._full_setup_inputs(*args, **kwargs)
             return self._capture_subroutine(*bound_args.args, **bound_args.kwargs)
-        op = self.operator(*args, id=id, **kwargs)
+        op = self.operator(*args, **kwargs)
         return op.output
 
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -113,16 +113,13 @@ class AmplitudeEmbedding(StatePrep):
     def resource_params(self):
         return {"num_wires": len(self.wires)}
 
-    def __init__(
-        self, features, wires, *, pad_with=None, normalize=False, id=None, validate_norm=True
-    ):
+    def __init__(self, features, wires, *, pad_with=None, normalize=False, validate_norm=True):
         super().__init__(
             features,
             wires=wires,
             pad_with=pad_with,
             normalize=normalize,
             validate_norm=validate_norm,
-            id=id,
         )
 
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -37,8 +37,6 @@ class AmplitudeEmbedding(StatePrep):
         wires (Any or Iterable[Any]): wires that the template acts on
         pad_with (float or complex): if not None, the input is padded with this constant to size :math:`2^n`
         normalize (bool): whether to automatically normalize the features
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified
         validate_norm (bool): whether to validate the norm of the input state
 
     Example:

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -93,7 +93,7 @@ class AngleEmbedding(Operation):
     def __repr__(self):
         return f"AngleEmbedding({self.data[0]}, wires={self.wires.tolist()}, rotation={self._rotation})"
 
-    def __init__(self, features, wires, rotation="X", id=None):
+    def __init__(self, features, wires, rotation="X"):
         if rotation not in ROT:
             raise ValueError(f"Rotation option {rotation} not recognized.")
 
@@ -108,7 +108,7 @@ class AngleEmbedding(Operation):
         self._hyperparameters = {"rotation": ROT[rotation]}
 
         wires = wires[:n_features]
-        super().__init__(features, wires=wires, id=id)
+        super().__init__(features, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -53,8 +53,6 @@ class AngleEmbedding(Operation):
             with :math:`N\leq n`
         wires (Any or Iterable[Any]): wires that the template acts on
         rotation (str): type of rotations used
-        id (str): custom label given to an operator instance,
-            can be useful for some applications where the instance has to be identified.
 
     Example:
 

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -72,8 +72,8 @@ class BasisEmbedding(BasisState):
     def _primitive_bind_call(cls, features, wires, **kwargs):
         return super()._primitive_bind_call(features, wires, **kwargs)
 
-    def __init__(self, features, wires, id=None):
-        super().__init__(features, wires=wires, id=id)
+    def __init__(self, features, wires):
+        super().__init__(features, wires=wires)
 
 
 BasisEmbedding._primitive = BasisState._primitive  # pylint: disable=protected-access

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -107,7 +107,7 @@ class DisplacementEmbedding(Operation):
         return new_op
 
     # pylint: disable=too-many-arguments
-    def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
+    def __init__(self, features, wires, method="amplitude", c=0.1):
         shape = math.shape(features)
         constants = [c] * shape[0]
         constants = math.convert_like(constants, features)
@@ -128,7 +128,7 @@ class DisplacementEmbedding(Operation):
         else:
             raise ValueError(f"did not recognize method {method}")
 
-        super().__init__(pars, wires=wires, id=id)
+        super().__init__(pars, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/embeddings/iqp.py
+++ b/pennylane/templates/embeddings/iqp.py
@@ -179,7 +179,7 @@ class IQPEmbedding(Operation):
 
     resource_keys = {"pattern_size", "n_repeats", "num_wires"}
 
-    def __init__(self, features, wires, n_repeats=1, pattern=None, id=None):
+    def __init__(self, features, wires, n_repeats=1, pattern=None):
         shape = math.shape(features)
 
         if len(shape) not in {1, 2}:
@@ -197,7 +197,7 @@ class IQPEmbedding(Operation):
             pattern = tuple(combinations(wires, 2))
         self._hyperparameters = {"pattern": pattern, "n_repeats": n_repeats}
 
-        super().__init__(features, wires=wires, id=id)
+        super().__init__(features, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/embeddings/qaoaembedding.py
+++ b/pennylane/templates/embeddings/qaoaembedding.py
@@ -176,7 +176,7 @@ class QAOAEmbedding(Operation):
 
     resource_keys = {"repeat", "n_features", "num_wires", "local_field"}
 
-    def __init__(self, features, weights, wires, local_field="Y", id=None):
+    def __init__(self, features, weights, wires, local_field="Y"):
         if local_field == "Z":
             local_field = RZ
         elif local_field == "X":
@@ -220,7 +220,7 @@ class QAOAEmbedding(Operation):
             raise ValueError(f"Weights tensor must be of shape {exp_shape}; got {shape}")
 
         self._hyperparameters = {"local_field": local_field}
-        super().__init__(features, weights, wires=wires, id=id)
+        super().__init__(features, weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -110,7 +110,7 @@ class SqueezingEmbedding(Operation):
         Operation.__init__(new_op, *data, wires=metadata[0])
         return new_op
 
-    def __init__(self, features, wires, method="amplitude", c=0.1, id=None):
+    def __init__(self, features, wires, method="amplitude", c=0.1):
         shape = math.shape(features)
         constants = [c] * shape[0]
         constants = math.convert_like(constants, features)
@@ -131,7 +131,7 @@ class SqueezingEmbedding(Operation):
         else:
             raise ValueError(f"did not recognize method {method}")
 
-        super().__init__(pars, wires=wires, id=id)
+        super().__init__(pars, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -129,7 +129,7 @@ class BasicEntanglerLayers(Operation):
 
     resource_keys = {"repeat", "num_wires", "rotation"}
 
-    def __init__(self, weights, wires=None, rotation=None, id=None):
+    def __init__(self, weights, wires=None, rotation=None):
         # convert weights to numpy array if weights is list otherwise keep unchanged
         interface = math.get_interface(weights)
         weights = math.asarray(weights, like=interface)
@@ -148,7 +148,7 @@ class BasicEntanglerLayers(Operation):
             )
 
         self._hyperparameters = {"rotation": rotation or RX}
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -101,7 +101,6 @@ class CVNeuralNetLayers(Operation):
         phi_a,
         k,
         wires,
-        id=None,
     ):
         n_wires = len(wires)
         # n_if -> theta and phi shape for Interferometer
@@ -137,7 +136,6 @@ class CVNeuralNetLayers(Operation):
             phi_a,
             k,
             wires=wires,
-            id=id,
         )
 
     @property

--- a/pennylane/templates/layers/gate_fabric.py
+++ b/pennylane/templates/layers/gate_fabric.py
@@ -188,7 +188,7 @@ class GateFabric(Operation):
 
     resource_keys = {"n_layers", "num_wires", "len_wire_pattern", "include_pi"}
 
-    def __init__(self, weights, wires, init_state, include_pi=False, id=None):
+    def __init__(self, weights, wires, init_state, include_pi=False):
         if len(wires) < 4:
             raise ValueError(
                 f"This template requires the number of qubits to be greater than four; got wires {wires}"
@@ -219,7 +219,7 @@ class GateFabric(Operation):
             "include_pi": include_pi,
         }
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/particle_conserving_u1.py
+++ b/pennylane/templates/layers/particle_conserving_u1.py
@@ -255,7 +255,7 @@ class ParticleConservingU1(Operation):
 
     resource_keys = {"num_wires", "n_layers"}
 
-    def __init__(self, weights, wires, init_state=None, id=None):
+    def __init__(self, weights, wires, init_state=None):
         if len(wires) < 2:
             raise ValueError(
                 f"Expected the number of qubits to be greater than one; " f"got wires {wires}"
@@ -280,7 +280,7 @@ class ParticleConservingU1(Operation):
 
         self._hyperparameters = {"init_state": tuple(init_state)}
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/particle_conserving_u2.py
+++ b/pennylane/templates/layers/particle_conserving_u2.py
@@ -160,7 +160,7 @@ class ParticleConservingU2(Operation):
 
     resource_keys = {"num_wires", "n_layers"}
 
-    def __init__(self, weights, wires, init_state=None, id=None):
+    def __init__(self, weights, wires, init_state=None):
         if len(wires) < 2:
             raise ValueError(
                 f"This template requires the number of qubits to be greater than one;"
@@ -181,7 +181,7 @@ class ParticleConservingU2(Operation):
 
         self._hyperparameters = {"init_state": tuple(init_state)}
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -163,7 +163,6 @@ class RandomLayers(Operation):
         imprimitive=None,
         rotations=None,
         seed=42,
-        id=None,
     ):
         shape = math.shape(weights)
         if len(shape) != 2:
@@ -176,7 +175,7 @@ class RandomLayers(Operation):
             "seed": seed,
         }
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -112,7 +112,7 @@ class SimplifiedTwoDesign(Operation):
 
     resource_keys = {"num_wires", "n_layers"}
 
-    def __init__(self, initial_layer_weights, weights, wires, id=None):
+    def __init__(self, initial_layer_weights, weights, wires):
         shape = math.shape(weights)
 
         if len(shape) > 1:
@@ -134,7 +134,7 @@ class SimplifiedTwoDesign(Operation):
 
         self.n_layers = shape[0]
 
-        super().__init__(initial_layer_weights, weights, wires=wires, id=id)
+        super().__init__(initial_layer_weights, weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -142,7 +142,7 @@ class StronglyEntanglingLayers(Operation):
 
     resource_keys = {"imprimitive", "n_wires", "n_layers"}
 
-    def __init__(self, weights, wires, ranges=None, imprimitive=CNOT, id=None):
+    def __init__(self, weights, wires, ranges=None, imprimitive=CNOT):
         shape = math.shape(weights)[-3:]
 
         if shape[1] != len(wires):
@@ -173,7 +173,7 @@ class StronglyEntanglingLayers(Operation):
 
         self._hyperparameters = {"ranges": ranges, "imprimitive": imprimitive or CNOT}
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/state_preparations/arbitrary_state_preparation.py
+++ b/pennylane/templates/state_preparations/arbitrary_state_preparation.py
@@ -88,14 +88,14 @@ class ArbitraryStatePreparation(Operation):
 
     resource_keys = {"num_wires"}
 
-    def __init__(self, weights, wires, id=None):
+    def __init__(self, weights, wires):
         shape = qp.math.shape(weights)
         if shape != (2 ** (len(wires) + 1) - 2,):
             raise ValueError(
                 f"Weights tensor must be of shape {(2 ** (len(wires) + 1) - 2,)}; got {shape}."
             )
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/state_preparations/basis_qutrit.py
+++ b/pennylane/templates/state_preparations/basis_qutrit.py
@@ -56,7 +56,7 @@ class QutritBasisStatePreparation(Operation):
     num_params = 1
     grad_method = None
 
-    def __init__(self, basis_state, wires, id=None):
+    def __init__(self, basis_state, wires):
         basis_state = qp.math.stack(basis_state)
 
         # check if the `basis_state` param is batched
@@ -87,7 +87,7 @@ class QutritBasisStatePreparation(Operation):
         # TODO: basis_state should be a hyperparameter, not a trainable parameter.
         # However, this breaks a test that ensures compatibility with batch_transform.
         # The transform should be rewritten to support hyperparameters as well.
-        super().__init__(basis_state, wires=wires, id=id)
+        super().__init__(basis_state, wires=wires)
 
     @staticmethod
     def compute_decomposition(basis_state, wires):  # pylint: disable=arguments-differ

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -345,7 +345,7 @@ class MottonenStatePreparation(Operation):
     num_params = 1
     ndim_params = (1,)
 
-    def __init__(self, state_vector, wires, id=None):
+    def __init__(self, state_vector, wires):
         # check shape of `state_vector` param
         shape = qp.math.shape(state_vector)
         if len(shape) > 2:
@@ -366,7 +366,7 @@ class MottonenStatePreparation(Operation):
             if not qp.math.is_abstract(norms) and not qp.math.allclose(norms, 1.0, atol=1e-3):
                 raise ValueError(f"state_vector has to be of norm 1.0, got norm(s) {norms}")
 
-        super().__init__(state_vector, wires=wires, id=id)
+        super().__init__(state_vector, wires=wires)
 
     @staticmethod
     def compute_decomposition(state_vector, wires, **_):  # pylint: disable=arguments-differ

--- a/pennylane/templates/state_preparations/multiplexer_state_prep.py
+++ b/pennylane/templates/state_preparations/multiplexer_state_prep.py
@@ -67,7 +67,7 @@ class MultiplexerStatePreparation(Operation):
     resource_keys = {"num_wires"}
 
     # pylint: disable=too-many-positional-arguments, too-many-arguments
-    def __init__(self, state_vector, wires, id=None):
+    def __init__(self, state_vector, wires):
 
         wires = Wires(wires)
         n_amplitudes = math.shape(state_vector)[0]
@@ -84,7 +84,7 @@ class MultiplexerStatePreparation(Operation):
                 )
 
         self.state_vector = state_vector
-        super().__init__(state_vector, wires=wires, id=id)
+        super().__init__(state_vector, wires=wires)
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):

--- a/pennylane/templates/state_preparations/qrom_state_prep.py
+++ b/pennylane/templates/state_preparations/qrom_state_prep.py
@@ -102,7 +102,7 @@ class QROMStatePreparation(Operation):
 
     # pylint: disable=too-many-positional-arguments
     def __init__(
-        self, state_vector, wires, precision_wires, work_wires=None, id=None
+        self, state_vector, wires, precision_wires, work_wires=None
     ):  # pylint: disable=too-many-arguments
 
         n_amplitudes = qp.math.shape(state_vector)[0]
@@ -130,7 +130,7 @@ class QROMStatePreparation(Operation):
             + self.hyperparameters["work_wires"]
         )
 
-        super().__init__(state_vector, wires=all_wires, id=id)
+        super().__init__(state_vector, wires=all_wires)
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):

--- a/pennylane/templates/state_preparations/state_prep_mps.py
+++ b/pennylane/templates/state_preparations/state_prep_mps.py
@@ -342,7 +342,7 @@ class MPSPrep(Operation):
     resource_keys = {"bond_dimensions", "num_sites", "num_work_wires"}
 
     def __init__(
-        self, mps, wires, work_wires=None, right_canonicalize=False, id=None
+        self, mps, wires, work_wires=None, right_canonicalize=False
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         _validate_mps_shape(mps)
@@ -357,7 +357,7 @@ class MPSPrep(Operation):
             self.hyperparameters["work_wires"] = None
             all_wires = self.hyperparameters["input_wires"]
 
-        super().__init__(*mps, wires=all_wires, id=id)
+        super().__init__(*mps, wires=all_wires)
 
     @property
     def mps(self):
@@ -399,9 +399,9 @@ class MPSPrep(Operation):
 
     # pylint: disable=arguments-differ, too-many-arguments
     @classmethod
-    def _primitive_bind_call(cls, mps, wires, work_wires=None, id=None, right_canonicalize=False):
+    def _primitive_bind_call(cls, mps, wires, work_wires=None, right_canonicalize=False):
         return super()._primitive_bind_call(
-            *mps, wires=wires, work_wires=work_wires, id=id, right_canonicalize=right_canonicalize
+            *mps, wires=wires, work_wires=work_wires, right_canonicalize=right_canonicalize
         )
 
     def decomposition(self):

--- a/pennylane/templates/state_preparations/superposition.py
+++ b/pennylane/templates/state_preparations/superposition.py
@@ -238,7 +238,7 @@ class Superposition(Operation):
     resource_keys = {"num_wires", "num_coeffs", "bases"}
 
     def __init__(
-        self, coeffs, bases, wires, work_wire, id=None
+        self, coeffs, bases, wires, work_wire
     ):  # pylint: disable=too-many-positional-arguments, too-many-arguments
 
         if not all(
@@ -266,7 +266,7 @@ class Superposition(Operation):
 
         all_wires = self.hyperparameters["target_wires"] + self.hyperparameters["work_wire"]
 
-        super().__init__(coeffs, wires=all_wires, id=id)
+        super().__init__(coeffs, wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/aqft.py
+++ b/pennylane/templates/subroutines/aqft.py
@@ -127,7 +127,7 @@ class AQFT(Operation):
 
     resource_keys = {"num_wires", "order"}
 
-    def __init__(self, order: int, wires: WiresLike, *, id=None) -> None:
+    def __init__(self, order: int, wires: WiresLike) -> None:
         wires = Wires(wires)
         n_wires = len(wires)
 
@@ -148,7 +148,7 @@ class AQFT(Operation):
             warnings.warn("order=0, applying Hadamard transform")
 
         self.hyperparameters["order"] = order
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arbitrary_unitary.py
+++ b/pennylane/templates/subroutines/arbitrary_unitary.py
@@ -101,7 +101,7 @@ class ArbitraryUnitary(Operation):
 
     resource_keys = {"num_wires"}
 
-    def __init__(self, weights, wires, id=None):
+    def __init__(self, weights, wires):
         shape = math.shape(weights)
         dim = 4 ** len(wires) - 1
         if len(shape) not in (1, 2) or shape[-1] != dim:
@@ -109,7 +109,7 @@ class ArbitraryUnitary(Operation):
                 f"Weights tensor must be of shape {(dim,)} or (batch_dim, {dim}); got {shape}."
             )
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/adder.py
+++ b/pennylane/templates/subroutines/arithmetic/adder.py
@@ -110,7 +110,7 @@ class Adder(Operation):
     resource_keys = {"num_x_wires", "mod"}
 
     def __init__(
-        self, k, x_wires: WiresLike, mod=None, work_wires: WiresLike = (), id=None
+        self, k, x_wires: WiresLike, mod=None, work_wires: WiresLike = ()
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         x_wires = Wires(x_wires)
@@ -140,7 +140,7 @@ class Adder(Operation):
         self.hyperparameters["work_wires"] = work_wires
         self.hyperparameters["x_wires"] = x_wires
 
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/mod_exp.py
+++ b/pennylane/templates/subroutines/arithmetic/mod_exp.py
@@ -118,7 +118,7 @@ class ModExp(Operation):
     resource_keys = {"num_x_wires", "num_output_wires", "mod", "num_work_wires"}
 
     def __init__(
-        self, x_wires: WiresLike, output_wires, base, mod=None, work_wires: WiresLike = (), id=None
+        self, x_wires: WiresLike, output_wires, base, mod=None, work_wires: WiresLike = ()
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         output_wires = Wires(output_wires)
@@ -157,7 +157,7 @@ class ModExp(Operation):
         base = base % mod
         self.hyperparameters["base"] = base
         self.hyperparameters["mod"] = mod
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -118,7 +118,7 @@ class Multiplier(Operation):
     resource_keys = {"num_x_wires", "mod", "num_work_wires"}
 
     def __init__(
-        self, k, x_wires: WiresLike, mod=None, work_wires: WiresLike = (), id=None
+        self, k, x_wires: WiresLike, mod=None, work_wires: WiresLike = ()
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         x_wires = Wires(x_wires)
@@ -150,7 +150,7 @@ class Multiplier(Operation):
         self.hyperparameters["work_wires"] = work_wires
         self.hyperparameters["x_wires"] = x_wires
         all_wires = x_wires + work_wires
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/out_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/out_adder.py
@@ -157,7 +157,6 @@ class OutAdder(Operation):
         output_wires: WiresLike,
         mod=None,
         work_wires: WiresLike = (),
-        id=None,
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         x_wires = Wires(x_wires)
@@ -200,7 +199,7 @@ class OutAdder(Operation):
             all_wires += self.hyperparameters["work_wires"]
 
         self.hyperparameters["mod"] = mod
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -221,7 +221,6 @@ class OutMultiplier(Operation):
         mod=None,
         work_wires: WiresLike = (),
         output_wires_zeroed: bool = False,
-        id=None,
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
 
         x_wires = Wires(x_wires)
@@ -268,7 +267,7 @@ class OutMultiplier(Operation):
 
         # pylint: disable=consider-using-generator
         all_wires = sum([self.hyperparameters[name] for name in wires_name], start=[])
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/out_poly.py
+++ b/pennylane/templates/subroutines/arithmetic/out_poly.py
@@ -276,7 +276,6 @@ class OutPoly(Operation):
         output_wires: WiresLike,
         mod=None,
         work_wires: WiresLike = (),
-        id=None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         r"""Initialize the OutPoly class"""
@@ -336,7 +335,7 @@ class OutPoly(Operation):
                 "None of the wires in a register should be included in other register."
             )
 
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     def _flatten(self):
         metadata1 = tuple((key, value) for key, value in self.hyperparameters.items())

--- a/pennylane/templates/subroutines/arithmetic/phase_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/phase_adder.py
@@ -137,7 +137,7 @@ class PhaseAdder(Operation):
     resource_keys = {"num_x_wires", "mod"}
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(self, k, x_wires: WiresLike, mod=None, work_wire: WiresLike = (), id=None):
+    def __init__(self, k, x_wires: WiresLike, mod=None, work_wire: WiresLike = ()):
 
         work_wire = Wires(() if work_wire is None else work_wire)
         x_wires = Wires(x_wires)
@@ -168,7 +168,7 @@ class PhaseAdder(Operation):
         self.hyperparameters["mod"] = mod
         self.hyperparameters["work_wire"] = work_wire
         self.hyperparameters["x_wires"] = x_wires
-        super().__init__(wires=x_wires, id=id)
+        super().__init__(wires=x_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/semi_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/semi_adder.py
@@ -206,9 +206,7 @@ class SemiAdder(Operation):
 
     resource_keys = {"num_x_wires", "num_y_wires", "num_work_wires"}
 
-    def __init__(
-        self, x_wires: WiresLike, y_wires: WiresLike, work_wires: WiresLike | None, id=None
-    ):
+    def __init__(self, x_wires: WiresLike, y_wires: WiresLike, work_wires: WiresLike | None):
 
         x_wires = Wires(x_wires)
         y_wires = Wires(y_wires)
@@ -233,7 +231,7 @@ class SemiAdder(Operation):
         else:
             all_wires = Wires.all_wires([x_wires, y_wires])
 
-        super().__init__(wires=all_wires, id=id)
+        super().__init__(wires=all_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/arithmetic/temporary_and.py
+++ b/pennylane/templates/subroutines/arithmetic/temporary_and.py
@@ -132,10 +132,10 @@ class TemporaryAND(Operation):
             return f"TemporaryAND(wires={self.wires})"
         return f"TemporaryAND(wires={self.wires}, control_values={cvals})"
 
-    def __init__(self, wires: WiresLike, control_values=(1, 1), id=None):
+    def __init__(self, wires: WiresLike, control_values=(1, 1)):
         wires = Wires(wires)
         self.hyperparameters["control_values"] = tuple(control_values)
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/controlled_sequence.py
+++ b/pennylane/templates/subroutines/controlled_sequence.py
@@ -88,7 +88,7 @@ class ControlledSequence(SymbolicOp, Operation):
     def _unflatten(cls, data, metadata):
         return cls(data[0], control=metadata[0])
 
-    def __init__(self, base, control, id=None):
+    def __init__(self, base, control):
         control_wires = Wires(control)
 
         if len(Wires.shared_wires([base.wires, control_wires])) != 0:
@@ -99,7 +99,7 @@ class ControlledSequence(SymbolicOp, Operation):
 
         self._name = "ControlledSequence"
 
-        super().__init__(base, id=id)
+        super().__init__(base)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -87,7 +87,7 @@ class FABLE(Operation):
 
     resource_keys = {"wires", "thetas", "control_wires", "tol"}
 
-    def __init__(self, input_matrix, wires, tol=0, id=None):
+    def __init__(self, input_matrix, wires, tol=0):
         wires = Wires(wires)
 
         if not math.is_abstract(input_matrix):
@@ -131,7 +131,7 @@ class FABLE(Operation):
 
         self._hyperparameters = {"tol": tol}
 
-        super().__init__(input_matrix, wires=wires, id=id)
+        super().__init__(input_matrix, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -76,7 +76,7 @@ class FlipSign(Operation):
     def __repr__(self):
         return f"FlipSign({self.hyperparameters['arr_bin']}, wires={self.wires.tolist()})"
 
-    def __init__(self, n, wires, id=None):
+    def __init__(self, n, wires):
         if not isinstance(wires, int) and len(wires) == 0:
             raise ValueError("At least one valid wire is required.")
 
@@ -94,7 +94,7 @@ class FlipSign(Operation):
             raise ValueError(f"The basis state {n} and wires {wires} must be of equal length.")
 
         self._hyperparameters = {"arr_bin": n}
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @property
     def resource_params(self):

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -90,12 +90,12 @@ class GQSP(Operation):
 
     resource_keys = {"unitary", "num_iters"}
 
-    def __init__(self, unitary, angles, control, id=None):
+    def __init__(self, unitary, angles, control):
         total_wires = Wires(control) + unitary.wires
 
         self._hyperparameters = {"unitary": unitary, "control": control}
 
-        super().__init__(angles, *unitary.data, wires=total_wires, id=id)
+        super().__init__(angles, *unitary.data, wires=total_wires)
 
     @property
     def resource_params(self) -> dict:
@@ -114,8 +114,8 @@ class GQSP(Operation):
 
     # pylint: disable=arguments-differ
     @classmethod
-    def _primitive_bind_call(cls, unitary, angles, control, id=None):
-        return super()._primitive_bind_call(unitary, angles, wires=control, id=id)
+    def _primitive_bind_call(cls, unitary, angles, control):
+        return super()._primitive_bind_call(unitary, angles, wires=control)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -112,7 +112,7 @@ class GroverOperator(Operation):
         hyperparameters = (("work_wires", self.hyperparameters["work_wires"]),)
         return tuple(), (self.wires, hyperparameters)
 
-    def __init__(self, wires: WiresLike, work_wires: WiresLike = (), id=None):
+    def __init__(self, wires: WiresLike, work_wires: WiresLike = ()):
         wires = Wires(wires)
         work_wires = Wires(() if work_wires is None else work_wires)
 
@@ -124,7 +124,7 @@ class GroverOperator(Operation):
             "work_wires": work_wires,
         }
 
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -62,7 +62,6 @@ class HilbertSchmidt(Operation):
     Args:
         V (Operator or Iterable[Operator]): The operators that represent the unitary `V`.
         U (Operator or Iterable[Operator]): The operators that represent the unitary `U`.
-        id (str or None): Optional identifier for the operation.
 
     Raises:
         ValueError: ``V`` is not an Operator or an iterable of Operators.
@@ -143,7 +142,6 @@ class HilbertSchmidt(Operation):
         self,
         V: Operator | Iterable[Operator],
         U: Operator | Iterable[Operator],
-        id: str | None = None,
     ) -> None:
 
         u_ops = (U,) if isinstance(U, Operator) else tuple(U)
@@ -168,7 +166,7 @@ class HilbertSchmidt(Operation):
             raise ValueError("Operators in U and V must act on distinct wires.")
 
         total_wires = Wires(u_wires + v_wires)
-        super().__init__(wires=total_wires, id=id)
+        super().__init__(wires=total_wires)
 
     def map_wires(self, wire_map: dict):
         raise NotImplementedError("Mapping the wires of HilbertSchmidt is not implemented.")
@@ -295,7 +293,6 @@ class LocalHilbertSchmidt(HilbertSchmidt):
     Args:
         V (Operator or Iterable[Operator]): The operators that represent the approximate compiled unitary `V`.
         U (Operator or Iterable[Operator]): The operators that represent the unitary `U`.
-        id (str or None): Optional identifier for the operation.
 
     Raises:
         ValueError: ``V`` is not an Operator or an iterable of Operators.

--- a/pennylane/templates/subroutines/interferometer.py
+++ b/pennylane/templates/subroutines/interferometer.py
@@ -170,7 +170,6 @@ class Interferometer(CVOperation):
         wires,
         mesh="rectangular",
         beamsplitter="pennylane",
-        id=None,
     ):
         wires = Wires(wires)
 
@@ -193,7 +192,7 @@ class Interferometer(CVOperation):
             "mesh": mesh,
             "beamsplitter": beamsplitter,
         }
-        super().__init__(theta, phi, varphi, wires=wires, id=id)
+        super().__init__(theta, phi, varphi, wires=wires)
 
     @staticmethod
     def compute_decomposition(

--- a/pennylane/templates/subroutines/iqp.py
+++ b/pennylane/templates/subroutines/iqp.py
@@ -90,7 +90,7 @@ class IQP(Operation):
     resource_keys = {"spin_sym", "pattern", "num_wires"}
 
     def __init__(
-        self, weights, num_wires, pattern, spin_sym=False, id=None
+        self, weights, num_wires, pattern, spin_sym=False
     ):  # pylint: disable=too-many-arguments
         if len(pattern) != len(weights):
             raise ValueError(
@@ -107,7 +107,7 @@ class IQP(Operation):
             "pattern": pattern,
             "num_wires": num_wires,
         }
-        super().__init__(wires=range(num_wires), id=id)
+        super().__init__(wires=range(num_wires))
 
     # pylint: disable=arguments-differ
     @staticmethod

--- a/pennylane/templates/subroutines/permute.py
+++ b/pennylane/templates/subroutines/permute.py
@@ -157,7 +157,7 @@ class Permute(Operation):
 
     resource_keys = {"wires", "permutation"}
 
-    def __init__(self, permutation, wires, id=None):
+    def __init__(self, permutation, wires):
         if len(permutation) <= 1 or len(wires) <= 1:
             raise ValueError("Permutations must involve at least 2 qubits.")
 
@@ -175,7 +175,7 @@ class Permute(Operation):
                 raise ValueError(f"Cannot permute wire {label} not present in wire set.")
 
         self._hyperparameters = {"permutation": tuple(permutation)}
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -93,7 +93,7 @@ class PrepSelPrep(Operation):
 
     grad_method = None
 
-    def __init__(self, lcu: SymbolicOp | CompositeOp, control: WiresLike, id=None) -> None:
+    def __init__(self, lcu: SymbolicOp | CompositeOp, control: WiresLike) -> None:
         control = Wires(control)
         target_wires = lcu.wires
 
@@ -105,7 +105,7 @@ class PrepSelPrep(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires, id=id)
+        super().__init__(*self.data, wires=all_wires)
 
     def _flatten(self):
         return (self.lcu,), (self.control,)
@@ -132,7 +132,7 @@ class PrepSelPrep(Operation):
     def label(self, decimals=None, base_label=None, cache=None) -> str:
         op_label = base_label or self.__class__.__name__
         if cache is None or not isinstance(cache.get("matrices", None), list):
-            return op_label if self._id is None else f'{op_label}("{self._id}")'
+            return op_label
 
         coeffs = math.array(self.coeffs)
         for i, mat in enumerate(cache["matrices"]):
@@ -144,7 +144,7 @@ class PrepSelPrep(Operation):
             cache["matrices"].append(coeffs)
             str_wo_id = f"{op_label}(M{mat_num})"
 
-        return str_wo_id if self._id is None else f'{str_wo_id[:-1]},"{self._id}")'
+        return str_wo_id
 
     @staticmethod
     def compute_decomposition(lcu, control):

--- a/pennylane/templates/subroutines/qchem/all_singles_doubles.py
+++ b/pennylane/templates/subroutines/qchem/all_singles_doubles.py
@@ -138,7 +138,6 @@ class AllSinglesDoubles(Operation):
         hf_state: Sequence[int],
         singles: Sequence[tuple[int, int]] | None = None,
         doubles: Sequence[tuple[int, int, int, int]] | None = None,
-        id=None,
     ):
         wires = Wires(wires)
         if len(wires) < 2:
@@ -176,18 +175,18 @@ class AllSinglesDoubles(Operation):
             "doubles": doubles,
         }
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     @classmethod
     def _primitive_bind_call(
-        cls, weights, wires, hf_state, singles=None, doubles=None, id=None
+        cls, weights, wires, hf_state, singles=None, doubles=None
     ):  # pylint: disable=arguments-differ
         singles = math.array(singles) if singles is not None else math.array(((),))
         doubles = math.array(doubles) if doubles is not None else math.array(((),))
         wires = math.array(wires)
         hf_state = math.array(hf_state)
         weights = math.array(weights)
-        return cls._primitive.bind(weights, wires, hf_state, singles, doubles, id=id)
+        return cls._primitive.bind(weights, wires, hf_state, singles, doubles)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/qchem/basis_rotation.py
+++ b/pennylane/templates/subroutines/qchem/basis_rotation.py
@@ -294,19 +294,19 @@ class BasisRotation(Operation):
     resource_keys = {"dim", "is_real"}
 
     @classmethod
-    def _primitive_bind_call(cls, wires, unitary_matrix, check=False, id=None):
+    def _primitive_bind_call(cls, wires, unitary_matrix, check=False):
         # pylint: disable=arguments-differ
         if cls._primitive is None:
             # guard against this being called when primitive is not defined.
-            return type.__call__(cls, wires, unitary_matrix, check=check, id=id)  # pragma: no cover
+            return type.__call__(cls, wires, unitary_matrix, check=check)  # pragma: no cover
 
-        return cls._primitive.bind(*wires, unitary_matrix, check=check, id=id)
+        return cls._primitive.bind(*wires, unitary_matrix, check=check)
 
     @classmethod
     def _unflatten(cls, data, metadata):
         return cls(wires=metadata[0], unitary_matrix=data[0])
 
-    def __init__(self, wires, unitary_matrix, check=False, id=None):
+    def __init__(self, wires, unitary_matrix, check=False):
         M, N = math.shape(unitary_matrix)
 
         if M != N:
@@ -323,7 +323,7 @@ class BasisRotation(Operation):
         if len(wires) < 2:
             raise ValueError(f"This template requires at least two wires, got {len(wires)}")
 
-        super().__init__(unitary_matrix, wires=wires, id=id)
+        super().__init__(unitary_matrix, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/qchem/fermionic_double_excitation.py
+++ b/pennylane/templates/subroutines/qchem/fermionic_double_excitation.py
@@ -523,7 +523,7 @@ class FermionicDoubleExcitation(Operation):
     def _unflatten(cls, data, metadata) -> "FermionicDoubleExcitation":
         return cls(data[0], wires1=metadata[0], wires2=metadata[1])
 
-    def __init__(self, weight: TensorLike, wires1: WiresLike, wires2: WiresLike, *, id=None):
+    def __init__(self, weight: TensorLike, wires1: WiresLike, wires2: WiresLike):
         wires1 = Wires(wires1)
         wires2 = Wires(wires2)
         if len(wires1) < 2:
@@ -550,7 +550,7 @@ class FermionicDoubleExcitation(Operation):
         }
 
         wires = wires1 + wires2
-        super().__init__(weight, wires=wires, id=id)
+        super().__init__(weight, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/qchem/fermionic_single_excitation.py
+++ b/pennylane/templates/subroutines/qchem/fermionic_single_excitation.py
@@ -127,7 +127,7 @@ class FermionicSingleExcitation(Operation):
 
     resource_keys = {"num_wires"}
 
-    def __init__(self, weight: float, wires: WiresLike, *, id=None):
+    def __init__(self, weight: float, wires: WiresLike):
         wires = Wires(wires)
         if len(wires) < 2:
             raise ValueError(f"expected at least two wires; got {len(wires)}")
@@ -136,7 +136,7 @@ class FermionicSingleExcitation(Operation):
         if shape != ():
             raise ValueError(f"Weight must be a scalar tensor {()}; got shape {shape}.")
 
-        super().__init__(weight, wires=wires, id=id)
+        super().__init__(weight, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/qchem/kupccgsd.py
+++ b/pennylane/templates/subroutines/qchem/kupccgsd.py
@@ -228,7 +228,6 @@ class kUpCCGSD(Operation):
         k: int = 1,
         delta_sz: int = 0,
         init_state: Sequence[int] | None = None,
-        id: str | None = None,
     ):
         wires = Wires(wires)
 
@@ -263,7 +262,7 @@ class kUpCCGSD(Operation):
             "k": k,
             "delta_sz": delta_sz,
         }
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     def map_wires(self, wire_map: dict):
         new_op = copy.deepcopy(self)

--- a/pennylane/templates/subroutines/qchem/uccsd.py
+++ b/pennylane/templates/subroutines/qchem/uccsd.py
@@ -201,7 +201,6 @@ class UCCSD(Operation):
         d_wires: Sequence[tuple[Sequence[int], Sequence[int]]] | None = None,
         init_state: Sequence[int] | None = None,
         n_repeats: int = 1,
-        id=None,
     ):
         if init_state is None:
             raise ValueError("Requires `init_state` to be provided.")
@@ -252,7 +251,7 @@ class UCCSD(Operation):
             "n_repeats": n_repeats,
         }
 
-        super().__init__(weights, wires=wires, id=id)
+        super().__init__(weights, wires=wires)
 
     def map_wires(self, wire_map: dict):
         new_op = copy.deepcopy(self)

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -129,10 +129,10 @@ class QFT(Operation):
     grad_method = None
     resource_keys = {"num_wires"}
 
-    def __init__(self, wires: WiresLike, id=None):
+    def __init__(self, wires: WiresLike):
         wires = Wires(wires)
         self.hyperparameters["num_wires"] = len(wires)
-        super().__init__(wires=wires, id=id)
+        super().__init__(wires=wires)
 
     def _flatten(self):
         return tuple(), (self.wires, tuple())

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -458,7 +458,7 @@ if QuantumMonteCarlo._primitive is not None:
     def _quantum_monte_carlo_impl(probs, *wires, func, num_target_wires):
         target_wires = wires[:num_target_wires]
         estimation_wires = wires[num_target_wires:]
-        return type.__call__(QuantumMonteCarlo, probs, func, target_wires, estimation_wires, id)
+        return type.__call__(QuantumMonteCarlo, probs, func, target_wires, estimation_wires)
 
 
 def _quantum_monte_carlo_resources(num_target_wires, num_estimation_wires, q_resource_rep):

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -344,7 +344,7 @@ class QuantumMonteCarlo(Operation):
 
     @classmethod
     def _primitive_bind_call(
-        cls, probs, func, target_wires, estimation_wires, id=None
+        cls, probs, func, target_wires, estimation_wires
     ):  # pylint: disable=arguments-differ
         # handle target wires and estimation wires
         return cls._primitive.bind(
@@ -353,7 +353,6 @@ class QuantumMonteCarlo(Operation):
             *estimation_wires,
             func=func,
             num_target_wires=len(target_wires),
-            id=id,
         )
 
     @classmethod
@@ -375,7 +374,7 @@ class QuantumMonteCarlo(Operation):
             ),
         }
 
-    def __init__(self, probs, func, target_wires, estimation_wires, id=None):
+    def __init__(self, probs, func, target_wires, estimation_wires):
         if isinstance(probs, np.ndarray) and probs.ndim != 1:
             raise ValueError("The probability distribution must be specified as a flat array")
 
@@ -403,7 +402,7 @@ class QuantumMonteCarlo(Operation):
         A = probs_to_unitary(probs)
         R = func_to_unitary(func, dim_p)
         Q = make_Q(A, R)
-        super().__init__(A, R, Q, wires=wires, id=id)
+        super().__init__(A, R, Q, wires=wires)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access
@@ -456,7 +455,7 @@ class QuantumMonteCarlo(Operation):
 if QuantumMonteCarlo._primitive is not None:
 
     @QuantumMonteCarlo._primitive.def_impl
-    def _quantum_monte_carlo_impl(probs, *wires, func, num_target_wires, id=None):
+    def _quantum_monte_carlo_impl(probs, *wires, func, num_target_wires):
         target_wires = wires[:num_target_wires]
         estimation_wires = wires[num_target_wires:]
         return type.__call__(QuantumMonteCarlo, probs, func, target_wires, estimation_wires, id)

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -180,7 +180,7 @@ class QuantumPhaseEstimation(ErrorOperation):
             "num_estimation_wires": len(self.estimation_wires),
         }
 
-    def __init__(self, unitary, target_wires=None, estimation_wires=None, id=None):
+    def __init__(self, unitary, target_wires=None, estimation_wires=None):
         if isinstance(unitary, Operator):
             # If the unitary is expressed in terms of operators, do not provide target wires
             if target_wires is not None:
@@ -216,7 +216,7 @@ class QuantumPhaseEstimation(ErrorOperation):
             "estimation_wires": estimation_wires,
         }
 
-        super().__init__(*unitary.data, wires=wires, id=id)
+        super().__init__(*unitary.data, wires=wires)
 
     @property
     def target_wires(self):

--- a/pennylane/templates/subroutines/qram.py
+++ b/pennylane/templates/subroutines/qram.py
@@ -215,7 +215,6 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
         control_wires: WiresLike,
         target_wires: WiresLike,
         work_wires: WiresLike,
-        id: str | None = None,
     ):  # pylint: disable=too-many-arguments
         control_wires = Wires(control_wires)
 
@@ -265,7 +264,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
             "wire_manager": wire_manager,
         }
 
-        super().__init__(data, wires=all_wires, id=id)
+        super().__init__(data, wires=all_wires)
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):
@@ -494,7 +493,6 @@ class HybridQRAM(Operation):
         target_wires: WiresLike,
         work_wires: WiresLike,
         k: int,  # define the select part size, remaining part is tree part
-        id: str | None = None,
     ):  # pylint: disable=too-many-arguments
 
         if isinstance(data, (list, tuple)):
@@ -554,7 +552,7 @@ class HybridQRAM(Operation):
 
         all_wires = list(control_wires) + list(target_wires) + list(work_wires)
 
-        super().__init__(data, wires=all_wires, id=id)
+        super().__init__(data, wires=all_wires)
 
         self._hyperparameters = {
             "select_wires": select_wires,
@@ -863,8 +861,6 @@ class SelectOnlyQRAM(Operation):
             If provided, only entries whose select bits match this value are loaded.
             The ``select_value`` must be an integer in :math:`[0, 2^{\texttt{len(select_wires)}}]`,
             and cannot be used if no ``select_wires`` are provided.
-        id (str or None):
-            Optional name for the operation.
 
     Raises:
         ValueError: if the ``data`` are of the wrong length, a ``select_value`` is provided without
@@ -957,7 +953,6 @@ class SelectOnlyQRAM(Operation):
         target_wires: WiresLike,
         select_wires: WiresLike | None = None,
         select_value: int | None = None,
-        id: str | None = None,
     ):
 
         if isinstance(data, (list, tuple)):
@@ -1002,9 +997,7 @@ class SelectOnlyQRAM(Operation):
             "select_value": select_value,
         }
 
-        super().__init__(
-            data, wires=list(control_wires) + list(target_wires) + list(select_wires), id=id
-        )
+        super().__init__(data, wires=list(control_wires) + list(target_wires) + list(select_wires))
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):

--- a/pennylane/templates/subroutines/qrom.py
+++ b/pennylane/templates/subroutines/qrom.py
@@ -195,7 +195,6 @@ class QROM(Operation):
         target_wires: WiresLike,
         work_wires: WiresLike,
         clean=True,
-        id=None,
     ):  # pylint: disable=too-many-arguments,disable=too-many-positional-arguments
 
         control_wires = Wires(control_wires)
@@ -242,7 +241,7 @@ class QROM(Operation):
             raise ValueError("Bitstring length must match the number of target wires.")
 
         all_wires = target_wires + control_wires + work_wires
-        super().__init__(data, wires=all_wires, id=id)
+        super().__init__(data, wires=all_wires)
 
     def _flatten(self):
         metadata = tuple((key, value) for key, value in self.hyperparameters.items())

--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -510,7 +510,7 @@ class QSVT(Operation):
 
     resource_keys = {"UA", "projectors"}
 
-    def __init__(self, UA, projectors, id=None):
+    def __init__(self, UA, projectors):
         if not isinstance(UA, Operator):
             raise ValueError("Input block encoding must be an Operator")
 
@@ -521,7 +521,7 @@ class QSVT(Operation):
 
         total_wires = Wires.all_wires([proj.wires for proj in projectors]) + Wires(UA.wires)
 
-        super().__init__(wires=total_wires, id=id)
+        super().__init__(wires=total_wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/qubitization.py
+++ b/pennylane/templates/subroutines/qubitization.py
@@ -81,7 +81,7 @@ class Qubitization(Operation):
     def _primitive_bind_call(cls, *args, **kwargs):
         return cls._primitive.bind(*args, **kwargs)
 
-    def __init__(self, hamiltonian, control, id=None):
+    def __init__(self, hamiltonian, control):
         wires = Wires(control) + hamiltonian.wires
 
         self._hyperparameters = {
@@ -89,7 +89,7 @@ class Qubitization(Operation):
             "control": Wires(control),
         }
 
-        super().__init__(*hamiltonian.data, wires=wires, id=id)
+        super().__init__(*hamiltonian.data, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/reflection.py
+++ b/pennylane/templates/subroutines/reflection.py
@@ -130,7 +130,7 @@ class Reflection(Operation):
         U, alpha = data
         return cls(U, alpha=alpha, reflection_wires=metadata[0])
 
-    def __init__(self, U, alpha=np.pi, reflection_wires=None, id=None):
+    def __init__(self, U, alpha=np.pi, reflection_wires=None):
         self._name = "Reflection"
         wires = U.wires
 
@@ -145,7 +145,7 @@ class Reflection(Operation):
             "reflection_wires": tuple(reflection_wires),
         }
 
-        super().__init__(alpha, *U.data, wires=wires, id=id)
+        super().__init__(alpha, *U.data, wires=wires)
 
     @property
     def resource_params(self) -> dict:

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -381,7 +381,7 @@ class Select(Operation):
         return f"Select(ops={self.ops}, control={self.control}, partial={self.partial})"
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(self, ops, control, work_wires=None, partial=False, id=None):
+    def __init__(self, ops, control, work_wires=None, partial=False):
         control = Wires(control)
         work_wires = Wires(() if work_wires is None else work_wires)
         self.hyperparameters["ops"] = tuple(ops)
@@ -414,7 +414,7 @@ class Select(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires, id=id)
+        super().__init__(*self.data, wires=all_wires)
 
     def map_wires(self, wire_map: dict) -> "Select":
         new_ops = [o.map_wires(wire_map) for o in self.hyperparameters["ops"]]

--- a/pennylane/templates/subroutines/select_pauli_rot.py
+++ b/pennylane/templates/subroutines/select_pauli_rot.py
@@ -103,7 +103,7 @@ class SelectPauliRot(Operation):
     resource_keys = {"num_wires", "rot_axis"}
 
     def __init__(
-        self, angles, control_wires, target_wire, rot_axis="Z", id=None
+        self, angles, control_wires, target_wire, rot_axis="Z"
     ):  # pylint: disable=too-many-arguments, too-many-positional-arguments
 
         self.hyperparameters["control_wires"] = Wires(control_wires)
@@ -120,7 +120,7 @@ class SelectPauliRot(Operation):
             raise ValueError("Only one target wire can be specified")
 
         all_wires = self.hyperparameters["control_wires"] + self.hyperparameters["target_wire"]
-        super().__init__(angles, wires=all_wires, id=id)
+        super().__init__(angles, wires=all_wires)
 
     def _flatten(self):
         metadata = tuple((key, value) for key, value in self.hyperparameters.items())

--- a/pennylane/templates/subroutines/time_evolution/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/time_evolution/approx_time_evolution.py
@@ -146,7 +146,7 @@ class ApproxTimeEvolution(Operation):
             "n": self.hyperparameters["n"],
         }
 
-    def __init__(self, hamiltonian, time, n, id=None):
+    def __init__(self, hamiltonian, time, n):
         if getattr(hamiltonian, "pauli_rep", None) is None:
             raise ValueError(
                 f"hamiltonian must be a linear combination of pauli words, got {type(hamiltonian).__name__}"
@@ -158,7 +158,7 @@ class ApproxTimeEvolution(Operation):
         self._hyperparameters = {"hamiltonian": hamiltonian, "n": n}
 
         # trainable parameters are passed to the base init method
-        super().__init__(*hamiltonian.data, time, wires=wires, id=id)
+        super().__init__(*hamiltonian.data, time, wires=wires)
 
     def map_wires(self, wire_map: dict):
         new_op = copy.deepcopy(self)

--- a/pennylane/templates/subroutines/time_evolution/commuting_evolution.py
+++ b/pennylane/templates/subroutines/time_evolution/commuting_evolution.py
@@ -136,7 +136,7 @@ class CommutingEvolution(Operation):
             "words": tuple(self.hyperparameters["hamiltonian"].pauli_rep.keys()),
         }
 
-    def __init__(self, hamiltonian, time, frequencies=None, shifts=None, id=None):
+    def __init__(self, hamiltonian, time, frequencies=None, shifts=None):
         # pylint: disable=import-outside-toplevel,too-many-positional-arguments
         from pennylane.gradients.general_shift_rules import generate_shift_rule
 
@@ -158,7 +158,7 @@ class CommutingEvolution(Operation):
             "shifts": shifts,
         }
 
-        super().__init__(time, *hamiltonian.parameters, wires=hamiltonian.wires, id=id)
+        super().__init__(time, *hamiltonian.parameters, wires=hamiltonian.wires)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access

--- a/pennylane/templates/subroutines/time_evolution/qdrift.py
+++ b/pennylane/templates/subroutines/time_evolution/qdrift.py
@@ -195,9 +195,7 @@ class QDrift(Operation):
     def _unflatten(cls, data, metadata):
         return cls(*data, **dict(metadata))
 
-    def __init__(  # pylint: disable=too-many-arguments
-        self, hamiltonian, time, n=1, seed=None, id=None
-    ):
+    def __init__(self, hamiltonian, time, n=1, seed=None):  # pylint: disable=too-many-arguments
         r"""Initialize the QDrift class"""
 
         _check_hamiltonian_type(hamiltonian)
@@ -215,7 +213,7 @@ class QDrift(Operation):
             )
 
         self._hyperparameters = {"n": n, "seed": seed, "base": hamiltonian}
-        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires, id=id)
+        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires)
 
     def map_wires(self, wire_map: dict):
         # pylint: disable=protected-access

--- a/pennylane/templates/subroutines/time_evolution/trotter.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter.py
@@ -253,7 +253,7 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
         return cls._primitive.bind(*args, **kwargs)
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        self, hamiltonian, time, n=1, order=1, check_hermitian=True, id=None
+        self, hamiltonian, time, n=1, order=1, check_hermitian=True
     ):
         r"""Initialize the TrotterProduct class"""
 
@@ -298,7 +298,7 @@ class TrotterProduct(ErrorOperation, ResourcesOperation):
             "check_hermitian": check_hermitian,
         }
 
-        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires, id=id)
+        super().__init__(*hamiltonian.data, time, wires=hamiltonian.wires)
 
     @property
     def resource_params(self) -> dict:
@@ -656,7 +656,6 @@ class TrotterizedQfunc(Operation):
         n=1,
         order=2,
         reverse=False,
-        id=None,
         **non_trainable_kwargs,
     ):
         # This class requires the input function (qfunc) has a very specific
@@ -680,7 +679,7 @@ class TrotterizedQfunc(Operation):
         self._hyperparameters["qfunc"] = qfunc
         self._hyperparameters["reverse"] = reverse
 
-        super().__init__(time, *trainable_args, wires=wires, id=id)
+        super().__init__(time, *trainable_args, wires=wires)
 
     def decomposition(self) -> list[Operator]:
         """The decomposition"""

--- a/pennylane/templates/swapnetworks/ccl2.py
+++ b/pennylane/templates/swapnetworks/ccl2.py
@@ -101,7 +101,6 @@ class TwoLocalSwapNetwork(Operation):
         weights=None,
         fermionic=True,
         shift=False,
-        id=None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
         if len(wires) < 2:
@@ -134,9 +133,9 @@ class TwoLocalSwapNetwork(Operation):
         }
 
         if acquaintances is not None and self._weights is not None:
-            super().__init__(self._weights, wires=wires, id=id)
+            super().__init__(self._weights, wires=wires)
         else:
-            super().__init__(wires=wires, id=id)
+            super().__init__(wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/tensornetworks/mera.py
+++ b/pennylane/templates/tensornetworks/mera.py
@@ -180,7 +180,7 @@ class MERA(Operation):
 
     @classmethod
     def _primitive_bind_call(
-        cls, wires, n_block_wires, block, n_params_block, template_weights=None, id=None
+        cls, wires, n_block_wires, block, n_params_block, template_weights=None
     ):  # pylint: disable=arguments-differ
         return super()._primitive_bind_call(
             wires=wires,
@@ -188,7 +188,6 @@ class MERA(Operation):
             block=block,
             n_params_block=n_params_block,
             template_weights=template_weights,
-            id=id,
         )
 
     @classmethod
@@ -205,7 +204,6 @@ class MERA(Operation):
         block: Callable,
         n_params_block,
         template_weights=None,
-        id=None,
     ):
         ind_gates = compute_indices(wires, n_block_wires)
         n_wires = len(wires)
@@ -227,7 +225,7 @@ class MERA(Operation):
 
         self._hyperparameters = {"ind_gates": ind_gates, "block": block}
 
-        super().__init__(template_weights, wires=wires, id=id)
+        super().__init__(template_weights, wires=wires)
 
     @staticmethod
     def compute_decomposition(weights, wires, block, ind_gates):  # pylint: disable=arguments-differ

--- a/pennylane/templates/tensornetworks/mps.py
+++ b/pennylane/templates/tensornetworks/mps.py
@@ -172,7 +172,6 @@ class MPS(Operation):
         n_params_block,
         template_weights=None,
         offset=None,
-        id=None,
         **kwargs,
     ):  # pylint: disable=arguments-differ
         return super()._primitive_bind_call(
@@ -181,7 +180,6 @@ class MPS(Operation):
             block=block,
             n_params_block=n_params_block,
             template_weights=template_weights,
-            id=id,
             offset=offset,
             **kwargs,
         )
@@ -202,7 +200,6 @@ class MPS(Operation):
         n_params_block=0,
         template_weights=None,
         offset=None,
-        id=None,
         **kwargs,
     ):
         ind_gates = compute_indices_MPS(wires, n_block_wires, offset)
@@ -223,9 +220,9 @@ class MPS(Operation):
         self._hyperparameters = {"ind_gates": ind_gates, "block": block, **kwargs}
 
         if self._weights is None:
-            super().__init__(wires=wires, id=id)
+            super().__init__(wires=wires)
         else:
-            super().__init__(self._weights, wires=wires, id=id)
+            super().__init__(self._weights, wires=wires)
 
     @property
     def num_params(self):

--- a/pennylane/templates/tensornetworks/ttn.py
+++ b/pennylane/templates/tensornetworks/ttn.py
@@ -151,7 +151,7 @@ class TTN(Operation):
 
     @classmethod
     def _primitive_bind_call(
-        cls, wires, n_block_wires, block, n_params_block, template_weights=None, id=None
+        cls, wires, n_block_wires, block, n_params_block, template_weights=None
     ):  # pylint: disable=arguments-differ
         return super()._primitive_bind_call(
             wires=wires,
@@ -159,7 +159,6 @@ class TTN(Operation):
             block=block,
             n_params_block=n_params_block,
             template_weights=template_weights,
-            id=id,
         )
 
     @classmethod
@@ -176,7 +175,6 @@ class TTN(Operation):
         block,
         n_params_block,
         template_weights=None,
-        id=None,
     ):
         ind_gates = compute_indices(wires, n_block_wires)
         n_wires = len(wires)
@@ -198,7 +196,7 @@ class TTN(Operation):
 
         self._hyperparameters = {"ind_gates": ind_gates, "block": block}
 
-        super().__init__(template_weights, wires=wires, id=id)
+        super().__init__(template_weights, wires=wires)
 
     @staticmethod
     def compute_decomposition(weights, wires, block, ind_gates):  # pylint: disable=arguments-differ

--- a/pennylane/workflow/__init__.py
+++ b/pennylane/workflow/__init__.py
@@ -26,7 +26,6 @@ Execution functions and utilities
     ~workflow.construct_tape
     ~workflow.construct_batch
     ~workflow.construct_execution_config
-    ~workflow.get_transform_program
     ~workflow.get_compile_pipeline
     ~workflow.get_best_diff_method
     ~workflow.set_shots
@@ -48,7 +47,7 @@ Jacobian Product Calculation
 
 from ._cache_transform import _cache_transform
 from ._setup_transform_program import _setup_transform_program
-from .construct_batch import construct_batch, get_transform_program
+from .construct_batch import construct_batch
 from .construct_execution_config import construct_execution_config
 from .construct_tape import construct_tape
 from .execution import execute

--- a/pennylane/workflow/construct_batch.py
+++ b/pennylane/workflow/construct_batch.py
@@ -15,12 +15,10 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal
 
 from pennylane import math
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.tape import make_qscript
 
 from ._setup_transform_program import _setup_transform_program
@@ -138,170 +136,6 @@ def _get_inner_transform_slice(
     return slice(start, stop, level.step)
 
 
-def get_transform_program(qnode, level="device", gradient_fn="unset"):
-    """Extract a transform program at a designated level.
-
-    .. warning::
-        This function has been deprecated and is superceded by :func:`~.workflow.get_compile_pipeline`. Access to this function will be removed in v0.46.
-
-    Args:
-        qnode (QNode): the qnode to get the transform program for.
-        level (str, int, slice): An indication of what transforms to use from the full program.
-
-            - ``"device"``: Uses the entire transformation pipeline.
-            - ``"top"``: Ignores transformations and returns the original tape as defined.
-            - ``"user"``: Includes transformations that are manually applied by the user.
-            - ``"gradient"``: Extracts the gradient-level tape.
-            - ``int``: Can also accept an integer, corresponding to a number of transforms in the program. ``level=0`` corresponds to the start of the program.
-            - ``slice``: Can also accept a ``slice`` object to select an arbitrary subset of the transform program.
-
-        gradient_fn (None, str, Transform): The processed gradient fn for the workflow.
-
-    Returns:
-        CompilePipeline: the transform program corresponding to the requested level.
-
-    .. details::
-        :title: Usage Details
-
-        The transforms are organized as:
-
-        .. image:: ../../_static/transforms_order.png
-            :align: center
-            :width: 800px
-            :target: javascript:void(0);
-
-        where ``transform1`` is first applied to the ``QNode`` followed by ``transform2``.  First, user transforms are run on the tapes,
-        followed by the gradient expansion, followed by the device expansion. "Final" transforms, like ``param_shift`` and ``metric_tensor``,
-        always occur at the end of the program, despite being part of user transforms. Note that when requesting a level by name
-        (e.g. "gradient" or "device"), the preceding levels would be applied as well.
-
-        .. code-block:: python
-
-            dev = qp.device('default.qubit')
-
-            @qp.metric_tensor # final transform
-            @qp.transforms.merge_rotations # transform 2
-            @qp.transforms.cancel_inverses # transform 1
-            @qp.qnode(dev, diff_method="parameter-shift", gradient_kwargs={"shifts": np.pi / 4})
-            def circuit():
-                return qp.expval(qp.Z(0))
-
-        By default, we get the full transform program. This can be explicitly specified by ``level="device"``.
-
-        >>> print(qp.workflow.get_transform_program(circuit))
-        CompilePipeline(
-          [1] cancel_inverses(),
-          [2] merge_rotations(),
-          [3] _expand_metric_tensor(device_wires=None),
-          [4] metric_tensor(device_wires=None),
-          [5] _expand_transform_param_shift(shifts=0.7853981633974483),
-          [6] defer_measurements(allow_postselect=True),
-          [7] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [8] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [9] validate_device_wires(None, name=default.qubit),
-          [10] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-          [11] _conditional_broadcast_expand()
-        )
-
-        The ``"user"`` transforms are the ones manually applied to the qnode, :func:`~.cancel_inverses`,
-        :func:`~.merge_rotations` and :func:`~.metric_tensor`.
-
-        >>> print(qp.workflow.get_transform_program(circuit, level="user"))
-        CompilePipeline(
-          [1] cancel_inverses(),
-          [2] merge_rotations(),
-          [3] _expand_metric_tensor(device_wires=None),
-          [4] metric_tensor(device_wires=None)
-        )
-
-        The ``_expand_transform_param_shift`` is the ``"gradient"`` transform.
-        This expands all trainable operations to a state where the parameter shift transform can operate on them. For example,
-        it will decompose any parametrized templates into operators that have generators. Note how ``metric_tensor`` is still
-        present at the very end of resulting program.
-
-        >>> print(qp.workflow.get_transform_program(circuit, level="gradient"))
-        CompilePipeline(
-          [1] cancel_inverses(),
-          [2] merge_rotations(),
-          [3] _expand_metric_tensor(device_wires=None),
-          [4] metric_tensor(device_wires=None),
-          [5] _expand_transform_param_shift(shifts=0.7853981633974483)
-        )
-
-        ``"top"`` and ``0`` both return empty transform programs.
-
-        >>> print(qp.workflow.get_transform_program(circuit, level="top"))
-        CompilePipeline()
-        >>> print(qp.workflow.get_transform_program(circuit, level=0))
-        CompilePipeline()
-
-        The ``level`` can also be any integer, corresponding to a number of transforms in the program.
-
-        >>> print(qp.workflow.get_transform_program(circuit, level=2))
-        CompilePipeline(
-          [1] cancel_inverses(),
-          [2] merge_rotations()
-        )
-
-        ``level`` can also accept a ``slice`` object to select out any arbitrary subset of the
-        transform program.  This allows you to select different starting transforms or strides.
-        For example, you can skip the first transform or reverse the order:
-
-        >>> print(qp.workflow.get_transform_program(circuit, level=slice(1,3)))
-        CompilePipeline(
-          [1] merge_rotations(),
-          [2] _expand_metric_tensor(device_wires=None)
-        )
-        >>> print(qp.workflow.get_transform_program(circuit, level=slice(None, None, -1)))
-        CompilePipeline(
-          [1] _conditional_broadcast_expand(),
-          [2] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit),
-          [3] validate_device_wires(None, name=default.qubit),
-          [4] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [5] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [6] defer_measurements(allow_postselect=True),
-          [7] _expand_transform_param_shift(shifts=0.7853981633974483),
-          [8] metric_tensor(device_wires=None),
-          [9] _expand_metric_tensor(device_wires=None),
-          [10] merge_rotations(),
-          [11] cancel_inverses()
-        )
-
-        You can get creative and pick a single category of transforms as follows, excluding
-        any preceding transforms (and the final transform if it exists):
-
-        >>> user_prog = qp.workflow.get_transform_program(circuit, level="user")
-        >>> grad_prog = qp.workflow.get_transform_program(circuit, level="gradient")
-        >>> dev_prog = qp.workflow.get_transform_program(circuit, level="device")
-        >>> print(grad_prog[len(user_prog) - 1 : -1])
-        CompilePipeline(
-          [1] metric_tensor(device_wires=None)
-        )
-        >>> print(dev_prog[len(grad_prog) - 1 : -1])
-        CompilePipeline(
-          [1] _expand_transform_param_shift(shifts=0.7853981633974483),
-          [2] defer_measurements(allow_postselect=True),
-          [3] decompose(stopping_condition=..., device_wires=None, target_gates=..., name=default.qubit),
-          [4] device_resolve_dynamic_wires(wires=None, allow_resets=False),
-          [5] validate_device_wires(None, name=default.qubit),
-          [6] validate_measurements(analytic_measurements=..., sample_measurements=..., name=default.qubit)
-        )
-
-    """
-    warnings.warn(
-        "The 'get_transform_program' function is deprecated and will be removed in v0.46. "
-        "To retrieve the execution pipeline of a QNode, please consider using "
-        "'pennylane.workflow.get_compile_pipeline'.",
-        PennyLaneDeprecationWarning,
-    )
-    # pylint: disable=import-outside-toplevel
-
-    # NOTE: Remove once deprecation cycle is complete
-    from pennylane.noise.add_noise import _get_transform_program
-
-    return _get_transform_program(qnode, level, gradient_fn)
-
-
 def construct_batch(
     qnode: QNode | TorchLayer,
     level: str | int | slice = "user",
@@ -311,7 +145,7 @@ def construct_batch(
     Args:
         qnode (QNode): the qnode we want to get the tapes and post-processing for.
         level (str, int, slice): An indication of what transforms to apply before
-            drawing. Check :func:`~.workflow.get_transform_program` for more
+            drawing. Check :func:`~.workflow.get_compile_pipeline` for more
             information on the allowed values and usage details of this argument.
 
     Returns:
@@ -319,7 +153,7 @@ def construct_batch(
             A function with the same call signature as the initial quantum function.
             This function returns a batch (tuple) of tapes and postprocessing function.
 
-    .. seealso:: :func:`pennylane.workflow.get_transform_program` to inspect the contents of the transform program for a specified level.
+    .. seealso:: :func:`pennylane.workflow.get_compile_pipeline` to inspect the contents of the transform program for a specified level.
 
     .. details::
         :title: Usage Details

--- a/pennylane/workflow/qnode.py
+++ b/pennylane/workflow/qnode.py
@@ -653,23 +653,6 @@ class QNode:
         self._interface = Interface(value)
 
     @property
-    def transform_program(self) -> CompilePipeline:
-        """The transform program used by the QNode.
-
-        .. warning::
-
-            The ``transform_program`` property of the QNode has been renamed to ``compile_pipeline``.
-            Access through ``transform_program`` will be removed in PennyLane v0.46.
-
-        """
-        warnings.warn(
-            "The 'transform_program' property of the QNode has been renamed to 'compile_pipeline'. "
-            "Access through 'transform_program' will be removed in PennyLane v0.46.",
-            PennyLaneDeprecationWarning,
-        )
-        return self.compile_pipeline
-
-    @property
     def compile_pipeline(self) -> CompilePipeline:
         """The compile pipeline used by the QNode."""
         return self._compile_pipeline

--- a/tests/capture/test_nested_plxpr.py
+++ b/tests/capture/test_nested_plxpr.py
@@ -45,7 +45,7 @@ class TestAdjointQfunc:
 
         nested_jaxpr = plxpr.eqns[0].params["jaxpr"]
         assert nested_jaxpr.eqns[0].primitive == qp.PauliRot._primitive
-        assert nested_jaxpr.eqns[0].params == {"id": None, "n_wires": 2, "pauli_word": "XY"}
+        assert nested_jaxpr.eqns[0].params == {"n_wires": 2, "pauli_word": "XY"}
 
         assert plxpr.eqns[0].params["lazy"] is True
 

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -253,7 +253,7 @@ class TestSpecialOps:
         eqn = jaxpr.eqns[0]
 
         assert eqn.primitive == qp.PauliRot._primitive
-        assert eqn.params == {"pauli_word": "XY", "id": None, "n_wires": 2}
+        assert eqn.params == {"pauli_word": "XY", "n_wires": 2}
 
         assert len(eqn.invars) == 3  # The rotation parameter and the two wires
         assert jaxpr.jaxpr.invars == eqn.invars
@@ -500,7 +500,7 @@ class TestAbstractDunders:
         assert eqn.invars[0] == jaxpr.eqns[0].outvars[0]
         assert eqn.invars[1] == jaxpr.eqns[1].outvars[0]
 
-        assert eqn.params == {"grouping_type": None, "id": None, "method": "lf"}
+        assert eqn.params == {"grouping_type": None, "method": "lf"}
 
         assert isinstance(eqn.outvars[0].aval, AbstractOperator)
 
@@ -522,7 +522,7 @@ class TestAbstractDunders:
         assert eqn.invars[0] == jaxpr.eqns[0].outvars[0]
         assert eqn.invars[1] == jaxpr.eqns[1].outvars[0]
 
-        assert eqn.params == {"id": None}
+        assert eqn.params == {}
 
         assert isinstance(eqn.outvars[0].aval, AbstractOperator)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,18 +45,6 @@ class DummyDevice(DefaultGaussian):
     _operation_map["Kerr"] = lambda *x, **y: np.identity(2)
 
 
-@pytest.fixture
-def ignore_id_deprecation():
-    """Fixture to suppress PennyLaneDeprecationWarning for 'id' tests."""
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=PennyLaneDeprecationWarning,
-            message="The 'id' argument is deprecated",
-        )
-        yield
-
-
 @pytest.fixture(scope="session")
 def tol():
     """Numerical tolerance for equality tests."""

--- a/tests/data/attributes/test_serialization.py
+++ b/tests/data/attributes/test_serialization.py
@@ -192,7 +192,7 @@ H_TWO_QUBITS = np.array(
             shots=50,
             trainable_params=[0, 1],
         ),
-        Prod(qp.X(0), qp.RX(0.1, wires=0), qp.X(1), id="id"),
+        Prod(qp.X(0), qp.RX(0.1, wires=0), qp.X(1)),
         Sum(
             qp.Hermitian(H_ONE_QUBIT, 2),
             qp.Hermitian(H_TWO_QUBITS, [0, 1]),
@@ -223,7 +223,7 @@ def test_pennylane_pytree_roundtrip(obj_in: Any):
                 [qp.expval(2 * qp.X(0))],
                 trainable_params=[0, 1],
             ),
-            Prod(qp.X(0), qp.RX(0.1, wires=0), qp.X(1), id="id"),
+            Prod(qp.X(0), qp.RX(0.1, wires=0), qp.X(1)),
             Sum(
                 qp.Hermitian(H_ONE_QUBIT, 2),
                 qp.Hermitian(H_TWO_QUBITS, [0, 1]),

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
@@ -41,8 +41,8 @@ class CustomChannel(Channel):  # pylint: disable=too-few-public-methods
     num_params = 1
     num_wires = 1
 
-    def __init__(self, p, wires, id=None):
-        super().__init__(p, wires=wires, id=id)
+    def __init__(self, p, wires):
+        super().__init__(p, wires=wires)
 
     @staticmethod
     def compute_kraus_matrices(p):
@@ -312,8 +312,8 @@ class TestChannels:  # pylint: disable=too-few-public-methods
         num_params = 1
         num_wires = 1
 
-        def __init__(self, p, wires, id=None):
-            super().__init__(p, wires=wires, id=id)
+        def __init__(self, p, wires):
+            super().__init__(p, wires=wires)
 
         @staticmethod
         def compute_kraus_matrices(p):

--- a/tests/estimator/test_estimator_mapping.py
+++ b/tests/estimator/test_estimator_mapping.py
@@ -556,8 +556,8 @@ class TestMapToResourceOp:
         class DummyOp(Operation):
             num_wires = 2
 
-            def __init__(self, theta, wires=None, id=None):
-                super().__init__(theta, wires=wires, id=id)
+            def __init__(self, theta, wires=None):
+                super().__init__(theta, wires=wires)
 
             @staticmethod
             def compute_decomposition(theta, wires):

--- a/tests/fourier/test_circuit_spectrum.py
+++ b/tests/fourier/test_circuit_spectrum.py
@@ -20,27 +20,8 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as pnp
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.fourier.circuit_spectrum import circuit_spectrum
 from pennylane.fourier.mark import mark
-
-
-def test_deprecated_usage():
-    """Tests that an informative warning is raised when a user
-    uses 'id' with 'circuit_spectrum'"""
-
-    dev = qp.device("default.qubit", wires=1)
-
-    @qp.qnode(dev)
-    def _circuit(x):
-        qp.RX(x, wires=0, id="x")
-        return qp.expval(qp.PauliZ(wires=0))
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="Using 'id' with 'circuit_spectrum' is deprecated"
-    ):
-        with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-            _ = circuit_spectrum(_circuit)(0.1)
 
 
 class TestCircuits:

--- a/tests/ftqc/test_parametric_mid_measure.py
+++ b/tests/ftqc/test_parametric_mid_measure.py
@@ -20,7 +20,7 @@ import pytest
 
 import pennylane as qp
 from pennylane.devices.qubit import measure as apply_qubit_measurement
-from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import QuantumFunctionError
 from pennylane.ftqc import (
     ParametricMidMeasure,
     XMidMeasure,
@@ -33,20 +33,6 @@ from pennylane.ftqc import (
 )
 from pennylane.ops import MeasurementValue, MidMeasure
 from pennylane.wires import Wires
-
-
-@pytest.mark.parametrize("test_class", [ParametricMidMeasure, XMidMeasure, YMidMeasure])
-def test_id_deprecations(test_class):
-    """Tests that 'id' is deprecated properly."""
-
-    additional_kwargs = {}
-    if test_class is ParametricMidMeasure:
-        additional_kwargs = {"angle": 0, "plane": "XY"}
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'id' argument has been renamed to 'meas_uid'"
-    ):
-        _ = test_class(Wires(0), **additional_kwargs, id="something")
 
 
 class TestParametricMidMeasure:

--- a/tests/measurements/test_measurements.py
+++ b/tests/measurements/test_measurements.py
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane.exceptions import DeviceError, PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import DeviceError, QuantumFunctionError
 from pennylane.measurements import (
     ClassicalShadowMP,
     CountsMP,
@@ -63,16 +63,6 @@ def test_mid_measure_deprecations():
 
 class NotValidMeasurement(MeasurementProcess):
     _shortname = "NotValidReturnType"
-
-
-def test_id_deprecation():
-    """Tests that using 'id' is deprecated."""
-
-    class DummyMP(MeasurementProcess):
-        """Dummy measurement process with no return type."""
-
-    with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-        _ = DummyMP(wires=qp.wires.Wires(0), id="something")
 
 
 def test_no_measure():

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -34,7 +34,7 @@ class TempOperator(qp.operation.Operator):
 
 
 # pylint: disable=unused-argument
-def pow_using_dunder_method(base, z, id=None):
+def pow_using_dunder_method(base, z):
     """Helper function which computes the base raised to the power invoking the __pow__ dunder
     method."""
     return base**z

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -88,7 +88,7 @@ def _get_pw(w, pauli_op):
 
 
 # pylint: disable=unused-argument
-def sum_using_dunder_method(*summands, id=None):
+def sum_using_dunder_method(*summands):
     """Helper function which computes the sum of all the summands to invoke the
     __add__ dunder method."""
     return sum(summands)

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -19,17 +19,9 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as np
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import Operator
 from pennylane.ops.op_math import ScalarSymbolicOp, SymbolicOp
 from pennylane.wires import Wires
-
-
-def test_id_deprecation():
-    """Tests that the id kwarg is deprecated"""
-
-    with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-        _ = SymbolicOp(qp.X(0), id="something")
 
 
 class TempScalar(ScalarSymbolicOp):  # pylint:disable=too-few-public-methods

--- a/tests/ops/test_mid_measure.py
+++ b/tests/ops/test_mid_measure.py
@@ -19,21 +19,11 @@ import pytest
 
 import pennylane as qp
 import pennylane.numpy as np
-from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import QuantumFunctionError
 from pennylane.ops import MeasurementValue, MidMeasure
 from pennylane.wires import Wires
 
 # pylint: disable=too-few-public-methods, too-many-public-methods
-
-
-def test_id_is_deprecated():
-    """Tests that the 'id' argument is deprecated and renamed."""
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'id' argument has been renamed to 'meas_uid'"
-    ):
-        op = MidMeasure(0, id="blah")
-    assert op.meas_uid == "blah"
 
 
 @pytest.mark.external

--- a/tests/ops/test_pauli_measure.py
+++ b/tests/ops/test_pauli_measure.py
@@ -17,19 +17,8 @@ import pytest
 
 import pennylane as qp
 from pennylane import queuing
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.ops import MeasurementValue, PauliMeasure
 from pennylane.wires import Wires
-
-
-def test_id_is_deprecated():
-    """Tests that the 'id' argument is deprecated and renamed."""
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'id' argument has been renamed to 'meas_uid'"
-    ):
-        op = PauliMeasure("XY", wires=[0, 1], id="blah")
-    assert op.meas_uid == "blah"
 
 
 class TestPauliMeasure:

--- a/tests/templates/embeddings/test_amplitude.py
+++ b/tests/templates/embeddings/test_amplitude.py
@@ -306,12 +306,6 @@ class TestInputs:
         # No normalization error is raised
         circuit(x=inputs)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.AmplitudeEmbedding(np.array([1, 0]), wires=[0], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features, pad_with=None, normalize=False):
     """AmplitudeEmbedding circuit. For three wires, all test features match

--- a/tests/templates/embeddings/test_angle.py
+++ b/tests/templates/embeddings/test_angle.py
@@ -203,12 +203,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Rotation option"):
             circuit(x=[1])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.AngleEmbedding(np.array([1, 2]), wires=[0, 1], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features):
     qp.AngleEmbedding(features, range(3))

--- a/tests/templates/embeddings/test_basis.py
+++ b/tests/templates/embeddings/test_basis.py
@@ -187,12 +187,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="State must be one-dimensional"):
             circuit(x=[[1], [0]])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.BasisEmbedding([0, 1], wires=[0, 1], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features):
     qp.BasisEmbedding(features, wires=range(3))

--- a/tests/templates/embeddings/test_displacement_emb.py
+++ b/tests/templates/embeddings/test_displacement_emb.py
@@ -165,12 +165,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Features must be a one-dimensional"):
             circuit(x=[[1], [0]])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.DisplacementEmbedding(np.array([1, 2]), wires=[0, 1], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features):
     qp.DisplacementEmbedding(features, range(3))

--- a/tests/templates/embeddings/test_iqp_emb.py
+++ b/tests/templates/embeddings/test_iqp_emb.py
@@ -194,12 +194,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Features must be a one-dimensional"):
             circuit(f=features)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.IQPEmbedding(np.array([1, 2]), wires=[0, 1], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features):
     qp.IQPEmbedding(features, range(2))

--- a/tests/templates/embeddings/test_iqp_emb.py
+++ b/tests/templates/embeddings/test_iqp_emb.py
@@ -153,7 +153,7 @@ class TestDecomposition:
     @pytest.mark.capture
     @pytest.mark.parametrize(("features", "wires", "num_repeats", "pattern"), DECOMP_PARAMS)
     def test_decomposition_new(self, features, wires, num_repeats, pattern):
-        op = qp.IQPEmbedding(features, wires, n_repeats=num_repeats, pattern=pattern, id=None)
+        op = qp.IQPEmbedding(features, wires, n_repeats=num_repeats, pattern=pattern)
 
         for rule in qp.list_decomps(qp.IQPEmbedding):
             _test_decomposition_rule(op, rule)

--- a/tests/templates/embeddings/test_qaoa_emb.py
+++ b/tests/templates/embeddings/test_qaoa_emb.py
@@ -379,12 +379,6 @@ class TestInputs:
         shape = qp.QAOAEmbedding.shape(n_layers, n_wires, n_broadcast)
         assert shape == expected_shape
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.QAOAEmbedding(np.array([0]), weights=np.array([[0]]), wires=[0], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features, weights):
     qp.QAOAEmbedding(features, weights, range(2))

--- a/tests/templates/embeddings/test_squeezing_emb.py
+++ b/tests/templates/embeddings/test_squeezing_emb.py
@@ -165,12 +165,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Features must be a one-dimensional"):
             circuit(x=[[1], [0]])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.SqueezingEmbedding(np.array([1, 2]), wires=[0, 1], id="a")
-        assert template.id == "a"
-
 
 def circuit_template(features):
     qp.SqueezingEmbedding(features, range(3))

--- a/tests/templates/layers/test_basic_entangler.py
+++ b/tests/templates/layers/test_basic_entangler.py
@@ -161,12 +161,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Weights tensor must have last dimension of length"):
             circuit([[1, 0], [1, 0]])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.BasicEntanglerLayers(np.array([[1]]), wires=[0], id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/layers/test_cv_neural_net.py
+++ b/tests/templates/layers/test_cv_neural_net.py
@@ -151,15 +151,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Got unexpected shape for one or more parameters"):
             circuit()
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        shapes = expected_shapes(1, 2)
-        weights = [np.random.random(shape) for shape in shapes]
-
-        template = qp.CVNeuralNetLayers(*weights, wires=range(2), id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Test methods and attributes."""

--- a/tests/templates/layers/test_gate_fabric.py
+++ b/tests/templates/layers/test_gate_fabric.py
@@ -706,89 +706,77 @@ class TestDecomposition:  # pylint: disable=too-few-public-methods
         assert res_wires == exp_wires
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
-
-    @pytest.mark.parametrize(
-        ("weights", "wires", "msg_match"),
-        [
-            (
-                qp.math.array([[[-0.080, 2.629]]]),
-                [0],
-                "This template requires the number of qubits to be greater than four",
-            ),
-            (
-                qp.math.array([[[-0.080, 2.629]]]),
-                [5],
-                "This template requires the number of qubits to be greater than four",
-            ),
-            (
-                qp.math.array([[[-0.080, 2.629]]]),
-                [0, 1, 2, 3, 4],
-                "This template requires an even number of qubits",
-            ),
-            (
-                qp.math.array([[[-0.080]]]),
-                [0, 1, 2, 3],
-                "Weights tensor must have third dimension of length 2",
-            ),
-            (
-                qp.math.array([[[-0.080, 2.629, -0.710, 5.383]]]),
-                [0, 1, 2, 3],
-                "Weights tensor must have third dimension of length 2",
-            ),
-            (
-                qp.math.array(
+@pytest.mark.parametrize(
+    ("weights", "wires", "msg_match"),
+    [
+        (
+            qp.math.array([[[-0.080, 2.629]]]),
+            [0],
+            "This template requires the number of qubits to be greater than four",
+        ),
+        (
+            qp.math.array([[[-0.080, 2.629]]]),
+            [5],
+            "This template requires the number of qubits to be greater than four",
+        ),
+        (
+            qp.math.array([[[-0.080, 2.629]]]),
+            [0, 1, 2, 3, 4],
+            "This template requires an even number of qubits",
+        ),
+        (
+            qp.math.array([[[-0.080]]]),
+            [0, 1, 2, 3],
+            "Weights tensor must have third dimension of length 2",
+        ),
+        (
+            qp.math.array([[[-0.080, 2.629, -0.710, 5.383]]]),
+            [0, 1, 2, 3],
+            "Weights tensor must have third dimension of length 2",
+        ),
+        (
+            qp.math.array(
+                [
                     [
-                        [
-                            [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
-                            [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
-                        ]
+                        [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
+                        [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
                     ]
-                ),
-                [0, 1, 2, 3],
-                "Weights tensor must have second dimension of length",
+                ]
             ),
-            (
-                qp.math.array([[[-0.080, 2.629], [-0.710, 5.383]]]),
-                [0, 1, 2, 3],
-                "Weights tensor must have second dimension of length",
-            ),
-            (
-                qp.math.array([-0.080, 2.629, -0.710, 5.383, 0.646, -2.872]),
-                [0, 1, 2, 3],
-                "Weights tensor must be 3-dimensional",
-            ),
-        ],
-    )
-    def test_exceptions(self, weights, wires, msg_match):
-        """Test that GateFabric template throws an exception if the parameters have illegal
-        shapes, types or values."""
-        N = len(wires)
-        init_state = qp.math.array([1, 1, 0, 0])
+            [0, 1, 2, 3],
+            "Weights tensor must have second dimension of length",
+        ),
+        (
+            qp.math.array([[[-0.080, 2.629], [-0.710, 5.383]]]),
+            [0, 1, 2, 3],
+            "Weights tensor must have second dimension of length",
+        ),
+        (
+            qp.math.array([-0.080, 2.629, -0.710, 5.383, 0.646, -2.872]),
+            [0, 1, 2, 3],
+            "Weights tensor must be 3-dimensional",
+        ),
+    ],
+)
+def test_exceptions(weights, wires, msg_match):
+    """Test that GateFabric template throws an exception if the parameters have illegal
+    shapes, types or values."""
+    N = len(wires)
+    init_state = qp.math.array([1, 1, 0, 0])
 
-        dev = qp.device("default.qubit", wires=N)
+    dev = qp.device("default.qubit", wires=N)
 
-        @qp.qnode(dev)
-        def circuit():
-            qp.GateFabric(
-                weights=weights,
-                wires=wires,
-                init_state=init_state,
-            )
-            return qp.expval(qp.PauliZ(0))
-
-        with pytest.raises(ValueError, match=msg_match):
-            circuit()
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        init_state = qp.math.array([1, 1, 0, 0])
-        template = qp.GateFabric(
-            weights=np.random.random(size=(1, 1, 2)), wires=range(4), init_state=init_state, id="a"
+    @qp.qnode(dev)
+    def circuit():
+        qp.GateFabric(
+            weights=weights,
+            wires=wires,
+            init_state=init_state,
         )
-        assert template.id == "a"
+        return qp.expval(qp.PauliZ(0))
+
+    with pytest.raises(ValueError, match=msg_match):
+        circuit()
 
 
 class TestAttributes:

--- a/tests/templates/layers/test_particle_conserving_u1.py
+++ b/tests/templates/layers/test_particle_conserving_u1.py
@@ -261,45 +261,34 @@ class TestDecomposition:
         assert np.allclose(circuit(weights), exp_state, atol=tol)
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
+@pytest.mark.parametrize(
+    ("weights", "n_wires", "msg_match"),
+    [
+        (np.ones((4, 3)), 4, "Weights tensor must"),
+        (np.ones((4, 2, 2)), 4, "Weights tensor must"),
+        (np.ones((4, 3, 1)), 4, "Weights tensor must"),
+        (
+            np.ones((4, 3, 1)),
+            1,
+            "Expected the number of qubits",
+        ),
+    ],
+)
+def test_exceptions(weights, n_wires, msg_match):
+    """Test that ParticleConservingU1 throws an exception if the parameter array has an illegal
+    shape."""
 
-    @pytest.mark.parametrize(
-        ("weights", "n_wires", "msg_match"),
-        [
-            (np.ones((4, 3)), 4, "Weights tensor must"),
-            (np.ones((4, 2, 2)), 4, "Weights tensor must"),
-            (np.ones((4, 3, 1)), 4, "Weights tensor must"),
-            (
-                np.ones((4, 3, 1)),
-                1,
-                "Expected the number of qubits",
-            ),
-        ],
-    )
-    def test_exceptions(self, weights, n_wires, msg_match):
-        """Test that ParticleConservingU1 throws an exception if the parameter array has an illegal
-        shape."""
+    wires = range(n_wires)
+    init_state = np.array([1, 1, 0, 0])
+    dev = qp.device("default.qubit", wires=n_wires)
 
-        wires = range(n_wires)
-        init_state = np.array([1, 1, 0, 0])
-        dev = qp.device("default.qubit", wires=n_wires)
+    @qp.qnode(dev)
+    def circuit():
+        qp.ParticleConservingU1(weights=weights, wires=wires, init_state=init_state)
+        return qp.expval(qp.PauliZ(0))
 
-        @qp.qnode(dev)
-        def circuit():
-            qp.ParticleConservingU1(weights=weights, wires=wires, init_state=init_state)
-            return qp.expval(qp.PauliZ(0))
-
-        with pytest.raises(ValueError, match=msg_match):
-            circuit()
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.ParticleConservingU1(
-            weights=np.array([[[0.2, -0.6]]]), wires=range(2), init_state=np.array([1, 1]), id="a"
-        )
-        assert template.id == "a"
+    with pytest.raises(ValueError, match=msg_match):
+        circuit()
 
 
 class TestAttributes:

--- a/tests/templates/layers/test_particle_conserving_u2.py
+++ b/tests/templates/layers/test_particle_conserving_u2.py
@@ -201,67 +201,55 @@ class TestDecomposition:  # pylint: disable=too-few-public-methods
         assert res_wires == exp_wires
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
-
-    @pytest.mark.parametrize(
-        ("weights", "wires", "msg_match"),
-        [
-            (
-                np.array([[-0.080, 2.629, -0.710, 5.383, 0.646, -2.872, -3.856]]),
-                [0],
-                "This template requires the number of qubits to be greater than one",
+@pytest.mark.parametrize(
+    ("weights", "wires", "msg_match"),
+    [
+        (
+            np.array([[-0.080, 2.629, -0.710, 5.383, 0.646, -2.872, -3.856]]),
+            [0],
+            "This template requires the number of qubits to be greater than one",
+        ),
+        (
+            np.array([[-0.080, 2.629, -0.710, 5.383]]),
+            [0, 1, 2, 3],
+            "Weights tensor must",
+        ),
+        (
+            np.array(
+                [
+                    [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
+                    [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
+                ]
             ),
-            (
-                np.array([[-0.080, 2.629, -0.710, 5.383]]),
-                [0, 1, 2, 3],
-                "Weights tensor must",
-            ),
-            (
-                np.array(
-                    [
-                        [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
-                        [-0.080, 2.629, -0.710, 5.383, 0.646, -2.872],
-                    ]
-                ),
-                [0, 1, 2, 3],
-                "Weights tensor must",
-            ),
-            (
-                np.array([-0.080, 2.629, -0.710, 5.383, 0.646, -2.872]),
-                [0, 1, 2, 3],
-                "Weights tensor must be 2-dimensional",
-            ),
-        ],
-    )
-    def test_exceptions(self, weights, wires, msg_match):
-        """Test that ParticleConservingU2 throws an exception if the parameters have illegal
-        shapes, types or values."""
-        N = len(wires)
-        init_state = np.array([1, 1, 0, 0])
+            [0, 1, 2, 3],
+            "Weights tensor must",
+        ),
+        (
+            np.array([-0.080, 2.629, -0.710, 5.383, 0.646, -2.872]),
+            [0, 1, 2, 3],
+            "Weights tensor must be 2-dimensional",
+        ),
+    ],
+)
+def test_exceptions(weights, wires, msg_match):
+    """Test that ParticleConservingU2 throws an exception if the parameters have illegal
+    shapes, types or values."""
+    N = len(wires)
+    init_state = np.array([1, 1, 0, 0])
 
-        dev = qp.device("default.qubit", wires=N)
+    dev = qp.device("default.qubit", wires=N)
 
-        @qp.qnode(dev)
-        def circuit():
-            qp.ParticleConservingU2(
-                weights=weights,
-                wires=wires,
-                init_state=init_state,
-            )
-            return qp.expval(qp.PauliZ(0))
-
-        with pytest.raises(ValueError, match=msg_match):
-            circuit()
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        init_state = np.array([1, 1, 0])
-        template = qp.ParticleConservingU2(
-            weights=np.random.random(size=(1, 5)), wires=range(3), init_state=init_state, id="a"
+    @qp.qnode(dev)
+    def circuit():
+        qp.ParticleConservingU2(
+            weights=weights,
+            wires=wires,
+            init_state=init_state,
         )
-        assert template.id == "a"
+        return qp.expval(qp.PauliZ(0))
+
+    with pytest.raises(ValueError, match=msg_match):
+        circuit()
 
 
 class TestAttributes:

--- a/tests/templates/layers/test_random.py
+++ b/tests/templates/layers/test_random.py
@@ -184,12 +184,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="Weights tensor must be 2-dimensional"):
             circuit(phi)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.RandomLayers(np.random.random(size=(1, 3)), wires=range(3), id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/layers/test_simplified_twodesign.py
+++ b/tests/templates/layers/test_simplified_twodesign.py
@@ -201,14 +201,6 @@ class TestInputs:
             weights = np.random.randn(2, 1, 2)
             circuit(initial_layer, weights)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        weights = np.random.random(size=(1, 2, 2))
-        initial_layer = np.random.randn(3)
-        template = qp.SimplifiedTwoDesign(initial_layer, weights, wires=range(3), id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/layers/test_strongly_entangling.py
+++ b/tests/templates/layers/test_strongly_entangling.py
@@ -334,12 +334,6 @@ class TestInputs:
             weights = np.random.randn(1, 2, 3)
             circuit(weights, ranges=[0])
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.StronglyEntanglingLayers(np.array([[[1, 2, 3]]]), wires=[0], id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/state_preparations/test_arbitrary_state_prep.py
+++ b/tests/templates/state_preparations/test_arbitrary_state_prep.py
@@ -228,14 +228,6 @@ class TestInputs:
             weights = np.zeros(12)
             circuit(weights)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.ArbitraryStatePreparation(
-            np.random.random(size=2**4 - 2), wires=[0, 1, 2], id="a"
-        )
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/state_preparations/test_cosine_window.py
+++ b/tests/templates/state_preparations/test_cosine_window.py
@@ -24,7 +24,6 @@ import pennylane as qp
 from pennylane.exceptions import WireError
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.transforms.decompose import DecomposeInterpreter
-from pennylane.wires import Wires
 
 
 @pytest.mark.jax
@@ -148,21 +147,10 @@ class TestDecomposition:
         assert np.allclose(state1, state2)
 
 
-class TestRepresentation:
-    """Test id and label."""
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        wires = [0, 1, 2]
-        template = qp.CosineWindow(wires=wires, id="a")
-        assert template.id == "a"
-        assert template.wires == Wires(wires)
-
-    def test_label(self):
-        """Test label method returns CosineWindow"""
-        op = qp.CosineWindow(wires=[0, 1])
-        assert op.label() == "CosineWindow"
+def test_label():
+    """Test label method returns CosineWindow"""
+    op = qp.CosineWindow(wires=[0, 1])
+    assert op.label() == "CosineWindow"
 
 
 class TestStateVector:

--- a/tests/templates/state_preparations/test_mottonen_state_prep.py
+++ b/tests/templates/state_preparations/test_mottonen_state_prep.py
@@ -431,12 +431,6 @@ class TestInputs:
         with pytest.raises(ValueError, match="state_vector must be one-dimensional"):
             qp.MottonenStatePreparation(state_vector, 2)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.MottonenStatePreparation(np.array([0, 1]), wires=[0], id="a")
-        assert template.id == "a"
-
 
 class TestGradient:
     """Tests gradients."""

--- a/tests/templates/state_preparations/test_qutrit_basis_state_prep.py
+++ b/tests/templates/state_preparations/test_qutrit_basis_state_prep.py
@@ -286,9 +286,3 @@ class TestInputs:
         with pytest.raises(ValueError, match="Basis states must only consist of"):
             basis_state = np.array([0, 3])
             circuit(basis_state, obs)
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.QutritBasisStatePreparation(np.array([0, 2]), wires=[0, 1], id="a")
-        assert template.id == "a"

--- a/tests/templates/subroutines/qchem/test_all_singles_doubles.py
+++ b/tests/templates/subroutines/qchem/test_all_singles_doubles.py
@@ -342,19 +342,6 @@ class TestInputs:
                 doubles=doubles,
             )
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.AllSinglesDoubles(
-            [1, 2],
-            wires=range(4),
-            hf_state=np.array([1, 1, 0, 0]),
-            singles=[[0, 1]],
-            doubles=[[0, 1, 2, 3]],
-            id="a",
-        )
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests additional methods and attributes"""

--- a/tests/templates/subroutines/qchem/test_basis_rotation.py
+++ b/tests/templates/subroutines/qchem/test_basis_rotation.py
@@ -388,73 +388,55 @@ class TestDecomposition:
         assert np.allclose([qp.math.fidelity_statevector(circuit(), exp_state)], [1.0], atol=1e-6)
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
-
-    @pytest.mark.parametrize(
-        ("wires", "unitary_matrix", "msg_match"),
-        [
-            (
-                [0, 1, 2],
-                np.array(
-                    [
-                        [0.51378719 + 0.0j, 0.0546265 + 0.79145487j, -0.2051466 + 0.2540723j],
-                        [0.62651582 + 0.0j, -0.00828925 - 0.60570321j, -0.36704948 + 0.32528067j],
-                    ]
-                ),
-                "The unitary matrix should be of shape NxN",
-            ),
-            (
-                [0, 1, 2],
-                np.array(
-                    [
-                        [0.21378719 + 0.0j, 0.0546265 - 0.79145487j, -0.2051466 + 0.2540723j],
-                        [0.0 + 0.0j, -0.00821925 - 0.60570321j, -0.36704948 + 0.32528067j],
-                        [-0.0 + 0.0j, 0.03902657 + 0.04633548j, -0.57220635 + 0.57044649j],
-                    ]
-                ),
-                "The provided transformation matrix should be unitary.",
-            ),
-            (
-                [0],
-                np.array([[1.0]]),
-                "This template requires at least two wires",
-            ),
-        ],
-    )
-    def test_basis_rotation_exceptions(self, wires, unitary_matrix, msg_match):
-        """Test that BasisRotation template throws an exception if the parameters have illegal
-        shapes, types or values."""
-
-        dev = qp.device("default.qubit", wires=len(wires))
-
-        @qp.qnode(dev)
-        def circuit():
-            qp.BasisRotation(wires=wires, unitary_matrix=unitary_matrix, check=True)
-            return qp.expval(qp.PauliZ(0))
-
-        with pytest.raises(ValueError, match=msg_match):
-            circuit()
-
-        with pytest.raises(ValueError, match=msg_match):
-            qp.BasisRotation.compute_decomposition(
-                wires=wires, unitary_matrix=unitary_matrix, check=True
-            )
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Test that the id attribute can be set."""
-        template = qp.BasisRotation(
-            wires=range(2),
-            unitary_matrix=qp.math.array(
+@pytest.mark.parametrize(
+    ("wires", "unitary_matrix", "msg_match"),
+    [
+        (
+            [0, 1, 2],
+            np.array(
                 [
-                    [-0.77228482 + 0.0j, -0.02959195 + 0.63458685j],
-                    [0.63527644 + 0.0j, -0.03597397 + 0.77144651j],
+                    [0.51378719 + 0.0j, 0.0546265 + 0.79145487j, -0.2051466 + 0.2540723j],
+                    [0.62651582 + 0.0j, -0.00828925 - 0.60570321j, -0.36704948 + 0.32528067j],
                 ]
             ),
-            id="a",
+            "The unitary matrix should be of shape NxN",
+        ),
+        (
+            [0, 1, 2],
+            np.array(
+                [
+                    [0.21378719 + 0.0j, 0.0546265 - 0.79145487j, -0.2051466 + 0.2540723j],
+                    [0.0 + 0.0j, -0.00821925 - 0.60570321j, -0.36704948 + 0.32528067j],
+                    [-0.0 + 0.0j, 0.03902657 + 0.04633548j, -0.57220635 + 0.57044649j],
+                ]
+            ),
+            "The provided transformation matrix should be unitary.",
+        ),
+        (
+            [0],
+            np.array([[1.0]]),
+            "This template requires at least two wires",
+        ),
+    ],
+)
+def test_basis_rotation_exceptions(wires, unitary_matrix, msg_match):
+    """Test that BasisRotation template throws an exception if the parameters have illegal
+    shapes, types or values."""
+
+    dev = qp.device("default.qubit", wires=len(wires))
+
+    @qp.qnode(dev)
+    def circuit():
+        qp.BasisRotation(wires=wires, unitary_matrix=unitary_matrix, check=True)
+        return qp.expval(qp.PauliZ(0))
+
+    with pytest.raises(ValueError, match=msg_match):
+        circuit()
+
+    with pytest.raises(ValueError, match=msg_match):
+        qp.BasisRotation.compute_decomposition(
+            wires=wires, unitary_matrix=unitary_matrix, check=True
         )
-        assert template.id == "a"
 
 
 def circuit_template(unitary_matrix, check=False):

--- a/tests/templates/subroutines/qchem/test_double_excitation.py
+++ b/tests/templates/subroutines/qchem/test_double_excitation.py
@@ -289,37 +289,28 @@ class TestDecomposition:
         assert np.allclose(state1, state2, atol=tol, rtol=0)
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
+@pytest.mark.parametrize(
+    ("weight", "wires1", "wires2", "msg_match"),
+    [
+        (0.2, [0], [1, 2], "expected at least two wires representing the occupied"),
+        (0.2, [0, 1], [2], "expected at least two wires representing the unoccupied"),
+        (0.2, [0], [1], "expected at least two wires representing the occupied"),
+        ([0.2, 1.1], [0, 2], [4, 6], "Weight must be a scalar"),
+    ],
+)
+def test_double_excitation_unitary_exceptions(weight, wires1, wires2, msg_match):
+    """Test exception if ``weight`` or
+    ``pphh`` parameter has illegal shapes, types or values."""
+    dev = qp.device("default.qubit", wires=10)
 
-    @pytest.mark.parametrize(
-        ("weight", "wires1", "wires2", "msg_match"),
-        [
-            (0.2, [0], [1, 2], "expected at least two wires representing the occupied"),
-            (0.2, [0, 1], [2], "expected at least two wires representing the unoccupied"),
-            (0.2, [0], [1], "expected at least two wires representing the occupied"),
-            ([0.2, 1.1], [0, 2], [4, 6], "Weight must be a scalar"),
-        ],
-    )
-    def test_double_excitation_unitary_exceptions(self, weight, wires1, wires2, msg_match):
-        """Test exception if ``weight`` or
-        ``pphh`` parameter has illegal shapes, types or values."""
-        dev = qp.device("default.qubit", wires=10)
+    def circuit(weight):
+        qp.FermionicDoubleExcitation(weight=weight, wires1=wires1, wires2=wires2)
+        return qp.expval(qp.PauliZ(0))
 
-        def circuit(weight):
-            qp.FermionicDoubleExcitation(weight=weight, wires1=wires1, wires2=wires2)
-            return qp.expval(qp.PauliZ(0))
+    qnode = qp.QNode(circuit, dev)
 
-        qnode = qp.QNode(circuit, dev)
-
-        with pytest.raises(ValueError, match=msg_match):
-            qnode(weight)
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.FermionicDoubleExcitation(0.4, wires1=[0, 2], wires2=[1, 4, 3], id="a")
-        assert template.id == "a"
+    with pytest.raises(ValueError, match=msg_match):
+        qnode(weight)
 
 
 def circuit_template(weight):

--- a/tests/templates/subroutines/qchem/test_kupccgsd.py
+++ b/tests/templates/subroutines/qchem/test_kupccgsd.py
@@ -438,19 +438,6 @@ class TestInputs:
         with pytest.raises(ValueError, match=msg_match):
             circuit()
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Test that the id attribute can be set."""
-        template = qp.kUpCCGSD(
-            qp.math.array([[0.55, 0.72, 0.6, 0.54, 0.42, 0.65]]),
-            wires=range(4),
-            k=1,
-            delta_sz=0,
-            init_state=qp.math.array([1, 1, 0, 0]),
-            id="a",
-        )
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Test additional methods and attributes"""

--- a/tests/templates/subroutines/qchem/test_single_excitation.py
+++ b/tests/templates/subroutines/qchem/test_single_excitation.py
@@ -180,36 +180,27 @@ class TestDecomposition:
             _test_decomposition_rule(op, rule)
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
+@pytest.mark.parametrize(
+    ("weight", "single_wires", "msg_match"),
+    [
+        (0.2, [0], "expected at least two wires"),
+        (0.2, [], "expected at least two wires"),
+        ([0.2, 1.1], [0, 1, 2], "Weight must be a scalar"),
+    ],
+)
+def test_single_excitation_unitary_exceptions(weight, single_wires, msg_match):
+    """Test that FermionicSingleExcitation throws an exception if ``weight`` or
+    ``single_wires`` parameter has illegal shapes, types or values."""
+    dev = qp.device("default.qubit", wires=5)
 
-    @pytest.mark.parametrize(
-        ("weight", "single_wires", "msg_match"),
-        [
-            (0.2, [0], "expected at least two wires"),
-            (0.2, [], "expected at least two wires"),
-            ([0.2, 1.1], [0, 1, 2], "Weight must be a scalar"),
-        ],
-    )
-    def test_single_excitation_unitary_exceptions(self, weight, single_wires, msg_match):
-        """Test that FermionicSingleExcitation throws an exception if ``weight`` or
-        ``single_wires`` parameter has illegal shapes, types or values."""
-        dev = qp.device("default.qubit", wires=5)
+    def circuit(weight=weight):
+        qp.FermionicSingleExcitation(weight=weight, wires=single_wires)
+        return qp.expval(qp.PauliZ(0))
 
-        def circuit(weight=weight):
-            qp.FermionicSingleExcitation(weight=weight, wires=single_wires)
-            return qp.expval(qp.PauliZ(0))
+    qnode = qp.QNode(circuit, dev)
 
-        qnode = qp.QNode(circuit, dev)
-
-        with pytest.raises(ValueError, match=msg_match):
-            qnode(weight=weight)
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.FermionicSingleExcitation(0.4, wires=[1, 0, 2], id="a")
-        assert template.id == "a"
+    with pytest.raises(ValueError, match=msg_match):
+        qnode(weight=weight)
 
 
 def circuit_template(weight):

--- a/tests/templates/subroutines/qchem/test_uccsd.py
+++ b/tests/templates/subroutines/qchem/test_uccsd.py
@@ -340,159 +340,143 @@ class TestDecomposition:
         assert np.allclose(state1, state2, atol=tol, rtol=0)
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
+@pytest.mark.parametrize(
+    ("weights", "s_wires", "d_wires", "init_state", "n_repeats", "msg_match"),
+    [
+        (
+            np.array([-2.8]),
+            [[0, 1, 2]],
+            [],
+            np.array([1.2, 1, 0, 0]),
+            1,
+            "Elements of 'init_state' must be integers",
+        ),
+        (
+            np.array([-2.8]),
+            [],
+            [],
+            np.array([1, 1, 0, 0]),
+            1,
+            "s_wires and d_wires lists can not be both empty",
+        ),
+        (
+            np.array([-2.8]),
+            [],
+            [[[0, 1, 2, 3]]],
+            np.array([1, 1, 0, 0]),
+            1,
+            "expected entries of d_wires to be of size 2",
+        ),
+        (
+            np.array([-2.8]),
+            [[0, 2]],
+            [],
+            np.array([1, 1, 0, 0, 0]),
+            1,
+            r"Expected length of 'init_state' to match number of wires \(4\)",
+        ),
+        (
+            np.array([-2.8]),
+            [[0, 2]],
+            [],
+            None,
+            1,
+            r"Requires `init_state` to be provided",
+        ),
+        (
+            np.array([-2.8, 1.6]),
+            [[0, 1, 2]],
+            [],
+            np.array([1, 1, 0, 0]),
+            1,
+            "For one-dimensional weights tensor",
+        ),
+        (
+            np.array([-2.8, 1.6]),
+            [],
+            [[[0, 1], [2, 3]]],
+            np.array([1, 1, 0, 0]),
+            1,
+            "For one-dimensional weights tensor",
+        ),
+        (
+            np.array([-2.8, 1.6]),
+            [[0, 1, 2], [1, 2, 3]],
+            [[[0, 1], [2, 3]]],
+            np.array([1, 1, 0, 0]),
+            1,
+            "For one-dimensional weights tensor",
+        ),
+        (
+            np.array([-2.8]),
+            [[0, 1, 2]],
+            [],
+            np.array([1, 1, 0, 0]),
+            0,
+            "Requires n_repeats to be at least 1",
+        ),
+        (
+            np.array([-2.8]),
+            [[0, 1, 2]],
+            [],
+            np.array([1, 1, 0, 0]),
+            -1,
+            "Requires n_repeats to be at least 1",
+        ),
+        (
+            np.array([-2.8]),
+            [[0, 1, 2]],
+            [],
+            np.array([1, 1, 0, 0]),
+            2,
+            "For one-dimensional weights tensor",
+        ),
+        (
+            np.array([[-2.8], [-1.8]]),
+            [[0, 1, 2]],
+            [],
+            np.array([1, 1, 0, 0]),
+            3,
+            "Weights tensor must be of",
+        ),
+    ],
+)
+def test_uccsd_xceptions(weights, s_wires, d_wires, init_state, n_repeats, msg_match):
+    """Test that UCCSD throws an exception if the parameters have illegal
+    shapes, types or values."""
+    N = 4
+    wires = range(4)
+    dev = qp.device("default.qubit", wires=N)
 
-    @pytest.mark.parametrize(
-        ("weights", "s_wires", "d_wires", "init_state", "n_repeats", "msg_match"),
-        [
-            (
-                np.array([-2.8]),
-                [[0, 1, 2]],
-                [],
-                np.array([1.2, 1, 0, 0]),
-                1,
-                "Elements of 'init_state' must be integers",
-            ),
-            (
-                np.array([-2.8]),
-                [],
-                [],
-                np.array([1, 1, 0, 0]),
-                1,
-                "s_wires and d_wires lists can not be both empty",
-            ),
-            (
-                np.array([-2.8]),
-                [],
-                [[[0, 1, 2, 3]]],
-                np.array([1, 1, 0, 0]),
-                1,
-                "expected entries of d_wires to be of size 2",
-            ),
-            (
-                np.array([-2.8]),
-                [[0, 2]],
-                [],
-                np.array([1, 1, 0, 0, 0]),
-                1,
-                r"Expected length of 'init_state' to match number of wires \(4\)",
-            ),
-            (
-                np.array([-2.8]),
-                [[0, 2]],
-                [],
-                None,
-                1,
-                r"Requires `init_state` to be provided",
-            ),
-            (
-                np.array([-2.8, 1.6]),
-                [[0, 1, 2]],
-                [],
-                np.array([1, 1, 0, 0]),
-                1,
-                "For one-dimensional weights tensor",
-            ),
-            (
-                np.array([-2.8, 1.6]),
-                [],
-                [[[0, 1], [2, 3]]],
-                np.array([1, 1, 0, 0]),
-                1,
-                "For one-dimensional weights tensor",
-            ),
-            (
-                np.array([-2.8, 1.6]),
-                [[0, 1, 2], [1, 2, 3]],
-                [[[0, 1], [2, 3]]],
-                np.array([1, 1, 0, 0]),
-                1,
-                "For one-dimensional weights tensor",
-            ),
-            (
-                np.array([-2.8]),
-                [[0, 1, 2]],
-                [],
-                np.array([1, 1, 0, 0]),
-                0,
-                "Requires n_repeats to be at least 1",
-            ),
-            (
-                np.array([-2.8]),
-                [[0, 1, 2]],
-                [],
-                np.array([1, 1, 0, 0]),
-                -1,
-                "Requires n_repeats to be at least 1",
-            ),
-            (
-                np.array([-2.8]),
-                [[0, 1, 2]],
-                [],
-                np.array([1, 1, 0, 0]),
-                2,
-                "For one-dimensional weights tensor",
-            ),
-            (
-                np.array([[-2.8], [-1.8]]),
-                [[0, 1, 2]],
-                [],
-                np.array([1, 1, 0, 0]),
-                3,
-                "Weights tensor must be of",
-            ),
-        ],
-    )
-    def test_uccsd_xceptions(self, weights, s_wires, d_wires, init_state, n_repeats, msg_match):
-        """Test that UCCSD throws an exception if the parameters have illegal
-        shapes, types or values."""
-        N = 4
-        wires = range(4)
-        dev = qp.device("default.qubit", wires=N)
-
-        def circuit(
+    def circuit(
+        weights=weights,
+        wires=wires,
+        s_wires=s_wires,
+        d_wires=d_wires,
+        init_state=init_state,
+        n_repeats=n_repeats,
+    ):
+        qp.UCCSD(
             weights=weights,
             wires=wires,
             s_wires=s_wires,
             d_wires=d_wires,
             init_state=init_state,
             n_repeats=n_repeats,
-        ):
-            qp.UCCSD(
-                weights=weights,
-                wires=wires,
-                s_wires=s_wires,
-                d_wires=d_wires,
-                init_state=init_state,
-                n_repeats=n_repeats,
-            )
-            return qp.expval(qp.PauliZ(0))
-
-        qnode = qp.QNode(circuit, dev)
-
-        with pytest.raises(ValueError, match=msg_match):
-            qnode(
-                weights=weights,
-                wires=wires,
-                s_wires=s_wires,
-                d_wires=d_wires,
-                init_state=init_state,
-                n_repeats=n_repeats,
-            )
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.UCCSD(
-            [0.1, 0.2],
-            wires=range(4),
-            s_wires=[[0, 1]],
-            d_wires=[[[0, 1], [2, 3]]],
-            init_state=np.array([0, 1, 0, 1]),
-            id="a",
         )
-        assert template.id == "a"
+        return qp.expval(qp.PauliZ(0))
+
+    qnode = qp.QNode(circuit, dev)
+
+    with pytest.raises(ValueError, match=msg_match):
+        qnode(
+            weights=weights,
+            wires=wires,
+            s_wires=s_wires,
+            d_wires=d_wires,
+            init_state=init_state,
+            n_repeats=n_repeats,
+        )
 
 
 def circuit_template(weights, n_repeats=1):

--- a/tests/templates/subroutines/test_arbitrary_unitary.py
+++ b/tests/templates/subroutines/test_arbitrary_unitary.py
@@ -223,12 +223,6 @@ class TestInputs:
             weights = np.zeros(shape)
             circuit(weights)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.ArbitraryUnitary(np.random.random(size=(63,)), wires=range(3), id="a")
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Tests class attributes and methods."""

--- a/tests/templates/subroutines/test_controlled_sequence.py
+++ b/tests/templates/subroutines/test_controlled_sequence.py
@@ -35,12 +35,6 @@ def test_standard_validity():
 
 class TestInitialization:
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        op = qp.ControlledSequence(qp.RX(0.25, wires=3), control=[0, 1, 2], id="a")
-        assert op.id == "a"
-
     def test_overlapping_wires_error(self):
         """Test that an error is raised if the wires of the base
         operator and the control wires overlap"""

--- a/tests/templates/subroutines/test_grover.py
+++ b/tests/templates/subroutines/test_grover.py
@@ -76,15 +76,6 @@ def test_single_wire_error(bad_wires):
         qp.GroverOperator(wires=bad_wires)
 
 
-@pytest.mark.usefixtures("ignore_id_deprecation")
-def test_id():
-    """Assert id keyword works"""
-
-    op = qp.GroverOperator(wires=(0, 1), id="hello")
-
-    assert op.id == "hello"
-
-
 decomp_3wires = [
     qp.Hadamard,
     qp.Hadamard,

--- a/tests/templates/subroutines/test_permute.py
+++ b/tests/templates/subroutines/test_permute.py
@@ -417,9 +417,3 @@ class TestInputs:
                 qp.Permute(permutation_order, wires=wire_labels)
 
         qp.tape.QuantumScript.from_queue(q)
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.Permute([0, 1, 2], wires=[0, 1, 2], id="a")
-        assert template.id == "a"

--- a/tests/templates/subroutines/test_prepselprep.py
+++ b/tests/templates/subroutines/test_prepselprep.py
@@ -298,34 +298,6 @@ class TestPrepSelPrep:
         c = qp.math.array(lcu.terms()[0])
         assert op.label(cache={"matrices": [0.1, c]}) == "PrepSelPrep(M1)"
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    @pytest.mark.parametrize("lcu", a_set_of_lcus)
-    def test_label_with_id(self, lcu):
-        """Test the custom label method of PrepSelPrep."""
-        op_with_id = qp.PrepSelPrep(lcu, control=0, id="myID")
-
-        # Default
-        assert op_with_id.label() == 'PrepSelPrep("myID")'
-
-        # decimals do not affect label
-        assert op_with_id.label(decimals=3) == 'PrepSelPrep("myID")'
-
-        # use different base label
-        assert op_with_id.label(base_label="U(A)") == 'U(A)("myID")'
-
-        # use cache without matrices
-        assert op_with_id.label(cache={}) == 'PrepSelPrep("myID")'
-
-        # use cache with empty matrices
-        assert op_with_id.label(cache={"matrices": []}) == 'PrepSelPrep(M0,"myID")'
-
-        # use cache with non-empty matrices
-        assert op_with_id.label(cache={"matrices": [0.1, 0.6]}) == 'PrepSelPrep(M2,"myID")'
-
-        # use cache with same matrix existing
-        c = qp.math.array(op_with_id.coeffs)
-        assert op_with_id.label(cache={"matrices": [c, 0.1, 0.6]}) == 'PrepSelPrep(M0,"myID")'
-
     def test_resources(self):
         """Test the registered resources."""
 

--- a/tests/templates/subroutines/test_qmc.py
+++ b/tests/templates/subroutines/test_qmc.py
@@ -486,22 +486,3 @@ class TestQuantumMonteCarlo:
 
         exact = 0.432332358381693654
         assert np.allclose(mu_estimated, exact, rtol=1e-3)
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        xs = np.linspace(-np.pi, np.pi, 2**5)
-        probs = np.array([norm().pdf(x) for x in xs])
-        probs /= np.sum(probs)
-
-        def func(i):
-            return np.cos(xs[i]) ** 2
-
-        target_wires = [0, "a", -1.1, -10, "bbb", 1000]
-        estimation_wires = ["bob", -3, 42, "penny", "lane", 247, "straw", "berry", 5.5, 6.6]
-
-        template = qp.QuantumMonteCarlo(
-            probs, func, target_wires=target_wires, estimation_wires=estimation_wires, id="a"
-        )
-
-        assert template.id == "a"

--- a/tests/templates/subroutines/test_qpe.py
+++ b/tests/templates/subroutines/test_qpe.py
@@ -428,20 +428,9 @@ class TestDecomposition:
         assert qp.math.allclose(circuit(), jit_circuit())
 
 
-class TestInputs:
-    """Test inputs and pre-processing."""
+def test_same_wires():
+    """Tests if a QuantumFunctionError is raised if target_wires and estimation_wires contain a
+    common element"""
 
-    def test_same_wires(self):
-        """Tests if a QuantumFunctionError is raised if target_wires and estimation_wires contain a
-        common element"""
-
-        with pytest.raises(QuantumFunctionError, match="The target wires and estimation wires"):
-            qp.QuantumPhaseEstimation(np.eye(4), target_wires=[0, 1], estimation_wires=[1, 2])
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        template = qp.QuantumPhaseEstimation(
-            np.eye(4), target_wires=[0, 1], estimation_wires=[2, 3], id="a"
-        )
-        assert template.id == "a"
+    with pytest.raises(QuantumFunctionError, match="The target wires and estimation wires"):
+        qp.QuantumPhaseEstimation(np.eye(4), target_wires=[0, 1], estimation_wires=[1, 2])

--- a/tests/templates/subroutines/time_evolution/test_approx_time_evolution.py
+++ b/tests/templates/subroutines/time_evolution/test_approx_time_evolution.py
@@ -263,13 +263,6 @@ class TestInputs:
         ):
             circuit()
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Tests that the id attribute can be set."""
-        h = qp.Hamiltonian([1, 1], [qp.PauliX(0), qp.PauliY(0)])
-        template = qp.ApproxTimeEvolution(h, 2, 3, id="a")
-        assert template.id == "a"
-
     def test_wire_indices(self):
         """Tests that correct wires are set."""
         wire_indices = [0, 1]

--- a/tests/templates/swapnetworks/test_ccl2.py
+++ b/tests/templates/swapnetworks/test_ccl2.py
@@ -279,19 +279,6 @@ class TestInputs:
                 shif=False,
             )
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Test that the id attribute can be set."""
-        template = qp.templates.TwoLocalSwapNetwork(
-            wires=range(4),
-            acquaintances=None,
-            weights=None,
-            fermionic=True,
-            shif=False,
-            id="a",
-        )
-        assert template.id == "a"
-
 
 class TestAttributes:
     """Test additional methods and attributes"""

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -358,18 +358,6 @@ class TestSubroutineCall:
         op = q.queue[0]
         assert op.bound_args.arguments["metadata"] == "default_value"
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_handle_id(self):
-        """Test that Subroutine's can handle accepting an id."""
-
-        @Subroutine
-        def f(wires):
-            pass
-
-        op = f.operator(0, id="val")
-
-        assert op.id == "val"
-
     def test_mcm_outputs(self):
         """Test that a subroutine can return mcms."""
 

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -498,21 +498,6 @@ class TestSubroutineCapture:
         inner_xpr = subroutine_eqn.params["jaxpr"]
         assert inner_xpr.eqns[-1].primitive == qp.capture.primitives.cond_prim
 
-    def test_id_ignored(self):
-        """Test that id is ignored with program capture."""
-
-        import jax  # pylint: disable=import-outside-toplevel
-
-        @Subroutine
-        def f(wires):
-            pass
-
-        def w():
-            return f(0, id="val")
-
-        jaxpr = jax.make_jaxpr(w)()
-        assert "id" not in jaxpr.eqns[-1].params
-
 
 @pytest.mark.capture
 class TestCollectedSubroutine:

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1844,14 +1844,14 @@ def test_docstring_example_of_operator_class(tol):
         grad_method = "A"
 
         # pylint: disable=too-many-arguments,too-many-positional-arguments
-        def __init__(self, angle, wire_rot, wire_flip=None, do_flip=False, id=None):
+        def __init__(self, angle, wire_rot, wire_flip=None, do_flip=False):
             if do_flip and wire_flip is None:
                 raise ValueError("Expected a wire to flip; got None.")
 
             self._hyperparameters = {"do_flip": do_flip}
 
             all_wires = qp.wires.Wires(wire_rot) + qp.wires.Wires(wire_flip)
-            super().__init__(angle, wires=all_wires, id=id)
+            super().__init__(angle, wires=all_wires)
 
         @property
         def num_params(self):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -23,7 +23,6 @@ from gate_data import CNOT, I, Toffoli, X
 
 import pennylane as qp
 from pennylane import numpy as pnp
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.operation import (
     _UNSET_BATCH_SIZE,
     Operation,
@@ -41,37 +40,6 @@ from pennylane.wires import Wires
 Toffoli_broadcasted = np.tensordot([0.1, -4.2j], Toffoli, axes=0)
 CNOT_broadcasted = np.tensordot([1.4], CNOT, axes=0)
 I_broadcasted = I[pnp.newaxis]
-
-
-@pytest.mark.parametrize("test_class", [Operator, Operation])
-def test_id_is_deprecated(test_class):
-    """Tests that the 'id' argument is deprecated."""
-
-    class DummyOp(test_class):
-        """Custom dummy operator."""
-
-    _ = DummyOp(0.5, [0])
-    _ = DummyOp(0.5, [0], id=None)
-
-    with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-        _ = DummyOp(0.5, [0], id="blah")
-
-
-@pytest.mark.parametrize("test_class", [Operator, Operation])
-def test_id_with_label_is_deprecated(test_class):
-    """Tests that using 'label' with a set 'id' argument gives useful warning."""
-
-    class DummyOp(test_class):
-        """Custom dummy operator."""
-
-    with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-        op = DummyOp(0.5, [0], id="blah")
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning,
-        match="Using 'id' to add a custom label to your operator is deprecated",
-    ):
-        _ = op.label()
 
 
 class TestOperatorConstruction:
@@ -969,19 +937,6 @@ class TestOperationConstruction:
         with pytest.raises(ValueError, match="Must specify the wires"):
             DummyOp(0.54)
 
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Test that the id attribute of an operator can be set."""
-
-        class DummyOp(qp.operation.Operation):
-            r"""Dummy custom operation"""
-
-            num_wires = 1
-            grad_method = None
-
-        op = DummyOp(1.0, wires=0, id="test")
-        assert op.id == "test"
-
     def test_control_wires(self):
         """Test that control_wires defaults to an empty Wires object."""
 
@@ -1071,19 +1026,6 @@ class TestObservableConstruction:
         m = qp.PauliZ(wires=["a"])
         expected = "Z('a')"
         assert str(m) == expected
-
-    @pytest.mark.usefixtures("ignore_id_deprecation")
-    def test_id(self):
-        """Test that the id attribute of an observable can be set."""
-
-        class DummyObserv(qp.operation.Operator):
-            r"""Dummy custom observable"""
-
-            num_wires = 1
-            grad_method = None
-
-        op = DummyObserv(1.0, wires=0, id="test")
-        assert op.id == "test"
 
     def test_raises_if_no_wire_is_given(self):
         """Test that an error is raised if no wire is passed at initialization."""
@@ -1338,26 +1280,6 @@ class TestOperatorIntegration:
         """Test that the __matmul__ dunder method raises an error when using a non-supported object."""
         with pytest.raises(TypeError, match="unsupported operand type"):
             _ = qp.PauliX(0) @ "dummy"
-
-    def test_label_for_operations_with_id(self):
-        """Test that the label is correctly generated for an operation with an id"""
-
-        with pytest.warns(PennyLaneDeprecationWarning, match="The 'id' argument is deprecated"):
-            op = qp.RX(1.344, wires=0, id="test_with_id")
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="Using 'id' to add a custom label to your operator is deprecated",
-        ):
-            assert '"test_with_id"' in op.label()
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="Using 'id' to add a custom label to your operator is deprecated",
-        ):
-            assert '"test_with_id"' in op.label(decimals=2)
-
-        op = qp.RX(1.344, wires=0)
-        assert '"test_with_id"' not in op.label()
-        assert '"test_with_id"' not in op.label(decimals=2)
 
 
 # Dummy class inheriting from Operator

--- a/tests/test_qcut.py
+++ b/tests/test_qcut.py
@@ -36,7 +36,6 @@ import pennylane as qp
 from pennylane import numpy as np
 from pennylane import qcut
 from pennylane.decomposition import gate_sets
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.queuing import WrappedObj
 from pennylane.transforms import decompose
 from pennylane.wires import Wires
@@ -300,19 +299,6 @@ def test_node_ids(monkeypatch):
 
         assert mn.node_uid == "some_string"
         assert pn.node_uid == "some_string"
-
-
-def test_id_is_deprecated():
-    """Tests that the 'id' argument is deprecated and renamed."""
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'id' kwarg has been renamed to 'node_uid'"
-    ):
-        _ = qcut.MeasureNode(wires=0, id="blah")
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'id' kwarg has been renamed to 'node_uid'"
-    ):
-        _ = qcut.PrepareNode(wires=0, id="blah")
 
 
 @pytest.mark.parametrize("cls", [qcut.MeasureNode, qcut.PrepareNode])

--- a/tests/workflow/test_construct_batch.py
+++ b/tests/workflow/test_construct_batch.py
@@ -21,7 +21,6 @@ import pytest
 from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qp
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.workflow import construct_batch
 
 
@@ -92,19 +91,6 @@ class TestMarker:
 
         res = c(0.5)
         assert qp.math.allclose(res, np.cos(0.5))
-
-
-def test_get_transform_program_is_deprecated():
-    """Tests that the 'get_transform_program' function is deprecated."""
-
-    @qp.qnode(qp.device("default.qubit"))
-    def circuit():
-        return qp.state()
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning, match="The 'get_transform_program' function is deprecated"
-    ):
-        _ = qp.workflow.get_transform_program(circuit)
 
 
 @qp.transforms.merge_rotations

--- a/tests/workflow/test_qnode.py
+++ b/tests/workflow/test_qnode.py
@@ -41,20 +41,6 @@ from pennylane.workflow.qnode import _make_execution_config
 from pennylane.workflow.set_shots import set_shots
 
 
-def test_transform_program_prop_is_deprecated():
-    """Tests that the deprecation warning is raised."""
-
-    @qp.qnode(qp.device("reference.qubit"))
-    def circuit():
-        return qp.expval(qp.Z(0))
-
-    with pytest.warns(
-        PennyLaneDeprecationWarning,
-        match="The 'transform_program' property of the QNode has been renamed",
-    ):
-        _ = circuit.transform_program
-
-
 def dummyfunc():
     """dummy func."""
     return None


### PR DESCRIPTION
**Context:**

After the large effort deprecation that occured last cycle (github.com/PennyLaneAI/pennylane/pull/8951/), it's time to review all usage of `id`! 🎉 

**Description of the Change:**

While it looks like a lot of lines changed it's essentially a large collection of the same few *simple* changes,
- Removing `id` kwarg from source code
- Removing `id` kwarg from docstring
- Removing tests that were marked with `ignore_id_deprecation` fixture

[sc-119262]