### PR TITLE
Removal of `None` valued `aux_wire` in Hadamard gradient

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -163,7 +163,7 @@ Completed deprecation cycles
 ----------------------------
 
 * Providing a value of ``None`` to ``aux_wire`` of ``qp.gradients.hadamard_grad`` with ``mode="reversed"`` or ``mode="standard"`` has been
-  deprecated and will no longer be supported in 0.46. An ``aux_wire`` will no longer be automatically assigned.
+  removed and will no longer be supported in 0.46. An ``aux_wire`` will no longer be automatically assigned.
 
   - Deprecated in v0.45
   - Removed in v0.46

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -90,12 +90,6 @@ Pending deprecations
   - Deprecated in v0.45
   - Will be removed in v0.46
 
-* Providing a value of ``None`` to ``aux_wire`` of ``qp.gradients.hadamard_grad`` with ``mode="reversed"`` or ``mode="standard"`` has been
-  deprecated and will no longer be supported in 0.46. An ``aux_wire`` will no longer be automatically assigned.
-
-  - Deprecated in v0.45
-  - Will be removed in v0.46
-
 * The ``transform_program`` property of ``QNode`` has been renamed to ``compile_pipeline``.
   The deprecated access through ``transform_program`` will be removed in PennyLane v0.46.
 
@@ -167,6 +161,12 @@ for details on how to port your legacy code to the new system. The following fun
 
 Completed deprecation cycles
 ----------------------------
+
+* Providing a value of ``None`` to ``aux_wire`` of ``qp.gradients.hadamard_grad`` with ``mode="reversed"`` or ``mode="standard"`` has been
+  deprecated and will no longer be supported in 0.46. An ``aux_wire`` will no longer be automatically assigned.
+
+  - Deprecated in v0.45
+  - Removed in v0.46
 
 * Maintenance support of NumPy<2.0 has been removed. PennyLane v0.45 and beyond are not guaranteed to work with NumPy<2.0.
   We recommend upgrading your version of NumPy to benefit from enhanced support and features.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -58,3 +58,5 @@
 <h3>Bug fixes 🐛</h3>
 
 <h3>Contributors ✍️</h3>
+
+Marcus Edwards,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,6 +47,10 @@
 
 <h3>Deprecations 👋</h3>
 
+* Providing a value of ``None`` to ``aux_wire`` of ``qp.gradients.hadamard_grad`` with ``mode="reversed"`` or ``mode="standard"``
+  is no longer supported as of 0.46. An ``aux_wire`` will no longer be automatically assigned.
+  [(#9468)](https://github.com/PennyLaneAI/pennylane/pull/9468)
+
 <h3>Internal changes ⚙️</h3>
 
 <h3>Documentation 📝</h3>

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -16,7 +16,6 @@ This module contains functions for computing the Hadamard-test gradient
 of a qubit-based quantum tape.
 """
 
-import warnings
 from functools import partial
 from itertools import islice
 from typing import Literal
@@ -25,7 +24,6 @@ import numpy as np
 
 from pennylane import math, ops
 from pennylane.decomposition import gate_sets
-from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.measurements import ProbabilityMP, expval
 from pennylane.operation import Operator
 from pennylane.ops import Sum
@@ -109,11 +107,6 @@ def hadamard_grad(
     r"""Transform a circuit to compute the Hadamard test gradient of all gates
     with respect to their inputs.
 
-    .. warning::
-        Providing a value of ``None`` to ``aux_wire`` of ``qp.gradients.hadamard_grad`` with ``mode="reversed"``
-        or ``mode="standard"`` has been deprecated and will no longer be supported in 0.46. An ``aux_wire`` will
-        no longer be automatically assigned.
-
     Args:
         tape (QNode or QuantumTape): quantum circuit to differentiate
         argnum (int or list[int] or None): Trainable tape parameter indices to differentiate
@@ -121,8 +114,6 @@ def hadamard_grad(
             trainable parameters are returned. Note that the indices are with respect to
             the list of trainable parameters.
         aux_wire (pennylane.wires.Wires or None): Auxiliary wire to be used for the Hadamard tests.
-            If ``None`` (the default) and ``mode`` is "standard" or "reversed", a suitable wire
-            is inferred from the wires used in the original circuit and ``device_wires``.
         device_wires (pennylane.wires.Wires): Wires of the device that are going to be used for the
             gradient. Facilitates finding a default for ``aux_wire`` if ``aux_wire`` is ``None``.
         mode (str): Specifies the gradient computation mode. Accepted values are
@@ -447,13 +438,10 @@ def hadamard_grad(
     # unless using direct or reversed-direct modes
 
     if mode in ["standard", "reversed"] and aux_wire is None:
-        warnings.warn(
-            """
-            Providing a value of None to aux_wire in reversed or standard mode has been deprecated and will
-            no longer be supported in v0.46. An aux_wire will no longer be automatically assigned.
-            """,
-            PennyLaneDeprecationWarning,
-        )
+        raise ValueError("""
+            The reversed and standard modes of hadamard_gradient require an auxiliary wire. Please 
+            specify an auxiliary in the aux_wire argument.
+            """)
 
     aux_wire = (
         _get_aux_wire(aux_wire, tape, device_wires)

--- a/tests/gradients/core/test_hadamard_gradient.py
+++ b/tests/gradients/core/test_hadamard_gradient.py
@@ -21,7 +21,7 @@ import pytest
 import pennylane as qp
 from pennylane import numpy as np
 from pennylane import qnode
-from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import QuantumFunctionError
 from pennylane.gradients import hadamard_gradient
 
 
@@ -501,24 +501,24 @@ class TestDifferentModes:
         assert standard.call_count == 1
         assert reverse.call_count == 0
 
-    def test_aux_wire_none_deprecated(self):
+    def test_aux_wire_none_raises(self):
         t = np.array(0.0)
 
         op = qp.evolve(qp.X(0) @ qp.X(1) + qp.Y(2) + qp.Z(0) @ qp.Z(1), t)
         mp = qp.expval(qp.Z(0) @ qp.X(1) + qp.Y(0) + qp.X(0) @ qp.Z(1))
         tape = qp.tape.QuantumScript([op], [mp, qp.probs((0, 1))])
 
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="Providing a value of None to aux_wire",
+        with pytest.raises(
+            ValueError,
+            match="require an auxiliary wire",
         ):
             _, _ = qp.gradients.hadamard_grad(tape, mode="standard", aux_wire=None)
 
         tape = qp.tape.QuantumScript([op], [mp])
 
-        with pytest.warns(
-            PennyLaneDeprecationWarning,
-            match="Providing a value of None to aux_wire",
+        with pytest.raises(
+            ValueError,
+            match="require an auxiliary wire",
         ):
             _, _ = qp.gradients.hadamard_grad(tape, mode="reversed", aux_wire=None)
 


### PR DESCRIPTION
**Context:** We would like to follow through with the removal of `None` valued `aux_wires` for `hadamard_gradient` since we now use whether we have an `aux_wire` to choose what method to use in `auto` mode.

**Description of the Change:** Removes the behaviour that finds an auxiliary on the tape, device, or by incementing past the number of wires when no `aux_wires` are provided. Note the function that actually implements this behaviour is used by other modules, so we don't remove any functionality there. We just make sure we don't pass it a `None` for `aux_wire` from `hadamard_gradient` anymore.

**Benefits:** We now have a more consistent and intuitive interface.

**Possible Drawbacks:** The behaviour of finding an auxiliary on the tape, device, or by incementing past the number of wires when no `aux_wires` are provided is still used in `metric_tensor` and elsewhere in the repo. This is beyond the scope of the removal.

**Related GitHub Issues:** [sc-119275]
