### PR TITLE
fix: update `Controlled.def_impl` to convert `control_wires` to inbuilt `int`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,6 +55,7 @@
 
 * Added support for JAX arrays as control wires during JAXpr evaluation.
   [(#9480)](https://github.com/PennyLaneAI/pennylane/pull/9480)
+  
 * Replaces arbitrary magic numbers across multiple modules with named, documented constants.
   Raw numeric literals in `pennylane/math`, `pennylane/ops`, `pennylane/devices`,
   `pennylane/gradients`, `pennylane/pauli`, `pennylane/qchem`, `pennylane/liealg`,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,6 +53,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Added support for JAX arrays as control wires during JAXpr evaluation.
+  [(#9480)](https://github.com/PennyLaneAI/pennylane/pull/9480)
+
 * Added usage of the `strict` keyword argument for `zip` throughout the codebase.
   [(#9393)](https://github.com/PennyLaneAI/pennylane/pull/9393)
   

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,10 +53,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
-<<<<<<< fix/capture-ctrl-control-wires
 * Added support for JAX arrays as control wires during JAXpr evaluation.
   [(#9480)](https://github.com/PennyLaneAI/pennylane/pull/9480)
-=======
 * Replaces arbitrary magic numbers across multiple modules with named, documented constants.
   Raw numeric literals in `pennylane/math`, `pennylane/ops`, `pennylane/devices`,
   `pennylane/gradients`, `pennylane/pauli`, `pennylane/qchem`, `pennylane/liealg`,
@@ -64,7 +62,6 @@
   ``#:`` doc-comments explaining their purpose and origin. Unused constants
   ``eps`` in :mod:`pennylane.math` and ``tolerance`` in ``default_qutrit`` are removed.
   [(#9374)](https://github.com/PennyLaneAI/pennylane/pull/9374)
->>>>>>> main
 
 * Added usage of the `strict` keyword argument for `zip` throughout the codebase.
   [(#9393)](https://github.com/PennyLaneAI/pennylane/pull/9393)

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -1149,6 +1149,7 @@ if Controlled._primitive is not None:  # pylint: disable=protected-access
         work_wire_type="borrowed",
         id=None,
     ):
+        control_wires = tuple(w if math.is_abstract(w) else int(w) for w in control_wires)
         return type.__call__(
             Controlled,
             base,

--- a/tests/capture/test_operators.py
+++ b/tests/capture/test_operators.py
@@ -421,6 +421,31 @@ class TestOpmath:
         assert isinstance(eqn.outvars[0].aval, AbstractOperator)
         assert eqn.params == {}
 
+    def test_controlled_with_non_int_control_wires(self):
+        """Tests that controlled works with non int control wires."""
+
+        def qfunc(control_wire):
+            qp.ctrl(qp.X(0), control=control_wire)
+
+        cjaxpr = jax.make_jaxpr(qfunc)(jax.numpy.array(1))
+
+        assert len(cjaxpr.eqns) == 2
+
+        base_eqn = cjaxpr.eqns[0]
+        assert base_eqn.primitive == qp.X._primitive
+
+        ctrl_eqn = cjaxpr.eqns[1]
+        assert ctrl_eqn.primitive == qp.ops.Controlled._primitive
+        assert ctrl_eqn.invars[0] == base_eqn.outvars[0]
+        assert ctrl_eqn.invars[1] == cjaxpr.jaxpr.invars[0]
+
+        with qp.queuing.AnnotatedQueue() as q:
+            jax.core.eval_jaxpr(cjaxpr.jaxpr, cjaxpr.consts, jax.numpy.array(1))
+
+        assert len(q) == 1
+        expected = qp.ctrl(qp.X(0), control=1)
+        qp.assert_equal(q.queue[0], expected)
+
     def test_Controlled(self):
         """Test a nested control operation."""
 


### PR DESCRIPTION
**Context:**

See thread in shortcut story below for context.

**Description of the Change:**

Simple convert the `control_wires` in the `Controlled.def_impl`.

**Benefits:** More robust code.

**Possible Drawbacks:** None identified.

[sc-119407]
