### PR TITLE
Revert RC version pins to unconstrained dev installs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,7 +76,7 @@ jobs:
           pre-build-command: >
             apt install -y graphviz
             && python -m pip install --upgrade pip
-            && pip3 install --extra-index-url https://test.pypi.org/simple/ "pennylane-catalyst>=0.15.0rc0,<=0.15.0" --pre
+            && pip3 install --extra-index-url https://test.pypi.org/simple/ pennylane-catalyst --pre
             && pip3 install --group docs
             && pip3 install .
           build-command: "sphinx-build -b html . _build -W --keep-going"

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Catalyst and Lightning (dev)
         run: |
-          pip install --upgrade --index-url https://test.pypi.org/simple/ --pre --no-deps "pennylane-catalyst>=0.15.0rc0,<=0.15.0" "pennylane-lightning>=0.45.0rc0,<=0.45.0"
+          pip install --upgrade --index-url https://test.pypi.org/simple/ --pre --no-deps pennylane-catalyst pennylane-lightning
 
       - name: Install dependencies of Catalyst and Lightning
         run: |

--- a/.github/workflows/interface-dependency-versions.yml
+++ b/.github/workflows/interface-dependency-versions.yml
@@ -65,11 +65,11 @@ jobs:
       
       - name: Nightly Catalyst Version
         id: catalyst
-        run: echo "nightly=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Catalyst PennyLane-Catalyst>=0.15.0rc0,<=0.15.0" >> $GITHUB_OUTPUT
+        run: echo "nightly=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Catalyst PennyLane-Catalyst" >> $GITHUB_OUTPUT
       
       - name: PennyLane-Lightning Latest Version
         id: pennylane-lightning
-        run: echo "latest=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Lightning PennyLane-Lightning>=0.45.0rc0,<=0.45.0" >> $GITHUB_OUTPUT
+        run: echo "latest=--extra-index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match --prerelease=allow --upgrade-package PennyLane-Lightning PennyLane-Lightning" >> $GITHUB_OUTPUT
     
     outputs:
       catalyst-jax-version: jax==${{ steps.catalyst-jax.outputs.version }} jaxlib==${{ steps.catalyst-jax.outputs.version }}

--- a/.github/workflows/rtd-check.yml
+++ b/.github/workflows/rtd-check.yml
@@ -45,7 +45,7 @@ jobs:
         pip install --upgrade --no-cache-dir pip setuptools 
         pip install --upgrade --no-cache-dir ${{ env.PIP_PACKAGES_TO_INSTALL }}
         pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir  .      
-        pip install --extra-index-url https://test.pypi.org/simple/ "pennylane-catalyst>=0.15.0rc0,<=0.15.0" --pre
+        pip install --extra-index-url https://test.pypi.org/simple/ pennylane-catalyst --pre
         pip install --group docs
 
     - name: Build Sphinx HTML

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,7 @@ build:
     - graphviz
   jobs:
     post_install:
-      - pip install --extra-index-url https://test.pypi.org/simple/ "pennylane-catalyst>=0.15.0rc0,<=0.15.0" --pre
+      - pip install --extra-index-url https://test.pypi.org/simple/ pennylane-catalyst --pre
       - pip install --group docs
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
Reverts the workflow version constraints introduced by the rc->main sync (#9439) that pinned Catalyst to >=0.15.0rc0,<=0.15.0 and Lightning to >=0.45.0rc0,<=0.45.0. These pins were appropriate during the v0.45 release freeze but now that we are back in dev mode, workflows should install the latest available dev wheels from TestPyPI without version constraints.
