### PR TITLE
fix global phase issue of abstract `BasisEmbedding`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -112,7 +112,7 @@
 * Fixed a sign error in the abstract decomposition of :class:`~.BasisState` that produced an
   incorrect global phase (off by −1 per qubit). The decomposition used
   ``GlobalPhase(basis * π/2)`` instead of ``GlobalPhase(-basis * π/2)``, introduced in
-  `#9406 <https://github.com/PennyLaneAI/pennylane/pull/9406>`__.
+  [#9406](https://github.com/PennyLaneAI/pennylane/pull/9406>).
   [(#9492)](https://github.com/PennyLaneAI/pennylane/pull/9492)
 
 * Fixed a bug where :class:`~.BasisEmbedding` was not normalized to :class:`~.BasisState` in

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -112,7 +112,7 @@
 * Fixed a sign error in the abstract decomposition of :class:`~.BasisState` that produced an
   incorrect global phase (off by −1 per qubit). The decomposition used
   ``GlobalPhase(basis * π/2)`` instead of ``GlobalPhase(-basis * π/2)``, introduced in
-  [#9406](https://github.com/PennyLaneAI/pennylane/pull/9406>).
+  [#9406](https://github.com/PennyLaneAI/pennylane/pull/9406).
   [(#9492)](https://github.com/PennyLaneAI/pennylane/pull/9492)
 
 * Fixed a bug where :class:`~.BasisEmbedding` was not normalized to :class:`~.BasisState` in

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -109,6 +109,12 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a sign error in the abstract decomposition of :class:`~.BasisState` that produced an
+  incorrect global phase (off by −1 per qubit). The decomposition used
+  ``GlobalPhase(basis * π/2)`` instead of ``GlobalPhase(-basis * π/2)``, introduced in
+  `#9406 <https://github.com/PennyLaneAI/pennylane/pull/9406>`__.
+  [(#9492)](https://github.com/PennyLaneAI/pennylane/pull/9492)
+
 * Fixed a bug where :class:`~.BasisEmbedding` was not normalized to :class:`~.BasisState` in
   :func:`~.controlled_resource_rep`, causing mismatches in the decomposition resource graph.
   [(#9460)](https://github.com/PennyLaneAI/pennylane/pull/9460)

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -168,7 +168,7 @@ class BasisState(StatePrepBase):
 
         op_list = []
         for wire, basis in zip(wires, state, strict=True):
-            op_list.append(qp.GlobalPhase(basis * np.pi / 2, wire))
+            op_list.append(qp.GlobalPhase(-basis * np.pi / 2, wire))
             op_list.append(qp.RX(basis * np.pi, wire))
 
         return op_list

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -212,7 +212,7 @@ class TestDecomposition:
 
         @qp.qjit
         @qp.qnode(dev)
-        def circuit(s: jax.core.ShapedArray([n_wires], int)):
+        def circuit(s):
             qp.BasisEmbedding(features=s, wires=range(n_wires))
             return qp.state()
 

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -188,6 +188,41 @@ class TestDecomposition:
         assert isinstance(ops1[0], qp.X)
         assert isinstance(ops2[0], qp.X)
 
+    @pytest.mark.external
+    @pytest.mark.catalyst
+    @pytest.mark.parametrize(
+        "state",
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 1, 1],
+        ],
+    )
+    def test_BasisState_abstract_decomposition_correctness(self, state):
+        """Test that the abstract decomposition of BasisState produces the correct
+        state vector when compiled and executed via ``qjit``.  Uses BasisEmbedding
+        which delegates to BasisState.compute_decomposition through the abstract
+        (traced) path, exercising the GlobalPhase+RX decomposition end-to-end."""
+        import jax  # pylint: disable=import-outside-toplevel
+
+        n_wires = len(state)
+        dev = qp.device("lightning.qubit", wires=n_wires)
+
+        @qp.qjit
+        @qp.qnode(dev)
+        def circuit(s: jax.core.ShapedArray([n_wires], int)):
+            qp.BasisEmbedding(features=s, wires=range(n_wires))
+            return qp.state()
+
+        result = circuit(jax.numpy.array(state))
+
+        expected = np.zeros(2**n_wires, dtype=complex)
+        expected[int("".join(str(b) for b in state), 2)] = 1.0
+
+        assert np.allclose(result, expected)
+
     def test_StatePrep_decomposition(self):
         """Test the decomposition for StatePrep."""
 

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -223,6 +223,39 @@ class TestDecomposition:
 
         assert np.allclose(result, expected)
 
+    @pytest.mark.jax
+    @pytest.mark.parametrize(
+        "state",
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 1, 1],
+        ],
+    )
+    def test_BasisState_abstract_decomposition_correctness_jax_jit(self, state):
+        """Test that the abstract decomposition of BasisState produces the correct
+        state vector when traced through ``jax.jit``.  Uses ``reference.qubit``
+        which decomposes BasisState with abstract parameters, exercising the
+        GlobalPhase+RX decomposition end-to-end without requiring Catalyst."""
+        import jax  # pylint: disable=import-outside-toplevel
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+
+        n_wires = len(state)
+
+        @qp.qnode(qp.device("reference.qubit", wires=n_wires))
+        def circuit(s):
+            qp.BasisState(s, wires=range(n_wires))
+            return qp.state()
+
+        result = jax.jit(circuit)(jnp.array(state))
+
+        expected = np.zeros(2**n_wires, dtype=complex)
+        expected[int("".join(str(b) for b in state), 2)] = 1.0
+
+        assert np.allclose(result, expected, atol=1e-6)
+
     def test_StatePrep_decomposition(self):
         """Test the decomposition for StatePrep."""
 


### PR DESCRIPTION
:smiley: thanks to copilot for putting things together

## Context
LLL failed at https://github.com/PennyLaneAI/catalyst/actions/runs/25856613784/job/75975962909#step:25:690

[sc-119772]

## Conventions

PennyLane defines:

- `RX(theta) = exp(-i * theta/2 * X) = cos(theta/2) * I  -  i * sin(theta/2) * X`
- `GlobalPhase(phi) = exp(-i * phi) * I`

## RX(pi)

```text
RX(pi) = cos(pi/2) * I  -  i * sin(pi/2) * X
       = 0 * I  -  i * 1 * X
       = -iX
```

## GlobalPhase(+pi/2) * RX(pi)

```text
exp(-i * pi/2) * (-iX)
= (-i) * (-iX)
= i^2 * X
= -X          <-- WRONG
```

This maps `|0>` to `-|1>`, introducing a factor of `-1` per qubit set to 1.
For `n` active qubits the overall sign error is `(-1)^n`.

## GlobalPhase(-pi/2) * RX(pi)

```text
exp(+i * pi/2) * (-iX)
= (i) * (-iX)
= -i^2 * X
= X            <-- CORRECT
```

## Why the old 3-gate version was correct

Before PR [#9406](https://github.com/PennyLaneAI/pennylane/pull/9406) the
abstract decomposition per qubit was:

```text
PhaseShift(pi/2) * RX(pi) * PhaseShift(pi/2)
```

where `PhaseShift(phi) = diag(1, exp(i*phi))`.

Writing out the matrices (`P = PhaseShift(pi/2)`, `R = RX(pi)`):

```text
P = | 1  0 |    R = | 0  -i |    P = | 1  0 |
    | 0  i |        | -i  0 |        | 0  i |
```

Multiply right-to-left:

```text
R * P = | 0  -i | * | 1  0 | = |  0    -i*i | = | 0   1 |
        | -i  0 |   | 0  i |   | -i*1   0   |   | -i  0 |

P * (R * P) = | 1  0 | * | 0   1 | = | 0    1   | = | 0  1 | = X  ✓
              | 0  i |   | -i  0 |   | -i*i  0   |   | 1  0 |
```

PR #9406 attempted to simplify this to 2 gates by replacing the two
`PhaseShift` gates with a single `GlobalPhase`, but used the wrong sign.

## Impact

Any execution path that traces through `BasisState.compute_decomposition`
with abstract (JAX-traced) inputs produces a sign error of `(-1)^n` where `n`
is the number of qubits set to `|1>`. Concrete inputs take a different
branch (`[qp.X(w) for ...]`) and are unaffected.
