### PR TITLE
Update `pl-device-test` to no longer set shots on the device

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -137,6 +137,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* The `pl-device-test` no longer uses the deprecated syntax that sets the shots on the device.
+
 * Fixed a sign error in the abstract decomposition of :class:`~.BasisState` that produced an
   incorrect global phase (off by −1 per qubit). The decomposition used
   ``GlobalPhase(basis * π/2)`` instead of ``GlobalPhase(-basis * π/2)``, introduced in

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,6 +138,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * The `pl-device-test` no longer uses the deprecated syntax that sets the shots on the device.
+  [(#9503)](https://github.com/PennyLaneAI/pennylane/pull/9503)
 
 * Fixed a sign error in the abstract decomposition of :class:`~.BasisState` that produced an
   incorrect global phase (off by −1 per qubit). The decomposition used

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -41,17 +41,14 @@ LIST_CORE_DEVICES = {
 
 
 @pytest.fixture(scope="function")
-def tol():
+def tol(shots):  # pylint: disable=redefined-outer-name
     """Numerical tolerance for equality tests. Returns a different tolerance for tests
     probing analytic or non-analytic devices, which allows us to define the
     standard for deterministic or stochastic test results dynamically."""
 
-    def _tol(shots):  # pylint: disable=redefined-outer-name
-        if shots is None:
-            return float(os.environ.get("TOL", TOL))
-        return TOL_STOCHASTIC
-
-    return _tol
+    if shots is None:
+        return float(os.environ.get("TOL", TOL))
+    return TOL_STOCHASTIC
 
 
 @pytest.fixture(scope="session")
@@ -114,7 +111,8 @@ def skip_if():
 @pytest.fixture
 def shots(request) -> None | int:
     """The number of shots to use during an execution."""
-    return int(request.config.getoption("--shots"))
+    shots_value = request.config.getoption("--shots")
+    return None if shots_value in (None, "None") else int(shots_value)
 
 
 @pytest.fixture
@@ -270,12 +268,6 @@ def pytest_generate_tests(metafunc):
 
     for dev in devices_to_test:
         device_kwargs = {"name": dev}
-
-        # if shots specified in command line,
-        # add to the device kwargs
-        if opt.shots is not None:
-            # translate command line string to None if necessary
-            device_kwargs["shots"] = None if (opt.shots == "None") else int(opt.shots)
 
         # store user defined device kwargs
         device_kwargs.update(opt.device_kwargs)

--- a/pennylane/devices/tests/conftest.py
+++ b/pennylane/devices/tests/conftest.py
@@ -46,7 +46,7 @@ def tol():
     probing analytic or non-analytic devices, which allows us to define the
     standard for deterministic or stochastic test results dynamically."""
 
-    def _tol(shots):
+    def _tol(shots):  # pylint: disable=redefined-outer-name
         if shots is None:
             return float(os.environ.get("TOL", TOL))
         return TOL_STOCHASTIC
@@ -112,11 +112,17 @@ def skip_if():
 
 
 @pytest.fixture
-def validate_diff_method(device, diff_method, device_kwargs):
+def shots(request) -> None | int:
+    """The number of shots to use during an execution."""
+    return int(request.config.getoption("--shots"))
+
+
+@pytest.fixture
+def validate_diff_method(device, diff_method, shots):  # pylint: disable=redefined-outer-name
     """Skip tests if a device does not support a diff_method"""
     if diff_method in {"parameter-shift", "hadamard"}:
         return
-    if diff_method == "backprop" and device_kwargs.get("shots") is not None:
+    if diff_method == "backprop" and shots is not None:
         pytest.skip(reason="test should only be run in analytic mode")
     dev = device(1)
     config = qp.devices.ExecutionConfig(gradient_method=diff_method)

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.skip_unsupported
 class TestComparison:
     """Test that a device different to default.qubit gives the same result"""
 
-    def test_hermitian_expectation(self, device, tol):
+    def test_hermitian_expectation(self, device, tol, shots):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -62,8 +62,8 @@ class TestComparison:
             qp.CNOT(wires=[0, 1])
             return qp.expval(qp.Hermitian(A_, wires=[0, 1]))
 
-        qnode_def = qp.QNode(circuit, dev_def)
-        qnode = qp.QNode(circuit, dev)
+        qnode_def = qp.QNode(circuit, dev_def, shots=shots)
+        qnode = qp.QNode(circuit, dev, shots=shots)
 
         grad_def = qp.grad(qnode_def, argnums=[0, 1])
         grad = qp.grad(qnode, argnums=[0, 1])
@@ -78,8 +78,8 @@ class TestComparison:
 
         qnode_res, qnode_def_res, grad_res, grad_def_res = workload()
 
-        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
-        assert pnp.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol)
+        assert pnp.allclose(grad_res, grad_def_res, atol=tol)
 
     @pytest.mark.parametrize(
         "state",
@@ -98,7 +98,7 @@ class TestComparison:
             np.array([1, 1, 1, 1]) / 2,
         ],
     )
-    def test_projector_expectation(self, device, state, tol):
+    def test_projector_expectation(self, device, state, tol, shots):
         """Test that arbitrary multi-mode Projector expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -122,8 +122,8 @@ class TestComparison:
             qp.CNOT(wires=[0, 1])
             return qp.expval(qp.Projector(state, wires=[0, 1]))
 
-        qnode_def = qp.QNode(circuit, dev_def)
-        qnode = qp.QNode(circuit, dev)
+        qnode_def = qp.QNode(circuit, dev_def, shots=shots)
+        qnode = qp.QNode(circuit, dev, shots=shots)
 
         grad_def = qp.grad(qnode_def, argnums=[0, 1])
         grad = qp.grad(qnode, argnums=[0, 1])
@@ -138,10 +138,10 @@ class TestComparison:
 
         qnode_res, qnode_def_res, grad_res, grad_def_res = workload()
 
-        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol(dev.shots))
-        assert pnp.allclose(grad_res, grad_def_res, atol=tol(dev.shots))
+        assert pnp.allclose(qnode_res, qnode_def_res, atol=tol)
+        assert pnp.allclose(grad_res, grad_def_res, atol=tol)
 
-    def test_pauliz_expectation_analytic(self, device, tol):
+    def test_pauliz_expectation_analytic(self, device, tol, shots):
         """Test that the tensor product of PauliZ expectation value is correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -169,17 +169,17 @@ class TestComparison:
             qp.CNOT(wires=[0, 1])
             return qp.expval(qp.Z(0) @ qp.Z(1))
 
-        qnode_def = qp.QNode(circuit, dev_def)
-        qnode = qp.QNode(circuit, dev)
+        qnode_def = qp.QNode(circuit, dev_def, shots=shots)
+        qnode = qp.QNode(circuit, dev, shots=shots)
 
         grad_def = qp.grad(qnode_def, argnums=[0, 1])
         grad = qp.grad(qnode, argnums=[0, 1])
 
-        assert pnp.allclose(qnode(theta, phi), qnode_def(theta, phi), atol=tol(dev.shots))
-        assert pnp.allclose(grad(theta, phi), grad_def(theta, phi), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(theta, phi), qnode_def(theta, phi), atol=tol)
+        assert pnp.allclose(grad(theta, phi), grad_def(theta, phi), atol=tol)
 
     @pytest.mark.parametrize("ret", ["expval", "var"])
-    def test_random_circuit(self, device, tol, ret):
+    def test_random_circuit(self, device, tol, ret, shots):
         """Compare the result of a random circuit to default.qubit"""
         n_wires = 2
         dev = device(n_wires)
@@ -207,16 +207,16 @@ class TestComparison:
             RandomLayers(weights, wires=range(n_wires))
             return ret_type(qp.Z(0) @ qp.X(1))
 
-        qnode_def = qp.QNode(circuit, dev_def)
-        qnode = qp.QNode(circuit, dev)
+        qnode_def = qp.QNode(circuit, dev_def, shots=shots)
+        qnode = qp.QNode(circuit, dev, shots=shots)
 
         grad_def = qp.grad(qnode_def, argnums=0)
         grad = qp.grad(qnode, argnums=0)
 
-        assert pnp.allclose(qnode(weights), qnode_def(weights), atol=tol(dev.shots))
-        assert pnp.allclose(grad(weights), grad_def(weights), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(weights), qnode_def(weights), atol=tol)
+        assert pnp.allclose(grad(weights), grad_def(weights), atol=tol)
 
-    def test_four_qubit_random_circuit(self, device, tol):
+    def test_four_qubit_random_circuit(self, device, tol, shots):
         """Compare a four-qubit random circuit with lots of different gates to default.qubit"""
         n_wires = 4
         dev = device(n_wires)
@@ -264,7 +264,7 @@ class TestComparison:
                     qp.apply(gate)
             return qp.expval(qp.Z(0))
 
-        qnode_def = qp.QNode(circuit, dev_def)
-        qnode = qp.QNode(circuit, dev)
+        qnode_def = qp.QNode(circuit, dev_def, shots=shots)
+        qnode = qp.QNode(circuit, dev, shots=shots)
 
-        assert pnp.allclose(qnode(), qnode_def(), atol=tol(dev.shots))
+        assert pnp.allclose(qnode(), qnode_def(), atol=tol)

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -38,7 +38,7 @@ class TestComparison:
         dev = device(n_wires)
         dev_def = qp.device("default.qubit")
 
-        if dev.shots:
+        if shots:
             pytest.skip("Device is in non-analytical mode.")
 
         if dev.name == "default.qubit":
@@ -104,7 +104,7 @@ class TestComparison:
         dev = device(n_wires)
         dev_def = qp.device("default.qubit", wires=n_wires)
 
-        if dev.shots:
+        if shots:
             pytest.skip("Device is in non-analytical mode.")
 
         if isinstance(dev, qp.devices.LegacyDevice) and "Projector" not in dev.observables:
@@ -157,7 +157,7 @@ class TestComparison:
         if not supports_tensor:
             pytest.skip("Device does not support tensor observables.")
 
-        if dev.shots:
+        if shots:
             pytest.skip("Device is in non-analytical mode.")
 
         theta = 0.432
@@ -195,7 +195,7 @@ class TestComparison:
         if not supports_tensor:
             pytest.skip("Device does not support tensor observables.")
 
-        if dev.shots:
+        if shots:
             pytest.skip("Device is in non-analytical mode.")
 
         n_layers = pnp.random.randint(1, 5)
@@ -225,7 +225,7 @@ class TestComparison:
         if dev.name == dev_def.name:
             pytest.skip("Device is default.qubit.")
 
-        if dev.shots:
+        if shots:
             pytest.skip("Device is in non-analytical mode.")
 
         gates = [

--- a/pennylane/devices/tests/test_gates.py
+++ b/pennylane/devices/tests/test_gates.py
@@ -356,10 +356,9 @@ class TestSupportedGates:
     """Test that the device can implement all gates that it claims to support."""
 
     @pytest.mark.parametrize("operation", all_ops)
-    def test_supported_gates_can_be_implemented(self, device_kwargs, operation):
+    def test_supported_gates_can_be_implemented(self, device, operation, shots):
         """Test that the device can implement all its supported gates."""
-        device_kwargs["wires"] = 4  # maximum size of current gates
-        dev = qp.device(**device_kwargs)
+        dev = device(wires=4)
 
         if isinstance(dev, qp.devices.LegacyDevice):
             if operation not in dev.operations:
@@ -373,7 +372,7 @@ class TestSupportedGates:
                 except DeviceError:
                     pytest.skip("operation not supported on the device")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.apply(ops[operation])
             return qp.expval(qp.Identity(wires=0))
@@ -394,14 +393,14 @@ class TestGatesQubit:
             np.array([1, 1, 1, 1]),
         ],
     )
-    def test_basis_state(self, device, basis_state, tol, skip_if):
+    def test_basis_state(self, device, basis_state, shots, tol, skip_if):
         """Test basis state initialization."""
         n_wires = 4
         dev = device(n_wires)
         if isinstance(dev, qp.devices.LegacyDevice):
             skip_if(dev, {"returns_probs": False})
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.BasisState(basis_state, wires=range(n_wires))
             return qp.probs(wires=range(n_wires))
@@ -410,9 +409,9 @@ class TestGatesQubit:
 
         expected = np.zeros([2**n_wires])
         expected[np.ravel_multi_index(basis_state, [2] * n_wires)] = 1
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_state_prep(self, device, init_state, tol, skip_if):
+    def test_state_prep(self, device, init_state, shots, tol, skip_if):
         """Test StatePrep initialisation."""
         n_wires = 1
         dev = device(n_wires)
@@ -421,7 +420,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             return qp.probs(range(n_wires))
@@ -429,10 +428,10 @@ class TestGatesQubit:
         res = circuit()
         expected = np.abs(rnd_state) ** 2
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("op,mat", single_qubit)
-    def test_single_qubit_no_parameters(self, device, init_state, op, mat, tol, skip_if):
+    def test_single_qubit_no_parameters(self, device, init_state, op, mat, shots, tol, skip_if):
         """Test PauliX application."""
         n_wires = 1
         dev = device(n_wires)
@@ -441,7 +440,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             op(wires=range(n_wires))
@@ -450,11 +449,13 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(mat @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("gamma", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", single_qubit_param)
-    def test_single_qubit_parameters(self, device, init_state, op, func, gamma, tol, skip_if):
+    def test_single_qubit_parameters(
+        self, device, init_state, op, func, gamma, shots, tol, skip_if
+    ):
         """Test single qubit gates taking a single scalar argument."""
         n_wires = 1
         dev = device(n_wires)
@@ -463,7 +464,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             op(gamma, wires=range(n_wires))
@@ -472,9 +473,9 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(func(gamma) @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_rotation(self, device, init_state, tol, skip_if):
+    def test_rotation(self, device, init_state, shots, tol, skip_if):
         """Test three axis rotation gate."""
         n_wires = 1
         dev = device(n_wires)
@@ -486,7 +487,7 @@ class TestGatesQubit:
         b = 1.3432
         c = -0.654
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             qp.Rot(a, b, c, wires=range(n_wires))
@@ -495,10 +496,10 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(rot(a, b, c) @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("op,mat", two_qubit)
-    def test_two_qubit_no_parameters(self, device, init_state, op, mat, tol, skip_if):
+    def test_two_qubit_no_parameters(self, device, init_state, op, mat, shots, tol, skip_if):
         """Test two qubit gates."""
         n_wires = 2
         dev = device(n_wires)
@@ -509,7 +510,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             op(wires=range(n_wires))
@@ -518,11 +519,11 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(mat @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("param", [0.5432, -0.232])
     @pytest.mark.parametrize("op,func", two_qubit_param)
-    def test_two_qubit_parameters(self, device, init_state, op, func, param, tol, skip_if):
+    def test_two_qubit_parameters(self, device, init_state, op, func, param, shots, tol, skip_if):
         """Test parametrized two qubit gates taking a single scalar argument."""
         n_wires = 2
         dev = device(n_wires)
@@ -531,7 +532,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             op(param, wires=range(n_wires))
@@ -540,10 +541,10 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(func(param) @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("mat", [U, U2])
-    def test_qubit_unitary(self, device, init_state, mat, tol, skip_if):
+    def test_qubit_unitary(self, device, init_state, mat, shots, tol, skip_if):
         """Test QubitUnitary gate."""
         n_wires = int(np.log2(len(mat)))
         dev = device(n_wires)
@@ -556,7 +557,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             qp.QubitUnitary(mat, wires=list(range(n_wires)))
@@ -565,10 +566,10 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(mat @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("theta_", [np.array([0.4, -0.1, 0.2]), np.ones(15) / 3])
-    def test_special_unitary(self, device, init_state, theta_, tol, skip_if):
+    def test_special_unitary(self, device, init_state, theta_, shots, tol, skip_if):
         """Test SpecialUnitary gate."""
         n_wires = int(np.log(len(theta_) + 1) / np.log(4))
         dev = device(n_wires)
@@ -581,7 +582,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             qp.SpecialUnitary(theta_, wires=list(range(n_wires)))
@@ -594,10 +595,10 @@ class TestGatesQubit:
         basis = basis_fn(n_wires)
         mat = qp.math.expm(1j * np.tensordot(theta_, basis, axes=[[0], [0]]))
         expected = np.abs(mat @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize("op, mat", three_qubit)
-    def test_three_qubit_no_parameters(self, device, init_state, op, mat, tol, skip_if):
+    def test_three_qubit_no_parameters(self, device, init_state, op, mat, shots, tol, skip_if):
         """Test three qubit gates without parameters."""
         n_wires = 3
         dev = device(n_wires)
@@ -607,7 +608,7 @@ class TestGatesQubit:
 
         rnd_state = init_state(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(rnd_state, wires=range(n_wires))
             op(wires=[0, 1, 2])
@@ -616,4 +617,4 @@ class TestGatesQubit:
         res = circuit()
 
         expected = np.abs(mat @ rnd_state) ** 2
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)

--- a/pennylane/devices/tests/test_gates_with_expval.py
+++ b/pennylane/devices/tests/test_gates_with_expval.py
@@ -43,17 +43,17 @@ class TestGatesQubitExpval:
         "par,wires,expected_output",
         [([1, 1], [0, 1], [-1, -1]), ([1], [0], [-1, 1]), ([1], [1], [1, -1])],
     )
-    def test_basis_state_2_qubit_subset(self, device, tol, par, wires, expected_output):
+    def test_basis_state_2_qubit_subset(self, device, tol, par, wires, expected_output, shots):
         """Tests qubit basis state preparation on subsets of qubits"""
         n_wires = 2
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.BasisState(np.array(par), wires=wires)
             return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
 
-        assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.allclose(circuit(), expected_output, atol=tol)
 
     # This test checks three Z expvals
     @pytest.mark.parametrize(
@@ -72,7 +72,7 @@ class TestGatesQubitExpval:
             ([0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)], [0, 1], [0.0, -1.0, 1.0]),
         ],
     )
-    def test_state_vector_3_qubit_subset(self, device, tol, par, wires, expected_output):
+    def test_state_vector_3_qubit_subset(self, device, tol, par, wires, expected_output, shots):
         """Tests qubit state vector preparation on subsets of 3 qubits"""
 
         n_wires = 3
@@ -80,12 +80,12 @@ class TestGatesQubitExpval:
 
         par = np.array(par)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(par, wires=wires)
             return qp.expval(qp.Z(0)), qp.expval(qp.Z(1)), qp.expval(qp.Z(2))
 
-        assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.allclose(circuit(), expected_output, atol=tol)
 
     # This test uses initial state |0> and checks one Z expval
     @pytest.mark.parametrize(
@@ -134,7 +134,7 @@ class TestGatesQubitExpval:
         ],
     )
     def test_supported_gate_single_wire_with_parameters(
-        self, device, tol, name, par, expected_output
+        self, device, tol, name, par, expected_output, shots
     ):
         """Tests supported parametrized gates that act on a single wire"""
 
@@ -142,12 +142,12 @@ class TestGatesQubitExpval:
         dev = device(n_wires)
         op = getattr(qp.ops, name)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             op(*par, wires=0)
             return qp.expval(qp.Z(0))
 
-        assert np.isclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.isclose(circuit(), expected_output, atol=tol)
 
     # This test uses initial state 1/2|00>+sqrt(3)/2|11> and checks two Z expvals
     @pytest.mark.parametrize(
@@ -202,7 +202,7 @@ class TestGatesQubitExpval:
         ],
     )
     def test_supported_gate_two_wires_with_parameters(
-        self, device, tol, name, par, expected_output
+        self, device, tol, name, par, expected_output, shots
     ):
         """Tests supported parametrized gates that act on two wires"""
 
@@ -210,13 +210,13 @@ class TestGatesQubitExpval:
         dev = device(n_wires)
         op = getattr(qp.ops, name)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(np.array([1 / 2, 0, 0, sqrt(3) / 2]), wires=[0, 1])
             op(*par, wires=[0, 1])
             return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
 
-        assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.allclose(circuit(), expected_output, atol=tol)
 
     # This test uses initial state |0> and checks one Z expval
     @pytest.mark.parametrize(
@@ -228,19 +228,21 @@ class TestGatesQubitExpval:
             ("Hadamard", 0),
         ],
     )
-    def test_supported_gate_single_wire_no_parameters(self, device, tol, name, expected_output):
+    def test_supported_gate_single_wire_no_parameters(
+        self, device, tol, name, expected_output, shots
+    ):
         """Tests supported non-parametrized gates that act on a single wire"""
         n_wires = 1
         dev = device(n_wires)
 
         op = getattr(qp.ops, name)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             op(wires=0)
             return qp.expval(qp.Z(0))
 
-        assert np.isclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.isclose(circuit(), expected_output, atol=tol)
 
     # This test uses initial state |Phi+> and checks two Z expvals
     @pytest.mark.parametrize(
@@ -251,7 +253,9 @@ class TestGatesQubitExpval:
             ("CZ", [-1 / 2, -1 / 2]),
         ],
     )
-    def test_supported_gate_two_wires_no_parameters(self, device, tol, name, expected_output):
+    def test_supported_gate_two_wires_no_parameters(
+        self, device, tol, name, expected_output, shots
+    ):
         """Tests supported parametrized gates that act on two wires"""
         n_wires = 2
         dev = device(n_wires)
@@ -260,13 +264,13 @@ class TestGatesQubitExpval:
         if isinstance(dev, qp.devices.LegacyDevice) and not dev.supports_operation(op):
             pytest.skip("operation not supported")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(np.array([1 / 2, 0, 0, sqrt(3) / 2]), wires=[0, 1])
             op(wires=[0, 1])
             return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
 
-        assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.allclose(circuit(), expected_output, atol=tol)
 
     @pytest.mark.parametrize(
         "name,expected_output",
@@ -274,17 +278,19 @@ class TestGatesQubitExpval:
             ("CSWAP", [-1, -1, 1]),
         ],
     )
-    def test_supported_gate_three_wires_no_parameters(self, device, tol, name, expected_output):
+    def test_supported_gate_three_wires_no_parameters(
+        self, device, tol, name, expected_output, shots
+    ):
         """Tests supported non-parametrized gates that act on three wires"""
         n_wires = 3
         dev = device(n_wires)
 
         op = getattr(qp.ops, name)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.BasisState(np.array([1, 0, 1]), wires=[0, 1, 2])
             op(wires=[0, 1, 2])
             return qp.expval(qp.Z(0)), qp.expval(qp.Z(1)), qp.expval(qp.Z(2))
 
-        assert np.allclose(circuit(), expected_output, atol=tol(dev.shots))
+        assert np.allclose(circuit(), expected_output, atol=tol)

--- a/pennylane/devices/tests/test_gradients_autograd.py
+++ b/pennylane/devices/tests/test_gradients_autograd.py
@@ -27,11 +27,10 @@ from pennylane import numpy as pnp
 class TestGradients:
     """Test various gradient computations."""
 
-    def test_basic_grad(self, diff_method, device, tol):
+    def test_basic_grad(self, diff_method, device, tol, shots):
         """Test a basic function with one RX and one expectation."""
         wires = 2 if diff_method == "hadamard" else 1
         dev = device(wires=wires + (diff_method == "hadamard"))
-        tol = tol(dev.shots)
 
         qnode_kwargs = {
             "diff_method": diff_method,
@@ -41,7 +40,7 @@ class TestGradients:
             tol += 0.01
             qnode_kwargs["gradient_kwargs"] = {"aux_wire": wires}
 
-        @qp.qnode(dev, **qnode_kwargs)
+        @qp.qnode(dev, shots=shots, **qnode_kwargs)
         def circuit(x):
             qp.RX(x, 0)
             return qp.expval(qp.Z(0))
@@ -50,7 +49,7 @@ class TestGradients:
         res = qp.grad(circuit)(x)
         assert np.isclose(res, -pnp.sin(x), atol=tol, rtol=0)
 
-    def test_backprop_state(self, diff_method, device, tol):
+    def test_backprop_state(self, diff_method, device, tol, shots):
         """Test the trainability of parameters in a circuit returning the state."""
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
@@ -59,12 +58,11 @@ class TestGradients:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")
-        tol = tol(dev.shots)
 
         x = pnp.array(0.543)
         y = pnp.array(-0.654)
 
-        @qp.qnode(dev, diff_method=diff_method, grad_on_execution=True)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, grad_on_execution=True)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -84,7 +82,7 @@ class TestGradients:
         res = qp.grad(cost_fn)(x, y)
         assert np.allclose(res, expected[0], atol=tol, rtol=0)
 
-    def test_parameter_shift(self, diff_method, device, tol):
+    def test_parameter_shift(self, diff_method, device, tol, shots):
         """Test a multi-parameter circuit with parameter-shift."""
         if diff_method != "parameter-shift":
             pytest.skip(reason="test only works with parameter-shift")
@@ -93,9 +91,8 @@ class TestGradients:
         b = pnp.array(0.2)
 
         dev = device(2)
-        tol = tol(dev.shots)
 
-        @qp.qnode(dev, diff_method="parameter-shift", grad_on_execution=False)
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift", grad_on_execution=False)
         def circuit(a, b):
             qp.RY(a, wires=0)
             qp.RX(b, wires=1)
@@ -111,11 +108,10 @@ class TestGradients:
         res = qp.grad(circuit)(a, b)
         assert np.allclose(res, expected[0], atol=tol, rtol=0)
 
-    def test_probs(self, diff_method, device, tol):
+    def test_probs(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit returning probs()."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = pnp.array(0.543)
         y = pnp.array(-0.654)
 
@@ -125,7 +121,7 @@ class TestGradients:
         if diff_method == "hadamard":
             qnode_kwargs["gradient_kwargs"] = {"aux_wire": wires - 1}
 
-        @qp.qnode(dev, **qnode_kwargs)
+        @qp.qnode(dev, shots=shots, **qnode_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -155,11 +151,10 @@ class TestGradients:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    def test_multi_meas(self, diff_method, device, tol):
+    def test_multi_meas(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit with both scalar and array-like returns."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = pnp.array(0.543)
         y = pnp.array(-0.654, requires_grad=False)
 
@@ -169,7 +164,7 @@ class TestGradients:
         if diff_method == "hadamard":
             qnode_kwargs["gradient_kwargs"] = {"aux_wire": wires - 1}
 
-        @qp.qnode(dev, **qnode_kwargs)
+        @qp.qnode(dev, shots=shots, **qnode_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -185,17 +180,16 @@ class TestGradients:
         assert isinstance(jac, pnp.ndarray)
         assert np.allclose(jac, expected, atol=tol, rtol=0)
 
-    def test_hessian(self, diff_method, device, tol):
+    def test_hessian(self, diff_method, device, tol, shots):
         """Test hessian computation."""
         wires = 3 if diff_method == "hadamard" else 1
         dev = device(wires=wires)
-        tol = tol(dev.shots)
 
         qnode_kwargs = {"diff_method": diff_method, "max_diff": 2}
         if diff_method == "hadamard":
             qnode_kwargs["gradient_kwargs"] = {"mode": "reversed-direct"}
 
-        @qp.qnode(dev, **qnode_kwargs)
+        @qp.qnode(dev, shots=shots, **qnode_kwargs)
         def circuit(x):
             qp.RY(x[0], wires=0)
             qp.RX(x[1], wires=0)

--- a/pennylane/devices/tests/test_gradients_autograd.py
+++ b/pennylane/devices/tests/test_gradients_autograd.py
@@ -54,7 +54,7 @@ class TestGradients:
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
         dev = device(2)
-        if dev.shots:
+        if shots:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")

--- a/pennylane/devices/tests/test_gradients_jax.py
+++ b/pennylane/devices/tests/test_gradients_jax.py
@@ -29,17 +29,16 @@ jnp = pytest.importorskip("jax.numpy")
 class TestGradients:
     """Test various gradient computations."""
 
-    def test_basic_grad(self, diff_method, device, tol):
+    def test_basic_grad(self, diff_method, device, tol, shots):
         """Test a basic function with one RX and one expectation."""
         wires = 2 if diff_method == "hadamard" else 1
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         gradient_kwargs = {}
         if diff_method == "hadamard":
             tol += 0.01
             gradient_kwargs["aux_wire"] = 1
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x):
             qp.RX(x, 0)
             return qp.expval(qp.Z(0))
@@ -48,7 +47,7 @@ class TestGradients:
         res = jax.grad(circuit)(x)
         assert np.isclose(res, -jnp.sin(x), atol=tol, rtol=0)
 
-    def test_backprop_state(self, diff_method, device, tol):
+    def test_backprop_state(self, diff_method, device, tol, shots):
         """Test the trainability of parameters in a circuit returning the state."""
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
@@ -57,12 +56,11 @@ class TestGradients:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")
-        tol = tol(dev.shots)
 
         x = jnp.array(0.543)
         y = jnp.array(-0.654)
 
-        @qp.qnode(dev, diff_method="backprop", grad_on_execution=True)
+        @qp.qnode(dev, shots=shots, diff_method="backprop", grad_on_execution=True)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -81,7 +79,7 @@ class TestGradients:
         res = jax.grad(cost_fn, argnums=[0])(x, y)
         assert np.allclose(res, expected[0], atol=tol, rtol=0)
 
-    def test_parameter_shift(self, diff_method, device, tol):
+    def test_parameter_shift(self, diff_method, device, tol, shots):
         """Test a multi-parameter circuit with parameter-shift."""
         if diff_method != "parameter-shift":
             pytest.skip(reason="test only works with parameter-shift")
@@ -90,9 +88,8 @@ class TestGradients:
         b = jnp.array(0.2)
 
         dev = device(2)
-        tol = tol(dev.shots)
 
-        @qp.qnode(dev, diff_method="parameter-shift", grad_on_execution=False)
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift", grad_on_execution=False)
         def circuit(a, b):
             qp.RY(a, wires=0)
             qp.RX(b, wires=1)
@@ -107,11 +104,10 @@ class TestGradients:
         res = jax.grad(circuit, argnums=[0])(a, b)
         assert np.allclose(res, expected[0], atol=tol, rtol=0)
 
-    def test_probs(self, diff_method, device, tol):
+    def test_probs(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit returning probs()."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = jnp.array(0.543)
         y = jnp.array(-0.654)
 
@@ -119,7 +115,7 @@ class TestGradients:
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -149,11 +145,10 @@ class TestGradients:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    def test_multi_meas(self, diff_method, device, tol):
+    def test_multi_meas(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit with both scalar and array-like returns."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = jnp.array(0.543)
         y = jnp.array(-0.654)
 
@@ -161,7 +156,7 @@ class TestGradients:
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -192,17 +187,18 @@ class TestGradients:
         assert jac[1][0].shape == (2,)
         assert np.allclose(jac[1][0], expected[1][0], atol=tol, rtol=0)
 
-    def test_hessian(self, diff_method, device, tol):
+    def test_hessian(self, diff_method, device, tol, shots):
         """Test hessian computation."""
         wires = 3 if diff_method == "hadamard" else 1
         dev = device(wires=wires)
-        tol = tol(dev.shots)
 
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["mode"] = "direct"
 
-        @qp.qnode(dev, diff_method=diff_method, max_diff=2, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(
+            dev, shots=shots, diff_method=diff_method, max_diff=2, gradient_kwargs=gradient_kwargs
+        )
         def circuit(x):
             qp.RY(x[0], wires=0)
             qp.RX(x[1], wires=0)

--- a/pennylane/devices/tests/test_gradients_jax.py
+++ b/pennylane/devices/tests/test_gradients_jax.py
@@ -52,7 +52,7 @@ class TestGradients:
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
         dev = device(2)
-        if dev.shots:
+        if shots:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")

--- a/pennylane/devices/tests/test_gradients_torch.py
+++ b/pennylane/devices/tests/test_gradients_torch.py
@@ -28,17 +28,16 @@ torch = pytest.importorskip("torch")
 class TestGradients:
     """Test various gradient computations."""
 
-    def test_basic_grad(self, diff_method, device, tol):
+    def test_basic_grad(self, diff_method, device, tol, shots):
         """Test a basic function with one RX and one expectation."""
         wires = 2 if diff_method == "hadamard" else 1
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         gradient_kwargs = {}
         if diff_method == "hadamard":
             tol += 0.01
             gradient_kwargs["aux_wire"] = 1
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x):
             qp.RX(x, 0)
             return qp.expval(qp.Z(0))
@@ -48,7 +47,7 @@ class TestGradients:
         res.backward()
         assert np.isclose(x.grad, -np.sin(x.detach()), atol=tol, rtol=0)
 
-    def test_backprop_state(self, diff_method, device, tol):
+    def test_backprop_state(self, diff_method, device, tol, shots):
         """Test the trainability of parameters in a circuit returning the state."""
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
@@ -57,12 +56,11 @@ class TestGradients:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")
-        tol = tol(dev.shots)
 
         x = torch.tensor(0.543, requires_grad=True)
         y = torch.tensor(-0.654, requires_grad=True)
 
-        @qp.qnode(dev, diff_method="backprop", grad_on_execution=True)
+        @qp.qnode(dev, shots=shots, diff_method="backprop", grad_on_execution=True)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -81,7 +79,7 @@ class TestGradients:
         expected = np.array([-np.sin(x) * np.cos(y) / 2, -np.cos(x) * np.sin(y) / 2])
         assert np.allclose(grad, expected, atol=tol, rtol=0)
 
-    def test_parameter_shift(self, diff_method, device, tol):
+    def test_parameter_shift(self, diff_method, device, tol, shots):
         """Test a multi-parameter circuit with parameter-shift."""
         if diff_method != "parameter-shift":
             pytest.skip(reason="test only works with parameter-shift")
@@ -90,9 +88,8 @@ class TestGradients:
         b = torch.tensor(0.2, requires_grad=True)
 
         dev = device(2)
-        tol = tol(dev.shots)
 
-        @qp.qnode(dev, diff_method="parameter-shift", grad_on_execution=False)
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift", grad_on_execution=False)
         def circuit(a, b):
             qp.RY(a, wires=0)
             qp.RX(b, wires=1)
@@ -106,11 +103,10 @@ class TestGradients:
         expected = [-np.sin(a) + np.sin(a) * np.sin(b), -np.cos(a) * np.cos(b)]
         assert np.allclose(grad, expected, atol=tol, rtol=0)
 
-    def test_probs(self, diff_method, device, tol):
+    def test_probs(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit returning probs()."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = torch.tensor(0.543, requires_grad=True)
         y = torch.tensor(-0.654, requires_grad=True)
 
@@ -118,7 +114,7 @@ class TestGradients:
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -149,11 +145,10 @@ class TestGradients:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    def test_multi_meas(self, diff_method, device, tol):
+    def test_multi_meas(self, diff_method, device, tol, shots):
         """Test differentiation of a circuit with both scalar and array-like returns."""
         wires = 3 if diff_method == "hadamard" else 2
         dev = device(wires=wires)
-        tol = tol(dev.shots)
         x = torch.tensor(0.543, requires_grad=True)
         y = torch.tensor(-0.654, requires_grad=True)
 
@@ -161,7 +156,7 @@ class TestGradients:
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
 
-        @qp.qnode(dev, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(dev, shots=shots, diff_method=diff_method, gradient_kwargs=gradient_kwargs)
         def circuit(x, y):
             qp.RX(x, wires=[0])
             qp.RY(y, wires=[1])
@@ -191,17 +186,18 @@ class TestGradients:
         assert all(isinstance(j, torch.Tensor) and j.shape == (2,) for j in jac[1])
         assert np.allclose(jac[1], expected[1], atol=tol, rtol=0)
 
-    def test_hessian(self, diff_method, device, tol):
+    def test_hessian(self, diff_method, device, tol, shots):
         """Test hessian computation."""
         wires = 3 if diff_method == "hadamard" else 1
         dev = device(wires=wires)
-        tol = tol(dev.shots)
 
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["mode"] = "direct"
 
-        @qp.qnode(dev, diff_method=diff_method, max_diff=2, gradient_kwargs=gradient_kwargs)
+        @qp.qnode(
+            dev, shots=shots, diff_method=diff_method, max_diff=2, gradient_kwargs=gradient_kwargs
+        )
         def circuit(x):
             qp.RY(x[0], wires=0)
             qp.RX(x[1], wires=0)

--- a/pennylane/devices/tests/test_gradients_torch.py
+++ b/pennylane/devices/tests/test_gradients_torch.py
@@ -52,7 +52,7 @@ class TestGradients:
         if diff_method != "backprop":
             pytest.skip(reason="test only works with backprop")
         dev = device(2)
-        if dev.shots:
+        if shots:
             pytest.skip("test uses backprop, must be in analytic mode")
         if "mixed" in dev.name:
             pytest.skip("mixed-state simulator will wrongly use grad on non-scalar results")

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -112,7 +112,7 @@ class TestSupportedObservables:
     """Test that the device can implement all observables that it supports."""
 
     @pytest.mark.parametrize("observable", all_obs)
-    def test_supported_observables_can_be_implemented(self, device_kwargs, observable):
+    def test_supported_observables_can_be_implemented(self, device_kwargs, observable, shots):
         """Test that the device can implement all its supported observables."""
         device_kwargs["wires"] = 3
         dev = qp.device(**device_kwargs)
@@ -127,7 +127,7 @@ class TestSupportedObservables:
 
         kwargs = {"diff_method": "parameter-shift"} if observable == "SparseHamiltonian" else {}
 
-        @qp.qnode(dev, **kwargs)
+        @qp.qnode(dev, shots=shots, **kwargs)
         def circuit(obs_circ):
             qp.PauliX(0)
             return qp.expval(obs_circ)
@@ -138,7 +138,7 @@ class TestSupportedObservables:
         else:
             assert isinstance(circuit(obs[observable]), (float, np.ndarray))
 
-    def test_tensor_observables_can_be_implemented(self, device_kwargs):
+    def test_tensor_observables_can_be_implemented(self, device_kwargs, shots):
         """Test that the device can implement a simple tensor observable.
         This test is skipped for devices that do not support tensor observables."""
         device_kwargs["wires"] = 2
@@ -149,7 +149,7 @@ class TestSupportedObservables:
         if not supports_tensor:
             pytest.skip("Device does not support tensor observables.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.PauliX(0)
             return qp.expval(qp.Identity(wires=0) @ qp.Identity(wires=1))
@@ -162,7 +162,7 @@ class TestSupportedObservables:
 class TestHamiltonianSupport:
     """Separate test to ensure that the device can differentiate Hamiltonian observables."""
 
-    def test_hamiltonian_diff(self, device_kwargs, tol):
+    def test_hamiltonian_diff(self, device_kwargs, tol, shots):
         """Tests a simple VQE gradient using parameter-shift rules."""
 
         device_kwargs["wires"] = 1
@@ -170,7 +170,7 @@ class TestHamiltonianSupport:
         coeffs = np.array([-0.05, 0.17])
         param = np.array(1.7, requires_grad=True)
 
-        @qp.qnode(dev, diff_method="parameter-shift")
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift")
         def circuit(coeffs, param):
             qp.RX(param, wires=0)
             qp.RY(param, wires=0)
@@ -196,8 +196,8 @@ class TestHamiltonianSupport:
             qp.RY(param, wires=0)
             return qp.expval(qp.Z(0))
 
-        half1 = qp.QNode(circuit1, dev, diff_method="parameter-shift")
-        half2 = qp.QNode(circuit2, dev, diff_method="parameter-shift")
+        half1 = qp.QNode(circuit1, dev, shots=shots, diff_method="parameter-shift")
+        half2 = qp.QNode(circuit2, dev, shots=shots, diff_method="parameter-shift")
 
         def combine(coeffs, param):
             return coeffs[0] * half1(param) + coeffs[1] * half2(param)
@@ -205,15 +205,15 @@ class TestHamiltonianSupport:
         grad_fn_expected = qp.grad(combine)
         grad_expected = grad_fn_expected(coeffs, param)
 
-        assert np.allclose(grad[0], grad_expected[0], atol=tol(dev.shots))
-        assert np.allclose(grad[1], grad_expected[1], atol=tol(dev.shots))
+        assert np.allclose(grad[0], grad_expected[0], atol=tol)
+        assert np.allclose(grad[1], grad_expected[1], atol=tol)
 
 
 @flaky(max_runs=10)
 class TestExpval:
     """Test expectation values"""
 
-    def test_identity_expectation(self, device, tol):
+    def test_identity_expectation(self, device, tol, shots):
         """Test that identity expectation value (i.e. the trace) is 1."""
         n_wires = 2
         dev = device(n_wires)
@@ -221,7 +221,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -229,9 +229,9 @@ class TestExpval:
             return qp.expval(qp.Identity(wires=0)), qp.expval(qp.Identity(wires=1))
 
         res = circuit()
-        assert np.allclose(res, np.array([1, 1]), atol=tol(dev.shots))
+        assert np.allclose(res, np.array([1, 1]), atol=tol)
 
-    def test_pauliz_expectation(self, device, tol):
+    def test_pauliz_expectation(self, device, tol, shots):
         """Test that PauliZ expectation value is correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -239,7 +239,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -248,9 +248,9 @@ class TestExpval:
 
         res = circuit()
         expected = np.array([np.cos(theta), np.cos(theta) * np.cos(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_paulix_expectation(self, device, tol):
+    def test_paulix_expectation(self, device, tol, shots):
         """Test that PauliX expectation value is correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -258,7 +258,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RY(theta, wires=[0])
             qp.RY(phi, wires=[1])
@@ -267,9 +267,9 @@ class TestExpval:
 
         res = circuit()
         expected = np.array([np.sin(theta) * np.sin(phi), np.sin(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_pauliy_expectation(self, device, tol):
+    def test_pauliy_expectation(self, device, tol, shots):
         """Test that PauliY expectation value is correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -277,7 +277,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -286,9 +286,9 @@ class TestExpval:
 
         res = circuit()
         expected = np.array([0.0, -np.cos(theta) * np.sin(phi)])
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_hadamard_expectation(self, device, tol):
+    def test_hadamard_expectation(self, device, tol, shots):
         """Test that Hadamard expectation value is correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -296,7 +296,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RY(theta, wires=[0])
             qp.RY(phi, wires=[1])
@@ -307,9 +307,9 @@ class TestExpval:
         expected = np.array(
             [np.sin(theta) * np.sin(phi) + np.cos(theta), np.cos(theta) * np.cos(phi) + np.sin(phi)]
         ) / np.sqrt(2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_hermitian_expectation(self, device, tol):
+    def test_hermitian_expectation(self, device, tol, shots):
         """Test that arbitrary Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -320,7 +320,7 @@ class TestExpval:
         theta = 0.432
         phi = 0.123
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RY(theta, wires=[0])
             qp.RY(phi, wires=[1])
@@ -336,9 +336,9 @@ class TestExpval:
         ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
         expected = np.array([ev1, ev2])
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_projector_expectation(self, device, tol):
+    def test_projector_expectation(self, device, tol, shots):
         """Test that arbitrary Projector expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -349,7 +349,7 @@ class TestExpval:
         theta = 0.732
         phi = 0.523
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RY(theta, wires=[0])
             qp.RY(phi, wires=[1])
@@ -358,25 +358,25 @@ class TestExpval:
 
         basis_state, state_vector = [0, 0], [1, 0, 0, 0]
         expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [0, 1], [0, 1, 0, 0]
         expected = (np.sin(phi / 2) * np.cos(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [1, 0], [0, 0, 1, 0]
         expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [1, 1], [0, 0, 0, 1]
         expected = (np.cos(phi / 2) * np.sin(theta / 2)) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
-    def test_multi_mode_hermitian_expectation(self, device, tol):
+    def test_multi_mode_hermitian_expectation(self, device, tol, shots):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         n_wires = 2
         dev = device(n_wires)
@@ -395,7 +395,7 @@ class TestExpval:
             ]
         )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RY(theta, wires=[0])
             qp.RY(phi, wires=[1])
@@ -414,7 +414,7 @@ class TestExpval:
             - 6
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.parametrize(
         "o",
@@ -424,7 +424,7 @@ class TestExpval:
             qp.sum(qp.s_prod(0.1, qp.Z(0)), qp.prod(qp.X(0), qp.Z(1))),
         ],
     )
-    def test_op_arithmetic_matches_default_qubit(self, o, device, tol):
+    def test_op_arithmetic_matches_default_qubit(self, o, device, tol, shots):
         """Test that devices (which support the observable) match default.qubit results."""
         dev = device(2)
         if isinstance(dev, qp.devices.LegacyDevice) and o.name not in dev.observables:
@@ -435,17 +435,17 @@ class TestExpval:
             qp.CNOT([0, 1])
             return qp.expval(o)
 
-        res_dq = qp.QNode(circuit, qp.device("default.qubit"))()
-        res = qp.QNode(circuit, dev)()
+        res_dq = qp.QNode(circuit, qp.device("default.qubit"), shots=shots)()
+        res = qp.QNode(circuit, dev, shots=shots)()
         assert qp.math.shape(res) == ()
-        assert np.isclose(res, res_dq, atol=tol(dev.shots))
+        assert np.isclose(res, res_dq, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestTensorExpval:
     """Test tensor expectation values"""
 
-    def test_paulix_pauliy(self, device, tol, skip_if):
+    def test_paulix_pauliy(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -456,7 +456,7 @@ class TestTensorExpval:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -468,9 +468,9 @@ class TestTensorExpval:
         res = circuit()
 
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_pauliz_hadamard(self, device, tol, skip_if):
+    def test_pauliz_hadamard(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -481,7 +481,7 @@ class TestTensorExpval:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -493,7 +493,7 @@ class TestTensorExpval:
         res = circuit()
 
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize(
@@ -501,7 +501,7 @@ class TestTensorExpval:
         list(zip(obs_lst, obs_permuted_lst, strict=True)),
     )
     def test_wire_order_in_tensor_prod_observables(
-        self, device, base_obs, permuted_obs, tol, skip_if
+        self, device, base_obs, permuted_obs, tol, skip_if, shots
     ):
         """Test that when given a tensor observable the expectation value is the same regardless of the order of terms
         in the tensor observable, provided the wires each term acts on remain constant.
@@ -510,7 +510,7 @@ class TestTensorExpval:
         ob1 = qp.Z(0) @ qp.Y(1)
         ob2 = qp.Y(1) @ qp.Z(0)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circ(obs):
             return qp.expval(obs)
 
@@ -521,15 +521,15 @@ class TestTensorExpval:
         if isinstance(dev, qp.devices.LegacyDevice):
             skip_if(dev, {"supports_tensor_observables": False})
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circ(ob):
             sub_routine(label_map=range(3))
             return qp.expval(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol, rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
-    def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
+    def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if, shots):
         """Test that when given a tensor observable the expectation value is the same regardless of how the
         wires are labelled, as long as they match the device order.
 
@@ -553,17 +553,17 @@ class TestTensorExpval:
             sub_routine(wire_labels)
             return qp.expval(qp.X(wire_labels[0]) @ qp.Y(wire_labels[1]) @ qp.Z(wire_labels[2]))
 
-        circ_base_label = qp.QNode(circ, device=dev)
-        circ_custom_label = qp.QNode(circ, device=dev_custom_labels)
+        circ_base_label = qp.QNode(circ, device=dev, shots=shots)
+        circ_custom_label = qp.QNode(circ, device=dev_custom_labels, shots=shots)
 
         assert np.allclose(
             circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
-            atol=tol(dev.shots),
+            atol=tol,
             rtol=0,
         )
 
-    def test_hermitian(self, device, tol, skip_if):
+    def test_hermitian(self, device, tol, skip_if, shots):
         """Test that a tensor product involving qp.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -586,7 +586,7 @@ class TestTensorExpval:
             ]
         )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -603,9 +603,9 @@ class TestTensorExpval:
             + 3 * np.cos(varphi) * np.sin(phi)
             + np.sin(phi)
         )
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_projector(self, device, tol, skip_if):
+    def test_projector(self, device, tol, skip_if, shots):
         """Test that a tensor product involving qp.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -620,7 +620,7 @@ class TestTensorExpval:
         phi = 0.523
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -633,31 +633,31 @@ class TestTensorExpval:
         expected = (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [0, 1], [0, 1, 0, 0]
         expected = (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [1, 0], [0, 0, 1, 0]
         expected = (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
         basis_state, state_vector = [1, 1], [0, 0, 0, 1]
         expected = (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)
         ) ** 2
-        assert np.allclose(circuit(basis_state), expected, atol=tol(dev.shots))
-        assert np.allclose(circuit(state_vector), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit(basis_state), expected, atol=tol)
+        assert np.allclose(circuit(state_vector), expected, atol=tol)
 
-    def test_sparse_hamiltonian_expval(self, device, tol):
+    def test_sparse_hamiltonian_expval(self, device, tol, shots):
         """Test that expectation values of sparse Hamiltonians are properly calculated."""
         n_wires = 4
         dev = device(n_wires)
@@ -677,7 +677,7 @@ class TestTensorExpval:
         )
         h = csr_matrix((h_data, (h_row, h_col)), shape=(16, 16))  # XXYY
 
-        @qp.qnode(dev, diff_method="parameter-shift")
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift")
         def result():
             qp.X(0)
             qp.X(2)
@@ -688,14 +688,14 @@ class TestTensorExpval:
 
         res = result()
         exp_res = 0.019833838076209875
-        assert np.allclose(res, exp_res, atol=tol(False))
+        assert np.allclose(res, exp_res, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestSample:
     """Tests for the sample return type."""
 
-    def test_sample_wires(self, device):
+    def test_sample_wires(self, device, shots):
         """Test that a device can return samples."""
 
         n_wires = 1
@@ -704,7 +704,7 @@ class TestSample:
         if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return qp.sample(wires=0)
@@ -714,7 +714,7 @@ class TestSample:
         assert qp.math.shape(res) == (dev.shots.total_shots, 1)
         assert qp.math.get_dtype_name(res)[0:3] == "int"  # either 32 or 64 precision.
 
-    def test_sample_values(self, device, tol):
+    def test_sample_values(self, device, tol, shots):
         """Tests if the samples returned by sample have
         the correct values
         """
@@ -724,7 +724,7 @@ class TestSample:
         if not dev.shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(1.5708, wires=[0])
             return qp.sample(qp.Z(0))
@@ -732,9 +732,9 @@ class TestSample:
         res = circuit()
 
         # res should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert np.allclose(res**2, 1, atol=tol)
 
-    def test_sample_values_hermitian(self, device, tol):
+    def test_sample_values_hermitian(self, device, tol, shots):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
         """
@@ -750,7 +750,7 @@ class TestSample:
         A_ = np.array([[1, 2j], [-2j, 0]])
         theta = 0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             return qp.sample(qp.Hermitian(A_, wires=0))
@@ -760,17 +760,13 @@ class TestSample:
         # res should only contain the eigenvalues of
         # the hermitian matrix
         eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol)
         # the analytic mean is 2*sin(theta)+0.5*cos(theta)+0.5
-        assert np.allclose(
-            np.mean(res), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, atol=tol(False)
-        )
+        assert np.allclose(np.mean(res), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, atol=tol)
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
-        assert np.allclose(
-            np.var(res), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, atol=tol(False)
-        )
+        assert np.allclose(np.var(res), 0.25 * (np.sin(theta) - 4 * np.cos(theta)) ** 2, atol=tol)
 
-    def test_sample_values_projector(self, device, tol):
+    def test_sample_values_projector(self, device, tol, shots):
         """Tests if the samples of a Projector observable returned by sample have
         the correct values
         """
@@ -785,7 +781,7 @@ class TestSample:
 
         theta = 0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RX(theta, wires=[0])
             return qp.sample(qp.Projector(state, wires=0))
@@ -794,31 +790,31 @@ class TestSample:
         res_basis = circuit([0]).flatten()
         res_state = circuit([1, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol(False))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
+        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol)
+        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol)
 
         expected = np.sin(theta / 2) ** 2
         res_basis = circuit([1]).flatten()
         res_state = circuit([0, 1]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol(False))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
+        assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol)
+        assert np.allclose(np.var(res_state), expected - (expected) ** 2, atol=tol)
 
         expected = 0.5
         res = circuit(np.array([1, 1]) / np.sqrt(2)).flatten()
-        assert np.allclose(sorted(list(set(res.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res), expected, atol=tol(False))
-        assert np.allclose(np.var(res), expected - (expected) ** 2, atol=tol(False))
+        assert np.allclose(sorted(list(set(res.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res), expected, atol=tol)
+        assert np.allclose(np.var(res), expected - (expected) ** 2, atol=tol)
 
-    def test_sample_values_hermitian_multi_qubit(self, device, tol):
+    def test_sample_values_hermitian_multi_qubit(self, device, tol, shots):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
         the correct values
         """
@@ -841,7 +837,7 @@ class TestSample:
             ]
         )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RY(2 * theta, wires=[1])
@@ -853,7 +849,7 @@ class TestSample:
         # res should only contain the eigenvalues of
         # the hermitian matrix
         eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol)
 
         # make sure the mean matches the analytic mean
         expected = (
@@ -865,9 +861,9 @@ class TestSample:
             + 27 * np.cos(3 * theta)
             + 6
         ) / 32
-        assert np.allclose(np.mean(res), expected, atol=tol(dev.shots))
+        assert np.allclose(np.mean(res), expected, atol=tol)
 
-    def test_sample_values_projector_multi_qubit(self, device, tol):
+    def test_sample_values_projector_multi_qubit(self, device, tol, shots):
         """Tests if the samples of a multi-qubit Projector observable returned by sample have
         the correct values
         """
@@ -882,7 +878,7 @@ class TestSample:
 
         theta = 0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RX(theta, wires=[0])
             qp.RY(2 * theta, wires=[1])
@@ -893,41 +889,41 @@ class TestSample:
         res_basis = circuit([0, 0]).flatten()
         res_state = circuit([1, 0, 0, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
         res_basis = circuit([0, 1]).flatten()
         res_state = circuit([0, 1, 0, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
         res_basis = circuit([1, 0]).flatten()
         res_state = circuit([0, 0, 1, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.sin(theta / 2) * np.cos(theta)) ** 2
         res_basis = circuit([1, 1]).flatten()
         res_state = circuit([0, 0, 0, 1]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_basis), expected, atol=tol(dev.shots))
-        assert np.allclose(np.mean(res_state), expected, atol=tol(dev.shots))
+        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected, atol=tol)
+        assert np.allclose(np.mean(res_state), expected, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestTensorSample:
     """Test tensor sample values."""
 
-    def test_paulix_pauliy(self, device, tol, skip_if):
+    def test_paulix_pauliy(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -942,7 +938,7 @@ class TestTensorSample:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -954,11 +950,11 @@ class TestTensorSample:
         res = circuit()
 
         # res should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert np.allclose(res**2, 1, atol=tol)
 
         mean = np.mean(res)
         expected = np.sin(theta) * np.sin(phi) * np.sin(varphi)
-        assert np.allclose(mean, expected, atol=tol(False))
+        assert np.allclose(mean, expected, atol=tol)
 
         var = np.var(res)
         expected = (
@@ -969,9 +965,9 @@ class TestTensorSample:
             + 2 * np.cos(2 * phi)
             + 14
         ) / 16
-        assert np.allclose(var, expected, atol=tol(False))
+        assert np.allclose(var, expected, atol=tol)
 
-    def test_pauliz_hadamard(self, device, tol, skip_if):
+    def test_pauliz_hadamard(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -986,7 +982,7 @@ class TestTensorSample:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -998,11 +994,11 @@ class TestTensorSample:
         res = circuit()
 
         # s1 should only contain 1 and -1
-        assert np.allclose(res**2, 1, atol=tol(False))
+        assert np.allclose(res**2, 1, atol=tol)
 
         mean = np.mean(res)
         expected = -(np.cos(varphi) * np.sin(phi) + np.sin(varphi) * np.cos(theta)) / np.sqrt(2)
-        assert np.allclose(mean, expected, atol=tol(False))
+        assert np.allclose(mean, expected, atol=tol)
 
         var = np.var(res)
         expected = (
@@ -1011,9 +1007,9 @@ class TestTensorSample:
             - np.cos(2 * theta) * np.sin(varphi) ** 2
             - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
         ) / 4
-        assert np.allclose(var, expected, atol=tol(False))
+        assert np.allclose(var, expected, atol=tol)
 
-    def test_hermitian(self, device, tol, skip_if):
+    def test_hermitian(self, device, tol, skip_if, shots):
         """Test that a tensor product involving qp.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1040,7 +1036,7 @@ class TestTensorSample:
             ]
         )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1055,7 +1051,7 @@ class TestTensorSample:
         # the hermitian matrix tensor product Z
         Z = np.diag([1, -1])
         eigvals = np.linalg.eigvalsh(np.kron(Z, A_))
-        assert np.allclose(sorted(np.unique(res)), sorted(eigvals), atol=tol(False))
+        assert np.allclose(sorted(np.unique(res)), sorted(eigvals), atol=tol)
 
         mean = np.mean(res)
         expected = (
@@ -1068,7 +1064,7 @@ class TestTensorSample:
                 + np.sin(phi)
             )
         )
-        assert np.allclose(mean, expected, atol=tol(False))
+        assert np.allclose(mean, expected, atol=tol)
 
         var = np.var(res)
         expected = (
@@ -1105,9 +1101,9 @@ class TestTensorSample:
             )
             / 16
         )
-        assert np.allclose(var, expected, atol=tol(False))
+        assert np.allclose(var, expected, atol=tol)
 
-    def test_projector(self, device, tol, skip_if):  # pylint: disable=too-many-statements
+    def test_projector(self, device, tol, skip_if, shots):  # pylint: disable=too-many-statements
         """Test that a tensor product involving qp.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1125,7 +1121,7 @@ class TestTensorSample:
         phi = 1.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1149,12 +1145,12 @@ class TestTensorSample:
             ** 2
         )
         # res should only contain the eigenvalues of the projector matrix tensor product Z, i.e. {-1, 0, 1}
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol)
+        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol)
+        assert np.allclose(np.mean(res_state), expected_mean, atol=tol)
+        assert np.allclose(np.var(res_basis), expected_var, atol=tol)
+        assert np.allclose(np.var(res_state), expected_var, atol=tol)
 
         res_basis = circuit([0, 1]).flatten()
         res_state = circuit([0, 1, 0, 0]).flatten()
@@ -1170,12 +1166,12 @@ class TestTensorSample:
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol)
+        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol)
+        assert np.allclose(np.mean(res_state), expected_mean, atol=tol)
+        assert np.allclose(np.var(res_basis), expected_var, atol=tol)
+        assert np.allclose(np.var(res_state), expected_var, atol=tol)
 
         res_basis = circuit([1, 0]).flatten()
         res_state = circuit([0, 0, 1, 0]).flatten()
@@ -1191,12 +1187,12 @@ class TestTensorSample:
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol)
+        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol)
+        assert np.allclose(np.mean(res_state), expected_mean, atol=tol)
+        assert np.allclose(np.var(res_basis), expected_var, atol=tol)
+        assert np.allclose(np.var(res_state), expected_var, atol=tol)
 
         res_basis = circuit([1, 1]).flatten()
         res_state = circuit([0, 0, 0, 1]).flatten()
@@ -1212,12 +1208,12 @@ class TestTensorSample:
             )
             ** 2
         )
-        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol(False))
-        assert np.allclose(np.mean(res_state), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res_basis), expected_var, atol=tol(False))
-        assert np.allclose(np.var(res_state), expected_var, atol=tol(False))
+        assert np.allclose(sorted(np.unique(res_basis)), [-1, 0, 1], atol=tol)
+        assert np.allclose(sorted(np.unique(res_state)), [-1, 0, 1], atol=tol)
+        assert np.allclose(np.mean(res_basis), expected_mean, atol=tol)
+        assert np.allclose(np.mean(res_state), expected_mean, atol=tol)
+        assert np.allclose(np.var(res_basis), expected_var, atol=tol)
+        assert np.allclose(np.var(res_state), expected_var, atol=tol)
 
         res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
         expected_mean = 0.5 * (
@@ -1236,33 +1232,33 @@ class TestTensorSample:
             )
             - expected_mean**2
         )
-        assert np.allclose(sorted(np.unique(res)), [-1, 0, 1], atol=tol(False))
-        assert np.allclose(np.mean(res), expected_mean, atol=tol(False))
-        assert np.allclose(np.var(res), expected_var, atol=tol(False))
+        assert np.allclose(sorted(np.unique(res)), [-1, 0, 1], atol=tol)
+        assert np.allclose(np.mean(res), expected_mean, atol=tol)
+        assert np.allclose(np.var(res), expected_var, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestSumExpval:
     """Test expectation values of Sum observables."""
 
-    def test_sum_containing_identity_on_no_wires(self, device, tol):
+    def test_sum_containing_identity_on_no_wires(self, device, tol, shots):
         """Test that the device can handle Identity on no wires."""
         dev = device(1)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return qp.expval(qp.sum(qp.Z(0) + 3 * qp.I()))
 
         res = circuit()
-        assert qp.math.allclose(res, 2.0, atol=tol(dev.shots))
+        assert qp.math.allclose(res, 2.0, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestVar:
     """Tests for the variance return type"""
 
-    def test_var(self, device, tol):
+    def test_var(self, device, tol, shots):
         """Tests if the samples returned by sample have
         the correct values
         """
@@ -1272,7 +1268,7 @@ class TestVar:
         phi = 0.543
         theta = 0.6543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(phi, wires=[0])
             qp.RY(theta, wires=[0])
@@ -1281,9 +1277,9 @@ class TestVar:
         res = circuit()
 
         expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_var_hermitian(self, device, tol):
+    def test_var_hermitian(self, device, tol, shots):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
         """
@@ -1298,7 +1294,7 @@ class TestVar:
         # test correct variance for <H> of a rotated state
         H = 0.1 * np.array([[4, -1 + 6j], [-1 - 6j, 2]])
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(phi, wires=[0])
             qp.RY(theta, wires=[0])
@@ -1317,9 +1313,9 @@ class TestVar:
             )
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_var_projector(self, device, tol):
+    def test_var_projector(self, device, tol, shots):
         """Tests if the samples of a Projector observable returned by sample have
         the correct values
         """
@@ -1332,7 +1328,7 @@ class TestVar:
         phi = 0.543
         theta = 0.654
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.RX(phi, wires=[0])
             qp.RY(theta, wires=[1])
@@ -1344,46 +1340,46 @@ class TestVar:
         expected = (np.cos(phi / 2) * np.cos(theta / 2)) ** 2 - (
             (np.cos(phi / 2) * np.cos(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([0, 1])
         res_state = circuit([0, 1, 0, 0])
         expected = (np.cos(phi / 2) * np.sin(theta / 2)) ** 2 - (
             (np.cos(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([1, 0])
         res_state = circuit([0, 0, 1, 0])
         expected = (np.sin(phi / 2) * np.sin(theta / 2)) ** 2 - (
             (np.sin(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([1, 1])
         res_state = circuit([0, 0, 0, 1])
         expected = (np.sin(phi / 2) * np.cos(theta / 2)) ** 2 - (
             (np.sin(phi / 2) * np.cos(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
         expected_mean = 0.5 * (
             (np.cos(theta / 2) * np.cos(phi / 2)) ** 2 + (np.cos(theta / 2) * np.sin(phi / 2)) ** 2
         )
         expected_var = expected_mean - expected_mean**2
-        assert np.allclose(res, expected_var, atol=tol(dev.shots))
+        assert np.allclose(res, expected_var, atol=tol)
 
 
 @flaky(max_runs=10)
 class TestTensorVar:
     """Test tensor variance measurements."""
 
-    def test_paulix_pauliy(self, device, tol, skip_if):
+    def test_paulix_pauliy(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1394,7 +1390,7 @@ class TestTensorVar:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1413,9 +1409,9 @@ class TestTensorVar:
             + 2 * np.cos(2 * phi)
             + 14
         ) / 16
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_pauliz_hadamard(self, device, tol, skip_if):
+    def test_pauliz_hadamard(self, device, tol, skip_if, shots):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1426,7 +1422,7 @@ class TestTensorVar:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1443,7 +1439,7 @@ class TestTensorVar:
             - np.cos(2 * theta) * np.sin(varphi) ** 2
             - 2 * np.cos(theta) * np.sin(phi) * np.sin(2 * varphi)
         ) / 4
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     # pylint: disable=too-many-arguments
 
@@ -1452,7 +1448,7 @@ class TestTensorVar:
         list(zip(obs_lst, obs_permuted_lst, strict=True)),
     )
     def test_wire_order_in_tensor_prod_observables(
-        self, device, base_obs, permuted_obs, tol, skip_if
+        self, device, base_obs, permuted_obs, tol, skip_if, shots
     ):
         """Test that when given a tensor observable the variance is the same regardless of the order of terms
         in the tensor observable, provided the wires each term acts on remain constant.
@@ -1461,7 +1457,7 @@ class TestTensorVar:
         ob1 = qp.Z(0) @ qp.Y(1)
         ob2 = qp.Y(1) @ qp.Z(0)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circ(obs):
             return qp.var(obs)
 
@@ -1472,15 +1468,15 @@ class TestTensorVar:
         if isinstance(dev, qp.devices.LegacyDevice):
             skip_if(dev, {"supports_tensor_observables": False})
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circ(ob):
             sub_routine(label_map=range(3))
             return qp.var(ob)
 
-        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol(dev.shots), rtol=0)
+        assert np.allclose(circ(base_obs), circ(permuted_obs), atol=tol, rtol=0)
 
     @pytest.mark.parametrize("label_map", label_maps)
-    def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if):
+    def test_wire_label_in_tensor_prod_observables(self, device, label_map, tol, skip_if, shots):
         """Test that when given a tensor observable the variance is the same regardless of how the
         wires are labelled, as long as they match the device order.
 
@@ -1503,17 +1499,17 @@ class TestTensorVar:
             sub_routine(wire_labels)
             return qp.var(qp.X(wire_labels[0]) @ qp.Y(wire_labels[1]) @ qp.Z(wire_labels[2]))
 
-        circ_base_label = qp.QNode(circ, device=dev)
-        circ_custom_label = qp.QNode(circ, device=dev_custom_labels)
+        circ_base_label = qp.QNode(circ, device=dev, shots=shots)
+        circ_custom_label = qp.QNode(circ, device=dev_custom_labels, shots=shots)
 
         assert np.allclose(
             circ_base_label(wire_labels=range(3)),
             circ_custom_label(wire_labels=label_map),
-            atol=tol(dev.shots),
+            atol=tol,
             rtol=0,
         )
 
-    def test_hermitian(self, device, tol, skip_if):
+    def test_hermitian(self, device, tol, skip_if, shots):
         """Test that a tensor product involving qp.Hermitian works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1537,7 +1533,7 @@ class TestTensorVar:
             ]
         )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1583,9 +1579,9 @@ class TestTensorVar:
             / 16
         )
 
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_projector(self, device, tol, skip_if):
+    def test_projector(self, device, tol, skip_if, shots):
         """Test that a tensor product involving qp.Projector works correctly"""
         n_wires = 3
         dev = device(n_wires)
@@ -1600,7 +1596,7 @@ class TestTensorVar:
         phi = 0.123
         varphi = -0.543
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(basis_state):
             qp.RX(theta, wires=[0])
             qp.RX(phi, wires=[1])
@@ -1618,8 +1614,8 @@ class TestTensorVar:
             (np.cos(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
             - (np.cos(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([0, 1])
         res_state = circuit([0, 1, 0, 0])
@@ -1630,8 +1626,8 @@ class TestTensorVar:
             (np.sin(varphi / 2) * np.cos(phi / 2) * np.cos(theta / 2)) ** 2
             - (np.sin(varphi / 2) * np.sin(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([1, 0])
         res_state = circuit([0, 0, 1, 0])
@@ -1642,8 +1638,8 @@ class TestTensorVar:
             (np.sin(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
             - (np.sin(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res_basis = circuit([1, 1])
         res_state = circuit([0, 0, 0, 1])
@@ -1654,8 +1650,8 @@ class TestTensorVar:
             (np.cos(varphi / 2) * np.sin(phi / 2) * np.cos(theta / 2)) ** 2
             - (np.cos(varphi / 2) * np.cos(phi / 2) * np.sin(theta / 2)) ** 2
         ) ** 2
-        assert np.allclose(res_basis, expected, atol=tol(dev.shots))
-        assert np.allclose(res_state, expected, atol=tol(dev.shots))
+        assert np.allclose(res_basis, expected, atol=tol)
+        assert np.allclose(res_state, expected, atol=tol)
 
         res = circuit(np.array([1, 0, 0, 1]) / np.sqrt(2))
         expected_mean = 0.5 * (
@@ -1674,7 +1670,7 @@ class TestTensorVar:
             )
             - expected_mean**2
         )
-        assert np.allclose(res, expected_var, atol=tol(False))
+        assert np.allclose(res, expected_var, atol=tol)
 
 
 def _skip_test_for_braket(dev):
@@ -1692,7 +1688,7 @@ def _skip_test_for_ionq(dev):
 class TestSampleMeasurement:
     """Tests for the SampleMeasurement class."""
 
-    def test_custom_sample_measurement(self, device):
+    def test_custom_sample_measurement(self, device, shots):
         """Test the execution of a custom sampled measurement."""
 
         dev = device(2)
@@ -1710,7 +1706,7 @@ class TestSampleMeasurement:
             def process_counts(self, counts: dict, wire_order: Wires):
                 return 1
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
@@ -1718,7 +1714,7 @@ class TestSampleMeasurement:
         res = circuit()
         assert qp.math.allequal(res, [1, 1])
 
-    def test_sample_measurement_without_shots(self, device):
+    def test_sample_measurement_without_shots(self, device, shots):
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""
         dev = device(2)
 
@@ -1734,7 +1730,7 @@ class TestSampleMeasurement:
             def process_counts(self, counts: dict, wire_order: Wires):
                 return 1
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return MyMeasurement(wires=[0]), MyMeasurement(wires=[1])
@@ -1742,7 +1738,7 @@ class TestSampleMeasurement:
         with pytest.raises((ValueError, DeviceError)):
             circuit()
 
-    def test_method_overriden_by_device(self, device):
+    def test_method_overriden_by_device(self, device, shots):
         """Test that the device can override a measurement process."""
         dev = device(2)
         if isinstance(dev, qp.devices.Device):
@@ -1755,7 +1751,7 @@ class TestSampleMeasurement:
                 "sample-based measurements."
             )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return qp.sample(wires=0), qp.sample(wires=1)
@@ -1769,7 +1765,7 @@ class TestSampleMeasurement:
 class TestStateMeasurement:
     """Tests for the SampleMeasurement class."""
 
-    def test_custom_state_measurement(self, device):
+    def test_custom_state_measurement(self, device, shots):
         """Test the execution of a custom state measurement."""
         dev = device(2)
         _skip_test_for_braket(dev)
@@ -1786,19 +1782,19 @@ class TestStateMeasurement:
             def process_density_matrix(self, density_matrix, wire_order):
                 return 1
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return MyMeasurement()
 
         assert circuit() == 1
 
-    def test_sample_measurement_with_shots(self, device):
+    def test_sample_measurement_with_shots(self, device, shots):
         """Test that executing a state measurement with shots raises a warning."""
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("If shots=None no warning is raised.")
 
         class MyMeasurement(StateMeasurement):
@@ -1810,7 +1806,7 @@ class TestStateMeasurement:
             def process_density_matrix(self, density_matrix, wire_order):
                 return 1
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return MyMeasurement()
@@ -1825,7 +1821,7 @@ class TestStateMeasurement:
         ):
             circuit()
 
-    def test_method_overriden_by_device(self, device):
+    def test_method_overriden_by_device(self, device, shots):
         """Test that the device can override a measurement process."""
         dev = device(2)
 
@@ -1833,7 +1829,7 @@ class TestStateMeasurement:
         if isinstance(dev, qp.devices.Device):
             pytest.skip("test is specific to old device interface")
 
-        @qp.qnode(dev, interface="autograd", diff_method=None)
+        @qp.qnode(dev, shots=shots, interface="autograd", diff_method=None)
         def circuit():
             qp.X(0)
             return qp.state()
@@ -1847,7 +1843,7 @@ class TestStateMeasurement:
 class TestCustomMeasurement:
     """Tests for the CustomMeasurement class."""
 
-    def test_custom_measurement(self, device):
+    def test_custom_measurement(self, device, shots):
         """Test the execution of a custom measurement."""
         dev = device(2)
         _skip_test_for_braket(dev)
@@ -1866,14 +1862,14 @@ class TestCustomMeasurement:
             except DeviceError:
                 pytest.xfail("Device does not support custom measurement transforms.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return MyMeasurement()
 
         assert circuit() == 1
 
-    def test_method_overriden_by_device(self, device):
+    def test_method_overriden_by_device(self, device, shots):
         """Test that the device can override a measurement process."""
         dev = device(2)
         if isinstance(dev, qp.devices.Device):
@@ -1886,7 +1882,7 @@ class TestCustomMeasurement:
                 "sample-based measurements."
             )
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return qp.classical_shadow(wires=0)

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -117,7 +117,7 @@ class TestSupportedObservables:
         device_kwargs["wires"] = 3
         dev = qp.device(**device_kwargs)
 
-        if dev.shots and observable == "SparseHamiltonian":
+        if shots and observable == "SparseHamiltonian":
             pytest.skip("SparseHamiltonian only supported in analytic mode")
 
         if isinstance(dev, qp.devices.LegacyDevice):
@@ -667,7 +667,7 @@ class TestTensorExpval:
                 pytest.skip(
                     "Skipped because device does not support the SparseHamiltonian observable."
                 )
-        if dev.shots:
+        if shots:
             pytest.skip("SparseHamiltonian only supported in analytic mode")
 
         h_row = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
@@ -701,7 +701,7 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         @qp.qnode(dev, shots=shots)
@@ -711,7 +711,7 @@ class TestSample:
 
         res = circuit()
         assert qp.math.allclose(res, 1)  # note, might be violated with a noisy device?
-        assert qp.math.shape(res) == (dev.shots.total_shots, 1)
+        assert qp.math.shape(res) == (shots, 1)
         assert qp.math.get_dtype_name(res)[0:3] == "int"  # either 32 or 64 precision.
 
     def test_sample_values(self, device, tol, shots):
@@ -721,7 +721,7 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         @qp.qnode(dev, shots=shots)
@@ -741,7 +741,7 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice) and "Hermitian" not in dev.observables:
@@ -773,7 +773,7 @@ class TestSample:
         n_wires = 1
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice) and "Projector" not in dev.observables:
@@ -821,7 +821,7 @@ class TestSample:
         n_wires = 2
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice) and "Hermitian" not in dev.observables:
@@ -870,7 +870,7 @@ class TestSample:
         n_wires = 2
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice) and "Projector" not in dev.observables:
@@ -928,7 +928,7 @@ class TestTensorSample:
         n_wires = 3
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice):
@@ -972,7 +972,7 @@ class TestTensorSample:
         n_wires = 3
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice):
@@ -1014,7 +1014,7 @@ class TestTensorSample:
         n_wires = 3
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice):
@@ -1108,7 +1108,7 @@ class TestTensorSample:
         n_wires = 3
         dev = device(n_wires)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Device is in analytic mode, cannot test sampling.")
 
         if isinstance(dev, qp.devices.LegacyDevice):
@@ -1694,7 +1694,7 @@ class TestSampleMeasurement:
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if not dev.shots:
+        if not shots:
             pytest.skip("Shots must be specified in the device to compute a sampled measurement.")
 
         class MyMeasurement(SampleMeasurement):
@@ -1718,7 +1718,7 @@ class TestSampleMeasurement:
         """Test that executing a sampled measurement with ``shots=None`` raises an error."""
         dev = device(2)
 
-        if dev.shots:
+        if shots:
             pytest.skip("If shots!=None no error is raised.")
 
         class MyMeasurement(SampleMeasurement):
@@ -1745,7 +1745,7 @@ class TestSampleMeasurement:
             pytest.skip("test specific for old device interface.")
         _skip_test_for_braket(dev)
 
-        if dev.shots is None:
+        if shots is None:
             pytest.skip(
                 "The number of shots has to be explicitly set on the device when using "
                 "sample-based measurements."
@@ -1770,7 +1770,7 @@ class TestStateMeasurement:
         dev = device(2)
         _skip_test_for_braket(dev)
 
-        if dev.shots:
+        if shots:
             pytest.skip("Some plugins don't update state information when shots is not None.")
 
         class MyMeasurement(StateMeasurement):
@@ -1876,7 +1876,7 @@ class TestCustomMeasurement:
             pytest.skip("test specific to old device interface.")
         _skip_test_for_braket(dev)
 
-        if dev.shots is None:
+        if shots is None:
             pytest.skip(
                 "The number of shots has to be explicitly set on the device when using "
                 "sample-based measurements."

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -71,38 +71,22 @@ class TestDeviceProperties:
     def test_load_device(self, device_kwargs):
         """Test that the device loads correctly."""
         device_kwargs["wires"] = 2
-        device_kwargs["shots"] = 1234
 
         dev = qp.device(**device_kwargs)
         if isinstance(dev, qp.devices.Device):
             assert isinstance(dev.wires, qp.wires.Wires)
             assert dev.wires == qp.wires.Wires((0, 1))
 
-            assert isinstance(dev.shots, qp.measurements.Shots)
-            assert dev.shots == qp.measurements.Shots(1234)
-
             assert device_kwargs["name"] == dev.name
             assert isinstance(dev.tracker, qp.Tracker)
             return
 
         assert dev.num_wires == 2
-        assert dev.shots == 1234
         assert dev.short_name == device_kwargs["name"]
 
     def test_no_wires_given(self, device_kwargs):
         """Test that the device requires correct arguments."""
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
-            dev = qp.device(**device_kwargs)
-            if isinstance(dev, qp.devices.Device):
-                pytest.skip("test is old interface specific.")
-
-    def test_no_0_shots(self, device_kwargs):
-        """Test that non-analytic devices cannot accept 0 shots."""
-        # first create a valid device to extract its capabilities
-        device_kwargs["wires"] = 2
-        device_kwargs["shots"] = 0
-
-        with pytest.raises(Exception):  # different types of error based on interface
             dev = qp.device(**device_kwargs)
             if isinstance(dev, qp.devices.Device):
                 pytest.skip("test is old interface specific.")
@@ -250,7 +234,7 @@ class TestCapabilities:
 
             assert state is None
         else:
-            if dev.shots is not None:
+            if shots is not None:
                 with pytest.warns(
                     UserWarning,
                     match="Requested state or density matrix with finite shots; the returned",

--- a/pennylane/devices/tests/test_properties.py
+++ b/pennylane/devices/tests/test_properties.py
@@ -120,7 +120,7 @@ class TestCapabilities:
         cap = get_legacy_capabilities(dev)
         assert isinstance(cap, dict)
 
-    def test_model_is_defined_valid_and_correct(self, device_kwargs):
+    def test_model_is_defined_valid_and_correct(self, device_kwargs, shots):
         """Test that the capabilities dictionary defines a valid model."""
         device_kwargs["wires"] = 1
         dev = qp.device(**device_kwargs)
@@ -132,14 +132,14 @@ class TestCapabilities:
 
         if cap["model"] == "qubit":
 
-            @qp.qnode(dev)
+            @qp.qnode(dev, shots=shots)
             def circuit():
                 qp.X(0)
                 return qp.expval(qp.Z(0))
 
         else:
 
-            @qp.qnode(dev)
+            @qp.qnode(dev, shots=shots)
             def circuit():
                 qp.Displacement(1.0, 1.2345, wires=0)
                 return qp.expval(qp.QuadX(wires=0))
@@ -147,7 +147,7 @@ class TestCapabilities:
         # assert that device can measure observable from its model
         circuit()
 
-    def test_passthru_interface_is_correct(self, device_kwargs):
+    def test_passthru_interface_is_correct(self, device_kwargs, shots):
         """Test that the capabilities dictionary defines a valid passthru interface, if not None."""
         device_kwargs["wires"] = 1
         dev = qp.device(**device_kwargs)
@@ -162,7 +162,7 @@ class TestCapabilities:
         assert interface in ["autograd", "jax", "torch"]  # for new interface, add test case
 
         qfunc = qfunc_with_scalar_input(cap["model"])
-        qnode = qp.QNode(qfunc, dev, interface=interface)
+        qnode = qp.QNode(qfunc, dev, shots=shots, interface=interface)
 
         # assert that we can do a simple gradient computation in the passthru interface
         # without raising an error
@@ -198,7 +198,7 @@ class TestCapabilities:
             else:
                 pytest.skip("Cannot import torch")
 
-    def test_supports_tensor_observables(self, device_kwargs):
+    def test_supports_tensor_observables(self, device_kwargs, shots):
         """Tests that the device reports correctly whether it supports tensor observables."""
         device_kwargs["wires"] = 2
         dev = qp.device(**device_kwargs)
@@ -209,7 +209,7 @@ class TestCapabilities:
         if "supports_tensor_observables" not in cap:
             pytest.skip("No supports_tensor_observables capability specified by device.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             """Model agnostic quantum function with tensor observable"""
             if cap["model"] == "qubit":
@@ -224,7 +224,7 @@ class TestCapabilities:
             with pytest.raises(QuantumFunctionError):
                 circuit()
 
-    def test_returns_state(self, device_kwargs):
+    def test_returns_state(self, device_kwargs, shots):
         """Tests that the device reports correctly whether it supports returning the state."""
         device_kwargs["wires"] = 1
         dev = qp.device(**device_kwargs)
@@ -232,7 +232,7 @@ class TestCapabilities:
             pytest.skip("test is old interface specific.")
         cap = get_legacy_capabilities(dev)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.X(0)
             return qp.state()
@@ -261,7 +261,7 @@ class TestCapabilities:
 
             assert dev.state is not None
 
-    def test_returns_probs(self, device_kwargs):
+    def test_returns_probs(self, device_kwargs, shots):
         """Tests that the device reports correctly whether it supports reversible differentiation."""
         device_kwargs["wires"] = 1
         dev = qp.device(**device_kwargs)
@@ -272,7 +272,7 @@ class TestCapabilities:
         if "returns_probs" not in cap:
             pytest.skip("No returns_probs capability specified by device.")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             if cap["model"] == "qubit":
                 qp.X(0)
@@ -286,7 +286,7 @@ class TestCapabilities:
             with pytest.raises(NotImplementedError):
                 circuit()
 
-    def test_supports_broadcasting(self, device_kwargs, mocker):
+    def test_supports_broadcasting(self, device_kwargs, mocker, shots):
         """Tests that the device reports correctly whether it supports parameter broadcasting
         and that it can execute broadcasted tapes in any case."""
 
@@ -298,7 +298,7 @@ class TestCapabilities:
 
         assert "supports_broadcasting" in cap
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(x):
             if cap["model"] == "qubit":
                 qp.RX(x, wires=0)

--- a/pennylane/devices/tests/test_return_system.py
+++ b/pennylane/devices/tests/test_return_system.py
@@ -35,7 +35,7 @@ class TestIntegrationMultipleReturns:
     measurements.
     """
 
-    def test_multiple_expval(self, device):
+    def test_multiple_expval(self, device, shots):
         """Return multiple expvals."""
         n_wires = 2
         dev = device(n_wires)
@@ -51,7 +51,7 @@ class TestIntegrationMultipleReturns:
             func(x)
             return qp.expval(obs1), qp.expval(obs2)
 
-        qnode = qp.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, shots=shots, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
@@ -61,7 +61,7 @@ class TestIntegrationMultipleReturns:
 
         assert isinstance(res[1], (float, np.ndarray))
 
-    def test_multiple_var(self, device):
+    def test_multiple_var(self, device, shots):
         """Return multiple vars."""
 
         n_wires = 2
@@ -78,7 +78,7 @@ class TestIntegrationMultipleReturns:
             func(x)
             return qp.var(obs1), qp.var(obs2)
 
-        qnode = qp.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, shots=shots, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
@@ -88,7 +88,7 @@ class TestIntegrationMultipleReturns:
 
         assert isinstance(res[1], (float, np.ndarray))
 
-    def test_multiple_prob(self, device):
+    def test_multiple_prob(self, device, shots):
         """Return multiple probs."""
 
         n_wires = 2
@@ -98,7 +98,7 @@ class TestIntegrationMultipleReturns:
             qubit_ansatz(x)
             return qp.probs(op=qp.Z(0)), qp.probs(op=qp.Y(1))
 
-        qnode = qp.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, shots=shots, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)
@@ -110,7 +110,7 @@ class TestIntegrationMultipleReturns:
         assert isinstance(res[1], np.ndarray)
         assert res[1].shape == (2**1,)
 
-    def test_mix_meas(self, device):
+    def test_mix_meas(self, device, shots):
         """Return multiple different measurements."""
         n_wires = 2
         dev = device(n_wires)
@@ -124,7 +124,7 @@ class TestIntegrationMultipleReturns:
                 qp.expval(qp.Y(1)),
             )
 
-        qnode = qp.QNode(circuit, dev, diff_method=None)
+        qnode = qp.QNode(circuit, dev, shots=shots, diff_method=None)
         res = qnode(0.5)
 
         assert isinstance(res, tuple)

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -53,12 +53,12 @@ def check_op_supported(op, dev):
 class TestTemplates:  # pylint:disable=too-many-public-methods
     """Test various templates."""
 
-    def test_AQFT(self, device, tol):
+    def test_AQFT(self, device, tol, shots):
         """Test the AQFT template."""
         wires = 3
         dev = device(wires=wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit_aqft():
             qp.X(0)
             qp.Hadamard(1)
@@ -66,9 +66,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
             return qp.probs()
 
         expected = [0.25, 0.125, 0.0, 0.125, 0.25, 0.125, 0.0, 0.125]
-        assert np.allclose(circuit_aqft(), expected, atol=tol(dev.shots))
+        assert np.allclose(circuit_aqft(), expected, atol=tol)
 
-    def test_AllSinglesDoubles(self, device, tol):
+    def test_AllSinglesDoubles(self, device, tol, shots):
         """Test the AllSinglesDoubles template."""
         qubits = 4
         dev = device(qubits)
@@ -83,7 +83,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         wires = range(qubits)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights, hf_state, singles, doubles):
             qp.AllSinglesDoubles(weights, wires, hf_state, singles, doubles)
             return qp.expval(qp.Z(0))
@@ -91,27 +91,27 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         # Evaluate the QNode for a given set of parameters
         params = np.array([0.12, 1.23, 2.34])
         res = circuit(params, hf_state, singles=singles, doubles=doubles)
-        assert np.isclose(res, 0.6905612772956113, atol=tol(dev.shots))
+        assert np.isclose(res, 0.6905612772956113, atol=tol)
 
-    def test_AmplitudeEmbedding(self, device, tol):
+    def test_AmplitudeEmbedding(self, device, tol, shots):
         """Test the AmplitudeEmbedding template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(f):
             qp.AmplitudeEmbedding(features=f, wires=range(2))
             return qp.probs()
 
         res = circuit([1 / 2] * 4)
         expected = [1 / 4] * 4
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_AngleEmbedding(self, device, tol):
+    def test_AngleEmbedding(self, device, tol, shots):
         """Test the AngleEmbedding template."""
         n_wires = 3
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(feature_vector):
             qp.AngleEmbedding(features=feature_vector, wires=range(n_wires), rotation="X")
             qp.Hadamard(0)
@@ -120,9 +120,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         x = [np.pi / 2] * 3
         res = circuit(x)
         expected = [0.125] * 8
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_ApproxTimeEvolution(self, device, tol):
+    def test_ApproxTimeEvolution(self, device, tol, shots):
         """Test the ApproxTimeEvolution template."""
         n_wires = 2
         dev = device(n_wires)
@@ -132,20 +132,20 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         obs = [qp.X(0), qp.X(1)]
         hamiltonian = qp.Hamiltonian(coeffs, obs)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(time):
             qp.ApproxTimeEvolution(hamiltonian, time, 1)
             return [qp.expval(qp.Z(i)) for i in wires]
 
         res = circuit(1)
         expected = [-0.41614684, -0.41614684]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_ArbitraryStatePreparation(self, device, tol):
+    def test_ArbitraryStatePreparation(self, device, tol, shots):
         """Test the ArbitraryStatePreparation template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.ArbitraryStatePreparation(weights, wires=[0, 1])
             return qp.probs()
@@ -153,13 +153,13 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         weights = np.arange(1, 7) / 10
         res = circuit(weights)
         expected = [0.784760658335564, 0.0693785880617069, 0.00158392607496555, 0.1442768275277600]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_ArbitraryUnitary(self, device, tol):
+    def test_ArbitraryUnitary(self, device, tol, shots):
         """Test the ArbitraryUnitary template."""
         dev = device(1)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.ArbitraryUnitary(weights, wires=[0])
             return qp.probs()
@@ -167,14 +167,14 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         weights = np.arange(3)
         res = circuit(weights)
         expected = [0.77015115293406, 0.22984884706593]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_BasicEntanglerLayers(self, device, tol):
+    def test_BasicEntanglerLayers(self, device, tol, shots):
         """Test the BasicEntanglerLayers template."""
         n_wires = 3
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.BasicEntanglerLayers(weights=weights, wires=range(n_wires))
             return [qp.expval(qp.Z(i)) for i in range(n_wires)]
@@ -182,13 +182,13 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         params = [[np.pi, np.pi, np.pi]]
         res = circuit(params)
         expected = [1.0, 1.0, -1.0]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_BasisEmbedding(self, device, tol):
+    def test_BasisEmbedding(self, device, tol, shots):
         """Test the BasisEmbedding template."""
         dev = device(3)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(basis):
             qp.BasisEmbedding(basis, wires=range(3))
             return qp.probs()
@@ -199,9 +199,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         basis_idx = np.dot(basis, 2 ** np.arange(3))
         expected = np.zeros(8)
         expected[basis_idx] = 1.0
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_BasisRotation(self, device, tol):
+    def test_BasisRotation(self, device, tol, shots):
         """Test the BasisRotation template."""
         dev = device(2)
         if dev.shots or "mixed" in dev.name or "Mixed" in dev.name:
@@ -216,7 +216,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         eigen_values = np.array([-1.45183325, 3.47550075])
         exp_state = np.array([0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, -0.43754907 - 0.89919453j])
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.PauliX(0)
             qp.PauliX(1)
@@ -226,16 +226,14 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
             qp.BasisRotation(wires=[0, 1], unitary_matrix=unitary_matrix)
             return qp.state()
 
-        assert np.allclose(
-            [math.fidelity_statevector(circuit(), exp_state)], [1.0], atol=tol(dev.shots)
-        )
+        assert np.allclose([math.fidelity_statevector(circuit(), exp_state)], [1.0], atol=tol)
 
     @pytest.mark.xfail(reason="most devices do not support CV")
-    def test_CVNeuralNetLayers(self, device):
+    def test_CVNeuralNetLayers(self, device, shots):
         """Test the CVNeuralNetLayers template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.CVNeuralNetLayers(*weights, wires=[0, 1])
             return qp.expval(qp.QuadX(0))
@@ -245,7 +243,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         circuit(weights)
 
-    def test_CommutingEvolution(self, device, tol):
+    def test_CommutingEvolution(self, device, tol, shots):
         """Test the CommutingEvolution template."""
         n_wires = 2
         dev = device(n_wires)
@@ -254,7 +252,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         hamiltonian = qp.Hamiltonian(coeffs, obs)
         frequencies = (2, 4)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(time):
             qp.X(0)
             qp.CommutingEvolution(hamiltonian, time, frequencies)
@@ -262,13 +260,13 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(1)
         expected = 0.6536436208636115
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_ControlledSequence(self, device, tol):
+    def test_ControlledSequence(self, device, tol, shots):
         """Test the ControlledSequence template."""
         dev = device(4)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             for i in range(3):
                 qp.Hadamard(wires=i)
@@ -287,27 +285,27 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
             0.00729619,
             0.02637178,
         ]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_CosineWindow(self, device, tol):
+    def test_CosineWindow(self, device, tol, shots):
         """Test the CosineWindow template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.CosineWindow(wires=range(2))
             return qp.probs()
 
         res = circuit()
         expected = [0.0, 0.25, 0.5, 0.25]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.xfail(reason="most devices do not support CV")
-    def test_DisplacementEmbedding(self, device, tol):
+    def test_DisplacementEmbedding(self, device, tol, shots):
         """Test the DisplacementEmbedding template."""
         dev = device(3)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(feature_vector):
             qp.DisplacementEmbedding(features=feature_vector, wires=range(3))
             qp.QuadraticPhase(0.1, wires=1)
@@ -317,46 +315,46 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(X)
         expected = 4.1215690638748494
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_FermionicDoubleExcitation(self, device, tol):
+    def test_FermionicDoubleExcitation(self, device, tol, shots):
         """Test the FermionicDoubleExcitation template."""
         dev = device(5)
         if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weight, wires1=None, wires2=None):
             qp.FermionicDoubleExcitation(weight, wires1=wires1, wires2=wires2)
             return qp.expval(qp.Z(0))
 
         res = circuit(1.34817, wires1=[0, 1], wires2=[2, 3, 4])
         expected = 1.0
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_FermionicSingleExcitation(self, device, tol):
+    def test_FermionicSingleExcitation(self, device, tol, shots):
         """Test the FermionicSingleExcitation template."""
         dev = device(3)
         if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weight, wires=None):
             qp.FermionicSingleExcitation(weight, wires=wires)
             return qp.expval(qp.Z(0))
 
         res = circuit(0.56, wires=[0, 1, 2])
         expected = 1.0
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_FlipSign(self, device, tol):
+    def test_FlipSign(self, device, tol, shots):
         """Test the FlipSign template."""
         dev = device(2)
         if dev.shots:
             pytest.skip("test only works with analytic-mode simulations")
         basis_state = [1, 0]
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             for wire in list(range(2)):
                 qp.Hadamard(wires=wire)
@@ -367,9 +365,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         expected = [0.5, 0.5, -0.5, 0.5]
         if "mixed" in dev.name or "Mixed" in dev.name:
             expected = math.dm_from_state_vector(expected)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_GroverOperator(self, device, tol):
+    def test_GroverOperator(self, device, tol, shots):
         """Test the GroverOperator template."""
         n_wires = 3
         dev = device(n_wires)
@@ -380,7 +378,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
             qp.Toffoli(wires=wires)
             qp.Hadamard(wires[-1])
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(num_iterations=1):
             for wire in wires:
                 qp.Hadamard(wire)
@@ -401,16 +399,16 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
             0.0078125,
             0.9453125,
         ]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_HilbertSchmidt(self, device, tol):
+    def test_HilbertSchmidt(self, device, tol, shots):
         """Test the HilbertSchmidt template."""
         dev = device(2)
 
         V = qp.RZ(0, wires=1)
         U = qp.Hadamard(0)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def hilbert_test(V, U):
             qp.HilbertSchmidt(V, U)
             return qp.probs()
@@ -421,27 +419,27 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = cost_hst(V, U)
         expected = 1.0
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_IQPEmbedding(self, device, tol):
+    def test_IQPEmbedding(self, device, tol, shots):
         """Test the IQPEmbedding template."""
         dev = device(3)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(features):
             qp.IQPEmbedding(features, wires=range(3), n_repeats=4)
             return [qp.expval(qp.Z(w)) for w in range(3)]
 
         res = circuit([1.0, 2.0, 3.0])
         expected = [0.40712208, 0.32709118, 0.89125407]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.xfail(reason="most devices do not support CV")
-    def test_Interferometer(self, device):
+    def test_Interferometer(self, device, shots):
         """Test the Interferometer template."""
         dev = device(4)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(params):
             qp.Interferometer(*params, wires=range(4))
             return qp.expval(qp.Identity(0))
@@ -453,7 +451,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         _ = circuit(params)
 
-    def test_LocalHilbertSchmidt(self, device, tol):
+    def test_LocalHilbertSchmidt(self, device, tol, shots):
         """Test the LocalHilbertSchmidt template."""
         dev = device(4)
 
@@ -468,7 +466,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
                 qp.CNOT(wires=[2, 3]),
             ]
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def local_hilbert_test(V, U):
             qp.LocalHilbertSchmidt(V, U)
             return qp.probs()
@@ -481,9 +479,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         V = V_function(v_params)
         res = cost_lhst(V, U)
         expected = 0.5
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_MERA(self, device, tol):
+    def test_MERA(self, device, tol, shots):
         """Test the MERA template."""
 
         def block(weights, wires):
@@ -498,16 +496,16 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         template_weights = [[0.1, -0.3]] * n_blocks
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(template_weights):
             qp.MERA(range(n_wires), n_block_wires, block, n_params_block, template_weights)
             return qp.expval(qp.Z(1))
 
         res = circuit(template_weights)
         expected = 0.799260896638786
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_MPS(self, device, tol):
+    def test_MPS(self, device, tol, shots):
         """Test the MPS template."""
 
         def block(weights, wires):
@@ -522,20 +520,20 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         template_weights = [[0.1, -0.3]] * n_blocks
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(template_weights):
             qp.MPS(range(n_wires), n_block_wires, block, n_params_block, template_weights)
             return qp.expval(qp.Z(n_wires - 1))
 
         res = circuit(template_weights)
         expected = 0.8719048589118708
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_MottonenStatePreparation_probs(self, device, tol):
+    def test_MottonenStatePreparation_probs(self, device, tol, shots):
         """Test the MottonenStatePreparation template (up to a phase)."""
         dev = device(3)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.MottonenStatePreparation(state_vector=state, wires=range(3))
             return qp.probs()
@@ -544,15 +542,15 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         state = state / np.linalg.norm(state)
         res = circuit(state)
         expected = np.abs(state**2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_MottonenStatePreparation_state(self, device, tol):
+    def test_MottonenStatePreparation_state(self, device, tol, shots):
         """Test the MottonenStatePreparation template on analytic-mode devices."""
         dev = device(3)
         if dev.shots:
             pytest.skip("test only works with analytic-mode simulations")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.MottonenStatePreparation(state_vector=state, wires=range(3))
             return qp.state()
@@ -563,7 +561,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         expected = state
         if "mixed" in dev.name or "Mixed" in dev.name:
             expected = math.dm_from_state_vector(expected)
-        if np.allclose(res, expected, atol=tol(dev.shots)):
+        if np.allclose(res, expected, atol=tol):
             # GlobalPhase supported
             return
         # GlobalPhase not supported
@@ -571,11 +569,11 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         global_phase = np.exp(-1j * global_phase)
         assert np.allclose(expected / res, global_phase)
 
-    def test_Permute(self, device, tol):
+    def test_Permute(self, device, tol, shots):
         """Test the Permute template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep([1 / np.sqrt(2), 0.4, 0.5, 0.3], wires=[0, 1])
             qp.Permute([1, 0], [0, 1])
@@ -583,13 +581,13 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit()
         expected = [0.5, 0.25, 0.16, 0.09]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_QAOAEmbedding(self, device, tol):
+    def test_QAOAEmbedding(self, device, tol, shots):
         """Test the QAOAEmbedding template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights, f=None):
             qp.QAOAEmbedding(features=f, weights=weights, wires=range(2))
             return qp.expval(qp.Z(0))
@@ -601,16 +599,16 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(weights, f=features)
         expected = 0.49628561029741747
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_QDrift(self, device, tol):
+    def test_QDrift(self, device, tol, shots):
         """Test the QDrift template."""
         dev = device(2)
         coeffs = [0.25, 0.75]
         ops = [qp.X(0), qp.Z(0)]
         H = qp.dot(coeffs, ops)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.Hadamard(0)
             qp.QDrift(H, time=1.2, n=10, seed=10)
@@ -618,14 +616,14 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit()
         expected = [0.65379493, 0.0, 0.34620507, 0.0]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_QFT(self, device, tol):
+    def test_QFT(self, device, tol, shots):
         """Test the QFT template."""
         wires = 3
         dev = device(wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit_qft(state):
             qp.StatePrep(state, wires=range(wires))
             qp.QFT(wires=range(wires))
@@ -633,9 +631,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit_qft([0.8, 0.6] + [0.0] * 6)
         expected = [0.245, 0.20985281, 0.125, 0.04014719, 0.005, 0.04014719, 0.125, 0.20985281]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_QSVT(self, device, tol):
+    def test_QSVT(self, device, tol, shots):
         """Test the QSVT template."""
         dev = device(2)
         A = np.array([[0.1]])
@@ -643,16 +641,16 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         check_op_supported(block_encode, dev)
         shifts = [qp.PCPhase(i + 0.1, dim=1, wires=[0, 1]) for i in range(3)]
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.QSVT(block_encode, shifts)
             return qp.expval(qp.Z(1))
 
         res = circuit()
         expected = 0.9370953557566887
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_QuantumMonteCarlo(self, device, tol):
+    def test_QuantumMonteCarlo(self, device, tol, shots):
         """Test the QuantumMonteCarlo template."""
         m = 2
         M = 2**m
@@ -674,7 +672,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         dev = device(wires=n + m + 1)
         check_op_supported(qp.ControlledQubitUnitary(np.eye(2), wires=[1, 0]), dev)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.QuantumMonteCarlo(
                 probs,
@@ -688,9 +686,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         phase_estimated = np.argmax(circuit()[: int(N / 2)]) / N
         res = (1 - np.cos(np.pi * phase_estimated)) / 2
         expected = 0.3086582838174551
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_QuantumPhaseEstimation(self, device, tol):
+    def test_QuantumPhaseEstimation(self, device, tol, shots):
         """Test the QuantumPhaseEstimation template."""
         unitary = qp.RX(np.pi / 2, wires=[0]) @ qp.CNOT(wires=[0, 1])
         eigenvector = np.array([-1 / 2, -1 / 2, 1 / 2, 1 / 2])
@@ -701,7 +699,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         dev = device(wires=n_estimation_wires + 2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.StatePrep(eigenvector, wires=target_wires)
             qp.QuantumPhaseEstimation(
@@ -712,15 +710,15 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = np.argmax(circuit()) / 2**n_estimation_wires
         expected = 0.125
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_QutritBasisStatePreparation(self, device, tol):
+    def test_QutritBasisStatePreparation(self, device, tol, shots):
         """Test the QutritBasisStatePreparation template."""
         dev = device(4)
         if "qutrit" not in dev.name:
             pytest.skip("QutritBasisState template only works on qutrit devices")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(basis_state, obs):
             qp.QutritBasisStatePreparation(basis_state, wires=range(4))
             return [qp.expval(qp.THermitian(obs, wires=i)) for i in range(4)]
@@ -730,30 +728,30 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(basis_state, obs)
         expected = np.array([1, -1, -1, 1]) / np.sqrt(2)
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_RandomLayers(self, device, tol):
+    def test_RandomLayers(self, device, tol, shots):
         """Test the RandomLayers template."""
         dev = device(2)
         weights = np.array([[0.1, -2.1, 1.4]])
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.RandomLayers(weights=weights, wires=range(2), seed=42)
             return qp.expval(qp.Z(0))
 
         res = circuit(weights)
         expected = 0.9950041652780259
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_Select(self, device, tol):
+    def test_Select(self, device, tol, shots):
         """Test the Select template."""
         dev = device(4)
         check_op_supported(qp.MultiControlledX(wires=[0, 1, 2]), dev)
 
         ops = [qp.X(2), qp.X(3), qp.Y(2), qp.SWAP([2, 3])]
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.Select(ops, control=[0, 1])
             return qp.probs()
@@ -761,14 +759,14 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         res = circuit()
         expected = np.zeros(16)
         expected[2] = 1.0
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_SimplifiedTwoDesign(self, device, tol):
+    def test_SimplifiedTwoDesign(self, device, tol, shots):
         """Test the SimplifiedTwoDesign template."""
         n_wires = 3
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(init_weights, weights):
             qp.SimplifiedTwoDesign(
                 initial_layer_weights=init_weights, weights=weights, wires=range(n_wires)
@@ -782,14 +780,14 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(init_weights, weights)
         expected = [1.0, -1.0, 1.0]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
     @pytest.mark.xfail(reason="most devices do not support CV")
-    def test_SqueezingEmbedding(self, device, tol):
+    def test_SqueezingEmbedding(self, device, tol, shots):
         """Test the SqueezingEmbedding template."""
         dev = device(2)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(feature_vector):
             qp.SqueezingEmbedding(features=feature_vector, wires=range(3))
             qp.QuadraticPhase(0.1, wires=1)
@@ -799,13 +797,13 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit(X)
         expected = 13.018280763205285
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_StronglyEntanglingLayers(self, device, tol):
+    def test_StronglyEntanglingLayers(self, device, tol, shots):
         """Test the StronglyEntanglingLayers template."""
         dev = device(4)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(parameters):
             qp.StronglyEntanglingLayers(weights=parameters, wires=range(4))
             return qp.expval(qp.Z(0))
@@ -814,9 +812,9 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         params = np.arange(1, np.prod(shape) + 1).reshape(shape) / 10
         res = circuit(params)
         expected = -0.07273693957824906
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_TTN(self, device, tol):
+    def test_TTN(self, device, tol, shots):
         """Test the TTN template."""
 
         def block(weights, wires):
@@ -831,23 +829,23 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         template_weights = [[0.1, -0.3]] * n_blocks
         dev = device(n_wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(template_weights):
             qp.TTN(range(n_wires), n_block_wires, block, n_params_block, template_weights)
             return qp.expval(qp.Z(n_wires - 1))
 
         res = circuit(template_weights)
         expected = 0.7845726663667097
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_TrotterProduct(self, device, tol):
+    def test_TrotterProduct(self, device, tol, shots):
         """Test the TrotterProduct template."""
         dev = device(2)
         coeffs = [0.25, 0.75]
         ops = [qp.X(0), qp.Z(0)]
         H = qp.dot(coeffs, ops)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit():
             qp.Hadamard(0)
             qp.TrotterProduct(H, time=2.4, order=2)
@@ -855,16 +853,16 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
 
         res = circuit()
         expected = [0.37506708, 0.0, 0.62493292, 0.0]
-        assert np.allclose(res, expected, atol=tol(dev.shots))
+        assert np.allclose(res, expected, atol=tol)
 
-    def test_TwoLocalSwapNetwork(self, device, tol):
+    def test_TwoLocalSwapNetwork(self, device, tol, shots):
         """Test the TwoLocalSwapNetwork template."""
         dev = device(3)
 
         def acquaintances(index, wires, param=None):  # pylint:disable=unused-argument
             return qp.CNOT(index)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(state):
             qp.StatePrep(state, range(3))
             qp.TwoLocalSwapNetwork(dev.wires, acquaintances, fermionic=True, shift=False)
@@ -875,7 +873,6 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
         probs = state**2
         res = circuit(state)
         order = np.argsort(np.argsort(res))
-        tol = tol(dev.shots)
         assert np.allclose(res, probs[order], atol=tol)
 
 
@@ -891,14 +888,14 @@ class TestMoleculeTemplates:
         ref_state = qp.qchem.hf_state(electrons, qubits)
         return qubits, ref_state, h
 
-    def test_GateFabric(self, device, tol, h2):
+    def test_GateFabric(self, device, tol, h2, shots):
         """Test the GateFabric template."""
         qubits, ref_state, H = h2
         dev = device(qubits)
         if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.GateFabric(weights, wires=[0, 1, 2, 3], init_state=ref_state, include_pi=True)
             return qp.expval(H)
@@ -908,15 +905,15 @@ class TestMoleculeTemplates:
         weights = np.array([0.1, 0.2, 0.3, 0.4]).reshape(shape)
         res = circuit(weights)
         expected = -0.9453094224618628
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_ParticleConservingU1(self, device, tol, h2):
+    def test_ParticleConservingU1(self, device, tol, h2, shots):
         """Test the ParticleConservingU1 template."""
         qubits, ref_state, h = h2
         dev = device(qubits)
         ansatz = partial(qp.ParticleConservingU1, init_state=ref_state, wires=dev.wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(params):
             ansatz(params)
             return qp.expval(h)
@@ -926,15 +923,15 @@ class TestMoleculeTemplates:
         params = np.arange(1, 13).reshape(shape) / 10
         res = circuit(params)
         expected = -0.5669084184194393
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_ParticleConservingU2(self, device, tol, h2):
+    def test_ParticleConservingU2(self, device, tol, h2, shots):
         """Test the ParticleConservingU2 template."""
         qubits, ref_state, h = h2
         dev = device(qubits)
         ansatz = partial(qp.ParticleConservingU2, init_state=ref_state, wires=dev.wires)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(params):
             ansatz(params)
             return qp.expval(h)
@@ -944,9 +941,9 @@ class TestMoleculeTemplates:
         params = np.arange(1, 8).reshape(shape) / 10
         res = circuit(params)
         expected = -0.8521967086461301
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_UCCSD(self, device, tol, h2):
+    def test_UCCSD(self, device, tol, h2, shots):
         """Test the UCCSD template."""
         qubits, hf_state, H = h2
         electrons = 2
@@ -954,7 +951,7 @@ class TestMoleculeTemplates:
         s_wires, d_wires = qp.qchem.excitations_to_wires(singles, doubles)
         dev = device(qubits)
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(params, wires, s_wires, d_wires, hf_state):
             qp.UCCSD(params, wires, s_wires, d_wires, hf_state)
             return qp.expval(H)
@@ -964,16 +961,16 @@ class TestMoleculeTemplates:
             params, wires=range(qubits), s_wires=s_wires, d_wires=d_wires, hf_state=hf_state
         )
         expected = -1.0864433121798176
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)
 
-    def test_kUpCCGSD(self, device, tol, h2):
+    def test_kUpCCGSD(self, device, tol, h2, shots):
         """Test the kUpCCGSD template."""
         qubits, ref_state, H = h2
         dev = device(qubits)
         if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
-        @qp.qnode(dev)
+        @qp.qnode(dev, shots=shots)
         def circuit(weights):
             qp.kUpCCGSD(weights, wires=[0, 1, 2, 3], k=1, delta_sz=0, init_state=ref_state)
             return qp.expval(H)
@@ -983,4 +980,4 @@ class TestMoleculeTemplates:
         weights = np.arange(np.prod(shape)).reshape(shape) / 10
         res = circuit(weights)
         expected = -1.072648130451027
-        assert np.isclose(res, expected, atol=tol(dev.shots))
+        assert np.isclose(res, expected, atol=tol)

--- a/pennylane/devices/tests/test_templates.py
+++ b/pennylane/devices/tests/test_templates.py
@@ -204,7 +204,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
     def test_BasisRotation(self, device, tol, shots):
         """Test the BasisRotation template."""
         dev = device(2)
-        if dev.shots or "mixed" in dev.name or "Mixed" in dev.name:
+        if shots or "mixed" in dev.name or "Mixed" in dev.name:
             pytest.skip("test only works with analytic-mode pure statevector simulators")
 
         unitary_matrix = np.array(
@@ -320,7 +320,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
     def test_FermionicDoubleExcitation(self, device, tol, shots):
         """Test the FermionicDoubleExcitation template."""
         dev = device(5)
-        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
+        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
         @qp.qnode(dev, shots=shots)
@@ -335,7 +335,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
     def test_FermionicSingleExcitation(self, device, tol, shots):
         """Test the FermionicSingleExcitation template."""
         dev = device(3)
-        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
+        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
         @qp.qnode(dev, shots=shots)
@@ -350,7 +350,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
     def test_FlipSign(self, device, tol, shots):
         """Test the FlipSign template."""
         dev = device(2)
-        if dev.shots:
+        if shots:
             pytest.skip("test only works with analytic-mode simulations")
         basis_state = [1, 0]
 
@@ -547,7 +547,7 @@ class TestTemplates:  # pylint:disable=too-many-public-methods
     def test_MottonenStatePreparation_state(self, device, tol, shots):
         """Test the MottonenStatePreparation template on analytic-mode devices."""
         dev = device(3)
-        if dev.shots:
+        if shots:
             pytest.skip("test only works with analytic-mode simulations")
 
         @qp.qnode(dev, shots=shots)
@@ -892,7 +892,7 @@ class TestMoleculeTemplates:
         """Test the GateFabric template."""
         qubits, ref_state, H = h2
         dev = device(qubits)
-        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
+        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
         @qp.qnode(dev, shots=shots)
@@ -967,7 +967,7 @@ class TestMoleculeTemplates:
         """Test the kUpCCGSD template."""
         qubits, ref_state, H = h2
         dev = device(qubits)
-        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and dev.shots:
+        if getattr(dev, "short_name", None) == "cirq.mixedsimulator" and shots:
             pytest.xfail(reason="device is generating negative probabilities")
 
         @qp.qnode(dev, shots=shots)

--- a/pennylane/devices/tests/test_tracker.py
+++ b/pennylane/devices/tests/test_tracker.py
@@ -36,7 +36,7 @@ class TestTracker:
 
         assert isinstance(dev.tracker, qp.Tracker)
 
-    def test_tracker_updated_in_execution_mode(self, device):
+    def test_tracker_updated_in_execution_mode(self, device, shots):
         """Tests that device update and records during tracking mode"""
 
         dev = device(1)
@@ -46,7 +46,7 @@ class TestTracker:
         ):
             pytest.skip("Device does not support a tracker")
 
-        @qp.qnode(dev, diff_method="parameter-shift")
+        @qp.qnode(dev, shots=shots, diff_method="parameter-shift")
         def circ():
             return qp.expval(qp.X(0))
 

--- a/pennylane/devices/tests/test_wires.py
+++ b/pennylane/devices/tests/test_wires.py
@@ -22,12 +22,12 @@ from pennylane import numpy as np
 # ===== Factories for circuits using arbitrary wire labels and numbers
 
 
-def make_simple_circuit_expval(device, wires):
+def make_simple_circuit_expval(device, wires, shots):
     """Factory for a qnode returning expvals."""
 
     n_wires = len(wires)
 
-    @qp.qnode(device)
+    @qp.qnode(device, shots=shots)
     def circuit():
         qp.RX(0.5, wires=wires[0 % n_wires])
         qp.RY(2.0, wires=wires[1 % n_wires])
@@ -57,13 +57,13 @@ class TestWiresIntegration:
     )
     @pytest.mark.parametrize("circuit_factory", [make_simple_circuit_expval])
     def test_wires_expval(
-        self, device, circuit_factory, wires1, wires2, tol
+        self, device, circuit_factory, wires1, wires2, shots, tol
     ):  # pylint: disable=too-many-arguments
         """Test that the expectation of a circuit is independent from the wire labels used."""
         dev1 = device(wires1)
         dev2 = device(wires2)
 
-        circuit1 = circuit_factory(dev1, wires1)
-        circuit2 = circuit_factory(dev2, wires2)
+        circuit1 = circuit_factory(dev1, wires1, shots)
+        circuit2 = circuit_factory(dev2, wires2, shots)
 
-        assert np.allclose(circuit1(), circuit2(), atol=tol(dev1.shots))
+        assert np.allclose(circuit1(), circuit2(), atol=tol)


### PR DESCRIPTION
**Context:**

While we deprecated setting shots on the device quite some time ago, we totally forgot about the pl-device-test .  It has been continueing to set shots on the device, instead of the QNode.  This fixes that.

Note that I tried out using Cursor to make these context-sensitive find-replaces.  Seems to have worked fairly decently.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related ShortCut Stories:** [sc-101299] [sc-120032]
