### PR TITLE
docs: remove impossible postselection examples

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -178,6 +178,10 @@
 * References to TensorFlow integration have been removed from the documentation following the end of maintenance support as of PennyLane v0.44.
   [(#9486)](https://github.com/PennyLaneAI/pennylane/pull/9486)
 
+* The :func:`~.measure` docstring no longer includes runnable examples that postselect on
+  outcomes with zero probability.
+  [(#9509)](https://github.com/PennyLaneAI/pennylane/pull/9509)
+
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug in `MPSPrep` where passing `work_wires` as a NumPy array or an integer caused initialization errors.
@@ -218,6 +222,7 @@ Guillermo Alonso,
 Astral Cai,
 Daniel Casota,
 Yushao Chen,
+Puneet Dixit,
 Marcus Edwards,
 Christina Lee,
 Anton Naim Ibrahim,

--- a/pennylane/ops/mid_measure/mid_measure.py
+++ b/pennylane/ops/mid_measure/mid_measure.py
@@ -323,38 +323,11 @@ def measure(
         Note that less than 10 samples are returned. This is because samples that do not meet the postselection criteria are
         thrown away.
 
-        If postselection is requested on a state with zero probability of being measured, the result may contain ``NaN``
-        or ``Inf`` values:
-
-        .. code-block:: python
-
-            dev = qp.device("default.qubit")
-
-            @qp.qnode(dev)
-            def func(x):
-                qp.RX(x, wires=0)
-                m0 = qp.measure(0, postselect=1)
-                qp.cond(m0, qp.X)(wires=1)
-                return qp.probs(wires=1)
-
-        >>> func(0.0)
-        array([nan, nan])
-
-        In the case of ``qp.sample`` and `mcm_method="deferred"`, an empty array will be returned:
-
-        .. code-block:: python
-
-            dev = qp.device("default.qubit")
-
-            @qp.qnode(dev, mcm_method="deferred")
-            def func(x):
-                qp.RX(x, wires=0)
-                m0 = qp.measure(0, postselect=1)
-                qp.cond(m0, qp.X)(wires=1)
-                return qp.sample(wires=[0, 1])
-
-        >>> qp.set_shots(func, shots=[10, 10])(0.0)
-        (array([], shape=(0, 2), dtype=int64), array([], shape=(0, 2), dtype=int64))
+        Avoid postselecting on a state with zero probability of being measured. Depending on the
+        execution method and measurement type, this may raise an error, return ``NaN`` or ``Inf``
+        values, or leave no valid samples after postselection. Use an input state that gives the
+        postselected outcome nonzero probability when writing examples or validating postselected
+        circuits.
 
         .. note::
 


### PR DESCRIPTION
**Context:**

Fixes #8480.

The `qml.measure` docstring included runnable examples that postselected on an outcome with zero probability. Those examples currently produce invalid outputs such as empty samples, which makes them poor examples for users and documentation checks.

**Description of the Change:**

This removes the runnable zero-probability postselection examples from the `qml.measure` docstring and replaces them with a short warning to avoid impossible postselection outcomes in examples and validation code.

The earlier nonzero-probability postselection example is kept.

**Benefits:**

The public `qml.measure` documentation no longer presents a failing impossible-postselection case as an example to run.

**Possible Drawbacks:**

This is documentation-only; it does not change runtime behavior for zero-probability postselection.

**Related GitHub Issues:**

Fixes #8480.

**Validation:**

- `git diff --check`
- `uv run --no-dev python -m compileall -q pennylane/ops/mid_measure/mid_measure.py`
- `uv run --group dev black --check pennylane/ops/mid_measure/mid_measure.py`
- Manually ran the remaining nonzero-probability `qml.measure(..., postselect=1)` sample path.

I also tried `uv run --group dev python -m pytest --doctest-modules pennylane/ops/mid_measure/mid_measure.py -q`; it still fails before the changed section because an earlier existing doctest example references `np` without doctest setup.

Assisted-by: OpenAI GPT-5
