### PR TITLE
Fix bad error import locations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -144,6 +144,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.
+  [(#9512)](https://github.com/PennyLaneAI/pennylane/pull/9512)
 
 * Documentation testing workflow now raises `PennyLaneDeprecationWarning` as errors.
   [(#9475)](https://github.com/PennyLaneAI/pennylane/pull/9475)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -143,6 +143,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.
+
 * Documentation testing workflow now raises `PennyLaneDeprecationWarning` as errors.
   [(#9475)](https://github.com/PennyLaneAI/pennylane/pull/9475)
 

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from pennylane import capture, math, ops
 from pennylane.decomposition.gate_set import GateSet
-from pennylane.exceptions import DeviceError
+from pennylane.exceptions import DecompositionUndefinedError, DeviceError
 from pennylane.logging import debug_logger, debug_logger_init
 from pennylane.measurements import (
     ClassicalShadowMP,
@@ -41,7 +41,6 @@ from pennylane.measurements import (
     StateMeasurement,
     StateMP,
 )
-from pennylane.operation import DecompositionUndefinedError
 from pennylane.ops import MidMeasure
 from pennylane.ops.op_math import Conditional
 from pennylane.tape import QuantumScript, QuantumScriptBatch, QuantumScriptOrBatch

--- a/pennylane/measurements/process_samples.py
+++ b/pennylane/measurements/process_samples.py
@@ -16,7 +16,7 @@
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import EigvalsUndefinedError
+from pennylane.exceptions import EigvalsUndefinedError
 from pennylane.ops import MeasurementValue
 from pennylane.typing import Sequence, TensorLike
 from pennylane.wires import WiresLike

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -18,7 +18,8 @@ from functools import lru_cache
 from pennylane import math, templates
 from pennylane.decomposition import gate_sets
 from pennylane.devices.preprocess import decompose, null_postprocessing
-from pennylane.operation import DecompositionUndefinedError, Operator
+from pennylane.exceptions import DecompositionUndefinedError
+from pennylane.operation import Operator
 from pennylane.ops.functions import equal
 from pennylane.ops.op_math import Adjoint
 from pennylane.tape import make_qscript

--- a/pennylane/noise/insert_ops.py
+++ b/pennylane/noise/insert_ops.py
@@ -21,7 +21,8 @@ from types import FunctionType
 from pennylane import templates
 from pennylane.decomposition import gate_sets
 from pennylane.devices.preprocess import decompose
-from pennylane.operation import DecompositionUndefinedError, Operation, Operator
+from pennylane.exceptions import DecompositionUndefinedError
+from pennylane.operation import Operation, Operator
 from pennylane.ops.op_math import Adjoint
 from pennylane.tape import QuantumScript, QuantumScriptBatch, make_qscript
 from pennylane.transforms import transform

--- a/pennylane/ops/op_math/change_op_basis.py
+++ b/pennylane/ops/op_math/change_op_basis.py
@@ -27,13 +27,13 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.decomposition.resources import adjoint_resource_rep
-from pennylane.operation import (
+from pennylane.exceptions import (
     DiagGatesUndefinedError,
     EigvalsUndefinedError,
     MatrixUndefinedError,
-    Operator,
     SparseMatrixUndefinedError,
 )
+from pennylane.operation import Operator
 from pennylane.ops.op_math import adjoint, ctrl, prod
 
 from .composite import CompositeOp, handle_recursion_error


### PR DESCRIPTION
**Context:**

While we supposedly moved all our exceptions and imports of exceptions to `pennylane/exceptions` in #7856 , we missed some.

**Description of the Change:**

Fixes import locations.

**Benefits:**

Clearer locations for objects.

**Possible Drawbacks:**

**Related GitHub Issues:**
