### PR TITLE
Print out 20 slowest tests during CI run

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -189,7 +189,7 @@ jobs:
           PYTEST_COVERAGE_ARGS: ${{ inputs.pytest_coverage_flags }}
           PYTEST_PARALLELISE_ARGS: -n auto
           PYTEST_ADDITIONAL_ARGS: ${{ inputs.pytest_additional_args }}
-          PYTEST_DURATIONS_ARGS: ${{ inputs.pytest_durations_file_path != '' && format('--durations-path="{0}" --store-durations --clean-durations', inputs.pytest_durations_file_path) || '' }}
+          PYTEST_DURATIONS_ARGS: --durations=20
           PYTEST_XML_ARGS: ${{ inputs.pytest_xml_file_path != '' && format('--junit-xml="{0}/{1}"', env.TEST_REPORTS_DIR, inputs.pytest_xml_file_path) || '' }}
         run: |
           echo "args=$PYTEST_COVERAGE_ARGS $PYTEST_PARALLELISE_ARGS $PYTEST_ADDITIONAL_ARGS $PYTEST_DURATIONS_ARGS $PYTEST_XML_ARGS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Context:**

Hopefully figure out why runner is taking so long?

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
