### PR TITLE
Add a link to the ArXiv paper for SelectCopyQROM

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -49,6 +49,7 @@
 * Created a new ``~.labs.estimator_beta.SelectCopyQROM`` resource operator which uses an optimal 
   decomposition to estimate the cost for QROM.
   [(#9500)](https://github.com/PennyLaneAI/pennylane/pull/9500)
+  [(#9516)](https://github.com/PennyLaneAI/pennylane/pull/9516)
 
   ```pycon
     >>> import pennylane.labs.estimator_beta as qre

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1530,9 +1530,9 @@ class SelectCopyQROM(ResourceOperator):
             should not be provided and will be determined from this value.
         batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
             loaded in parallel by adding more rows following Figure 1.C of
-            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
         bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-            the number of bits to load per QROM iteration (default value is ``size_bitstring``).
+            the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
         wires (WiresLike | None): The wires the operation acts on (control and target), excluding
             any additional qubits allocated or borrowed during the decomposition (e.g unary
             iteration wires).
@@ -1723,10 +1723,10 @@ class SelectCopyQROM(ResourceOperator):
                   ``bits_per_iter`` should not be provided and will be determined from this value.
                 * batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                   loaded in parallel by adding more rows following Figure 1.C of
-                  `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+                  `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
                 * bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil`
-                  representing the number of bits to load per QROM iteration (default value is
-                  ``size_bitstring``).
+                  representing the number of bits to load per QROM iteration. Default value is
+                  ``size_bitstring``.
         """
 
         return {
@@ -1757,9 +1757,9 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
+                the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
         Returns:
             :class:`~.pennylane.estimator.resource_operator.CompressedResourceOp`: the operator in a compressed representation
         """
@@ -1801,9 +1801,9 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
+                the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
 
         Resources:
             The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.
@@ -1910,9 +1910,9 @@ class SelectCopyQROM(ResourceOperator):
             size_bitstring (int): the length of each bitstring
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
+                the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
 
         Returns:
             list[:class:`~.pennylane.estimator.resource_operator.GateCount`]: A list of ``GateCount`` objects,

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1530,9 +1530,11 @@ class SelectCopyQROM(ResourceOperator):
             should not be provided and will be determined from this value.
         batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
             loaded in parallel by adding more rows following Figure 1.C of
-            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
+            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is used
+            if ``available_dirty_aux`` is not provided and this parameter is None.
         bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-            the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
+            the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is used
+            if ``available_dirty_aux`` is not provided and this parameter is None.
         wires (WiresLike | None): The wires the operation acts on (control and target), excluding
             any additional qubits allocated or borrowed during the decomposition (e.g unary
             iteration wires).
@@ -1723,10 +1725,12 @@ class SelectCopyQROM(ResourceOperator):
                   ``bits_per_iter`` should not be provided and will be determined from this value.
                 * batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                   loaded in parallel by adding more rows following Figure 1.C of
-                  `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
+                  `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
+                  used if ``available_dirty_aux`` is not provided and this parameter is None.
                 * bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil`
-                  representing the number of bits to load per QROM iteration. Default value is
-                  ``size_bitstring``.
+                  representing the number of bits to load per QROM iteration. Default value of
+                  ``size_bitstring`` is used if ``available_dirty_aux`` is not provided and this
+                  parameter is None.
         """
 
         return {
@@ -1757,9 +1761,11 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
+                the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
         Returns:
             :class:`~.pennylane.estimator.resource_operator.CompressedResourceOp`: the operator in a compressed representation
         """
@@ -1801,9 +1807,11 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value is :math:`2`.
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration. Default value is ``size_bitstring``.
+                the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
 
         Resources:
             The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1540,6 +1540,9 @@ class SelectCopyQROM(ResourceOperator):
             any additional qubits allocated or borrowed during the decomposition (e.g unary
             iteration wires).
 
+    Resources:
+        The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.
+
     **Example**
 
     The resources for this operation are computed using:
@@ -1815,6 +1818,9 @@ class SelectCopyQROM(ResourceOperator):
                 the number of bits to load per QROM iteration. If this parameter is provided, then the
                 ``batch_size`` must also be specified, these will be used to determine ``available_dirty_aux``.
 
+        Resources:
+            The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.
+
         Returns:
             list[:class:`~.pennylane.estimator.resource_operator.GateCount`]: A list of ``GateCount`` objects,
             where each object represents a specific quantum gate and the number of times it appears
@@ -2007,6 +2013,10 @@ class SelectCopyQROM(ResourceOperator):
             num_ctrl_wires (int): the number of qubits the operation is controlled on
             num_zero_ctrl (int): the number of control qubits, that are controlled when in the :math:`|0\rangle` state
             target_resource_params (dict): A dictionary containing the resource parameters of the target operator.
+
+        Resources:
+            The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_. Furthermore,
+            we only need to control the ``Select`` subroutines.
 
         Returns:
             list[:class:`~.pennylane.estimator.resource_operator.GateCount`]: A list of ``GateCount`` objects, where each object

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1633,9 +1633,11 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
+                the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
+                used if ``available_dirty_aux`` is not provided and this parameter is None.
 
         Raises:
             ValueError: If ``batch_size`` is not a positive integer power of 2.

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1530,12 +1530,9 @@ class SelectCopyQROM(ResourceOperator):
             should not be provided and will be determined from this value.
         batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
             loaded in parallel by adding more rows following Figure 1.C of
-            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. If this parameter is provided,
-            then the ``bits_per_iter`` must also be specified, these will be used to determine
-            ``available_dirty_aux``.
+            `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
         bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-            the number of bits to load per QROM iteration. If this parameter is provided, then the
-            ``batch_size`` must also be specified, these will be used to determine ``available_dirty_aux``.
+            the number of bits to load per QROM iteration (default value is ``size_bitstring``).
         wires (WiresLike | None): The wires the operation acts on (control and target), excluding
             any additional qubits allocated or borrowed during the decomposition (e.g unary
             iteration wires).
@@ -1634,11 +1631,9 @@ class SelectCopyQROM(ResourceOperator):
                 should not be provided and will be determined from this value.
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
-                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. If this parameter is provided,
-                then the ``bits_per_iter`` must also be specified, these will be used to determine ``available_dirty_aux``.
-            bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing the number
-                of bits to load per QROM iteration. If this parameter is provided, then the ``batch_size`` must also
-                be specified, these will be used to determine ``available_dirty_aux``.
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+            bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
+                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
 
         Raises:
             ValueError: If ``batch_size`` is not a positive integer power of 2.
@@ -1650,7 +1645,7 @@ class SelectCopyQROM(ResourceOperator):
         """
         if available_dirty_aux is None:
             batch_size = batch_size or 2  # default to 2 if None
-            bits_per_iter = bits_per_iter or 1  # default to 1 if None
+            bits_per_iter = bits_per_iter or size_bitstring  # default to size_bitstring if None
 
             exponent = int(math.log2(batch_size))
             if (2**exponent != batch_size) or (batch_size == 1):
@@ -1676,7 +1671,7 @@ class SelectCopyQROM(ResourceOperator):
             if (batch_size is not None) or (bits_per_iter is not None):
                 if (batch_size != new_batch_size) or (bits_per_iter != new_bits_per_iter):
                     raise ValueError(
-                        "The batch_size and bits_per_iter provided are not compatible with the available_dirty_aux. Please only provide either available_dirty_aux or (exclusively) batch_size and bits_per_iter"
+                        "The batch_size and bits_per_iter provided are not compatible with the available_dirty_aux. Please only provide either available_dirty_aux or (exclusively) both batch_size and bits_per_iter"
                     )
 
             batch_size = new_batch_size
@@ -1727,14 +1722,11 @@ class SelectCopyQROM(ResourceOperator):
                   used as parallel loading space. If this parameter is provided, ``batch_size`` and
                   ``bits_per_iter`` should not be provided and will be determined from this value.
                 * batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
-                  loaded in parallel by adding more rows following Figure 1.C of `Low et al. (2024)
-                  <https://arxiv.org/pdf/1812.00954>`_. If this parameter is provided, then the
-                  ``bits_per_iter`` must also be specified, these will be used to determine
-                  ``available_dirty_aux``.
+                  loaded in parallel by adding more rows following Figure 1.C of
+                  `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
                 * bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil`
-                  representing the number of bits to load per QROM iteration. If this parameter is
-                  provided, then the ``batch_size`` must also be specified, these will be used to determine
-                  ``available_dirty_aux``.
+                  representing the number of bits to load per QROM iteration (default value is
+                  ``size_bitstring``).
         """
 
         return {
@@ -1763,14 +1755,11 @@ class SelectCopyQROM(ResourceOperator):
             available_dirty_aux (int | None): The number of available dirty auxiliary qubits to be used
                 as parallel loading space. If this parameter is provided, ``batch_size`` and ``bits_per_iter``
                 should not be provided and will be determined from this value.
-            batch_size (int | None): A parameter :math:`\lambda` that determines if data will be loaded
-                in parallel by adding more rows following Figure 1.C of `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_.
-                If this parameter is provided, then the ``bits_per_iter`` must also be specified,
-                these will be used to determine ``available_dirty_aux``.
+            batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
+                loaded in parallel by adding more rows following Figure 1.C of
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration. If this parameter is provided, then the
-                ``batch_size`` must also be specified, these will be used to determine ``available_dirty_aux``.
-
+                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
         Returns:
             :class:`~.pennylane.estimator.resource_operator.CompressedResourceOp`: the operator in a compressed representation
         """
@@ -1799,8 +1788,8 @@ class SelectCopyQROM(ResourceOperator):
         num_bitstrings: int,
         size_bitstring: int,
         available_dirty_aux: int | None = None,
-        batch_size: int = 2,
-        bits_per_iter: int = 1,
+        batch_size: int | None = None,
+        bits_per_iter: int | None = None,
     ):
         r"""Returns a list of ``GateCount`` objects representing the operator's resources.
 
@@ -1810,13 +1799,11 @@ class SelectCopyQROM(ResourceOperator):
             available_dirty_aux (int | None): The number of available dirty auxiliary qubits to be used
                 as parallel loading space. If this parameter is provided, ``batch_size`` and ``bits_per_iter``
                 should not be provided and will be determined from this value.
-            batch_size (int | None): A parameter :math:`\lambda` that determines if data will be loaded
-                in parallel by adding more rows following Figure 1.C of `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_.
-                If this parameter is provided, then the ``bits_per_iter`` must also be specified,
-                these will be used to determine ``available_dirty_aux``.
+            batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
+                loaded in parallel by adding more rows following Figure 1.C of
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
-                the number of bits to load per QROM iteration. If this parameter is provided, then the
-                ``batch_size`` must also be specified, these will be used to determine ``available_dirty_aux``.
+                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
 
         Resources:
             The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.
@@ -1826,6 +1813,14 @@ class SelectCopyQROM(ResourceOperator):
             where each object represents a specific quantum gate and the number of times it appears
             in the decomposition.
         """
+        batch_size, bits_per_iter = SelectCopyQROM._resolve_params(
+            num_bitstrings,
+            size_bitstring,
+            available_dirty_aux,
+            batch_size,
+            bits_per_iter,
+        )
+
         gate_cost = []
         x = resource_rep(qre.X)
         cnot = resource_rep(qre.CNOT)
@@ -1901,25 +1896,23 @@ class SelectCopyQROM(ResourceOperator):
         return gate_cost
 
     @classmethod
-    def single_ctrl_res_decomp(
+    def _single_ctrl_res_decomp(
         cls,
         num_bitstrings: int,
         size_bitstring: int,
         batch_size: int = 2,
-        bits_per_iter: int = 1,
+        bits_per_iter: int | None = None,
     ):
         r"""Returns a list of ``GateCount`` objects representing the operator's resources.
 
         Args:
             num_bitstrings (int): the number of bitstrings that are to be encoded
             size_bitstring (int): the length of each bitstring
-            batch_size (int): A parameter :math:`\lambda` that determines if data will be loaded in
-                parallel by adding more rows following Figure 1.C of `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_.
-            bits_per_iter: A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing the number
-                of bits to load per QROM iteration.
-            wires (WiresLike | None): The wires the operation acts on (control and target), excluding
-                any additional qubits allocated or borrowed during the decomposition (e.g unary
-                iteration wires).
+            batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
+                loaded in parallel by adding more rows following Figure 1.C of
+                `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_ (default value is 2).
+            bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
+                the number of bits to load per QROM iteration (default value is ``size_bitstring``).
 
         Returns:
             list[:class:`~.pennylane.estimator.resource_operator.GateCount`]: A list of ``GateCount`` objects,
@@ -1930,6 +1923,7 @@ class SelectCopyQROM(ResourceOperator):
         x = resource_rep(qre.X)
         cnot = resource_rep(qre.CNOT)
 
+        bits_per_iter = bits_per_iter or size_bitstring
         num_data_blocks = math.ceil(num_bitstrings / batch_size)
 
         if bits_per_iter == size_bitstring:
@@ -2026,14 +2020,24 @@ class SelectCopyQROM(ResourceOperator):
         num_bitstrings = target_resource_params["num_bitstrings"]
         size_bitstring = target_resource_params["size_bitstring"]
         batch_size = target_resource_params.get("batch_size", 2)
-        bits_per_iter = target_resource_params.get("bits_per_iter", 1)
+        bits_per_iter = target_resource_params.get("bits_per_iter", size_bitstring)
+        available_dirty_aux = target_resource_params.get("available_dirty_aux", None)
+
+        batch_size, bits_per_iter = SelectCopyQROM._resolve_params(
+            num_bitstrings,
+            size_bitstring,
+            available_dirty_aux,
+            batch_size,
+            bits_per_iter,
+        )
+
         gate_cost = []
 
         if num_zero_ctrl:
             x = qre.X.resource_rep()
             gate_cost.append(GateCount(x, 2 * num_zero_ctrl))
 
-        single_ctrl_cost = cls.single_ctrl_res_decomp(
+        single_ctrl_cost = cls._single_ctrl_res_decomp(
             num_bitstrings,
             size_bitstring,
             batch_size,

--- a/pennylane/labs/estimator_beta/templates/subroutines.py
+++ b/pennylane/labs/estimator_beta/templates/subroutines.py
@@ -1531,10 +1531,10 @@ class SelectCopyQROM(ResourceOperator):
         batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
             loaded in parallel by adding more rows following Figure 1.C of
             `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is used
-            if ``available_dirty_aux`` is not provided and this parameter is None.
+            if ``available_dirty_aux`` is not provided and ``batch_size`` is None.
         bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
             the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is used
-            if ``available_dirty_aux`` is not provided and this parameter is None.
+            if ``available_dirty_aux`` is not provided and ``bits_per_iter`` is None.
         wires (WiresLike | None): The wires the operation acts on (control and target), excluding
             any additional qubits allocated or borrowed during the decomposition (e.g unary
             iteration wires).
@@ -1634,10 +1634,10 @@ class SelectCopyQROM(ResourceOperator):
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
                 `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``batch_size`` is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
                 the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``bits_per_iter`` is None.
 
         Raises:
             ValueError: If ``batch_size`` is not a positive integer power of 2.
@@ -1728,11 +1728,11 @@ class SelectCopyQROM(ResourceOperator):
                 * batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                   loaded in parallel by adding more rows following Figure 1.C of
                   `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
-                  used if ``available_dirty_aux`` is not provided and this parameter is None.
+                  used if ``available_dirty_aux`` is not provided and ``batch_size`` is None.
                 * bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil`
                   representing the number of bits to load per QROM iteration. Default value of
-                  ``size_bitstring`` is used if ``available_dirty_aux`` is not provided and this
-                  parameter is None.
+                  ``size_bitstring`` is used if ``available_dirty_aux`` is not provided and ``bits_per_iter``
+                  is None.
         """
 
         return {
@@ -1764,10 +1764,10 @@ class SelectCopyQROM(ResourceOperator):
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
                 `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``batch_size`` is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
                 the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``bits_per_iter`` is None.
         Returns:
             :class:`~.pennylane.estimator.resource_operator.CompressedResourceOp`: the operator in a compressed representation
         """
@@ -1810,10 +1810,10 @@ class SelectCopyQROM(ResourceOperator):
             batch_size (int | None): A parameter :math:`\lambda` that determines if data will be
                 loaded in parallel by adding more rows following Figure 1.C of
                 `Low et al. (2024) <https://arxiv.org/pdf/1812.00954>`_. Default value of :math:`2` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``batch_size`` is None.
             bits_per_iter (int | None): A parameter :math:`\lceil \frac{b}{\alpha} \rceil` representing
                 the number of bits to load per QROM iteration. Default value of ``size_bitstring`` is
-                used if ``available_dirty_aux`` is not provided and this parameter is None.
+                used if ``available_dirty_aux`` is not provided and ``bits_per_iter`` is None.
 
         Resources:
             The resources are derived from `Motlagh, Pocrnic (2026) <https://arxiv.org/abs/2605.20334>`_.

--- a/pennylane/labs/tests/estimator_beta/templates/test_subroutines_labs.py
+++ b/pennylane/labs/tests/estimator_beta/templates/test_subroutines_labs.py
@@ -2408,7 +2408,7 @@ class TestSelectCopyQROM:
                 None,
                 4,
                 None,
-                (4, 1),
+                (4, 2),
             ),
             (
                 100,


### PR DESCRIPTION
**Context:**
Add links to the ArXiv paper for `SelectCopyQROM` in labs. Updated the default value of `bits_per_iter` from 1 to `size_bitstring`. Updated docs and code to reflect the default behaviour.
