### PR TITLE
Informative error message for decomp rule missing resource

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,7 +20,7 @@
   [(#9506)](https://github.com/PennyLaneAI/pennylane/pull/9506)
 
 * A more informative error message is raised when quantum functions without registered resource
-  estimates are passed to the `fixed_decomps` and `alt_decomps` arguments of the :func:`~.decompose` transform.
+  estimates are passed to the `fixed_decomps` and `alt_decomps` arguments of the :func:`~.transforms.decompose` transform.
   [(#9528)](https://github.com/PennyLaneAI/pennylane/pull/9528)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,10 @@
   decomposition.
   [(#9506)](https://github.com/PennyLaneAI/pennylane/pull/9506)
 
+* A more informative error message is raised when quantum functions without registered resource
+  estimates are passed to the `fixed_decomps` and `alt_decomps` arguments of the :func:`~.decompose` transform.
+  [(#9528)](https://github.com/PennyLaneAI/pennylane/pull/9528)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * Created a new ``labs.templates.LeftQuantumComparator`` template for performing inequality test of two quantum registers.

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -267,8 +267,8 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         # Stores the library of custom decomposition rules
         fixed_decomps = fixed_decomps or {}
         alt_decomps = alt_decomps or {}
-        self._fixed_decomps = {to_name(k): v for k, v in fixed_decomps.items()}
-        self._alt_decomps = {to_name(k): v for k, v in alt_decomps.items()}
+        self._fixed_decomps = {to_name(k): _validate_rule(v) for k, v in fixed_decomps.items()}
+        self._alt_decomps = {to_name(k): _validate_rule(v) for k, v in alt_decomps.items()}
 
         # Initializes the graph.
         self._graph = rx.PyDiGraph()
@@ -604,6 +604,17 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         return DecompGraphSolution(
             visitor, self._all_op_indices, self._op_to_op_nodes, num_work_wires
         )
+
+
+def _validate_rule(rule):
+    if isinstance(rule, Iterable):
+        return [_validate_rule(r) for r in rule]
+    if not isinstance(rule, DecompositionRule):
+        raise TypeError(
+            f"{rule.__name__} is missing a resource estimate! A quantum function must be "
+            "decorated with @qp.register_resources to be used as a decomposition rule."
+        )
+    return rule
 
 
 class DecompGraphSolution:

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -388,7 +388,7 @@ class DefaultClifford(Device):
                 qp.BitFlip(0.2, wires=[1])
                 return qp.counts()
 
-        >>> circuit()
+        >>> circuit()  # doctest: +SKIP
         {np.str_('0000'): np.int64(424), np.str_('0100'): np.int64(91), np.str_('1011'): np.int64(94), np.str_('1111'): np.int64(415)}
 
     .. details::

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -118,6 +118,28 @@ class TestDecompositionGraph:
         )
         assert solution.resource_estimate(op) == expected_resource
 
+    def test_not_a_decomposition_rule(self, _):
+        """Tests that an error is raised for functions that does not have a resource estimate."""
+
+        def custom_hadamard(wires):
+            qp.PhaseShift(np.pi / 2, wires=wires)
+            qp.RX(np.pi / 2, wires=wires)
+            qp.PhaseShift(np.pi / 2, wires=wires)
+
+        with pytest.raises(TypeError, match="custom_hadamard is missing a resource estimate"):
+            _ = DecompositionGraph(
+                operations=[qp.Hadamard(0)],
+                gate_set={"RX", "RY", "RZ"},
+                fixed_decomps={qp.H: custom_hadamard},
+            )
+
+        with pytest.raises(TypeError, match="custom_hadamard is missing a resource estimate"):
+            _ = DecompositionGraph(
+                operations=[qp.Hadamard(0)],
+                gate_set={"RX", "RY", "RZ"},
+                alt_decomps={qp.H: [custom_hadamard]},
+            )
+
     def test_get_decomp_rule(self, _):
         """Tests the internal method that gets the decomposition rules for an operator."""
 

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -118,7 +118,7 @@ class TestDecompositionGraph:
         )
         assert solution.resource_estimate(op) == expected_resource
 
-    def test_not_a_decomposition_rule(self, _):
+    def test_decomp_rule_is_missing_resources(self, _):
         """Tests that an error is raised for functions that does not have a resource estimate."""
 
         def custom_hadamard(wires):

--- a/tests/templates/subroutines/test_qrom.py
+++ b/tests/templates/subroutines/test_qrom.py
@@ -20,6 +20,7 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as np
+from pennylane.decomposition.decomposition_rule import DecompositionRule
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.qrom import _calculate_n_select_work_wires, _qrom_decomposition
 from pennylane.templates.subroutines.select import _select_decomp_unary
@@ -341,10 +342,10 @@ class TestQROM:
         control_wires = [0, 1, 2]
         target_wires = [3, 4]
 
-        class SpyRule:
+        class SpyRule(DecompositionRule):
             """Wraps a DecompositionRule, tracking __call__ invocations."""
 
-            def __init__(self, original):
+            def __init__(self, original):  # pylint: disable=super-init-not-called
                 self._original = original
                 self.call_count = 0
 


### PR DESCRIPTION
**Context:**
Raise informative error message when functions missing resources are passed to `fixed_decomps` or `alt_decomps`

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-120568]