### PR TITLE
Remove `Operator._queue_category` and `MeasurementProcess._queue_category`

### DIFF
--- a/doc/code/qp_queuing.rst
+++ b/doc/code/qp_queuing.rst
@@ -6,13 +6,4 @@ Overview
 
 .. currentmodule:: pennylane.queuing
 
-.. warning::
-
-    Unless you are a PennyLane developer, you likely do not need
-    to use these classes directly.
-
-.. automodapi:: pennylane.queuing
-    :no-heading:
-    :include-all-objects:
-    :no-inherited-members:
-    :skip: contextmanager, Optional, OrderedDict, QueuingError, RLock, Union
+.. automodule:: pennylane.queuing

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,6 +148,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* `Operator._queue_category` and `MeasurementProcess._queue_category` have been removed in favor of `isisntance` checks
+  when processing an `AnnotatedQueue` into a `QuantumScript`.
+
 * Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.
   [(#9512)](https://github.com/PennyLaneAI/pennylane/pull/9512)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,7 +148,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* `Operator._queue_category` and `MeasurementProcess._queue_category` have been removed in favor of `isisntance` checks
+* `Operator._queue_category` and `MeasurementProcess._queue_category` have been removed in favor of `isinstance` checks
   when processing an `AnnotatedQueue` into a `QuantumScript`.
   [(#9530)](https://github.com/PennyLaneAI/pennylane/pull/9530)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,6 +150,7 @@
 
 * `Operator._queue_category` and `MeasurementProcess._queue_category` have been removed in favor of `isisntance` checks
   when processing an `AnnotatedQueue` into a `QuantumScript`.
+  [(#9530)](https://github.com/PennyLaneAI/pennylane/pull/9530)
 
 * Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.
   [(#9512)](https://github.com/PennyLaneAI/pennylane/pull/9512)

--- a/pennylane/measurements/measurements.py
+++ b/pennylane/measurements/measurements.py
@@ -383,16 +383,6 @@ class MeasurementProcess(ABC, metaclass=ABCCaptureMeta):
         return self
 
     @property
-    def _queue_category(self):
-        """Denotes that `MeasurementProcess` objects should be processed into the `_measurements` list
-        in `QuantumTape` objects.
-
-        This property is a temporary solution that should not exist long-term and should not be
-        used outside of ``QuantumTape._process_queue``.
-        """
-        return "_measurements"
-
-    @property
     def hash(self):
         """int: returns an integer hash uniquely representing the measurement process"""
         warnings.warn(

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1560,19 +1560,6 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         context.append(self)
         return self  # so pre-constructed Observable instances can be queued and returned in a single statement
 
-    @property
-    def _queue_category(self) -> Literal["_ops", "_measurements"]:
-        """Used for sorting objects into their respective lists in `QuantumTape` objects.
-
-        This property is a temporary solution that should not exist long-term and should not be
-        used outside of ``QuantumTape._process_queue``.
-
-        Options are:
-            * `"_ops"`
-            * `"_measurements"`
-        """
-        return "_ops"
-
     # pylint: disable=no-self-argument
     @classproperty
     def has_adjoint(cls) -> bool:

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -537,6 +537,7 @@ def apply(op, context: type[QueuingManager] | AnnotatedQueue = QueuingManager):
     return op
 
 
+# pylint: disable=protected-access
 def process_queue(
     queue: AnnotatedQueue,
 ) -> tuple[list["pennylane.operation.Operator"], list["pennylane.measurements.MeasurementProcess"]]:
@@ -547,17 +548,39 @@ def process_queue(
         queue (.AnnotatedQueue): The queue to be processed into individual lists
 
     Returns:
-        tuple[list(.Operator), list(.MeasurementProcess)]:
+        tuple[list(.Operation), list(.MeasurementProcess)]:
         The list of tape operations, the list of tape measurements
 
-    """
-    # tach-ignore
-    from pennylane.measurements import MeasurementProcess  # pylint: disable=import-outside-toplevel
+    Raises:
+        QueuingError: If the queue contains objects that cannot be processed into a QuantumScript
 
-    ops_and_meas = queue.queue
-    ind = 0
-    for obj in reversed(ops_and_meas):
-        if not isinstance(obj, MeasurementProcess):
-            break
-        ind -= 1
-    return ops_and_meas[:ind], ops_and_meas[ind:]
+    """
+    from pennylane.measurements import (  # pylint: disable=import-outside-toplevel # tach-ignore
+        MeasurementProcess,
+    )
+    from pennylane.operation import (  # pylint: disable=import-outside-toplevel # tach-ignore
+        Operator,
+    )
+    from pennylane.tape import QuantumTape  # pylint: disable=import-outside-toplevel # tach-ignore
+
+    ops = []
+    measurements = []
+    encountered_measurement = False
+
+    # cant use for obj in queue.queue, as OperatorRecorder overrides the definition of queue
+    # cant use for obj in queue, as QuantumTape overrides the definition of __iter__
+    for obj, _ in queue.items():
+        if isinstance(obj, (Operator, QuantumTape)):
+            if encountered_measurement:
+                raise ValueError(f"{obj} must occur prior to any measurements.")
+            ops.append(obj)
+        elif isinstance(obj, MeasurementProcess):
+            measurements.append(obj)
+            encountered_measurement = True
+        else:
+            raise QueuingError(
+                f"Encountered object {obj} in queue while processing."
+                " AnnotatedQueue should only contain Operator's and MeasurementProcess's."
+            )
+
+    return ops, measurements

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -597,7 +597,7 @@ def process_queue(
         else:
             raise QueuingError(
                 f"Encountered object {obj} in queue while processing."
-                " AnnotatedQueue should only contain Operator's and MeasurementProcess's."
+                " AnnotatedQueue should only contain `Operator`s and `MeasurementProcess`es."
             )
 
     return ops, measurements

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -182,7 +182,6 @@ import copy
 from collections import OrderedDict
 from contextlib import contextmanager
 from threading import RLock
-from typing import Optional, Union
 
 from pennylane.exceptions import QueuingError
 
@@ -251,7 +250,7 @@ class QueuingManager:
         return bool(cls._active_contexts)
 
     @classmethod
-    def active_context(cls) -> Optional["AnnotatedQueue"]:
+    def active_context(cls) -> "AnnotatedQueue" | None:
         """Returns the currently active queuing context."""
         return cls._active_contexts[-1] if cls.recording() else None
 
@@ -538,13 +537,9 @@ def apply(op, context: type[QueuingManager] | AnnotatedQueue = QueuingManager):
     return op
 
 
-ops_or_meas = Union["pennylane.operation.Operator", "pennylane.measurements.MeasurementProcess"]
-
-
-# pylint: disable=protected-access
 def process_queue(
     queue: AnnotatedQueue,
-) -> tuple[list[ops_or_meas], list["pennylane.measurements.MeasurementProcess"]]:
+) -> tuple[list["pennylane.operation.Operator"], list["pennylane.measurements.MeasurementProcess"]]:
     """Process the annotated queue, creating a list of quantum
     operations and measurement processes.
 
@@ -552,37 +547,17 @@ def process_queue(
         queue (.AnnotatedQueue): The queue to be processed into individual lists
 
     Returns:
-        tuple[list(.Operation), list(.MeasurementProcess)]:
+        tuple[list(.Operator), list(.MeasurementProcess)]:
         The list of tape operations, the list of tape measurements
 
-    Raises:
-        QueuingError: If the queue contains objects that cannot be processed into a QuantumScript
-
     """
-    lists = {"_ops": [], "_measurements": []}
-    list_order = {"_ops": 1, "_measurements": 2}
-    current_list = "_ops"
+    # tach-ignore
+    from pennylane.measurements import MeasurementProcess  # pylint: disable=import-outside-toplevel
 
-    # cant use for obj in queue.queue, as OperatorRecorder overrides the definition of queue
-    # cant use for obj in queue, as QuantumTape overrides the definition of __iter__
-    for obj, _ in queue.items():
-        if not hasattr(obj, "_queue_category"):
-            raise QueuingError(
-                f"{obj} encountered in AnnotatedQueue and is not an object that can "
-                "be processed into a QuantumScript. Queues should contain Operator or MeasurementProcess objects only."
-            )
-        if obj._queue_category is None:
-            raise ValueError(
-                f"_queue_category can no longer be set to None. Got None on object {obj}"
-            )
-
-        if list_order[obj._queue_category] > list_order[current_list]:
-            current_list = obj._queue_category
-        elif list_order[obj._queue_category] < list_order[current_list]:
-            raise ValueError(
-                f"{obj._queue_category[1:]} operation {obj} must occur prior "
-                f"to {current_list[1:]}. Please place earlier in the queue."
-            )
-        lists[obj._queue_category].append(obj)
-
-    return lists["_ops"], lists["_measurements"]
+    ops_and_meas = queue.queue
+    ind = 0
+    for obj in reversed(ops_and_meas):
+        if not isinstance(obj, MeasurementProcess):
+            break
+        ind -= 1
+    return ops_and_meas[:ind], ops_and_meas[ind:]

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -182,6 +182,7 @@ import copy
 from collections import OrderedDict
 from contextlib import contextmanager
 from threading import RLock
+from typing import Union
 
 from pennylane.exceptions import QueuingError
 
@@ -250,7 +251,7 @@ class QueuingManager:
         return bool(cls._active_contexts)
 
     @classmethod
-    def active_context(cls) -> "AnnotatedQueue" | None:
+    def active_context(cls) -> Union["AnnotatedQueue", None]:
         """Returns the currently active queuing context."""
         return cls._active_contexts[-1] if cls.recording() else None
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -14,6 +14,22 @@
 r"""
 This module contains the classes for placing objects into queues.
 
+.. warning::
+
+    Unless you are a PennyLane developer, you likely do not need
+    to use these classes directly.
+
+.. currentmodule:: pennylane.queuing
+
+.. autosummary::
+    :toctree: api
+
+    ~QueuingManager
+    ~AnnotatedQueue
+    ~apply
+    ~process_queue
+
+
 Description
 -----------
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -198,7 +198,7 @@ import copy
 from collections import OrderedDict
 from contextlib import contextmanager
 from threading import RLock
-from typing import Union
+from typing import Optional
 
 from pennylane.exceptions import QueuingError
 
@@ -267,7 +267,7 @@ class QueuingManager:
         return bool(cls._active_contexts)
 
     @classmethod
-    def active_context(cls) -> Union["AnnotatedQueue", None]:
+    def active_context(cls) -> Optional["AnnotatedQueue"]:
         """Returns the currently active queuing context."""
         return cls._active_contexts[-1] if cls.recording() else None
 

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -573,7 +573,7 @@ def process_queue(
     for obj, _ in queue.items():
         if isinstance(obj, (Operator, QuantumTape)):
             if encountered_measurement:
-                raise ValueError(f"{obj} must occur prior to any measurements.")
+                raise ValueError(f"{obj} must occur prior to measurements.")
             ops.append(obj)
         elif isinstance(obj, MeasurementProcess):
             measurements.append(obj)

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -300,10 +300,6 @@ class QuantumTape(QuantumScript, AnnotatedQueue):
     # construction methods
     # ========================================================
 
-    # This is a temporary attribute to fix the operator queuing behaviour.
-    # Tapes may be nested and therefore processed into the `_ops` list.
-    _queue_category = "_ops"
-
     def _process_queue(self):
         """Process the annotated queue, creating a list of quantum
         operations and measurement processes.

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -267,11 +267,6 @@ class TestProperties:
 
         assert op.has_diagonalizing_gates is False
 
-    def test_queue_category(self):
-        """Test that the queue category `"_ops"` carries over."""
-        op = Adjoint(qp.PauliX(0))
-        assert op._queue_category == "_ops"  # pylint: disable=protected-access
-
     @pytest.mark.parametrize("value", (True, False))
     def test_is_verified_hermitian(self, value):
         """Test `is_verified_hermitian` property mirrors that of the base."""

--- a/tests/ops/op_math/test_change_op_basis.py
+++ b/tests/ops/op_math/test_change_op_basis.py
@@ -325,12 +325,6 @@ class TestProperties:  # pylint: disable=too-few-public-methods
         change_op = change_op_basis(*ops_lst)
         assert middle_op.is_verified_hermitian == change_op.is_verified_hermitian
 
-    @pytest.mark.parametrize("ops_lst", ops)
-    def test_queue_category_ops(self, ops_lst):
-        """Test _queue_category property is '_ops' when all factors are `_ops`."""
-        change_op_basis_op = change_op_basis(*ops_lst)
-        assert change_op_basis_op._queue_category == "_ops"
-
 
 class TestWrapperFunc:  # pylint: disable=too-few-public-methods
     """Test wrapper function."""

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -384,15 +384,6 @@ class TestControlledProperties:
         op = Controlled(DummyOp(1), 0)
         assert op.has_diagonalizing_gates is value
 
-    def test_queue_cateogry(self):
-        """Test that Controlled belongs in the ops."""
-
-        class DummyOp(Operator):
-            pass
-
-        op = Controlled(DummyOp(1), 0)
-        assert op._queue_category == "_ops"
-
     @pytest.mark.parametrize("value", (True, False))
     def test_is_hermitian(self, value):
         """Test that Controlled defers `is_hermitian` to base operator."""

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -126,15 +126,6 @@ class TestProperties:
         assert op.base.data == (new_phi,)
         assert op.scalar == new_coeff
 
-    # pylint: disable=protected-access
-    def test_queue_category_ops(self):
-        """Test the _queue_category property."""
-        assert Exp(qp.PauliX(0), -1.234j)._queue_category == "_ops"
-
-        assert Exp(qp.PauliX(0), 1 + 2j)._queue_category == "_ops"
-
-        assert Exp(qp.RX(1.2, 0), -1.2j)._queue_category == "_ops"
-
     def test_is_verified_hermitian(self):
         """Test that the op is hermitian if the base is hermitian and the coeff is real."""
         assert Exp(qp.PauliX(0), -1.0).is_verified_hermitian

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -363,11 +363,6 @@ class TestProperties:
         op: Pow = power_method(base=DummyOp(1), z=2.5)
         assert op.is_verified_hermitian is value
 
-    def test_queue_category(self, power_method):
-        """Test that the queue category `"_ops"` carries over."""
-        op: Pow = power_method(base=qp.PauliX(0), z=3.5)
-        assert op._queue_category == "_ops"  # pylint: disable=protected-access
-
     def test_batching_properties(self, power_method):
         """Test the batching properties and methods."""
 

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -944,12 +944,6 @@ class TestProperties:
         for op, hermitian_state in zip(prod_ops, true_hermitian_states):
             assert qp.is_hermitian(op) == hermitian_state
 
-    @pytest.mark.parametrize("ops_lst", ops)
-    def test_queue_category_ops(self, ops_lst):
-        """Test _queue_category property is '_ops' when all factors are `_ops`."""
-        prod_op = prod(*ops_lst)
-        assert prod_op._queue_category == "_ops"
-
     def test_eigendecomposition(self):
         """Test that the computed Eigenvalues and Eigenvectors are correct."""
         diag_prod_op = Prod(qp.PauliZ(wires=0), qp.PauliZ(wires=1))

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -742,12 +742,6 @@ class TestSparseMatrix:
 
 
 class TestProperties:
-    @pytest.mark.parametrize("op_scalar_tup", ops)
-    def test_queue_category(self, op_scalar_tup):
-        """Test queue_category property is "_ops" by inheritance."""
-        scalar, op = op_scalar_tup
-        sprod_op = SProd(scalar, op)
-        assert sprod_op._queue_category == "_ops"  # pylint: disable=protected-access
 
     def test_eigvals(self):
         """Test that the eigvals of the scalar product op are correct."""

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -676,13 +676,6 @@ class TestProperties:
 
         assert sum_op.is_verified_hermitian == true_hermitian_state
 
-    @pytest.mark.parametrize("sum_method", [sum_using_dunder_method, qp.sum])
-    @pytest.mark.parametrize("ops_lst", ops)
-    def test_queue_category(self, ops_lst, sum_method):
-        """Test queue_category property is "_ops" by inheritance."""
-        sum_op = sum_method(*ops_lst)
-        assert sum_op._queue_category == "_ops"  # pylint: disable=protected-access
-
     def test_eigvals_Identity_no_wires(self):
         """Test that eigenvalues can be computed for a sum containing identity with no wires."""
 

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -156,15 +156,6 @@ class TestProperties:
         op = SymbolicOp(base)
         assert op.is_verified_hermitian == is_herm
 
-    def test_queuecateory(self):
-        """Test that a symbolic operator inherits the queue_category from its base."""
-
-        class DummyOp(Operator):
-            pass
-
-        op = SymbolicOp(DummyOp("b"))
-        assert op._queue_category == "_ops"  # pylint:disable=protected-access
-
     def test_map_wires(self):
         """Test that base wires can be set through the operator's private `_wires` property."""
         w = qp.wires.Wires("a")

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -467,19 +467,5 @@ def test_process_queue_error_if_not_operator_or_measurement():
     """
     q = AnnotatedQueue()
     q.append(1)
-    with pytest.raises(QueuingError, match="not an object that can be processed"):
-        qp.queuing.process_queue(q)
-
-
-def test_queue_category_none_removal():
-
-    class DummyOp(qp.operation.Operator):  # pylint: disable=too-few-public-methods
-        _queue_category = None
-        num_wires = 1
-        num_params = 0
-
-    q = AnnotatedQueue()
-    q.append(DummyOp(wires=[0]))
-
-    with pytest.raises(ValueError, match="_queue_category can no longer be set to None."):
+    with pytest.raises(QueuingError, match="Encountered object 1 in queue while processing."):
         qp.queuing.process_queue(q)

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -462,9 +462,7 @@ class TestWrappedObj:
 
 
 def test_process_queue_error_if_not_operator_or_measurement():
-    """Test that a QueuingError is raised if process queue encounters an object that does not have a
-    _queue_category property
-    """
+    """Test that a QueuingError is raised if process queue encounters an object it cant handle."""
     q = AnnotatedQueue()
     q.append(1)
     with pytest.raises(QueuingError, match="Encountered object 1 in queue while processing."):


### PR DESCRIPTION
**Context:**

We may finally be at a point where we can remove `Operator._queue_category` and `MeasurementProcess._queue_category` and due away with a four year old "temporary patch" 🤦 .

**Description of the Change:**

Delete `Operator._queue_category` and `MeasurementProcess._queue_category` in favour of using `isinstance` checks.

**Benefits:**

Simpler processing behaviour. One less thing we have to add onto the new `Operator2` class.

**Possible Drawbacks:**

Why did we still have logic for nested tapes!

**Related GitHub Issues:**

[sc-120699]