### PR TITLE
chore: bump `autoray` pin to latest (`v0.8.10`)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,7 +148,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Bump `autoray` pin to `v0.8.10`.
+* Bump `autoray` package pin to `v0.8.10`.
   [(#9535)](https://github.com/PennyLaneAI/pennylane/pull/9535)
 
 * Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -148,6 +148,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Bump `autoray` pin to `v0.8.10`.
+  [(#9535)](https://github.com/PennyLaneAI/pennylane/pull/9535)
+
 * Fixes imports of exceptions from `pennylane.operation` instead of `pennylane.exceptions`.
   [(#9512)](https://github.com/PennyLaneAI/pennylane/pull/9512)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "rustworkx>=0.14.0",
     "autograd",
     "appdirs",
-    "autoray==0.8.4",
+    "autoray==0.8.10",
     "cachetools",
     "pennylane-lightning>=0.45",
     "requests",


### PR DESCRIPTION
Time to bump our `autoray` pin!

[sc-120710]