### PR TITLE
Raise on impossible postselected samples

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -347,6 +347,10 @@
   exists from an operator to a controlled/adjoint version of itself.
   [(#9457)](https://github.com/PennyLaneAI/pennylane/pull/9457)
 
+* Fixed a bug where finite-shot circuits returning :func:`~.sample` could produce invalid results
+  when postselecting on a zero-probability mid-circuit measurement outcome.
+  [(#9536)](https://github.com/PennyLaneAI/pennylane/pull/9536)
+
 * Fixed a bug in `MPSPrep` where passing `work_wires` as a NumPy array or an integer caused initialization errors.
   [(#9448)](https://github.com/PennyLaneAI/pennylane/pull/9448)
 

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -38,7 +38,7 @@ from pennylane.measurements import (
 from pennylane.operation import StatePrepBase
 from pennylane.ops import MidMeasure
 from pennylane.tape import QuantumScript
-from pennylane.transforms.dynamic_one_shot import gather_mcm
+from pennylane.transforms.dynamic_one_shot import _raise_impossible_postselection_error, gather_mcm
 from pennylane.typing import Result
 
 from .apply_operation import apply_operation
@@ -131,6 +131,7 @@ def _postselection_postprocess(state, is_state_batched, shots, **execution_kwarg
     rng = execution_kwargs.get("rng", None)
     prng_key = execution_kwargs.get("prng_key", None)
     postselect_mode = execution_kwargs.get("postselect_mode", None)
+    has_sample_measurement = execution_kwargs.get("has_sample_measurement", False)
 
     # The floor function is being used here so that a norm very close to zero becomes exactly
     # equal to zero so that the state can become invalid. This way, execution can continue, and
@@ -139,6 +140,8 @@ def _postselection_postprocess(state, is_state_batched, shots, **execution_kwarg
     norm = math.norm(state)
 
     if not math.is_abstract(state) and math.allclose(norm, 0.0):
+        if has_sample_measurement and shots:
+            _raise_impossible_postselection_error()
         if postselect_mode == "fill-shots" and shots:
             raise RuntimeError(
                 "The probability of the postselected mid-circuit measurement outcome is 0. "
@@ -211,6 +214,7 @@ def get_final_state(circuit, debugger=None, **execution_kwargs):
     # initial state is batched only if the state preparation (if it exists) is batched
     is_state_batched = bool(prep and prep.batch_size is not None)
     key = prng_key
+    has_sample_measurement = any(isinstance(m, SampleMP) for m in circuit.measurements)
 
     for op in circuit.operations[bool(prep) :]:
         if isinstance(op, MidMeasure):
@@ -228,7 +232,12 @@ def get_final_state(circuit, debugger=None, **execution_kwargs):
         if isinstance(op, qp.Projector):
             prng_key, key = jax_random_split(prng_key)
             state, new_shots = _postselection_postprocess(
-                state, is_state_batched, circuit.shots, prng_key=key, **execution_kwargs
+                state,
+                is_state_batched,
+                circuit.shots,
+                prng_key=key,
+                has_sample_measurement=has_sample_measurement,
+                **execution_kwargs,
             )
             circuit._shots = new_shots
 
@@ -941,6 +950,8 @@ def _(original_measurement: SampleMP, measures):
     new_sample = tuple(
         math.atleast_1d(m[1]) for m in measures.values() if m[0] and m[1] is not tuple()
     )
+    if not new_sample:
+        _raise_impossible_postselection_error()
     return math.concatenate(new_sample)
 
 

--- a/pennylane/exceptions.py
+++ b/pennylane/exceptions.py
@@ -42,6 +42,7 @@ General Execution Errors
     ~QueuingError
     ~WireError
     ~MeasurementShapeError
+    ~PostselectionImpossibleError
     ~AutoGraphError
     ~CompileError
     ~DecompositionError
@@ -119,6 +120,10 @@ class WireError(Exception):
 class MeasurementShapeError(ValueError):
     """An error raised when an unsupported operation is attempted with a
     quantum tape."""
+
+
+class PostselectionImpossibleError(RuntimeError):
+    """Raised when postselecting a zero-probability mid-circuit measurement outcome."""
 
 
 # =============================================================================

--- a/pennylane/ops/mid_measure/mid_measure.py
+++ b/pennylane/ops/mid_measure/mid_measure.py
@@ -340,7 +340,8 @@ def measure(
         >>> func(0.0)
         array([nan, nan])
 
-        In the case of ``qp.sample`` and `mcm_method="deferred"`, an empty array will be returned:
+        In the case of ``qp.sample`` and `mcm_method="deferred"`, an error is raised if the
+        postselected outcome has zero probability:
 
         .. code-block:: python
 
@@ -354,7 +355,9 @@ def measure(
                 return qp.sample(wires=[0, 1])
 
         >>> qp.set_shots(func, shots=[10, 10])(0.0)
-        (array([], shape=(0, 2), dtype=int64), array([], shape=(0, 2), dtype=int64))
+        Traceback (most recent call last):
+        ...
+        pennylane.exceptions.PostselectionImpossibleError: The probability of the postselected mid-circuit measurement outcome is 0. This leads to invalid sample results.
 
         .. note::
 

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import math
-from pennylane.exceptions import QuantumFunctionError, TransformError
+from pennylane.exceptions import PostselectionImpossibleError, QuantumFunctionError, TransformError
 from pennylane.measurements import (
     CountsMP,
     ExpectationMP,
@@ -252,7 +252,7 @@ def _measurement_with_no_shots(measurement):
 
 
 def _raise_impossible_postselection_error():
-    raise RuntimeError(
+    raise PostselectionImpossibleError(
         "The probability of the postselected mid-circuit measurement outcome is 0. "
         "This leads to invalid sample results."
     )
@@ -374,8 +374,10 @@ def _handle_measurement(
 ):
     if interface != "jax" and not has_valid:
         if isinstance(m, SampleMP):
-            _raise_impossible_postselection_error()
-        return _measurement_with_no_shots(m), m_count + int(m.mv is None)
+            if postselect_mode != "hw-like":
+                _raise_impossible_postselection_error()
+        else:
+            return _measurement_with_no_shots(m), m_count + int(m.mv is None)
 
     if m.mv is not None:
         return gather_mcm(m, mcm_samples, is_valid, postselect_mode=postselect_mode), m_count

--- a/pennylane/transforms/dynamic_one_shot.py
+++ b/pennylane/transforms/dynamic_one_shot.py
@@ -251,6 +251,13 @@ def _measurement_with_no_shots(measurement):
     )
 
 
+def _raise_impossible_postselection_error():
+    raise RuntimeError(
+        "The probability of the postselected mid-circuit measurement outcome is 0. "
+        "This leads to invalid sample results."
+    )
+
+
 def _get_is_valid_has_valid(mcm_samples, all_mcms, interface):
     # Can't use boolean dtype array with tf, hence why conditionally setting items to 0 or 1
     has_postselect = math.array(
@@ -366,6 +373,8 @@ def _handle_measurement(
     is_valid,
 ):
     if interface != "jax" and not has_valid:
+        if isinstance(m, SampleMP):
+            _raise_impossible_postselection_error()
         return _measurement_with_no_shots(m), m_count + int(m.mv is None)
 
     if m.mv is not None:

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -2087,8 +2087,7 @@ class TestPostselection:
     def test_postselection_invalid_finite_shots(
         self, mp, expected_shape, shots, interface, use_jit
     ):
-        """Test that the results of a qnode are nan values of the correct shape if the state
-        that we are postselecting has a zero probability of occurring with finite shots."""
+        """Test the result of zero-probability postselection with finite shots."""
 
         if use_jit and interface != "jax":
             pytest.skip("Can't jit with non-jax interfaces.")
@@ -2110,6 +2109,11 @@ class TestPostselection:
             )
             # import jax
             # circ = jax.jit(circ)
+
+        if isinstance(mp, qp.measurements.SampleMP):
+            with pytest.raises(RuntimeError, match="probability of the postselected"):
+                circ()
+            return
 
         res = circ()
 

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -22,7 +22,7 @@ import pytest
 
 import pennylane as qp
 from pennylane.devices import DefaultQubit, ExecutionConfig
-from pennylane.exceptions import DeviceError
+from pennylane.exceptions import DeviceError, PostselectionImpossibleError
 
 max_workers_list = [
     None,
@@ -2111,7 +2111,9 @@ class TestPostselection:
             # circ = jax.jit(circ)
 
         if isinstance(mp, qp.measurements.SampleMP):
-            with pytest.raises(RuntimeError, match="probability of the postselected"):
+            with pytest.raises(
+                PostselectionImpossibleError, match="probability of the postselected"
+            ):
                 circ()
             return
 

--- a/tests/devices/default_qubit/test_default_qubit_native_mcm.py
+++ b/tests/devices/default_qubit/test_default_qubit_native_mcm.py
@@ -80,6 +80,23 @@ def test_all_invalid_shots_circuit(obs, mcm_method):
         assert np.all(np.isnan(r2))
 
 
+@pytest.mark.parametrize("mcm_method", [None, "one-shot", "deferred", "tree-traversal"])
+@pytest.mark.parametrize("shots", [10, [10, 10]])
+def test_impossible_postselected_sample_raises(mcm_method, shots):
+    """Test that impossible postselection raises instead of returning invalid samples."""
+    dev = qp.device("default.qubit")
+
+    @qp.qnode(dev, mcm_method=mcm_method)
+    def circuit(x):
+        qp.RX(x, wires=0)
+        m0 = qp.measure(0, postselect=1)
+        qp.cond(m0, qp.X)(wires=1)
+        return qp.sample(wires=1)
+
+    with pytest.raises(RuntimeError, match="probability of the postselected"):
+        qp.set_shots(circuit, shots=shots)(0.0)
+
+
 @pytest.mark.parametrize("mcm_method", ["one-shot", "tree-traversal"])
 def test_unsupported_measurement(mcm_method):
     """Test that circuits with unsupported measurements raise the correct error."""

--- a/tests/devices/default_qubit/test_default_qubit_native_mcm.py
+++ b/tests/devices/default_qubit/test_default_qubit_native_mcm.py
@@ -21,6 +21,7 @@ import pytest
 
 import pennylane as qp
 from pennylane.devices.qubit.simulate import combine_measurements_core, measurement_with_no_shots
+from pennylane.exceptions import PostselectionImpossibleError
 from pennylane.ops import MidMeasure
 from pennylane.transforms.dynamic_one_shot import fill_in_value
 
@@ -93,8 +94,26 @@ def test_impossible_postselected_sample_raises(mcm_method, shots):
         qp.cond(m0, qp.X)(wires=1)
         return qp.sample(wires=1)
 
-    with pytest.raises(RuntimeError, match="probability of the postselected"):
+    with pytest.raises(PostselectionImpossibleError, match="probability of the postselected"):
         qp.set_shots(circuit, shots=shots)(0.0)
+
+
+def test_hw_like_postselected_sample_all_invalid_shots():
+    """Test hw-like postselection returns empty samples when a nonzero-probability
+    postselection draws no valid shots."""
+    dev = qp.device("default.qubit", seed=123)
+
+    @qp.set_shots(1)
+    @qp.qnode(dev, mcm_method="one-shot", postselect_mode="hw-like")
+    def circuit(x):
+        qp.RX(x, wires=0)
+        m0 = qp.measure(0, postselect=1)
+        qp.cond(m0, qp.X)(wires=1)
+        return qp.sample(wires=1)
+
+    res = circuit(0.01)
+
+    assert res.shape == (0, 1)
 
 
 @pytest.mark.parametrize("mcm_method", ["one-shot", "tree-traversal"])


### PR DESCRIPTION
**Context:**

Issue #8480 reports that finite-shot circuits with impossible mid-circuit postselection can return invalid sample results instead of a clear error. The earlier docs-only PR #9509 was closed because it did not address the underlying behavior.

**Description of the Change:**

This adds a RuntimeError for zero-probability postselection when the circuit returns sample measurements, covering native one-shot, deferred, and tree-traversal paths. Existing non-sample invalid-shot behavior is preserved.

**Benefits:**

Users get a clear error instead of `(nan, nan)`, empty sample arrays, or a raw concatenate ValueError for impossible postselected samples.

**Possible Drawbacks:**

This changes deferred `sample(...)` behavior from returning empty samples to raising the same user-facing error as the other sample execution paths.

**Related GitHub Issues:**

Fixes #8480

**Tests:**

- `/tmp/pennylane-8480-venv/bin/python -m pytest tests/devices/default_qubit/test_default_qubit_native_mcm.py::test_impossible_postselected_sample_raises tests/devices/default_qubit/test_default_qubit_native_mcm.py::test_all_invalid_shots_circuit tests/devices/qubit/test_simulate.py::TestMidMeasurements::test_defer_measurements_fill_shots_zero_prob_postselection_error tests/devices/default_qubit/test_default_qubit.py::TestPostselection::test_defer_measurements_fill_shots_zero_prob_postselection_error tests/devices/default_qubit/test_default_qubit.py::TestPostselection::test_postselection_invalid_finite_shots -q`
- `/tmp/pennylane-8480-venv/bin/python -m black --check pennylane/devices/qubit/simulate.py pennylane/transforms/dynamic_one_shot.py tests/devices/default_qubit/test_default_qubit.py tests/devices/default_qubit/test_default_qubit_native_mcm.py`
- `/tmp/pennylane-8480-venv/bin/python -m isort --check-only pennylane/devices/qubit/simulate.py pennylane/transforms/dynamic_one_shot.py tests/devices/default_qubit/test_default_qubit.py tests/devices/default_qubit/test_default_qubit_native_mcm.py`
- `git diff --check -- doc/releases/changelog-dev.md pennylane/devices/qubit/simulate.py pennylane/transforms/dynamic_one_shot.py tests/devices/default_qubit/test_default_qubit.py tests/devices/default_qubit/test_default_qubit_native_mcm.py`

**AI assistance:**

Assisted by OpenAI GPT-5; I reviewed and tested the changes before requesting review.