### PR TITLE
feat: `make_selectpaulirot_to_phase_gradient_decomp` is capture compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -21,6 +21,9 @@
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
+* Updated the `make_selectpaulirot_to_phase_gradient_decomp` decomposition rule factory to be compatible with program capture.
+  [(#9537)](https://github.com/PennyLaneAI/pennylane/pull/9537)
+
 * Created a new ``labs.templates.LeftQuantumComparator`` template for performing inequality test of two quantum registers.
   [(#9277)](https://github.com/PennyLaneAI/pennylane/pull/9277)
 

--- a/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
@@ -259,7 +259,6 @@ def test_capture_compatibility():
                 return qp.state()
 
             cjaxpr = jax.make_jaxpr(f)(angles)
-            print(cjaxpr)
 
             collector = CollectOpsandMeas()
             collector.eval(cjaxpr.jaxpr, cjaxpr.consts, angles)

--- a/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
@@ -245,9 +245,7 @@ def test_capture_compatibility():
                 "Adjoint(QROM)",
                 "SemiAdder",
                 "CNOT",
-                "Adjoint(CNOT)",
                 "PauliX",
-                "Adjoint(PauliX)",
                 "GlobalPhase",
             }
 
@@ -264,6 +262,9 @@ def test_capture_compatibility():
             collector.eval(cjaxpr.jaxpr, cjaxpr.consts, angles)
 
             op_names = {op.name for op in collector.state["ops"]}
+            # NOTE: Because `adjoint` is lazy in ChangeOpBasis,
+            # unsimplified operators will be collected.
+            gate_set |= {"Adjoint(CNOT)", "Adjoint(PauliX)"}
             assert op_names.issubset(
                 gate_set
             ), f"Following ops are present but not in gateset: {op_names - gate_set}"

--- a/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
@@ -24,6 +24,8 @@ from pennylane.labs.transforms.decomp_selectpaulirot_phase_gradient import (
     make_selectpaulirot_to_phase_gradient_decomp,
 )
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
+from pennylane.tape.plxpr_conversion import CollectOpsandMeas
+from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.wires import WireError
 
 
@@ -83,7 +85,6 @@ def test_as_fixed_decomps(prec, num_controls):
     with qp.decomposition.toggle_graph_ctx(
         True
     ):  # safe alternative to avoid enabling graph globally on the labs test runner
-
         angles = (
             np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]])
             @ np.array([1 / 2, 1 / 4, 1 / 8])
@@ -203,3 +204,69 @@ def test_integration_multi_wire(seed):
         out_state_expected = np.kron(zeros, out_state_expected)
 
         assert np.allclose(out_state, out_state_expected)
+
+
+@pytest.mark.jax
+def test_capture_compatibility():
+    """Ensures capture compatibility."""
+
+    # pylint: disable=import-outside-toplevel
+    import jax
+
+    qp.capture.enable()
+    try:
+        with qp.decomposition.toggle_graph_ctx(True):
+            prec = 3
+            num_controls = 2
+            control_wires = list(range(num_controls))
+            target_wire = num_controls
+            first_aux = num_controls + 1
+
+            angle_wires = list(range(first_aux, first_aux + prec))
+            phase_grad_wires = list(range(first_aux + prec, first_aux + 2 * prec))
+            num_work_wires = max(prec, num_controls + 1) - 1
+            work_wires = list(range(first_aux + 2 * prec, first_aux + 2 * prec + num_work_wires))
+
+            angles = np.array(
+                [
+                    (1 / 2 + 1 / 4 + 1 / 8) * 4 * np.pi,
+                    (1 / 2 + 1 / 4 + 0 / 8) * 4 * np.pi,
+                    (1 / 2 + 0 / 4 + 1 / 8) * 4 * np.pi,
+                    (0 / 2 + 1 / 4 + 1 / 8) * 4 * np.pi,
+                ]
+            )
+
+            custom_decomp = make_selectpaulirot_to_phase_gradient_decomp(
+                angle_wires, phase_grad_wires, work_wires
+            )
+
+            gate_set = {
+                "QROM",
+                "Adjoint(QROM)",
+                "SemiAdder",
+                "CNOT",
+                "Adjoint(CNOT)",
+                "PauliX",
+                "Adjoint(PauliX)",
+                "GlobalPhase",
+            }
+
+            @DecomposeInterpreter(
+                gate_set=gate_set, fixed_decomps={qp.SelectPauliRot: custom_decomp}
+            )
+            def f(angles):
+                qp.SelectPauliRot(angles, control_wires=control_wires, target_wire=target_wire)
+                return qp.state()
+
+            cjaxpr = jax.make_jaxpr(f)(angles)
+            print(cjaxpr)
+
+            collector = CollectOpsandMeas()
+            collector.eval(cjaxpr.jaxpr, cjaxpr.consts, angles)
+
+            op_names = {op.name for op in collector.state["ops"]}
+            assert op_names.issubset(
+                gate_set
+            ), f"Following ops are present but not in gateset: {op_names - gate_set}"
+    finally:
+        qp.capture.disable()

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -79,11 +79,7 @@ def _select_pauli_rot_phase_gradient(
                 qp.adjoint(qp.S(target_wire))
                 qp.Hadamard(target_wire)
 
-            def y_basis_uncomp():
-                qp.Hadamard(target_wire)
-                qp.S(target_wire)
-
-            return qp.change_op_basis(y_basis_comp, inner_cob, y_basis_uncomp)
+            return qp.change_op_basis(y_basis_comp, inner_cob)
 
     return inner_cob()
 

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -28,7 +28,6 @@ from pennylane.decomposition import (
 from pennylane.operation import Operator
 from pennylane.ops import Prod
 from pennylane.ops.op_math import change_op_basis
-from pennylane.ops.qubit.non_parametric_ops import Hadamard
 from pennylane.wires import WireError, Wires
 
 
@@ -65,26 +64,26 @@ def _select_pauli_rot_phase_gradient(
         qp.SemiAdder(angle_wires, phase_grad_wires, work_wires=work_wires[: len(angle_wires) - 1])
 
     def inner_cob():
-        change_op_basis(compute_fn, target_fn, compute_fn)
+        change_op_basis(compute_fn, target_fn)
 
     match rot_axis:
         case "X":
 
-            def basis_comp():
+            def x_basis_comp():
                 qp.Hadamard(target_wire)
 
-            return qp.change_op_basis(basis_comp, inner_cob, basis_comp)
+            return qp.change_op_basis(x_basis_comp, inner_cob)
         case "Y":
 
-            def basis_comp():
+            def y_basis_comp():
                 qp.Hadamard(target_wire)
                 qp.adjoint(qp.S(target_wire))
 
-            def basis_uncomp():
+            def y_basis_uncomp():
                 qp.S(target_wire)
                 qp.Hadamard(target_wire)
 
-            return qp.change_op_basis(basis_comp, inner_cob, basis_uncomp)
+            return qp.change_op_basis(y_basis_comp, inner_cob, y_basis_uncomp)
 
     return inner_cob()
 

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -64,7 +64,7 @@ def _select_pauli_rot_phase_gradient(
         qp.SemiAdder(angle_wires, phase_grad_wires, work_wires=work_wires[: len(angle_wires) - 1])
 
     def inner_cob():
-        change_op_basis(compute_fn, target_fn)
+        return change_op_basis(compute_fn, target_fn)
 
     match rot_axis:
         case "X":
@@ -76,12 +76,12 @@ def _select_pauli_rot_phase_gradient(
         case "Y":
 
             def y_basis_comp():
-                qp.Hadamard(target_wire)
                 qp.adjoint(qp.S(target_wire))
+                qp.Hadamard(target_wire)
 
             def y_basis_uncomp():
-                qp.S(target_wire)
                 qp.Hadamard(target_wire)
+                qp.S(target_wire)
 
             return qp.change_op_basis(y_basis_comp, inner_cob, y_basis_uncomp)
 

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -27,6 +27,8 @@ from pennylane.decomposition import (
 )
 from pennylane.operation import Operator
 from pennylane.ops import Prod
+from pennylane.ops.op_math import change_op_basis
+from pennylane.ops.qubit.non_parametric_ops import Hadamard
 from pennylane.wires import WireError, Wires
 
 
@@ -47,11 +49,8 @@ def _select_pauli_rot_phase_gradient(
     precision = len(angle_wires)
     binary_int = qp.math.binary_decimals(phis, precision, unit=4 * np.pi)
 
-    cnots = [
-        qp.ctrl(qp.X(wire), control=target_wire, control_values=[0]) for wire in phase_grad_wires
-    ]
-
-    ops = [  # we can set clean=False because we are doing QROM - something - QROM†
+    def compute_fn():
+        # we can set clean=False because we are doing QROM - something - QROM†
         qp.QROM(
             binary_int,
             control_wires,
@@ -59,23 +58,35 @@ def _select_pauli_rot_phase_gradient(
             work_wires=work_wires[len(angle_wires) - 1 :],
             clean=False,
         )
-    ] + cnots
+        for wire in phase_grad_wires:
+            qp.ctrl(qp.X(wire), control=target_wire, control_values=[0])
 
-    pg_op = qp.change_op_basis(
-        qp.prod(*ops[::-1]),
-        qp.SemiAdder(angle_wires, phase_grad_wires, work_wires=work_wires[: len(angle_wires) - 1]),
-    )
+    def target_fn():
+        qp.SemiAdder(angle_wires, phase_grad_wires, work_wires=work_wires[: len(angle_wires) - 1])
+
+    def inner_cob():
+        change_op_basis(compute_fn, target_fn, compute_fn)
 
     match rot_axis:
         case "X":
-            comp = uncomp = qp.Hadamard(target_wire)
-            pg_op = qp.change_op_basis(comp, pg_op, uncomp)
-        case "Y":
-            comp = qp.Hadamard(target_wire) @ qp.adjoint(qp.S(target_wire))
-            uncomp = qp.S(target_wire) @ qp.Hadamard(target_wire)
-            pg_op = qp.change_op_basis(comp, pg_op, uncomp)
 
-    return pg_op
+            def basis_comp():
+                qp.Hadamard(target_wire)
+
+            return qp.change_op_basis(basis_comp, inner_cob, basis_comp)
+        case "Y":
+
+            def basis_comp():
+                qp.Hadamard(target_wire)
+                qp.adjoint(qp.S(target_wire))
+
+            def basis_uncomp():
+                qp.S(target_wire)
+                qp.Hadamard(target_wire)
+
+            return qp.change_op_basis(basis_comp, inner_cob, basis_uncomp)
+
+    return inner_cob()
 
 
 def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
@@ -153,6 +164,11 @@ def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, 
     work_1: ─╰QROM(M0)──────────╰SemiAdder──────────╰QROM(M0)†─┤  State
 
     """
+    # Sanitize wires
+    angle_wires = Wires(angle_wires)
+    phase_grad_wires = Wires(phase_grad_wires)
+    work_wires = Wires(work_wires)
+
     if len(angle_wires) != len(phase_grad_wires):
         raise WireError(
             f"angle_wires and phase_grad wires must be of same size, received {len(angle_wires)} and {len(phase_grad_wires-1)}"
@@ -259,17 +275,14 @@ def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, 
                     qp.RZ(angles[0], target_wire)
             return
 
-        with qp.QueuingManager.stop_recording():
-            pg_op = _select_pauli_rot_phase_gradient(
-                angles,
-                rot_axis,
-                control_wires=control_wires,
-                target_wire=target_wire,
-                angle_wires=angle_wires,
-                phase_grad_wires=phase_grad_wires,
-                work_wires=work_wires,
-            )
-
-        qp.apply(pg_op)
+        _select_pauli_rot_phase_gradient(
+            angles,
+            rot_axis,
+            control_wires=control_wires,
+            target_wire=target_wire,
+            angle_wires=angle_wires,
+            phase_grad_wires=phase_grad_wires,
+            work_wires=work_wires,
+        )
 
     return _decomp_fn


### PR DESCRIPTION
**Context:**

This decomp rule factory needs to be capture compatible.

**Benefits:**

This unlocks a necessary step to make it `qjit(capture=True)` compatible.

**Possible Drawbacks:** None identified.

[sc-120723]