### PR TITLE
Small follow up to #9400: stack wire args when possible for subroutines

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -190,7 +190,7 @@
   list of abstract integer values. This is to better define the set of operations allowed on
   allocated qubits.
   [(#9400)](https://github.com/PennyLaneAI/pennylane/pull/9400)
-  [(#????)](https://github.com/PennyLaneAI/pennylane/pull/????)
+  [(#9541)](https://github.com/PennyLaneAI/pennylane/pull/9541)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -15,7 +15,7 @@
   [(#8900)](https://github.com/PennyLaneAI/pennylane/pull/8900)
 
 * Added a dispatcher for `qp.pauli_measure` to call `catalyst.pauli_measure` when qjit is enabled
-  while using the non-capture workflow. This also added an alias for `MidCircuitPauliMeasure` for 
+  while using the non-capture workflow. This also added an alias for `MidCircuitPauliMeasure` for
   decomposition.
   [(#9506)](https://github.com/PennyLaneAI/pennylane/pull/9506)
 
@@ -56,11 +56,11 @@
   ```
 
 * Update phase gradient transforms to use ``BasisState`` instead of ``BasisEmbedding``.
-  This is an improvement as the latter is not consistently dispatched to ``C(BasisState)`` in ``controlled_resource_rep``, which 
+  This is an improvement as the latter is not consistently dispatched to ``C(BasisState)`` in ``controlled_resource_rep``, which
   led to compilation errors when using the old Catalyst frontend ``catalyst.device.decomposition.catalyst_decompose``.
   [(#9493)](https://github.com/PennyLaneAI/pennylane/pull/9493)
 
-* Created a new ``labs.estimator_beta.SelectCopyQROM`` resource operator which uses an optimal 
+* Created a new ``labs.estimator_beta.SelectCopyQROM`` resource operator which uses an optimal
   decomposition to estimate the cost for QROM.
   [(#9500)](https://github.com/PennyLaneAI/pennylane/pull/9500)
   [(#9516)](https://github.com/PennyLaneAI/pennylane/pull/9516)
@@ -73,7 +73,7 @@
     ...     size_bitstring = 8,
     ...     available_dirty_aux = 300,
     ... )
-    >>> 
+    >>>
     >>> print(qre.estimate(qrom_op))
     --- Resources: ---
     Total wires: 308
@@ -190,12 +190,13 @@
   list of abstract integer values. This is to better define the set of operations allowed on
   allocated qubits.
   [(#9400)](https://github.com/PennyLaneAI/pennylane/pull/9400)
+  [(#????)](https://github.com/PennyLaneAI/pennylane/pull/????)
 
 <h3>Documentation 📝</h3>
 
 * Fixed expected outputs in documentation of `"default.clifford"` device due to a new Stim version.
   [(#9533)](https://github.com/PennyLaneAI/pennylane/pull/9533)
- 
+
 * References to TensorFlow integration have been removed from the documentation following the end of maintenance support as of PennyLane v0.44.
   [(#9486)](https://github.com/PennyLaneAI/pennylane/pull/9486)
 

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -827,6 +827,8 @@ class Subroutine:
                 if len(register) > 0 and math.get_interface(register) != "jax":
                     # convert the integers in wires to tracers
                     wires = [(w if is_abstract_qubit(w) else jax.numpy.array(w)) for w in register]
+                    if not any(is_abstract_qubit(w) for w in wires):
+                        wires = math.array(wires, like="jax")
                     bound_args.arguments[wire_argname] = wires
 
             else:

--- a/tests/capture/transforms/test_capture_decompose.py
+++ b/tests/capture/transforms/test_capture_decompose.py
@@ -153,15 +153,15 @@ class TestDecomposeInterpreter:
             f(x, (1, 2))
 
         jaxpr = jax.make_jaxpr(w)(0.5)
-        eqn1 = jaxpr.eqns[0]  # the first subroutine prim
-        eqn2 = jaxpr.eqns[1]  # the second subroutine prim
+        eqn1 = jaxpr.eqns[3]  # the first subroutine prim
+        eqn2 = jaxpr.eqns[7]  # the second subroutine prim
 
         for eqn in [eqn1, eqn2]:
             assert eqn.primitive == qp.capture.primitives.quantum_subroutine_prim
             j = eqn.params["jaxpr"]
-            assert j.eqns[0].primitive == qp.CNOT._primitive
-            assert j.eqns[1].primitive == qp.RX._primitive
-            assert j.eqns[2].primitive == qp.CNOT._primitive
+            assert j.eqns[4].primitive == qp.CNOT._primitive
+            assert j.eqns[5].primitive == qp.RX._primitive
+            assert j.eqns[6].primitive == qp.CNOT._primitive
 
         assert eqn1.params["jaxpr"] is eqn2.params["jaxpr"]
 

--- a/tests/ops/op_math/test_change_op_basis.py
+++ b/tests/ops/op_math/test_change_op_basis.py
@@ -191,8 +191,8 @@ def test_change_op_basis_callables_capture():
     jaxpr = jax.make_jaxpr(circuit)()
 
     assert jaxpr.eqns[-1].primitive.name == "quantum_subroutine_prim"
-    assert jaxpr.eqns[-2].primitive.name == "PauliX"
-    assert jaxpr.eqns[-3].primitive.name == "quantum_subroutine_prim"
+    assert jaxpr.eqns[-3].primitive.name == "PauliX"
+    assert jaxpr.eqns[-4].primitive.name == "quantum_subroutine_prim"
 
 
 def test_change_op_basis_with_mixed_types():

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -497,6 +497,32 @@ class TestSubroutineCapture:
         inner_xpr = subroutine_eqn.params["jaxpr"]
         assert inner_xpr.eqns[-1].primitive == qp.capture.primitives.cond_prim
 
+    def test_stack_wires(self):
+        """Test that wire arguments to a subroutine are stacked"""
+
+        import jax  # pylint: disable=import-outside-toplevel
+
+        @Subroutine
+        def f(wires):
+            @qp.for_loop(len(wires))
+            def l(i):
+                qp.X(wires[i])
+
+            l()
+
+        def c():
+            f((0, 1, 2))
+
+        jaxpr = jax.make_jaxpr(c)()
+
+        subroutine_eqn = jaxpr.eqns[-1]
+        assert subroutine_eqn.primitive == qp.capture.primitives.quantum_subroutine_prim
+        assert len(subroutine_eqn.invars) == 1
+        assert subroutine_eqn.invars[0].aval.shape == (3,)
+
+        inner_xpr = subroutine_eqn.params["jaxpr"]
+        assert inner_xpr.eqns[-1].primitive == qp.capture.primitives.for_loop_prim
+
 
 @pytest.mark.capture
 class TestCollectedSubroutine:

--- a/tests/templates/test_subroutine.py
+++ b/tests/templates/test_subroutine.py
@@ -412,6 +412,7 @@ class TestSubroutineCapture:
 
         @qp.templates.Subroutine
         def f(wires):
+            assert wires.shape == (1,)
             qp.X(wires[0])
 
         jaxpr1 = jax.make_jaxpr(f)(0)
@@ -431,7 +432,7 @@ class TestSubroutineCapture:
 
         for jaxpr in [jaxpr1, jaxpr2, jaxpr3, jaxpr4, jaxpr5]:
             assert jaxpr.eqns[-1].primitive == qp.capture.primitives.quantum_subroutine_prim
-            assert jaxpr.eqns[-1].invars[0].aval.shape == ()
+            assert jaxpr.eqns[-1].invars[0].aval.shape == (1,)
             assert "int" in jaxpr.eqns[-1].invars[0].aval.dtype.name
 
     def test_mcm_return(self):


### PR DESCRIPTION
**Context:**
In #9400 we added a new `AbstractQubit` type, and changed some code around wire handling. 

In particular, the stacking of wire arguments to a subroutine was accidentally removed. 

**Description of the Change:**
Restore the stacking of wire arguments to a subroutine when none of the wires are `AbstractQubit`s.

