### PR TITLE
move process_queue to pennylane.tape.qscript

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -92,6 +92,7 @@
 <h3>Breaking changes 💔</h3>
 
 * `qp.queuing.process_queue` has been moved to `qp.tape.qscript.process_queue`.
+  [(#9542)](https://github.com/PennyLaneAI/pennylane/pull/9542)
 
 * The ability to specify shots as a keyword argument on call to a `QNode` is removed. Specifying the
   shots on creation of the `QNode` or using :func:`pennylane.set_shots` should be used instead.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -91,6 +91,8 @@
 
 <h3>Breaking changes 💔</h3>
 
+* `qp.queuing.process_queue` has been moved to `qp.tape.qscript.process_queue`.
+
 * The ability to specify shots as a keyword argument on call to a `QNode` is removed. Specifying the
   shots on creation of the `QNode` or using :func:`pennylane.set_shots` should be used instead.
   [(#9469)](https://github.com/PennyLaneAI/pennylane/pull/9469)

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -27,7 +27,6 @@ This module contains the classes for placing objects into queues.
     ~QueuingManager
     ~AnnotatedQueue
     ~apply
-    ~process_queue
 
 
 Description
@@ -158,7 +157,7 @@ Only the operators that will end up in the circuit will remain.
 [X(0)]
 [X(0)**1.5]
 
-Once the queue is constructed, the :func:`~.process_queue` function converts it into the operations
+Once the queue is constructed, the :meth:`~pennylane.tape.QuantumScript.from_queue` method converts it into the operations
 and measurements in the final circuit. This step eliminates any object that has an owner.
 
 .. code-block:: python
@@ -169,16 +168,11 @@ and measurements in the final circuit. This step eliminates any object that has 
         pow_op = base ** 1.5
         qp.expval(qp.Z(0) @ qp.X(1))
 
->>> ops, measurements = qp.queuing.process_queue(q)
->>> ops
+>>> tape = qp.tape.QuantumScript.from_queue(q)
+>>> tape.operations
 [StatePrep(array([1., 0.]), wires=[0]), X(0)**1.5]
->>> measurements
+>>> tape.measurements
 [expval(Z(0) @ X(1))]
-
-These lists can be used to construct a :class:`~.QuantumScript`:
-
->>> qp.tape.QuantumScript(ops, measurements)
-<QuantumScript: wires=[0, 1], params=1>
 
 In order to construct new operators within a recording, but without queuing them
 use the :meth:`~.queuing.QueuingManager.stop_recording` context upon construction:
@@ -554,50 +548,9 @@ def apply(op, context: type[QueuingManager] | AnnotatedQueue = QueuingManager):
     return op
 
 
-# pylint: disable=protected-access
-def process_queue(
-    queue: AnnotatedQueue,
-) -> tuple[list["pennylane.operation.Operator"], list["pennylane.measurements.MeasurementProcess"]]:
-    """Process the annotated queue, creating a list of quantum
-    operations and measurement processes.
-
-    Args:
-        queue (.AnnotatedQueue): The queue to be processed into individual lists
-
-    Returns:
-        tuple[list(.Operation), list(.MeasurementProcess)]:
-        The list of tape operations, the list of tape measurements
-
-    Raises:
-        QueuingError: If the queue contains objects that cannot be processed into a QuantumScript
-
-    """
-    from pennylane.measurements import (  # pylint: disable=import-outside-toplevel # tach-ignore
-        MeasurementProcess,
-    )
-    from pennylane.operation import (  # pylint: disable=import-outside-toplevel # tach-ignore
-        Operator,
-    )
-    from pennylane.tape import QuantumTape  # pylint: disable=import-outside-toplevel # tach-ignore
-
-    ops = []
-    measurements = []
-    encountered_measurement = False
-
-    # cant use for obj in queue.queue, as OperatorRecorder overrides the definition of queue
-    # cant use for obj in queue, as QuantumTape overrides the definition of __iter__
-    for obj, _ in queue.items():
-        if isinstance(obj, (Operator, QuantumTape)):
-            if encountered_measurement:
-                raise ValueError(f"{obj} must occur prior to measurements.")
-            ops.append(obj)
-        elif isinstance(obj, MeasurementProcess):
-            measurements.append(obj)
-            encountered_measurement = True
-        else:
-            raise QueuingError(
-                f"Encountered object {obj} in queue while processing."
-                " AnnotatedQueue should only contain `Operator`s and `MeasurementProcess`es."
-            )
-
-    return ops, measurements
+def __getattr__(key):
+    if key == "process_queue":
+        raise AttributeError(
+            "pennylane.queuing.process_queue has been moved to qp.tape.qscript.from_queue"
+        )
+    return AttributeError(f"module 'pennylane.queuing' has no attribute '{key}'")

--- a/pennylane/queuing.py
+++ b/pennylane/queuing.py
@@ -553,4 +553,4 @@ def __getattr__(key):
         raise AttributeError(
             "pennylane.queuing.process_queue has been moved to qp.tape.qscript.from_queue"
         )
-    return AttributeError(f"module 'pennylane.queuing' has no attribute '{key}'")
+    raise AttributeError(f"module 'pennylane.queuing' has no attribute '{key}'")

--- a/pennylane/tape/operation_recorder.py
+++ b/pennylane/tape/operation_recorder.py
@@ -15,9 +15,9 @@
 This module contains the :class:`OperationRecorder`.
 """
 
-from pennylane.queuing import AnnotatedQueue, QueuingManager, process_queue
+from pennylane.queuing import AnnotatedQueue, QueuingManager
 
-from .tape import QuantumScript
+from .qscript import QuantumScript, process_queue
 
 
 class OperationRecorder(QuantumScript, AnnotatedQueue):

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -56,7 +56,6 @@ def process_queue(
         ValueError: If the queue contains objects that cannot be processed into a QuantumScript
 
     """
-    from pennylane.tape import QuantumTape  # pylint: disable=import-outside-toplevel # tach-ignore
 
     ops = []
     measurements = []
@@ -65,7 +64,7 @@ def process_queue(
     # cant use for obj in queue.queue, as OperatorRecorder overrides the definition of queue
     # cant use for obj in queue, as QuantumTape overrides the definition of __iter__
     for obj, _ in queue.items():
-        if isinstance(obj, (Operator, QuantumTape)):
+        if isinstance(obj, (Operator, QuantumScript)):
             if encountered_measurement:
                 raise ValueError(f"{obj} must occur prior to measurements.")
             ops.append(obj)

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -32,11 +32,53 @@ from pennylane.measurements import MeasurementProcess
 from pennylane.measurements.shots import Shots, ShotsLike
 from pennylane.operation import _UNSET_BATCH_SIZE, Operation, Operator
 from pennylane.pytrees import register_pytree
-from pennylane.queuing import AnnotatedQueue, process_queue
+from pennylane.queuing import AnnotatedQueue
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 
 QS = TypeVar("QS", bound="QuantumScript")
+
+
+def process_queue(
+    queue: AnnotatedQueue,
+) -> tuple[list[Operator], list[MeasurementProcess]]:
+    """Process the annotated queue, creating a list of quantum
+    operations and measurement processes.
+
+    Args:
+        queue (.AnnotatedQueue): The queue to be processed into individual lists
+
+    Returns:
+        tuple[list(.Operation), list(.MeasurementProcess)]:
+        The list of tape operations, the list of tape measurements
+
+    Raises:
+        ValueError: If the queue contains objects that cannot be processed into a QuantumScript
+
+    """
+    from pennylane.tape import QuantumTape  # pylint: disable=import-outside-toplevel # tach-ignore
+
+    ops = []
+    measurements = []
+    encountered_measurement = False
+
+    # cant use for obj in queue.queue, as OperatorRecorder overrides the definition of queue
+    # cant use for obj in queue, as QuantumTape overrides the definition of __iter__
+    for obj, _ in queue.items():
+        if isinstance(obj, (Operator, QuantumTape)):
+            if encountered_measurement:
+                raise ValueError(f"{obj} must occur prior to measurements.")
+            ops.append(obj)
+        elif isinstance(obj, MeasurementProcess):
+            measurements.append(obj)
+            encountered_measurement = True
+        else:
+            raise ValueError(
+                f"Encountered object {obj} in queue while processing."
+                " AnnotatedQueue should only contain `Operator`s and `MeasurementProcess`es."
+            )
+
+    return ops, measurements
 
 
 class QuantumScript:

--- a/pennylane/tape/tape.py
+++ b/pennylane/tape/tape.py
@@ -25,9 +25,9 @@ import pennylane as qp
 from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
 from pennylane.measurements import CountsMP, ProbabilityMP, SampleMP
 from pennylane.pytrees import register_pytree
-from pennylane.queuing import AnnotatedQueue, QueuingManager, process_queue
+from pennylane.queuing import AnnotatedQueue, QueuingManager
 
-from .qscript import QuantumScript
+from .qscript import QuantumScript, process_queue
 
 
 def _err_msg_for_some_meas_not_qwc(measurements):

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -22,9 +22,17 @@ import pennylane as qp
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.measurements import Shots, StateMP
 from pennylane.operation import _UNSET_BATCH_SIZE
-from pennylane.tape import QuantumScript
+from pennylane.tape.qscript import QuantumScript, process_queue
 
 # pylint: disable=protected-access, unused-argument, too-few-public-methods, use-implicit-booleaness-not-comparison
+
+
+def test_process_queue_error_if_not_operator_or_measurement():
+    """Test that a QueuingError is raised if process queue encounters an object it cant handle."""
+    q = qp.queuing.AnnotatedQueue()
+    q.append(1)
+    with pytest.raises(ValueError, match="Encountered object 1 in queue while processing."):
+        process_queue(q)
 
 
 def test_adjoint_deprecated():

--- a/tests/tape/test_qscript.py
+++ b/tests/tape/test_qscript.py
@@ -28,7 +28,7 @@ from pennylane.tape.qscript import QuantumScript, process_queue
 
 
 def test_process_queue_error_if_not_operator_or_measurement():
-    """Test that a QueuingError is raised if process queue encounters an object it cant handle."""
+    """Test that a QueuingError is raised if process queue encounters an object it can't handle."""
     q = qp.queuing.AnnotatedQueue()
     q.append(1)
     with pytest.raises(ValueError, match="Encountered object 1 in queue while processing."):

--- a/tests/templates/subroutines/test_qsvt.py
+++ b/tests/templates/subroutines/test_qsvt.py
@@ -103,7 +103,7 @@ class TestQSVTBasics:
         with qp.queuing.AnnotatedQueue() as q:
             decomp = op.decomposition()
 
-        ops, _ = qp.queuing.process_queue(q)
+        ops = qp.tape.QuantumScript.from_queue(q).operations
         for op1, op2 in zip(ops, decomp):
             qp.assert_equal(op1, op2)
 

--- a/tests/test_queuing.py
+++ b/tests/test_queuing.py
@@ -461,9 +461,15 @@ class TestWrappedObj:
         assert wo.__repr__() == "Wrapped(test_repr)"
 
 
-def test_process_queue_error_if_not_operator_or_measurement():
-    """Test that a QueuingError is raised if process queue encounters an object it cant handle."""
-    q = AnnotatedQueue()
-    q.append(1)
-    with pytest.raises(QueuingError, match="Encountered object 1 in queue while processing."):
-        qp.queuing.process_queue(q)
+def test_error_on_process_queue():
+    """Test that an informative error is raised indicating that process_queue has moved."""
+
+    with pytest.raises(AttributeError, match="has been moved to qp.tape.qscript.from_queue"):
+        _ = qp.queuing.process_queue
+
+
+def test_error_on_nonexistent_item():
+    """Test an AttributeError is raised if an object does not exist."""
+
+    with pytest.raises(AttributeError, match="module 'pennylane.queuing' has no attribute 'thing'"):
+        _ = qp.queuing.thing


### PR DESCRIPTION
**Context:**

#9530 made `process_queue` use isinstance checks instead of an un-official interface for `_queue_category`. As @astralcai rightly pointed out, this introduced some circular dependency and import-outside-toplevel issues. This PR just follows up on that and moves `process_queue` to a better place.
 
**Description of the Change:**

Moves `qp.queuing.process_queue` to `qp.tape.qscript.process_queue`.

**Benefits:**

No more circular dependencies.

**Possible Drawbacks:**

It's a straight breaking change. But we don't really even use it independently ourselves.

**Related GitHub Issues:**

[sc-120925]
