### PR TITLE
Allow empty registers in `qp.registers`.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,7 +38,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* Allowed `qp.registers` to produce empty registers.
+* Updated `qp.registers` to accept empty registers (e.g., `qp.registers({"algo_wires": 5, "work_wires": 0})). 
   [(#9543)](https://github.com/PennyLaneAI/pennylane/pull/9543)
 
 * Removed instances of using the deprecated way to set shots on a device `device(..., shots=...)`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,6 +38,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Allowed `qp.registers` to produce empty registers.
+  [(#9543)](https://github.com/PennyLaneAI/pennylane/pull/9543)
+
 * Removed instances of using the deprecated way to set shots on a device `device(..., shots=...)`.
   [(#9495)](https://github.com/PennyLaneAI/pennylane/pull/9495)
 

--- a/pennylane/registers.py
+++ b/pennylane/registers.py
@@ -31,7 +31,8 @@ def registers(register_dict):
 
     Args:
         register_dict (dict): a dictionary where keys are register names and values are either
-            positive integers indicating the number of qubits or nested dictionaries of more registers
+            non-negative integers indicating the number of qubits or nested dictionaries of
+            more registers
 
     Returns:
         dict: Dictionary where the keys are the names (str) of the registers, and the
@@ -39,12 +40,12 @@ def registers(register_dict):
 
     **Example**
 
-    Given flat input dictionary:
+    Given a flat input dictionary:
 
     >>> qp.registers({"alice": 2, "bob": 3})
     {'alice': Wires([0, 1]), 'bob': Wires([2, 3, 4])}
 
-    Given nested input dictionary:
+    Given a nested input dictionary:
 
     >>> wire_registers = qp.registers({"people": {"alice": 2, "bob": 1}})
     >>> wire_registers
@@ -107,10 +108,10 @@ def registers(register_dict):
                 )
                 _start_wire_index = wire_vals[-1] + 1
             elif isinstance(register_wires, int):
-                if register_wires < 1:
+                if register_wires < 0:
                     raise ValueError(
-                        f"Expected '{register_wires}' to be greater than 0. Please ensure that "
-                        "the number of wires for the register is a positive integer"
+                        f"Expected '{register_wires}' to be larger than or equal to 0. Please "
+                        "ensure that the number of wires for the register is a non-negative integer"
                     )
                 all_reg[register_name] = Wires(
                     range(_start_wire_index, register_wires + _start_wire_index)

--- a/tests/test_registers.py
+++ b/tests/test_registers.py
@@ -91,10 +91,6 @@ class TestRegisters:
                 "Got an empty dictionary",
             ),
             (
-                {"alice": 3, "bob": {"nest1": 0}, "cleo": 3},
-                "Expected '0' to be greater than 0. Please ensure that the number of wires for the register is a positive integer",
-            ),
-            (
                 {"alice": 3, "bob": {"nest1": {"nest2": {"nest3": {1}}}}, "cleo": 3},
                 r"Expected '\{1\}' to be either a dict or an int",
             ),
@@ -104,3 +100,17 @@ class TestRegisters:
         """Test that the registers function raises the right error for given Wires dictionaries"""
         with pytest.raises(ValueError, match=expected_error_msg):
             qp.registers(wire_dict)
+
+    def test_with_empty_register(self):
+        """Test that empty wire registers are allowed and processed correctly."""
+
+        out_0 = qp.registers({"a": 2, "b": 0})
+        assert out_0 == {"a": Wires([0, 1]), "b": Wires([])}
+
+        out_1 = qp.registers({"a": 2, "b": {"first b": 0, "second b": 4}})
+        assert out_1 == {
+            "a": Wires([0, 1]),
+            "b": Wires([2, 3, 4, 5]),
+            "first b": Wires([]),
+            "second b": Wires([2, 3, 4, 5]),
+        }


### PR DESCRIPTION
**Context:**
`qp.registers` disallows empty registers.
- This is inconsistent with `Wires([])` being legitimate PennyLane code
- It is annoying when programmatically processing registers that may become empty in edge cases.

**Description of the Change:**
Remove error raising for a zero-sized register.

**Benefits:**
see above. Consistency+ convenience

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
