### PR TITLE
Support functools.partial in inspection tools (#9394)

### DIFF
--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -18,6 +18,7 @@ Contains the drawing function.
 from __future__ import annotations
 
 import warnings
+import functools
 from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Literal
@@ -36,6 +37,27 @@ if TYPE_CHECKING:
 def catalyst_qjit(qnode):
     """A method checking whether a qnode is compiled by catalyst.qjit"""
     return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
+
+
+def _unwrap_partial(func):
+    """Recursively unwraps a functools.partial object.
+
+    Returns:
+        tuple: (original_func, bound_args, bound_kwargs)
+    """
+    bound_args = []
+    bound_kwargs = {}
+
+    while isinstance(func, functools.partial):
+        bound_args = list(func.args) + bound_args
+
+        new_kwargs = func.keywords.copy()
+        new_kwargs.update(bound_kwargs)
+        bound_kwargs = new_kwargs
+
+        func = func.func
+
+    return func, tuple(bound_args), bound_kwargs
 
 
 # pylint: disable=too-many-arguments
@@ -288,6 +310,8 @@ def draw(
         2: ─╰●─────────────────┤
 
     """
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -296,6 +320,8 @@ def draw(
             qnode,
             wire_order=wire_order,
             show_all_wires=show_all_wires,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
             decimals=decimals,
             max_length=max_length,
             show_matrices=show_matrices,
@@ -311,7 +337,10 @@ def draw(
 
     @wraps(qnode)
     def wrapper(*args, **kwargs):
-        tape = make_qscript(qnode)(*args, **kwargs)
+        merged_kwargs = bound_kwargs.copy()
+        merged_kwargs.update(kwargs)
+        merged_args = bound_args + args
+        tape = make_qscript(qnode)(*merged_args, **merged_kwargs)
 
         if wire_order:
             _wire_order = wire_order
@@ -340,15 +369,23 @@ def _draw_qnode(
     wire_order: Sequence | None = None,
     show_all_wires: bool = False,
     *,
+    bound_args=None,
+    bound_kwargs=None,
     decimals: int | None = 2,
     max_length=100,
     show_matrices=True,
     show_wire_labels=True,
     level: Literal["top", "user", "device", "gradient"] | int | slice = "gradient",
 ):
+    bound_args = bound_args or ()
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs):
-        tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs)
+        merged_kwargs = bound_kwargs.copy()
+        merged_kwargs.update(kwargs)
+        merged_args = bound_args + args
+        tapes, _ = construct_batch(qnode, level=level)(*merged_args, **merged_kwargs)
 
         if wire_order:
             _wire_order = wire_order
@@ -780,6 +817,8 @@ def draw_mpl(
             :target: javascript:void(0);
 
     """
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -789,6 +828,8 @@ def draw_mpl(
             wire_order=wire_order,
             show_all_wires=show_all_wires,
             decimals=decimals,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
             max_length=max_length,
             level=level,
             style=style,
@@ -803,8 +844,11 @@ def draw_mpl(
         )
 
     @wraps(qnode)
-    def wrapper(*args, **kwargs):
-        tape = make_qscript(qnode)(*args, **kwargs)
+    def wrapper(*args, **kwargs_qnode):
+        merged_kwargs = bound_kwargs.copy()
+        merged_kwargs.update(kwargs_qnode)
+        merged_args = bound_args + args
+        tape = make_qscript(qnode)(*merged_args, **merged_kwargs)
         if wire_order:
             _wire_order = wire_order
         else:
@@ -835,14 +879,22 @@ def _draw_mpl_qnode(
     show_all_wires=False,
     decimals: int | None = None,
     *,
+    bound_args=None,
+    bound_kwargs=None,
     level="gradient",
     style="black_white",
     fig=None,
     **kwargs,
 ):
+    bound_args = bound_args or ()
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
-        tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs_qnode)
+        merged_kwargs = bound_kwargs.copy()
+        merged_kwargs.update(kwargs_qnode)
+        merged_args = bound_args + args
+        tapes, _ = construct_batch(qnode, level=level)(*merged_args, **merged_kwargs)
 
         if len(tapes) > 1:
             warnings.warn(

--- a/pennylane/noise/insert_ops.py
+++ b/pennylane/noise/insert_ops.py
@@ -39,17 +39,17 @@ def _check_position(position):
         req_ops = position.copy()
         for operation in req_ops:
             try:
-                if Operation not in operation.__bases__:
+                if not issubclass(operation, Operation):
                     not_op = True
-            except AttributeError:
+            except TypeError:
                 not_op = True
     elif not isinstance(position, list):
         try:
-            if Operation in position.__bases__:
+            if issubclass(position, Operation):
                 req_ops = [position]
             else:
                 not_op = True
-        except AttributeError:
+        except TypeError:
             not_op = True
     return not_op, req_ops
 
@@ -231,15 +231,18 @@ def insert(
         error=DecompositionUndefinedError,
     )
 
-    if not isinstance(op, FunctionType) and op.num_wires != 1:
-        raise ValueError("Only single-qubit operations can be inserted into the circuit")
-
     not_op, req_ops = _check_position(position)
 
     if position not in ("start", "end", "all") and not_op:
         raise ValueError(
             "Position must be either 'start', 'end', or 'all' (default) OR a PennyLane operation or list of operations."
         )
+
+    if not isinstance(op, FunctionType) and getattr(op, "num_wires", 1) != 1:
+        if not req_ops:
+            raise ValueError(
+                "Multi-qubit operations can only be inserted into the circuit if the position specifies target operations."
+            )
 
     if not isinstance(op_args, Sequence):
         op_args = [op_args]
@@ -267,9 +270,19 @@ def insert(
                 # circuit_op is an instance of an operation.
                 # operation is a type; either Operator or some subclass of Operator.
                 if isinstance(circuit_op, operation):
-                    for w in circuit_op.wires:
-                        sub_tape = make_qscript(op)(*op_args, wires=w)
+                    op_wires = getattr(op, "num_wires", 1)
+                    if not isinstance(op, FunctionType) and op_wires != 1:
+                        if op_wires not in {len(circuit_op.wires), None, -1}:
+                            raise ValueError(
+                                f"Number of wires of the inserted operation ({op_wires}) does not match "
+                                f"the number of wires of the target operation ({len(circuit_op.wires)})."
+                            )
+                        sub_tape = make_qscript(op)(*op_args, wires=circuit_op.wires)
                         new_operations.extend(sub_tape.operations)
+                    else:
+                        for w in circuit_op.wires:
+                            sub_tape = make_qscript(op)(*op_args, wires=w)
+                            new_operations.extend(sub_tape.operations)
 
         if before:
             new_operations.append(circuit_op)

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -153,18 +153,7 @@ def _create_commute_function():
 _commutes = _create_commute_function()
 
 
-def _check_opmath_operations(operation1, operation2):
-    """Check that `SProd`, `Prod`, and `Sum` instances only contain Pauli words."""
 
-    for op in [operation1, operation2]:
-
-        if op.pauli_rep is not None:
-            continue
-
-        if isinstance(op, (SProd, Prod, Sum)):
-            raise QuantumFunctionError(
-                f"Operation {op} currently not supported. Prod, Sprod, and Sum instances must have a valid Pauli representation."
-            )
 
 
 def intersection(wires1, wires2):
@@ -318,8 +307,20 @@ def is_commuting(operation1, operation2):
         operation1 = qp.simplify(operation1)
         operation2 = qp.simplify(operation2)
 
-    # Arithmetic non-disjoint operations only contain Pauli words
-    _check_opmath_operations(operation1, operation2)
+    if isinstance(operation1, SProd):
+        return is_commuting(operation1.base, operation2)
+    if isinstance(operation2, SProd):
+        return is_commuting(operation1, operation2.base)
+
+    if isinstance(operation1, Prod):
+        return all(is_commuting(op, operation2) for op in operation1)
+    if isinstance(operation2, Prod):
+        return all(is_commuting(operation1, op) for op in operation2)
+
+    if isinstance(operation1, Sum):
+        return all(is_commuting(op, operation2) for op in operation1)
+    if isinstance(operation2, Sum):
+        return all(is_commuting(operation1, op) for op in operation2)
 
     # Two CRot that cannot be simplified
     if operation1.name == "CRot" and operation2.name == "CRot":

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -24,7 +24,7 @@ import time
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from functools import partial
+from functools import partial, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -39,6 +39,28 @@ if TYPE_CHECKING:
 _RESOURCE_TRACKING_PREFIX = "pennylane_specs_qjit_resources"
 # Used for MLIR analysis pass JSON filenames with pass-by-pass specs
 _RESOURCE_ANALYSIS_PREFIX = "pennylane_specs_analysis_pass"
+
+
+def _unwrap_partial(func):
+    """Recursively unwraps a functools.partial object.
+
+    Returns:
+        tuple: (original_func, bound_args, bound_kwargs)
+    """
+    bound_args = []
+    bound_kwargs = {}
+
+    while isinstance(func, partial):
+        bound_args = list(func.args) + bound_args
+
+        new_kwargs = func.keywords.copy()
+        new_kwargs.update(bound_kwargs)
+        bound_kwargs = new_kwargs
+
+        func = func.func
+
+    return func, tuple(bound_args), bound_kwargs
+
 
 
 def _make_level_name_unique(level_name: str, existing_names: set[str]) -> str:
@@ -1000,24 +1022,38 @@ def specs(
     # pylint: disable=import-outside-toplevel
     # Have to import locally to prevent circular imports as well as accounting for Catalyst not being installed
 
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
+    handler = None
+
     if isinstance(qnode, qp.QNode):
-        return partial(_specs_qnode, qnode, level, compute_depth)
+        handler = _specs_qnode
+    else:
+        try:
+            from ..qnn.torch import TorchLayer
 
-    try:
-        from ..qnn.torch import TorchLayer
+            if isinstance(qnode, TorchLayer) and isinstance(qnode.qnode, qp.QNode):
+                handler = _specs_qnode
+        except ImportError:  # pragma: no cover
+            pass
 
-        if isinstance(qnode, TorchLayer) and isinstance(qnode.qnode, qp.QNode):
-            return partial(_specs_qnode, qnode, level, compute_depth)
-    except ImportError:  # pragma: no cover
-        pass
+        if handler is None:
+            try:  # pragma: no cover
+                # This is tested by integration tests within the Catalyst frontend
+                import catalyst
 
-    try:  # pragma: no cover
-        # This is tested by integration tests within the Catalyst frontend
-        import catalyst
+                if isinstance(qnode, catalyst.jit.QJIT):
+                    handler = _specs_qjit
+            except ImportError:  # pragma: no cover
+                pass
 
-        if isinstance(qnode, catalyst.jit.QJIT):
-            return partial(_specs_qjit, qnode, level, compute_depth)
-    except ImportError:  # pragma: no cover
-        pass
+    if handler is None:
+        raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")
 
-    raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")
+    @wraps(qnode)
+    def wrapper(*args, **kwargs):
+        merged_kwargs = bound_kwargs.copy()
+        merged_kwargs.update(kwargs)
+        merged_args = bound_args + args
+        return handler(qnode, level, compute_depth, *merged_args, **merged_kwargs)
+
+    return wrapper

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -186,6 +186,11 @@ def compile(
     if num_passes < 1 or not isinstance(num_passes, int):
         raise ValueError("Number of passes must be an integer with value at least 1.")
 
+    if basis_set is not None and not all(isinstance(op, str) for op in basis_set):
+        raise ValueError(
+            "basis_set must only contain strings. "
+            "Please provide the operation names rather than the operations themselves."
+        )
     # Expand the tape; this is done to unroll any templates that may be present,
     # as well as to decompose over a specified basis set
     # First, though, we have to stop whatever tape may be recording so that we

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -1244,3 +1244,51 @@ def test_sort_wires_fallback(use_qnode):
 
     expected = "4: ──X─┤     \na: ──X─┤     \n0: ──X─┤  <Z>"
     assert qp.draw(func)() == expected
+
+
+class TestFunctoolsPartial:
+    """Test that draw handles functools.partial properly."""
+
+    def test_partial_circuit(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
+            
+        fixed_circ = functools.partial(circ, 1.23)
+        expected = "0: ──RX(1.23)─┤  <Z>\n1: ──RY(2.34)─┤     "
+        assert qp.draw(fixed_circ)(2.34) == expected
+
+    def test_nested_partial_circuit(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y, z):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.RZ(z, wires=0)
+            return qp.expval(qp.PauliZ(0))
+            
+        p1 = functools.partial(circ, 1.23)
+        p2 = functools.partial(p1, z=3.45)
+        
+        expected = "0: ──RX(1.23)──RZ(3.45)─┤  <Z>\n1: ──RY(2.34)───────────┤     "
+        assert qp.draw(p2)(2.34) == expected
+        
+    def test_partial_kwargs_override(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
+            
+        p1 = functools.partial(circ, y=2.34)
+        p2 = functools.partial(p1, y=3.45)
+        
+        expected = "0: ──RX(1.23)─┤  <Z>\n1: ──RY(3.45)─┤     "
+        assert qp.draw(p2)(1.23) == expected

--- a/tests/noise/test_insert_ops.py
+++ b/tests/noise/test_insert_ops.py
@@ -58,7 +58,7 @@ class TestInsert:
 
     def test_multiwire_op(self):
         """Tests if a ValueError is raised when multiqubit operations are requested"""
-        with pytest.raises(ValueError, match="Only single-qubit operations can be inserted into"):
+        with pytest.raises(ValueError, match="Multi-qubit operations can only be inserted into"):
             insert(self.tape, qp.CNOT, [])
 
     @pytest.mark.parametrize("pos", [1, ["all", qp.RY, int], "ABC", str])
@@ -530,3 +530,40 @@ def test_insert_transform_works_with_non_qwc_obs():
         return qp.expval(qp.PauliX(0)), qp.expval(qp.PauliY(0)), qp.expval(qp.PauliZ(0))
 
     assert np.allclose(noisy_circuit(0.4), explicit_circuit(0.4))
+
+
+def test_insert_multiqubit_operation():
+    """Test that a multi-qubit operation can be inserted when targeting a gate with matching wires."""
+    dev = qp.device("default.qubit", wires=2)
+
+    @qp.qnode(dev)
+    @insert(op=qp.CRX, op_args=0.5, position=[qp.CNOT])
+    def noisy_circuit():
+        qp.RY(0.3, wires=0)
+        qp.RY(0.4, wires=1)
+        qp.CNOT(wires=[0, 1])
+        return qp.expval(qp.PauliZ(0))
+
+    @qp.qnode(dev)
+    def explicit_circuit():
+        qp.RY(0.3, wires=0)
+        qp.RY(0.4, wires=1)
+        qp.CNOT(wires=[0, 1])
+        qp.CRX(0.5, wires=[0, 1])
+        return qp.expval(qp.PauliZ(0))
+
+    assert np.allclose(noisy_circuit(), explicit_circuit())
+
+
+def test_insert_multiqubit_operation_wire_mismatch():
+    """Test that inserting a multi-qubit operation raises an error if wire counts do not match."""
+    dev = qp.device("default.qubit", wires=3)
+
+    @qp.qnode(dev)
+    @insert(op=qp.CRX, op_args=0.5, position=[qp.Toffoli])
+    def noisy_circuit():
+        qp.Toffoli(wires=[0, 1, 2])
+        return qp.expval(qp.PauliZ(0))
+
+    with pytest.raises(ValueError, match="Number of wires of the inserted operation"):
+        noisy_circuit()

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -853,20 +853,20 @@ class TestCommutingFunction:
         assert do_they_commute == commute_status
 
     @pytest.mark.parametrize(
-        "pauli_word_1,pauli_word_2",
+        "pauli_word_1,pauli_word_2,expected",
         [
             (
                 qp.prod(qp.PauliX(0), qp.Hadamard(1), qp.Identity(2)),
                 qp.sum(qp.PauliX(0), qp.PauliY(2)),
+                True,
             ),
-            (qp.PauliX(2), qp.sum(qp.Hadamard(1), qp.prod(qp.PauliX(1), qp.Identity(2)))),
-            (qp.prod(qp.PauliX(1), qp.PauliY(2)), qp.s_prod(0.5, qp.Hadamard(1))),
+            (qp.PauliX(2), qp.sum(qp.Hadamard(1), qp.prod(qp.PauliX(1), qp.Identity(2))), True),
+            (qp.prod(qp.PauliX(1), qp.PauliY(2)), qp.s_prod(0.5, qp.Hadamard(1)), False),
         ],
     )
-    def test_non_pauli_word_ops_not_supported(self, pauli_word_1, pauli_word_2):
-        """Ensure invalid inputs are handled properly when determining commutativity."""
-        with pytest.raises(QuantumFunctionError):
-            qp.is_commuting(pauli_word_1, pauli_word_2)
+    def test_non_pauli_word_ops_supported(self, pauli_word_1, pauli_word_2, expected):
+        """Ensure inputs without pauli rep are handled properly when determining commutativity."""
+        assert qp.is_commuting(pauli_word_1, pauli_word_2) == expected
 
     def test_operation_1_not_supported(self):
         """Test that giving a non supported operation raises an error."""

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -681,3 +681,57 @@ class TestSpecsGraphModeExclusive:
         # No work wires available (2 device wires - 2 tape wires = 0)
         assert specs["num_device_wires"] == 2
         assert specs["resources"].num_allocs == 2
+
+
+class TestFunctoolsPartial:
+    """Test that specs handles functools.partial properly."""
+
+    def test_partial_circuit(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
+            
+        fixed_circ = functools.partial(circ, 1.23)
+        specs = qp.specs(fixed_circ)(2.34)
+        
+        assert specs["resources"].gate_types == {"RX": 1, "RY": 1}
+        assert specs["resources"].num_allocs == 2
+        assert specs["resources"].depth == 1
+
+    def test_nested_partial_circuit(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y, z):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            qp.RZ(z, wires=0)
+            return qp.expval(qp.PauliZ(0))
+            
+        p1 = functools.partial(circ, 1.23)
+        p2 = functools.partial(p1, z=3.45)
+        
+        specs = qp.specs(p2)(2.34)
+        assert specs["resources"].gate_types == {"RX": 1, "RY": 1, "RZ": 1}
+        assert specs["resources"].depth == 2
+        
+    def test_partial_kwargs_override(self):
+        import functools
+        
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def circ(x, y):
+            qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.PauliZ(0))
+            
+        p1 = functools.partial(circ, y=2.34)
+        p2 = functools.partial(p1, y=3.45)
+        
+        specs = qp.specs(p2)(1.23)
+        assert specs["resources"].gate_types == {"RX": 1, "RY": 1}
+        assert specs["resources"].num_allocs == 2
+

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -73,6 +73,15 @@ class TestCompile:
         with pytest.raises(ValueError, match="Number of passes must be an integer"):
             transformed_qnode(0.1, 0.2, 0.3)
 
+    def test_compile_invalid_basis_set(self):
+        """Test that error is raised for a basis_set containing non-strings."""
+        qfunc = build_qfunc([0, 1, 2])
+        transformed_qfunc = compile(qfunc, basis_set=["RX", qp.RY(0.1, wires=0)])
+        transformed_qnode = qp.QNode(transformed_qfunc, dev_3wires)
+
+        with pytest.raises(ValueError, match="basis_set must only contain strings"):
+            transformed_qnode(0.1, 0.2, 0.3)
+
     def test_compile_mixed_tape_qfunc_transform(self):
         """Test that we can interchange tape and qfunc transforms."""
 


### PR DESCRIPTION
Fixes #9394. This PR adds a recursive unwrapping helper _unwrap_partial to pennylane/drawer/draw.py and pennylane/resource/specs.py. This ensures that nested unctools.partial objects are unwrapped properly, their rgs and kwargs are merged, and then passed into the inspection tool (qp.draw, qp.draw_mpl, qp.specs) wrappers.