### PR TITLE
Add Tracker repr

### DIFF
--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -179,6 +179,12 @@ class Tracker:
                 raise ValueError(f"Device '{dev.short_name}' does not support device tracking")
             dev.tracker = self
 
+    def __repr__(self):
+        return (
+            f"Tracker(active={self.active!r}, totals={self.totals!r}, "
+            f"persistent={self.persistent!r}, history={self.history!r}, latest={self.latest!r})"
+        )
+
     def __enter__(self):
         if not self.persistent:
             self.reset()

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -41,6 +41,28 @@ class TestTrackerCoreBehavior:
 
         assert tracker.active is False
 
+    def test_repr_default_tracker(self):
+        """Test the representation of a default tracker."""
+
+        tracker = Tracker()
+
+        assert repr(tracker) == (
+            "Tracker(active=False, totals={}, persistent=False, history={}, latest={})"
+        )
+
+    def test_repr_updated_tracker(self):
+        """Test the representation after a tracker has stored data."""
+
+        tracker = Tracker(persistent=True)
+        tracker.update(a=2, b="b2", c=1)
+        tracker.active = True
+
+        assert repr(tracker) == (
+            "Tracker(active=True, totals={'a': 2, 'c': 1}, persistent=True, "
+            "history={'a': [2], 'b': ['b2'], 'c': [1]}, "
+            "latest={'a': 2, 'b': 'b2', 'c': 1})"
+        )
+
     def test_device_assignment(self):
         """Assert gets assigned to device"""
 


### PR DESCRIPTION
## Summary

- Add a readable `Tracker.__repr__` that exposes the tracker state users need while debugging: `active`, `totals`, `persistent`, `history`, and `latest`.
- Keep the change scoped to representation only; callback behavior and tracking logic are unchanged.
- Add focused tests for the default representation and a populated tracker after an update.

Closes #9389

## Tests

- `python3 -m py_compile pennylane/devices/tracker.py tests/devices/test_tracker.py`
- `git diff --check`
- `uv run python -m pytest tests/devices/test_tracker.py -q`

## AI Assistance Disclosure

This contribution was AI-assisted. I used Codex as a coding assistant, reviewed the issue requirements and implementation scope, and verified the change locally with the tests listed above.
