### PR TITLE
Add documentation testing support for pennylane/shadows

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -84,7 +84,6 @@ jobs:
           --ignore=pennylane/math
           --ignore=pennylane/compiler
           --ignore=pennylane/capture
-          --ignore=pennylane/shadows
           --ignore=pennylane/gradients
           --ignore=pennylane/optimize
           --ignore=pennylane/pulse

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -382,6 +382,10 @@
 
 <h3>Documentation 📝</h3>
 
+* Enabled documentation testing for the :mod:`pennylane.shadows` module by updating its executable examples and
+  removing the module from the documentation-test skip list.
+  [(#9566)](https://github.com/PennyLaneAI/pennylane/pull/9566)
+
 * Fixed expected outputs in documentation of `"default.clifford"` device due to a new Stim version.
   [(#9533)](https://github.com/PennyLaneAI/pennylane/pull/9533)
 
@@ -460,5 +464,6 @@ Andrija Paurevic,
 Francesco Pernice Botta,
 Jay Soni,
 Paul Haochen Wang,
+Dennis Wayo,
 David Wierichs,
 Jake Zaia.

--- a/pennylane/shadows/__init__.py
+++ b/pennylane/shadows/__init__.py
@@ -76,11 +76,13 @@ Basic usage
 
 The easiest way of computing expectation values with classical shadows in PennyLane is to return :func:`shadow_expval` directly from the qnode.
 
-.. code-block:: python3
+.. code-block:: python
+
+    from pennylane import numpy as np
 
     H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.Z(1)])
 
-    dev = qp.device("default.qubit")
+    dev = qp.device("default.qubit", seed=42)
 
     # shadow_expval + mid-circuit measurements require to defer measurements
     @qp.defer_measurements
@@ -91,16 +93,16 @@ The easiest way of computing expectation values with classical shadows in PennyL
         qp.CNOT((0,1))
         qp.RX(x, wires=0)
         qp.measure(1)
-        return qp.shadow_expval(H)
+        return qp.shadow_expval(H, seed=99)
 
     x = np.array(0.5, requires_grad=True)
 
 The big advantage of this way of computing expectation values is that it is differentiable.
 
 >>> qnode(x)
-array(0.8406)
->>> qp.grad(qnode)(x)
--0.49680000000000013
+array(0.8532)
+>>> print(qp.grad(qnode)(x))
+-0.46440000000000015
 
 There are more options for post-processing classical shadows in :class:`ClassicalShadow`.
 """

--- a/pennylane/shadows/__init__.py
+++ b/pennylane/shadows/__init__.py
@@ -102,7 +102,7 @@ The big advantage of this way of computing expectation values is that it is diff
 >>> qnode(x)
 array(0.8532)
 >>> print(qp.grad(qnode)(x))
--0.46440000000000015
+-0.4644...
 
 There are more options for post-processing classical shadows in :class:`ClassicalShadow`.
 """

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -63,9 +63,9 @@ class ClassicalShadow:
 
     We obtain the ``bits`` and ``recipes`` via :func:`~.pennylane.classical_shadow` measurement:
 
-    .. code-block:: python3
+    .. code-block:: python
 
-        dev = qp.device("default.qubit", wires=range(2))
+        dev = qp.device("default.qubit", wires=range(2), seed=42)
 
         @qp.set_shots(shots=1000)
         @qp.qnode(dev)
@@ -73,7 +73,7 @@ class ClassicalShadow:
             qp.Hadamard(0)
             qp.CNOT((0,1))
             qp.RX(x, wires=0)
-            return qp.classical_shadow(wires=range(2))
+            return qp.classical_shadow(wires=range(2), seed=99)
 
         bits, recipes = qnode(0)
         shadow = qp.ClassicalShadow(bits, recipes)
@@ -82,13 +82,13 @@ class ClassicalShadow:
     For example, we can compute the expectation value of a Pauli string
 
     >>> shadow.expval(qp.X(0) @ qp.X(1), k=1)
-    array(0.972)
+    array(1.017)
 
     or of a Hamiltonian:
 
     >>> H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.X(1)])
     >>> shadow.expval(H, k=1)
-    array(1.917)
+    array(2.007)
 
     The parameter ``k`` is used to estimate the expectation values via the `median of means` algorithm (see `2002.08953 <https://arxiv.org/abs/2002.08953>`_). The case ``k=1`` corresponds to simply taking the mean
     value over all local snapshots. ``k>1`` corresponds to splitting the ``T`` local snapshots into ``k`` equal parts, and taking the median of their individual means. For the case of measuring only in the Pauli basis,
@@ -194,19 +194,19 @@ class ClassicalShadow:
 
         We can approximately reconstruct a Bell state:
 
-        .. code-block:: python3
+        .. code-block:: python
 
-            dev = qp.device("default.qubit", wires=range(2))
+            dev = qp.device("default.qubit", wires=range(2), seed=42)
 
             @qp.set_shots(shots=1000)
             @qp.qnode(dev)
             def qnode():
                 qp.Hadamard(0)
                 qp.CNOT((0,1))
-                return classical_shadow(wires=range(2))
+                return qp.classical_shadow(wires=range(2), seed=99)
 
             bits, recipes = qnode()
-            shadow = ClassicalShadow(bits, recipes)
+            shadow = qp.ClassicalShadow(bits, recipes)
             shadow_state = np.mean(shadow.global_snapshots(), axis=0)
 
             bell_state = np.array([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
@@ -299,9 +299,9 @@ class ClassicalShadow:
 
         **Example**
 
-        .. code-block:: python3
+        .. code-block:: python
 
-            dev = qp.device("default.qubit", wires=range(2))
+            dev = qp.device("default.qubit", wires=range(2), seed=42)
 
             @qp.set_shots(shots=1000)
             @qp.qnode(dev)
@@ -309,7 +309,7 @@ class ClassicalShadow:
                 qp.Hadamard(0)
                 qp.CNOT((0,1))
                 qp.RX(x, wires=0)
-                return qp.classical_shadow(wires=range(2))
+                return qp.classical_shadow(wires=range(2), seed=99)
 
             bits, recipes = qnode(0)
             shadow = qp.ClassicalShadow(bits, recipes)
@@ -317,13 +317,13 @@ class ClassicalShadow:
         Compute Pauli string observables
 
         >>> shadow.expval(qp.X(0) @ qp.X(1), k=1)
-        array(1.116)
+        array(1.017)
 
         or of a Hamiltonian using `the same` measurement results
 
         >>> H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.X(1)])
         >>> shadow.expval(H, k=1)
-        array(1.9980000000000002)
+        array(2.007)
         """
         if not isinstance(H, (list, tuple)):
             H = [H]
@@ -387,10 +387,10 @@ class ClassicalShadow:
         For the maximally entangled state of ``n`` qubits, the reduced state has two constant eigenvalues :math:`\frac{1}{2}`. For constant distributions, all Renyi entropies are
         equivalent:
 
-        .. code-block:: python3
+        .. code-block:: python
 
             wires = 4
-            dev = qp.device("default.qubit", wires=range(wires))
+            dev = qp.device("default.qubit", wires=range(wires), seed=42)
 
             @qp.set_shots(shots=1000)
             @qp.qnode(dev)
@@ -398,7 +398,7 @@ class ClassicalShadow:
                 qp.Hadamard(wires=0)
                 for i in range(1, wires):
                     qp.CNOT(wires=[0, i])
-                return qp.classical_shadow(wires=range(wires))
+                return qp.classical_shadow(wires=range(wires), seed=99)
 
             bits, recipes = max_entangled_circuit()
             shadow = qp.ClassicalShadow(bits, recipes)
@@ -410,8 +410,11 @@ class ClassicalShadow:
 
         For non-uniform reduced states that is not the case anymore and the entropy differs for each order ``alpha``:
 
-        .. code-block:: python3
+        .. code-block:: python
 
+            dev = qp.device("default.qubit", wires=range(wires), seed=42)
+
+            @qp.set_shots(shots=1000)
             @qp.qnode(dev)
             def qnode(x):
                 for i in range(wires):
@@ -420,14 +423,14 @@ class ClassicalShadow:
                 for i in range(wires - 1):
                     qp.CNOT((i, i + 1))
 
-                return qp.classical_shadow(wires=range(wires))
+                return qp.classical_shadow(wires=range(wires), seed=99)
 
             x = np.linspace(0.5, 1.5, num=wires)
             bitstrings, recipes = qnode(x)
             shadow = qp.ClassicalShadow(bitstrings, recipes)
 
-        >>> [shadow.entropy(wires=wires, alpha=alpha) for alpha in [1., 2., 3.]]
-        [1.5419292874423107, 1.1537924276625828, 0.9593638767763727]
+        >>> [float(shadow.entropy(wires=[0, 1], alpha=alpha)) for alpha in [1., 2., 3.]]
+        [0.3294975328851038, 0.18807402049095295, 0.14794589906838812]
 
         """
 

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -430,7 +430,7 @@ class ClassicalShadow:
             shadow = qp.ClassicalShadow(bitstrings, recipes)
 
         >>> [float(shadow.entropy(wires=[0, 1], alpha=alpha)) for alpha in [1., 2., 3.]]
-        [0.3294975328851038, 0.18807402049095295, 0.14794589906838812]
+        [0.32949..., 0.18807..., 0.14794...]
 
         """
 

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -145,9 +145,12 @@ def shadow_state(
 
     **Example**
 
-    .. code-block:: python3
+    .. code-block:: python
 
-        dev = qp.device("default.qubit", wires=2)
+        import numpy as onp
+        from pennylane import numpy as np
+
+        dev = qp.device("default.qubit", wires=2, seed=42)
 
         @qp.set_shots(shots=10000)
         @qp.shadows.shadow_state(wires=[0, 1], diffable=True)
@@ -156,19 +159,26 @@ def shadow_state(
             qp.Hadamard(wires=0)
             qp.CNOT(wires=[0, 1])
             qp.RX(x, wires=0)
-            return qp.classical_shadow(wires=[0, 1])
+            return qp.classical_shadow(wires=[0, 1], seed=99)
 
-    >>> x = np.array(1.2)
+    >>> x = np.array(1.2, requires_grad=True)
+    >>> onp.random.seed(123)
     >>> circuit(x)
-    array([[ 0.33835   +0.j     , -0.01215   +0.2241j , -0.00465   +0.237j  ,  0.35504997-0.01755j],
-       [-0.01215   -0.2241j ,  0.1528    +0.j     ,  0.16919999-0.0036j , -0.00285   -0.22065j],
-       [-0.00465   -0.237j  ,  0.16919999+0.0036j ,  0.17529999+0.j     ,  0.0099    -0.2358j ],
-       [ 0.35504997+0.01755j, -0.00285   +0.22065j,  0.0099    +0.2358j ,  0.33355   +0.j     ]], dtype=complex64)
+    array([[ 3.2582501e-01+0.j      , -8.2500000e-03+0.238425j,
+             2.9999996e-04+0.230925j,  3.3142501e-01+0.009j   ],
+           [-8.2500000e-03-0.238425j,  1.6337499e-01+0.j      ,
+             1.5997499e-01-0.0099j  , -5.5499999e-03-0.251475j],
+           [ 2.9999996e-04-0.230925j,  1.5997499e-01+0.0099j  ,
+             1.5797499e-01+0.j      ,  2.9999996e-04-0.241275j],
+           [ 3.3142501e-01-0.009j   , -5.5499999e-03+0.251475j,
+             2.9999996e-04+0.241275j,  3.5282502e-01+0.j      ]],
+          dtype=complex64)
+    >>> onp.random.seed(123)
     >>> qp.jacobian(lambda x: np.real(circuit(x)))(x)
-    array([[-0.245025, -0.005325,  0.004275, -0.2358  ],
-           [-0.005325,  0.235275,  0.2358  , -0.004275],
-           [ 0.004275,  0.2358  ,  0.244875, -0.002175],
-           [-0.2358  , -0.004275, -0.002175, -0.235125]])
+    array([[-2.30550e-01,  5.62500e-03,  2.25000e-04, -2.29725e-01],
+           [ 5.62500e-03,  2.30550e-01,  2.29725e-01, -1.57500e-03],
+           [ 2.25000e-04,  2.29725e-01,  2.37900e-01,  2.47500e-03],
+           [-2.29725e-01, -1.57500e-03,  2.47500e-03, -2.37900e-01]])
     """
     tapes, fn = (
         _shadow_state_diffable(tape, wires) if diffable else _shadow_state_undiffable(tape, wires)


### PR DESCRIPTION
Closes PennyLaneAI/pennylane#9396

This PR enables documentation testing for the `pennylane/shadows` module by removing the `pennylane/shadows` ignore entry from the documentation test workflow and updating the module doc examples so they execute correctly under Sybil.

## Summary

- Removed `--ignore=pennylane/shadows` from `.github/workflows/documentation-tests.yml`.
- Converted `pennylane/shadows` setup examples from `.. code-block:: python3` to Sybil-executed `.. code-block:: python` blocks.
- Added deterministic device and classical-shadow seeds to examples with sampled outputs.
- Updated expected outputs to match the deterministic examples.
- Fixed examples that previously depended on unexecuted setup context.
- Fixed the `shadow_state` differentiability example to use a trainable PennyLane NumPy value.
- Fixed an entropy example to run with finite shots and an explicit subsystem wire list.

## Testing

```bash
.venv/bin/python -m pytest pennylane/shadows
```

Result:

```text
23 passed, 1 warning in 0.41s
```

I also ran:

```bash
git diff --check
```

Result: passed.

## Notes

I attempted a broader workflow-style documentation command for the enabled `pennylane` package docs, but it encountered unrelated failures in `_grad` and device documentation before reaching this issue's scope, then aborted locally in `pennylane/devices/default_tensor.py` due to a macOS Matplotlib backend fatal error. The targeted `pennylane/shadows` documentation tests pass.

## AI Assistance Disclosure

I used ChatGPT to help inspect the failing Sybil doctests, identify the minimal docstring changes, and run local validation. I manually reviewed the changes and verified the targeted documentation tests locally.
