### PR TITLE
fix: update `_check_capture` to loudly fail if JAX is missing and `skip_capture=False`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -353,6 +353,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* ``assert_valid`` will now correctly raise an ``ImportError`` if `skip_capture=False` and JAX is not installed.
+  [(#9567)](https://github.com/PennyLaneAI/pennylane/pull/9567)
+
 * CI workflows now install CPU-only PyTorch (`--index-url https://download.pytorch.org/whl/cpu`)
   instead of the default GPU-enabled build. This eliminates transitive NVIDIA package downloads
   and reduces CI install times. The GPU test workflow (`tests-gpu.yml`) is excluded from this change.

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -456,7 +456,8 @@ def _check_capture(op):
     except ImportError as e:  # pragma: no cover
         raise ImportError(
             "assert_valid(..., skip_capture=False) requires JAX to validate program capture. "
-            "Either install JAX, set skip_capture=True, or mark the test with @pytest.mark.jax."
+            "To skip the capture test, set skip_capture=True. "
+            "To remove this error, install JAX (for local testing) or mark the test with @pytest.mark.jax (for CI)."
         ) from e
 
     if not all(isinstance(w, int) for w in op.wires):

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -453,7 +453,7 @@ def _check_capture(op):
         return
     try:
         import jax
-    except ImportError as e:
+    except ImportError as e:  # pragma: no cover
         raise ImportError(
             "assert_valid(..., skip_capture=False) requires JAX to validate program capture. "
             "Either install JAX, set skip_capture=True, or mark the test with @pytest.mark.jax."

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -453,8 +453,11 @@ def _check_capture(op):
         return
     try:
         import jax
-    except ImportError:
-        return
+    except ImportError as e:
+        raise ImportError(
+            "assert_valid(..., skip_capture=False) requires JAX to validate program capture. "
+            "Either install JAX, set skip_capture=True, or mark the test with @pytest.mark.jax."
+        ) from e
 
     if not all(isinstance(w, int) for w in op.wires):
         return

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -118,6 +118,7 @@ class TestGraphStatePrep:
         assert repr(GraphStatePrep(graph=q, wires=wires)) == "GraphStatePrep(Hadamard, CZ)"
         assert GraphStatePrep(graph=q, wires=wires).label() == "GraphStatePrep(Hadamard, CZ)"
 
+    @pytest.mark.jax
     @pytest.mark.parametrize(
         "dims, shape, wires",
         [

--- a/tests/ftqc/test_ftqc_graph_state_prep.py
+++ b/tests/ftqc/test_ftqc_graph_state_prep.py
@@ -92,6 +92,7 @@ class TestGraphStatePrep:
         assert len(res) == 2 ** len(lattice.graph)
         assert np.isclose(np.sum(res), 1.0, rtol=0)
 
+    @pytest.mark.jax
     @pytest.mark.parametrize(
         "dims, shape, wires",
         [

--- a/tests/ftqc/test_operations.py
+++ b/tests/ftqc/test_operations.py
@@ -36,6 +36,7 @@ class TestRotXZX:
         assert op.wires == Wires(wires)
         assert op.data == (phi, theta, omega)
 
+    @pytest.mark.jax
     def test_is_valid_op(self):
         """Assert RotXZX is a valid operator"""
         op = RotXZX(1.2, 2.3, -0.5, wires=0)

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -113,6 +113,7 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="decomposition must match queued operations"):
             assert_valid(BadDecompQueue(wires=[0, 1]), skip_pickle=True)
 
+    @pytest.mark.jax
     def test_decomposition_wires_must_be_mapped(self):
         """Test that an error is raised if the operators in decomposition do not have mapped
         wires after mapping the op."""
@@ -155,6 +156,7 @@ class TestDecompositionErrors:
         with pytest.raises(AssertionError, match="should not be included in its own decomposition"):
             assert_valid(BadDecomp(wires=0), skip_pickle=True)
 
+    @pytest.mark.jax
     def test_mcms_can_be_compared(self):
         """Tests that decompositions with mid-circuit measurements can be compared correctly."""
 

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -29,6 +29,7 @@ class PlainOperator(qp.operation.Operator):
     """just an operator."""
 
 
+@pytest.mark.jax
 @pytest.mark.parametrize("target", (qp.PauliZ(0), qp.Rot(1.2, 2.3, 3.4, wires=0)))
 def test_basic_validity(target):
     """Run basic operator validity fucntions."""

--- a/tests/ops/op_math/test_change_op_basis.py
+++ b/tests/ops/op_math/test_change_op_basis.py
@@ -43,6 +43,7 @@ ops = (
 )
 
 
+@pytest.mark.jax
 def test_basic_validity():
     """Run basic validity checks on a change_op_basis operator."""
     op1 = qp.PauliZ(0)

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -226,6 +226,7 @@ class TestControlledInit:
         with pytest.raises(ValueError, match="Work wires must be different."):
             Controlled(self.temp_op, control_wires="b", work_wires="b")
 
+    @pytest.mark.jax
     @pytest.mark.parametrize(
         "base",
         [

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -64,6 +64,7 @@ class TestControlledQubitUnitary:
         with pytest.raises(qp.operation.DecompositionUndefinedError):
             op.decomposition()
 
+    @pytest.mark.jax
     @pytest.mark.parametrize(
         "op",
         [

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -21,6 +21,7 @@ from pennylane.exceptions import QuantumFunctionError
 from pennylane.ops.op_math import Evolution, Exp
 
 
+@pytest.mark.jax
 def test_basic_validity():
     """Assert the basic validity of an evolution op."""
     base = qp.prod(qp.PauliX(0), qp.PauliY(1))

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -40,6 +40,7 @@ def pow_using_dunder_method(base, z):
     return base**z
 
 
+@pytest.mark.jax
 def test_basic_validity():
     """Run basic operator validity checks."""
     op = qp.pow(qp.RX(1.2, wires=0), 3)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -91,6 +91,7 @@ ops_hermitian_status = (  # computed manually
 )
 
 
+@pytest.mark.jax
 def test_basic_validity():
     """Run basic validity checks on a prod operator."""
     op1 = qp.PauliZ(0)

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1708,6 +1708,7 @@ class TestDecomposition:
 
         assert q.queue == list(op[::-1])
 
+    @pytest.mark.jax
     def test_controlled_prod_basic_validity(self):
         """Check that Controlled(Prod) is valid, in particular its custom decomp rule"""
         op = qp.ctrl(

--- a/tests/ops/qubit/test_observables.py
+++ b/tests/ops/qubit/test_observables.py
@@ -537,6 +537,7 @@ class TestHermitian:  # pylint: disable=too-many-public-methods
 class TestProjector:
     """Tests for the projector observable."""
 
+    @pytest.mark.jax
     def test_basisstate_projector(self):
         """Tests that we obtain a _BasisStateProjector when input is a basis state."""
         basis_state = [0, 1, 1, 0]
@@ -549,6 +550,7 @@ class TestProjector:
 
         qp.ops.functions.assert_valid(basis_state_projector, skip_differentiation=True)
 
+    @pytest.mark.jax
     def test_statevector_projector(self):
         """Test that we obtain a _StateVectorProjector when input is a state vector."""
         state_vector = np.array([1, 1, 1, 1]) / 2

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -162,6 +162,7 @@ SKIP_ASSERT_VALID = {
 
 class TestOperations:
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("op", ALL_OPERATIONS)
     def test_assert_valid(self, op):
         kwargs = SKIP_ASSERT_VALID.get(type(op), {})

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -2827,6 +2827,7 @@ PAULI_ROT_MATRIX_TEST_DATA = [
 class TestPauliRot:
     """Test the PauliRot operation."""
 
+    @pytest.mark.jax
     def test_assert_valid(self):
         """Tests that a PauliRot is valid"""
 
@@ -3312,6 +3313,7 @@ class TestMultiRZ:
         assert decomp_ops[4].name == "CNOT"
         assert decomp_ops[4].wires == Wires([3, 2])
 
+    @pytest.mark.jax
     def test_MultiRZ_assert_valid(self):
         """Tests that MultiRZ is valid."""
 

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -37,6 +37,7 @@ def test_basis_state_input_cast_to_int():
 class TestStandardValidityBasisState:
     """Test `BasisState` validity, including its decomposition in JIT contexts."""
 
+    @pytest.mark.jax
     def test_assert_valid(self):
         """Test standard validity."""
         # pylint: disable=import-outside-toplevel

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -404,6 +404,7 @@ class TestSumOfSlatersPrep:
         indices = tuple(rng.choice(2**num_wires, size=num_entries, replace=False))
         return coefficients, indices
 
+    @pytest.mark.jax
     @pytest.mark.parametrize(
         "num_wires, num_entries",
         [(2, 1), (2, 2), (2, 4), (4, 3), (4, 6), (10, 3), (10, 10), (10, 137), (13, 1421)],
@@ -415,6 +416,7 @@ class TestSumOfSlatersPrep:
         op = SumOfSlatersPrep(coefficients, wires, indices=indices)
         assert_valid(op, skip_differentiation=True)
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("n", [7, 9, 15, 16, 17])
     def test_standard_validity_non_id_encoding(self, n, seed):
         """Test that SumOfSlatersPrep is a valid PennyLane operator for non-identity

--- a/tests/templates/subroutines/arithmetic/test_phase_adder.py
+++ b/tests/templates/subroutines/arithmetic/test_phase_adder.py
@@ -34,6 +34,7 @@ def test_standard_validity_Phase_Adder():
     qp.ops.functions.assert_valid(op)
 
 
+@pytest.mark.jax
 def test_falsy_zero_as_work_wire():
     """Test that work wire is not treated as a falsy zero."""
     k = 6

--- a/tests/templates/subroutines/time_evolution/test_trotter.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter.py
@@ -1318,6 +1318,7 @@ class TestTrotterizedQfuncInitialization:
                 kwargs = {special_key: 1}
                 qp.trotterize(my_dummy_qfunc)(0.1, wires=[0, 1], **kwargs)
 
+    @pytest.mark.jax
     def test_standard_validity(self):
         """Test standard validity criteria using assert_valid."""
 

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -120,6 +120,7 @@ def test_dynamic_register_not_hashable():
         qp.wires.Wires((0, reg))
 
 
+@pytest.mark.jax
 def test_Deallocate_validity():
     """Test that Deallocate is a valid operation."""
     wires = [DynamicWire(), DynamicWire()]


### PR DESCRIPTION
**Context:**

If I have a test like,
```python
def test_op_validity():
    op = ...
    assert_valid(op)
```
and I don't mark it with `pytest.mark.jax` , the test lands in the core-tests job, where jax isn't installed, and _check_capture silently no-ops. 

Given that skip_capture is by default False, this should have error'd out loudly saying jax need to be installed (or the pytest.mark.jax marker is required)?

If you look at the implementation, there are three silent returns, 
```python
def _check_capture(op):
    if isinstance(op, qp.templates.SubroutineOp):
        return
    try:
        import jax
    except ImportError:
        return

    if not all(isinstance(w, int) for w in op.wires):
        return

    ...
```

**Description of the Change:**

Error out if `skip_capture=False` and we are using `assert_valid` without `JAX`.

**Benefits:** No silent false positives.

[sc-121430]