### PR TITLE
Add readable Tracker repr

### DIFF
--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -179,6 +179,15 @@ class Tracker:
                 raise ValueError(f"Device '{dev.short_name}' does not support device tracking")
             dev.tracker = self
 
+    def __repr__(self):
+        return (
+            f"Tracker(active={self.active}, "
+            f"totals={self.totals}, "
+            f"history={self.history}, "
+            f"latest={self.latest}, "
+            f"persistent={self.persistent})"
+        )
+
     def __enter__(self):
         if not self.persistent:
             self.reset()

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -143,6 +143,29 @@ class TestTrackerCoreBehavior:
 
         assert tracker.latest == {"a": 2, "b": "b2", "c": 1}
 
+    def test_repr_default(self):
+        """Tests the default tracker representation."""
+        tracker = Tracker()
+
+        assert (
+            repr(tracker)
+            == "Tracker(active=False, totals={}, history={}, latest={}, persistent=False)"
+        )
+
+    def test_repr_with_tracked_values(self):
+        """Tests the tracker representation with stored tracking values."""
+        tracker = Tracker(persistent=True)
+        tracker.active = True
+
+        tracker.update(a=1, b="b")
+        tracker.update(a=2, b="b2")
+
+        assert repr(tracker) == (
+            "Tracker(active=True, totals={'a': 3}, "
+            "history={'a': [1, 2], 'b': ['b', 'b2']}, "
+            "latest={'a': 2, 'b': 'b2'}, persistent=True)"
+        )
+
     def test_record_callback(self, mocker):
         # pylint: disable=too-few-public-methods
         class callback_wrapper:


### PR DESCRIPTION
Closes #9389.

This adds a readable representation for `Tracker` showing the user-facing tracking state: `active`, `totals`, `history`, `latest`, and `persistent`.

Tests:
- `python -m pytest tests/devices/test_tracker.py -q`
- `python -m black -t py311 -t py312 -t py313 -l 100 pennylane/devices/tracker.py tests/devices/test_tracker.py --check`
- `python -m isort --py 312 --profile black -l 100 -o autoray -p ./pennylane --skip __init__.py --filter-files pennylane/devices/tracker.py tests/devices/test_tracker.py --check`
- `python -m pylint --rcfile .pylintrc pennylane/devices/tracker.py`
- `python -m pylint --rcfile tests/.pylintrc tests/devices/test_tracker.py`
- `git diff --check`