### PR TITLE
Support functools.partial in inspection tools

### DIFF
--- a/pennylane/_partial.py
+++ b/pennylane/_partial.py
@@ -1,0 +1,21 @@
+"""Utilities for working with :class:`functools.partial` callables."""
+
+from functools import partial
+
+
+def unwrap_partial(func):
+    """Return the base callable and arguments bound by nested partial wrappers."""
+    bound_args = ()
+    bound_kwargs = {}
+
+    while isinstance(func, partial):
+        bound_args = func.args + bound_args
+        bound_kwargs = {**(func.keywords or {}), **bound_kwargs}
+        func = func.func
+
+    return func, bound_args, bound_kwargs
+
+
+def merge_partial_args(bound_args, bound_kwargs, call_args, call_kwargs):
+    """Merge partial-bound arguments with call-time arguments."""
+    return bound_args + call_args, {**bound_kwargs, **call_kwargs}

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -23,6 +23,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Literal
 
 from pennylane import math
+from pennylane._partial import merge_partial_args, unwrap_partial
 from pennylane.tape import make_qscript
 from pennylane.workflow import construct_batch
 
@@ -288,6 +289,8 @@ def draw(
         2: ─╰●─────────────────┤
 
     """
+    qnode, bound_args, bound_kwargs = unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -301,6 +304,8 @@ def draw(
             show_matrices=show_matrices,
             show_wire_labels=show_wire_labels,
             level=level,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
         )
 
     if level not in {"gradient", 0, "top"}:  # default and no transform options
@@ -311,6 +316,7 @@ def draw(
 
     @wraps(qnode)
     def wrapper(*args, **kwargs):
+        args, kwargs = merge_partial_args(bound_args, bound_kwargs, args, kwargs)
         tape = make_qscript(qnode)(*args, **kwargs)
 
         if wire_order:
@@ -345,9 +351,14 @@ def _draw_qnode(
     show_matrices=True,
     show_wire_labels=True,
     level: Literal["top", "user", "device", "gradient"] | int | slice = "gradient",
+    bound_args=(),
+    bound_kwargs=None,
 ):
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs):
+        args, kwargs = merge_partial_args(bound_args, bound_kwargs, args, kwargs)
         tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs)
 
         if wire_order:
@@ -780,6 +791,8 @@ def draw_mpl(
             :target: javascript:void(0);
 
     """
+    qnode, bound_args, bound_kwargs = unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -793,6 +806,8 @@ def draw_mpl(
             level=level,
             style=style,
             fig=fig,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
             **kwargs,
         )
 
@@ -802,9 +817,12 @@ def draw_mpl(
             UserWarning,
         )
 
+    draw_mpl_kwargs = kwargs
+
     @wraps(qnode)
-    def wrapper(*args, **kwargs):
-        tape = make_qscript(qnode)(*args, **kwargs)
+    def wrapper(*args, **kwargs_qnode):
+        args, kwargs_qnode = merge_partial_args(bound_args, bound_kwargs, args, kwargs_qnode)
+        tape = make_qscript(qnode)(*args, **kwargs_qnode)
         if wire_order:
             _wire_order = wire_order
         else:
@@ -822,7 +840,7 @@ def draw_mpl(
             style=style,
             fig=fig,
             level=level,
-            **kwargs,
+            **draw_mpl_kwargs,
         )
 
     return wrapper
@@ -838,10 +856,15 @@ def _draw_mpl_qnode(
     level="gradient",
     style="black_white",
     fig=None,
+    bound_args=(),
+    bound_kwargs=None,
     **kwargs,
 ):
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
+        args, kwargs_qnode = merge_partial_args(bound_args, bound_kwargs, args, kwargs_qnode)
         tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs_qnode)
 
         if len(tapes) > 1:

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -23,11 +23,12 @@ import time
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from functools import partial
+from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pennylane as qp
+from pennylane._partial import merge_partial_args, unwrap_partial
 
 from .mlir_specs import make_level_name_unique, resources_from_analysis_pass
 from .resource import CircuitSpecs, SpecsResources, resources_from_tape
@@ -828,24 +829,36 @@ def specs(
     # pylint: disable=import-outside-toplevel
     # Have to import locally to prevent circular imports as well as accounting for Catalyst not being installed
 
+    qnode, bound_args, bound_kwargs = unwrap_partial(qnode)
+    specs_fn = None
+
     if isinstance(qnode, qp.QNode):
-        return partial(_specs_qnode, qnode, level, compute_depth)
+        specs_fn = _specs_qnode
 
     try:
         from ..qnn.torch import TorchLayer
 
         if isinstance(qnode, TorchLayer) and isinstance(qnode.qnode, qp.QNode):
-            return partial(_specs_qnode, qnode, level, compute_depth)
+            specs_fn = _specs_qnode
     except ImportError:  # pragma: no cover
         pass
 
-    try:  # pragma: no cover
-        # This is tested by integration tests within the Catalyst frontend
-        import catalyst
+    if specs_fn is None:
+        try:  # pragma: no cover
+            # This is tested by integration tests within the Catalyst frontend
+            import catalyst
 
-        if isinstance(qnode, catalyst.jit.QJIT):
-            return partial(_specs_qjit, qnode, level, compute_depth)
-    except ImportError:  # pragma: no cover
-        pass
+            if isinstance(qnode, catalyst.jit.QJIT):
+                specs_fn = _specs_qjit
+        except ImportError:  # pragma: no cover
+            pass
 
-    raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")
+    if specs_fn is None:
+        raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")
+
+    @wraps(qnode)
+    def wrapper(*args, **kwargs):
+        args, kwargs = merge_partial_args(bound_args, bound_kwargs, args, kwargs)
+        return specs_fn(qnode, level, compute_depth, *args, **kwargs)
+
+    return wrapper

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -16,6 +16,8 @@ Integration tests for the draw transform
 """
 
 # pylint: disable=import-outside-toplevel
+from functools import partial
+
 import pytest
 
 import pennylane as qp
@@ -1190,6 +1192,57 @@ def test_applied_transforms():
 
     expected = "0: ──X─┤  "
     assert qp.draw(my_circuit)(1.234) == expected
+
+
+def test_draw_qnode_with_nested_partial():
+    """Test that partial-wrapped QNodes can still be drawn."""
+
+    @qp.qnode(qp.device("default.qubit", wires=2))
+    def partial_circuit(x, y, repeat=1):
+        for _ in range(repeat):
+            qp.RX(x, wires=0)
+        qp.RY(y, wires=1)
+        return qp.expval(qp.Z(0))
+
+    fixed = partial(partial(partial_circuit, y=0.1, repeat=1), y=0.3, repeat=2)
+    drawing = qp.draw(fixed)(0.2)
+
+    assert drawing.count("RX(0.20)") == 2
+    assert "RY(0.30)" in drawing
+
+
+def test_draw_qnode_with_positional_partial():
+    """Test that partial-wrapped QNodes can bind positional arguments."""
+
+    @qp.qnode(qp.device("default.qubit", wires=2))
+    def partial_circuit(x, y, repeat=1):
+        for _ in range(repeat):
+            qp.RX(x, wires=0)
+        qp.RY(y, wires=1)
+        return qp.expval(qp.Z(0))
+
+    fixed = partial(partial_circuit, 0.2, repeat=2)
+    drawing = qp.draw(fixed)(0.3)
+
+    assert drawing.count("RX(0.20)") == 2
+    assert "RY(0.30)" in drawing
+
+
+def test_draw_qnode_with_partial_keyword_override():
+    """Test that call-time keywords override partial-bound QNode keywords."""
+
+    @qp.qnode(qp.device("default.qubit", wires=2))
+    def partial_circuit(x, y=0.1, repeat=1):
+        for _ in range(repeat):
+            qp.RX(x, wires=0)
+        qp.RY(y, wires=1)
+        return qp.expval(qp.Z(0))
+
+    fixed = partial(partial_circuit, y=0.2, repeat=1)
+    drawing = qp.draw(fixed)(0.4, y=0.5, repeat=3)
+
+    assert drawing.count("RX(0.40)") == 3
+    assert "RY(0.50)" in drawing
 
 
 def test_draw_with_qfunc():

--- a/tests/drawer/test_draw_catalyst.py
+++ b/tests/drawer/test_draw_catalyst.py
@@ -14,6 +14,8 @@
 """Test the pennylane drawer with Catalyst."""
 
 # pylint: disable=import-outside-toplevel,protected-access
+from functools import partial
+
 import pytest
 
 import pennylane as qp
@@ -41,6 +43,23 @@ class TestCatalystDraw:
 
         expected = "    0: ──RX─┤  <Z>\n    a: ──RY─┤     \n1.234: ──RZ─┤     "
         assert qp.draw(circuit, decimals=None)(1.234, 2.345, 3.456) == expected
+
+    def test_partial_circuit(self):
+        """Test a partial-wrapped Catalyst jitted QNode."""
+
+        @qp.qjit
+        @qp.qnode(qp.device("lightning.qubit", wires=(0, "a", 1.234)))
+        def circuit(x, y, z):
+            """A quantum circuit on three wires."""
+            qp.RX(x, wires=0)
+            qp.RY(y, wires="a")
+            qp.RZ(z, wires=1.234)
+            return qp.expval(qp.PauliZ(0))
+
+        fixed = partial(circuit, 1.234, z=3.456)
+
+        expected = "    0: ──RX─┤  <Z>\n    a: ──RY─┤     \n1.234: ──RZ─┤     "
+        assert qp.draw(fixed, decimals=None)(2.345) == expected
 
     @pytest.mark.parametrize("c", [0, 1])
     def test_cond_circuit(self, c):
@@ -143,6 +162,24 @@ class TestCatalystDrawMpl:
             return qp.expval(qp.PauliZ(0))
 
         fig, ax = qp.draw_mpl(circuit, decimals=None)(1.234, 2.345, 3.456)
+        assert isinstance(fig, mpl.figure.Figure)
+        assert isinstance(ax, mpl.axes._axes.Axes)
+
+    def test_partial_circuit(self):
+        """Test a partial-wrapped Catalyst jitted QNode."""
+
+        @qp.qjit
+        @qp.qnode(qp.device("lightning.qubit", wires=(0, "a", 1.234)))
+        def circuit(x, y, z):
+            """A quantum circuit on three wires."""
+            qp.RX(x, wires=0)
+            qp.RY(y, wires="a")
+            qp.RZ(z, wires=1.234)
+            return qp.expval(qp.PauliZ(0))
+
+        fixed = partial(circuit, 1.234, z=3.456)
+
+        fig, ax = qp.draw_mpl(fixed, decimals=None)(2.345)
         assert isinstance(fig, mpl.figure.Figure)
         assert isinstance(ax, mpl.axes._axes.Axes)
 

--- a/tests/drawer/test_draw_mpl.py
+++ b/tests/drawer/test_draw_mpl.py
@@ -18,6 +18,8 @@ See section on "Testing Matplotlib based code" in the "Software Tests"
 page in the developement guide.
 """
 
+from functools import partial
+
 import pytest
 
 import pennylane as qp
@@ -78,6 +80,42 @@ def test_fig_argument():
     output_fig, ax = qp.draw_mpl(circuit1, fig=fig)(1.23, 2.34)
     assert ax.get_figure() == fig
     assert output_fig == fig
+    plt.close("all")
+
+
+def test_draw_mpl_qnode_with_partial():
+    """Test that partial-wrapped QNodes can still be drawn with matplotlib."""
+
+    fixed = partial(circuit1, y=2.34)
+    fig, ax = qp.draw_mpl(fixed)(1.23)
+
+    assert isinstance(fig, mpl.figure.Figure)
+    assert isinstance(ax, mpl.axes._axes.Axes)  # pylint:disable=protected-access
+    assert len(ax.patches) == 7
+    assert len(ax.lines) == 6
+
+    texts = [t.get_text() for t in ax.texts]
+    assert "RX" in texts
+    assert "RY" in texts
+
+    plt.close("all")
+
+
+def test_draw_mpl_qnode_with_positional_partial():
+    """Test that draw_mpl works when partial binds QNode positional arguments."""
+
+    fixed = partial(circuit1, 1.23)
+    fig, ax = qp.draw_mpl(fixed)(2.34)
+
+    assert isinstance(fig, mpl.figure.Figure)
+    assert isinstance(ax, mpl.axes._axes.Axes)  # pylint:disable=protected-access
+    assert len(ax.patches) == 7
+    assert len(ax.lines) == 6
+
+    texts = [t.get_text() for t in ax.texts]
+    assert "RX" in texts
+    assert "RY" in texts
+
     plt.close("all")
 
 
@@ -573,6 +611,22 @@ def test_draw_mpl_supports_qfuncs():
     assert len(ax.lines) == 1
     assert len(ax.texts) == 2
     assert ax.texts[0].get_text() == "0"
+    assert ax.texts[1].get_text() == "RX"
+    plt.close("all")
+
+
+def test_draw_mpl_supports_partial_qfuncs():
+    """Test that draw_mpl works with partial-wrapped quantum functions."""
+
+    def qfunc(x):
+        qp.RX(x, 0)
+
+    fig, ax = qp.draw_mpl(partial(qfunc, x=1.1))()
+
+    assert isinstance(fig, mpl.figure.Figure)
+    assert isinstance(ax, mpl.axes._axes.Axes)  # pylint:disable=protected-access
+    assert len(ax.patches) == 1
+    assert len(ax.lines) == 1
     assert ax.texts[1].get_text() == "RX"
     plt.close("all")
 

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -14,6 +14,8 @@
 """Unit tests for the specs transform"""
 
 # pylint: disable=invalid-sequence-index
+from functools import partial
+
 import pytest
 
 import pennylane as qp
@@ -245,6 +247,78 @@ class TestSpecsTransform:
         assert info["device_name"] == dev.name
         assert info["level"] == "gradient"
         assert info["shots"] == Shots(None)
+
+    def test_specs_qnode_with_nested_partial(self):
+        """Test that specs works with partial-wrapped QNodes."""
+
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def partial_circuit(x, y=0.1, repeat=1):
+            for _ in range(repeat):
+                qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.Z(0))
+
+        fixed = partial(partial(partial_circuit, y=0.2, repeat=1), y=0.3, repeat=3)
+        info = qp.specs(fixed)(0.4)
+
+        assert info["resources"].gate_types == {"RX": 3, "RY": 1}
+        assert info["resources"].num_gates == 4
+        assert info["level"] == "gradient"
+
+    def test_specs_qnode_with_positional_partial(self):
+        """Test that specs works when partial binds QNode positional arguments."""
+
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def partial_circuit(x, y=0.1, repeat=1):
+            for _ in range(repeat):
+                qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.Z(0))
+
+        fixed = partial(partial_circuit, 0.4, repeat=2)
+        info = qp.specs(fixed)(0.3)
+
+        assert info["resources"].gate_types == {"RX": 2, "RY": 1}
+        assert info["resources"].num_gates == 3
+        assert info["level"] == "gradient"
+
+    def test_specs_qnode_with_partial_keyword_override(self):
+        """Test that call-time keywords override partial-bound QNode keywords."""
+
+        @qp.qnode(qp.device("default.qubit", wires=2))
+        def partial_circuit(x, y=0.1, repeat=1):
+            for _ in range(repeat):
+                qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.Z(0))
+
+        fixed = partial(partial_circuit, y=0.2, repeat=1)
+        info = qp.specs(fixed)(0.4, y=0.5, repeat=3)
+
+        assert info["resources"].gate_types == {"RX": 3, "RY": 1}
+        assert info["resources"].num_gates == 4
+        assert info["level"] == "gradient"
+
+    @pytest.mark.external
+    @pytest.mark.catalyst
+    def test_specs_qjit_with_partial(self):
+        """Test that specs works with partial-wrapped QJIT objects."""
+
+        pytest.importorskip("catalyst")
+
+        @qp.qjit
+        @qp.qnode(qp.device("lightning.qubit", wires=2))
+        def partial_circuit(x, y=0.1, repeat=1):
+            for _ in range(repeat):
+                qp.RX(x, wires=0)
+            qp.RY(y, wires=1)
+            return qp.expval(qp.Z(0))
+
+        fixed = partial(partial_circuit, 0.4, repeat=2)
+        info = qp.specs(fixed, level=0)(0.3)
+
+        assert info["resources"].gate_types == {"RX": 2, "RY": 1}
+        assert info["resources"].num_gates == 3
 
     @pytest.mark.parametrize("compute_depth", [True, False])
     def test_specs_compute_depth(self, compute_depth):


### PR DESCRIPTION
## Summary

- unwrap nested `functools.partial` callables before dispatching `qml.draw`, `qml.draw_mpl`, and `qml.specs`
- preserve partial-bound positional and keyword arguments when constructing tapes/specs
- add regression coverage for nested, positional, and call-time-overridden QNode partials, qfunc draw_mpl partials, and Catalyst-marked QJIT partial paths

Fixes #9394.

## Tests

- `.venv\Scripts\python -m black --check --target-version py312 pennylane/_partial.py pennylane/drawer/draw.py pennylane/resource/specs.py tests/drawer/test_draw.py tests/drawer/test_draw_mpl.py tests/drawer/test_draw_catalyst.py tests/resource/test_specs.py`
- `$env:MPLBACKEND='Agg'; uv run pytest tests/drawer/test_draw.py tests/drawer/test_draw_mpl.py tests/resource/test_specs.py -q`
