### PR TITLE
Support functools.partial wrappers in qml.draw, qml.draw_mpl, and qml…

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -233,6 +233,11 @@
   trace time, and only the correct branch will be queued.
   [(#9630)](https://github.com/PennyLaneAI/pennylane/pull/9630)
 
+* `qml.draw`, `qml.draw_mpl`, and `qml.specs` now support `functools.partial`
+  wrappers around `QNode` objects, including arbitrarily nested partials with
+  mixed positional and keyword arguments.
+  [(#9573)](https://github.com/PennyLaneAI/pennylane/pull/9573)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * Added a variant of `SumOfSlatersPrep` to labs, accessible as `labs.templates.SumOfSlatersPrep2`.

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -38,7 +38,6 @@ def catalyst_qjit(qnode):
     """A method checking whether a qnode is compiled by catalyst.qjit"""
     return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
 
-
 def _unwrap_partial(func):
     """Unwrap nested :class:`functools.partial` objects to retrieve the
     underlying callable and all pre-bound arguments.
@@ -48,14 +47,19 @@ def _unwrap_partial(func):
 
     Returns:
         tuple[callable, tuple, dict]: ``(inner_func, bound_args, bound_kwargs)``
+        where ``inner_func`` is the innermost non-partial callable,
+        ``bound_args`` collects positional bindings outermost-first, and
+        ``bound_kwargs`` collects keyword bindings with inner layers taking
+        precedence.
     """
     bound_args = ()
     bound_kwargs = {}
     while isinstance(func, functools.partial):
         bound_args = func.args + bound_args
-        bound_kwargs = {**func.keywords, **bound_kwargs}
+        bound_kwargs = {**(func.keywords or {}), **bound_kwargs}
         func = func.func
     return func, bound_args, bound_kwargs
+
 
 # pylint: disable=too-many-arguments
 def draw(
@@ -382,7 +386,6 @@ def _draw_qnode(
         merged_kwargs = {**bound_kwargs, **kwargs}
         merged_args = bound_args + args
         tapes, _ = construct_batch(qnode, level=level)(*merged_args, **merged_kwargs)
-
         if wire_order:
             _wire_order = wire_order
         elif qnode.device.wires:
@@ -887,7 +890,7 @@ def _draw_mpl_qnode(
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
         args = bound_args + args
-        kwargs_qnode = {**bound_kwargs, **kwargs_qnode}
+        kwargs_qnode = {**(bound_kwargs or {}), **kwargs_qnode}
         tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs_qnode)
 
         if len(tapes) > 1:

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -18,6 +18,7 @@ Contains the drawing function.
 from __future__ import annotations
 
 import warnings
+import functools
 from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Literal
@@ -37,6 +38,24 @@ def catalyst_qjit(qnode):
     """A method checking whether a qnode is compiled by catalyst.qjit"""
     return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
 
+
+def _unwrap_partial(func):
+    """Unwrap nested :class:`functools.partial` objects to retrieve the
+    underlying callable and all pre-bound arguments.
+
+    Args:
+        func (callable): The callable to unwrap.
+
+    Returns:
+        tuple[callable, tuple, dict]: ``(inner_func, bound_args, bound_kwargs)``
+    """
+    bound_args = ()
+    bound_kwargs = {}
+    while isinstance(func, functools.partial):
+        bound_args = func.args + bound_args
+        bound_kwargs = {**func.keywords, **bound_kwargs}
+        func = func.func
+    return func, bound_args, bound_kwargs
 
 # pylint: disable=too-many-arguments
 def draw(
@@ -288,6 +307,8 @@ def draw(
         2: ─╰●─────────────────┤
 
     """
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -296,6 +317,8 @@ def draw(
             qnode,
             wire_order=wire_order,
             show_all_wires=show_all_wires,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
             decimals=decimals,
             max_length=max_length,
             show_matrices=show_matrices,
@@ -311,7 +334,9 @@ def draw(
 
     @wraps(qnode)
     def wrapper(*args, **kwargs):
-        tape = make_qscript(qnode)(*args, **kwargs)
+        merged_kwargs = {**bound_kwargs, **kwargs}
+        merged_args = bound_args + args
+        tape = make_qscript(qnode)(*merged_args, **merged_kwargs)
 
         if wire_order:
             _wire_order = wire_order
@@ -340,15 +365,23 @@ def _draw_qnode(
     wire_order: Sequence | None = None,
     show_all_wires: bool = False,
     *,
+    bound_args=None,
+    bound_kwargs=None,
     decimals: int | None = 2,
     max_length=100,
     show_matrices=True,
     show_wire_labels=True,
     level: Literal["top", "user", "device", "gradient"] | int | slice = "gradient",
 ):
+
+    bound_args = bound_args or ()
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs):
-        tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs)
+        merged_kwargs = {**bound_kwargs, **kwargs}
+        merged_args = bound_args + args
+        tapes, _ = construct_batch(qnode, level=level)(*merged_args, **merged_kwargs)
 
         if wire_order:
             _wire_order = wire_order
@@ -780,6 +813,8 @@ def draw_mpl(
             :target: javascript:void(0);
 
     """
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
+
     if catalyst_qjit(qnode):
         qnode = qnode.user_function
 
@@ -788,6 +823,8 @@ def draw_mpl(
             qnode,
             wire_order=wire_order,
             show_all_wires=show_all_wires,
+            bound_args=bound_args,
+            bound_kwargs=bound_kwargs,
             decimals=decimals,
             max_length=max_length,
             level=level,
@@ -804,7 +841,9 @@ def draw_mpl(
 
     @wraps(qnode)
     def wrapper(*args, **kwargs):
-        tape = make_qscript(qnode)(*args, **kwargs)
+        merged_kwargs = {**bound_kwargs, **kwargs}
+        merged_args = bound_args + args
+        tape = make_qscript(qnode)(*merged_args, **merged_kwargs)
         if wire_order:
             _wire_order = wire_order
         else:
@@ -835,13 +874,20 @@ def _draw_mpl_qnode(
     show_all_wires=False,
     decimals: int | None = None,
     *,
+    bound_args=None,
+    bound_kwargs=None,
     level="gradient",
     style="black_white",
     fig=None,
     **kwargs,
 ):
+    bound_args = bound_args or ()
+    bound_kwargs = bound_kwargs or {}
+
     @wraps(qnode)
     def wrapper(*args, **kwargs_qnode):
+        args = bound_args + args
+        kwargs_qnode = {**bound_kwargs, **kwargs_qnode}
         tapes, _ = construct_batch(qnode, level=level)(*args, **kwargs_qnode)
 
         if len(tapes) > 1:

--- a/pennylane/drawer/draw.py
+++ b/pennylane/drawer/draw.py
@@ -17,8 +17,8 @@ Contains the drawing function.
 
 from __future__ import annotations
 
-import warnings
 import functools
+import warnings
 from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Literal
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 def catalyst_qjit(qnode):
     """A method checking whether a qnode is compiled by catalyst.qjit"""
     return qnode.__class__.__name__ == "QJIT" and hasattr(qnode, "user_function")
+
 
 def _unwrap_partial(func):
     """Unwrap nested :class:`functools.partial` objects to retrieve the

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 # Used for device-level qjit resource tracking
 _RESOURCE_TRACKING_PREFIX = "pennylane_specs_qjit_resources"
 
+
 def _unwrap_partial(func):
     """Unwrap nested :class:`functools.partial` objects to get the underlying
     callable and all pre-bound arguments.
@@ -55,6 +56,7 @@ def _unwrap_partial(func):
         bound_kwargs = {**(func.keywords or {}), **bound_kwargs}
         func = func.func
     return func, bound_args, bound_kwargs
+
 
 def _specs_qnode(qnode, level, compute_depth, *args, **kwargs) -> CircuitSpecs:
     """Returns information on the structure and makeup of provided QNode.
@@ -847,16 +849,24 @@ def specs(
     qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
 
     if isinstance(qnode, qp.QNode):
+
         def wrapper(*args, **kwargs):
-            return _specs_qnode(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+            return _specs_qnode(
+                qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs}
+            )
+
         return wrapper
 
     try:
         from ..qnn.torch import TorchLayer
 
         if isinstance(qnode, TorchLayer) and isinstance(qnode.qnode, qp.QNode):
+
             def wrapper_torch(*args, **kwargs):
-                return _specs_qnode(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+                return _specs_qnode(
+                    qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs}
+                )
+
             return wrapper_torch
     except ImportError:  # pragma: no cover
         pass
@@ -865,11 +875,14 @@ def specs(
         import catalyst
 
         if isinstance(qnode, catalyst.jit.QJIT):
+
             def wrapper_qjit(*args, **kwargs):
-                return _specs_qjit(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+                return _specs_qjit(
+                    qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs}
+                )
+
             return wrapper_qjit
     except ImportError:  # pragma: no cover
         pass
-
 
     raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -38,6 +38,23 @@ if TYPE_CHECKING:
 # Used for device-level qjit resource tracking
 _RESOURCE_TRACKING_PREFIX = "pennylane_specs_qjit_resources"
 
+def _unwrap_partial(func):
+    """Unwrap nested :class:`functools.partial` objects to get the underlying
+    callable and all pre-bound arguments.
+
+    Args:
+        func (callable): The callable to unwrap.
+
+    Returns:
+        tuple[callable, tuple, dict]: ``(inner_func, bound_args, bound_kwargs)``
+    """
+    bound_args = ()
+    bound_kwargs = {}
+    while isinstance(func, partial):
+        bound_args = func.args + bound_args
+        bound_kwargs = {**func.keywords, **bound_kwargs}
+        func = func.func
+    return func, bound_args, bound_kwargs
 
 def _specs_qnode(qnode, level, compute_depth, *args, **kwargs) -> CircuitSpecs:
     """Returns information on the structure and makeup of provided QNode.
@@ -827,24 +844,30 @@ def specs(
     """
     # pylint: disable=import-outside-toplevel
     # Have to import locally to prevent circular imports as well as accounting for Catalyst not being installed
+    qnode, bound_args, bound_kwargs = _unwrap_partial(qnode)
 
     if isinstance(qnode, qp.QNode):
-        return partial(_specs_qnode, qnode, level, compute_depth)
+        def wrapper(*args, **kwargs):
+            return _specs_qnode(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+        return wrapper
 
     try:
         from ..qnn.torch import TorchLayer
 
         if isinstance(qnode, TorchLayer) and isinstance(qnode.qnode, qp.QNode):
-            return partial(_specs_qnode, qnode, level, compute_depth)
+            def wrapper_torch(*args, **kwargs):
+                return _specs_qnode(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+            return wrapper_torch
     except ImportError:  # pragma: no cover
         pass
 
     try:  # pragma: no cover
-        # This is tested by integration tests within the Catalyst frontend
         import catalyst
 
         if isinstance(qnode, catalyst.jit.QJIT):
-            return partial(_specs_qjit, qnode, level, compute_depth)
+            def wrapper_qjit(*args, **kwargs):
+                return _specs_qjit(qnode, level, compute_depth, *(bound_args + args), **{**bound_kwargs, **kwargs})
+            return wrapper_qjit
     except ImportError:  # pragma: no cover
         pass
 

--- a/pennylane/resource/specs.py
+++ b/pennylane/resource/specs.py
@@ -52,7 +52,7 @@ def _unwrap_partial(func):
     bound_kwargs = {}
     while isinstance(func, partial):
         bound_args = func.args + bound_args
-        bound_kwargs = {**func.keywords, **bound_kwargs}
+        bound_kwargs = {**(func.keywords or {}), **bound_kwargs}
         func = func.func
     return func, bound_args, bound_kwargs
 
@@ -870,5 +870,6 @@ def specs(
             return wrapper_qjit
     except ImportError:  # pragma: no cover
         pass
+
 
     raise ValueError("qp.specs can only be applied to a QNode or qjit'd QNode")

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -1246,3 +1246,78 @@ def test_sort_wires_fallback(use_qnode):
 
     expected = "4: ──X─┤     \na: ──X─┤     \n0: ──X─┤  <Z>"
     assert qp.draw(func)() == expected
+
+class TestPartialSupport:
+    """Tests that qp.draw and qp.draw_mpl handle functools.partial wrappers."""
+
+    @pytest.fixture
+    def circuit(self):
+        dev = qp.device("default.qubit")
+
+        @qp.qnode(dev)
+        def _circuit(x, n_iter):
+            for _ in range(n_iter):
+                qp.RX(x, 0)
+            return qp.expval(qp.Z(0))
+
+        return _circuit
+
+    def test_draw_partial_positional_args(self, circuit):
+        """draw works when positional args are pre-bound via partial."""
+        from functools import partial
+
+        fixed = partial(circuit, 0.5)
+        result = draw(fixed)(3)
+        assert "RX" in result
+        assert result.count("RX") == 3
+
+    def test_draw_partial_keyword_args(self, circuit):
+        """draw works when keyword args are pre-bound via partial."""
+        from functools import partial
+
+        fixed = partial(circuit, n_iter=3)
+        result = draw(fixed)(0.5)
+        assert "RX" in result
+        assert result.count("RX") == 3
+
+    def test_draw_partial_nested(self, circuit):
+        """draw works with nested partial(partial(...))."""
+        from functools import partial
+
+        fixed = partial(partial(circuit, 0.5), n_iter=2)
+        result = draw(fixed)()
+        assert "RX" in result
+        assert result.count("RX") == 2
+
+    def test_draw_partial_mixed(self, circuit):
+        """draw works when both positional and keyword args are pre-bound."""
+        from functools import partial
+
+        fixed = partial(circuit, 0.5, n_iter=4)
+        result = draw(fixed)()
+        assert result.count("RX") == 4
+
+    def test_draw_plain_qnode_unaffected(self, circuit):
+        """Non-partial QNode still works correctly (regression check)."""
+        result = draw(circuit)(0.5, 2)
+        assert "RX" in result
+
+    def test_draw_mpl_partial_keyword_args(self, circuit):
+        """draw_mpl works when keyword args are pre-bound via partial."""
+        from functools import partial
+        import matplotlib
+        matplotlib.use("Agg")
+
+        fixed = partial(circuit, n_iter=2)
+        fig, ax = qp.draw_mpl(fixed)(0.5)
+        assert fig is not None
+
+    def test_draw_mpl_partial_nested(self, circuit):
+        """draw_mpl works with nested partial."""
+        from functools import partial
+        import matplotlib
+        matplotlib.use("Agg")
+
+        fixed = partial(partial(circuit, 0.3), n_iter=1)
+        fig, ax = qp.draw_mpl(fixed)()
+        assert fig is not None

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -21,6 +21,7 @@ import pytest
 import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.drawer import draw
+from functools import partial
 
 
 @qp.qnode(qp.device("default.qubit", wires=(0, "a", 1.234)))
@@ -1264,7 +1265,6 @@ class TestPartialSupport:
 
     def test_draw_partial_positional_args(self, circuit):
         """draw works when positional args are pre-bound via partial."""
-        from functools import partial
 
         fixed = partial(circuit, 0.5)
         result = draw(fixed)(3)
@@ -1273,7 +1273,6 @@ class TestPartialSupport:
 
     def test_draw_partial_keyword_args(self, circuit):
         """draw works when keyword args are pre-bound via partial."""
-        from functools import partial
 
         fixed = partial(circuit, n_iter=3)
         result = draw(fixed)(0.5)
@@ -1282,7 +1281,6 @@ class TestPartialSupport:
 
     def test_draw_partial_nested(self, circuit):
         """draw works with nested partial(partial(...))."""
-        from functools import partial
 
         fixed = partial(partial(circuit, 0.5), n_iter=2)
         result = draw(fixed)()
@@ -1291,7 +1289,6 @@ class TestPartialSupport:
 
     def test_draw_partial_mixed(self, circuit):
         """draw works when both positional and keyword args are pre-bound."""
-        from functools import partial
 
         fixed = partial(circuit, 0.5, n_iter=4)
         result = draw(fixed)()
@@ -1304,20 +1301,18 @@ class TestPartialSupport:
 
     def test_draw_mpl_partial_keyword_args(self, circuit):
         """draw_mpl works when keyword args are pre-bound via partial."""
-        from functools import partial
         import matplotlib
         matplotlib.use("Agg")
 
         fixed = partial(circuit, n_iter=2)
         fig, ax = qp.draw_mpl(fixed)(0.5)
-        assert fig is not None
+        assert len(fig.axes) > 0
 
     def test_draw_mpl_partial_nested(self, circuit):
         """draw_mpl works with nested partial."""
-        from functools import partial
         import matplotlib
         matplotlib.use("Agg")
 
         fixed = partial(partial(circuit, 0.3), n_iter=1)
         fig, ax = qp.draw_mpl(fixed)()
-        assert fig is not None
+        assert len(fig.axes) > 0

--- a/tests/drawer/test_draw.py
+++ b/tests/drawer/test_draw.py
@@ -16,12 +16,13 @@ Integration tests for the draw transform
 """
 
 # pylint: disable=import-outside-toplevel
+from functools import partial
+
 import pytest
 
 import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.drawer import draw
-from functools import partial
 
 
 @qp.qnode(qp.device("default.qubit", wires=(0, "a", 1.234)))
@@ -1248,11 +1249,12 @@ def test_sort_wires_fallback(use_qnode):
     expected = "4: ──X─┤     \na: ──X─┤     \n0: ──X─┤  <Z>"
     assert qp.draw(func)() == expected
 
+
 class TestPartialSupport:
     """Tests that qp.draw and qp.draw_mpl handle functools.partial wrappers."""
 
     @pytest.fixture
-    def circuit(self):
+    def partial_circuit(self):
         dev = qp.device("default.qubit")
 
         @qp.qnode(dev)
@@ -1263,56 +1265,58 @@ class TestPartialSupport:
 
         return _circuit
 
-    def test_draw_partial_positional_args(self, circuit):
+    def test_draw_partial_positional_args(self, partial_circuit):
         """draw works when positional args are pre-bound via partial."""
 
-        fixed = partial(circuit, 0.5)
+        fixed = partial(partial_circuit, 0.5)
         result = draw(fixed)(3)
         assert "RX" in result
         assert result.count("RX") == 3
 
-    def test_draw_partial_keyword_args(self, circuit):
+    def test_draw_partial_keyword_args(self, partial_circuit):
         """draw works when keyword args are pre-bound via partial."""
 
-        fixed = partial(circuit, n_iter=3)
+        fixed = partial(partial_circuit, n_iter=3)
         result = draw(fixed)(0.5)
         assert "RX" in result
         assert result.count("RX") == 3
 
-    def test_draw_partial_nested(self, circuit):
+    def test_draw_partial_nested(self, partial_circuit):
         """draw works with nested partial(partial(...))."""
 
-        fixed = partial(partial(circuit, 0.5), n_iter=2)
+        fixed = partial(partial(partial_circuit, 0.5), n_iter=2)
         result = draw(fixed)()
         assert "RX" in result
         assert result.count("RX") == 2
 
-    def test_draw_partial_mixed(self, circuit):
+    def test_draw_partial_mixed(self, partial_circuit):
         """draw works when both positional and keyword args are pre-bound."""
 
-        fixed = partial(circuit, 0.5, n_iter=4)
+        fixed = partial(partial_circuit, 0.5, n_iter=4)
         result = draw(fixed)()
         assert result.count("RX") == 4
 
-    def test_draw_plain_qnode_unaffected(self, circuit):
+    def test_draw_plain_qnode_unaffected(self, partial_circuit):
         """Non-partial QNode still works correctly (regression check)."""
-        result = draw(circuit)(0.5, 2)
+        result = draw(partial_circuit)(0.5, 2)
         assert "RX" in result
 
-    def test_draw_mpl_partial_keyword_args(self, circuit):
+    def test_draw_mpl_partial_keyword_args(self, partial_circuit):
         """draw_mpl works when keyword args are pre-bound via partial."""
         import matplotlib
+
         matplotlib.use("Agg")
 
-        fixed = partial(circuit, n_iter=2)
-        fig, ax = qp.draw_mpl(fixed)(0.5)
+        fixed = partial(partial_circuit, n_iter=2)
+        fig, _ = qp.draw_mpl(fixed)(0.5)
         assert len(fig.axes) > 0
 
-    def test_draw_mpl_partial_nested(self, circuit):
+    def test_draw_mpl_partial_nested(self, partial_circuit):
         """draw_mpl works with nested partial."""
         import matplotlib
+
         matplotlib.use("Agg")
 
-        fixed = partial(partial(circuit, 0.3), n_iter=1)
-        fig, ax = qp.draw_mpl(fixed)()
+        fixed = partial(partial(partial_circuit, 0.3), n_iter=1)
+        fig, _ = qp.draw_mpl(fixed)()
         assert len(fig.axes) > 0

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -481,9 +481,7 @@ class TestSpecsTransform:
             ],
         }
 
-        assert (
-            str(specs_output)
-            == """Device: default.qubit
+        assert str(specs_output) == """Device: default.qubit
 Device wires: None
 Shots: Shots(total=None)
 Level: 2
@@ -523,7 +521,6 @@ Batched tape c:
     Measurements:
     - expval(Prod(num_wires=2, num_terms=2)): 1
     Depth: 5"""
-        )
 
     @pytest.mark.parametrize(
         "device,num_wires",

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -644,8 +644,10 @@ class TestSpecsPartialSupport:
         @catalyst.qjit
         @qp.qnode(dev)
         def circuit(x, n_iter: int):
-            for _ in range(n_iter):
+            @catalyst.for_loop(0, n_iter, 1)
+            def loop(_):
                 qp.RX(x, 0)
+            loop()
             return qp.expval(qp.Z(0))
 
         fixed = partial(circuit, n_iter=3)

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -14,13 +14,14 @@
 """Unit tests for the specs transform"""
 
 # pylint: disable=invalid-sequence-index
+from functools import partial
+
 import pytest
 
 import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.measurements import Shots
 from pennylane.resource import SpecsResources
-from functools import partial
 from pennylane.resource.specs import (
     _get_last_tape_transform_level,
     _preprocess_level_input,
@@ -480,7 +481,9 @@ class TestSpecsTransform:
             ],
         }
 
-        assert str(specs_output) == """Device: default.qubit
+        assert (
+            str(specs_output)
+            == """Device: default.qubit
 Device wires: None
 Shots: Shots(total=None)
 Level: 2
@@ -520,6 +523,7 @@ Batched tape c:
     Measurements:
     - expval(Prod(num_wires=2, num_terms=2)): 1
     Depth: 5"""
+        )
 
     @pytest.mark.parametrize(
         "device,num_wires",
@@ -570,6 +574,7 @@ Batched tape c:
         )
 
         assert qp.specs(c, level="my_level")()["resources"] == expected
+
 
 class TestSpecsPartialSupport:
     """Tests that qp.specs handles functools.partial wrappers."""
@@ -750,4 +755,3 @@ class TestSpecsGraphModeExclusive:
         # No work wires available (2 device wires - 2 tape wires = 0)
         assert specs["num_device_wires"] == 2
         assert specs["resources"].num_allocs == 2
-

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -570,6 +570,71 @@ Batched tape c:
 
         assert qp.specs(c, level="my_level")()["resources"] == expected
 
+class TestSpecsPartialSupport:
+    """Tests that qp.specs handles functools.partial wrappers."""
+
+    @pytest.fixture
+    def circuit(self):
+        dev = qp.device("default.qubit")
+
+        @qp.qnode(dev)
+        def _circuit(x, n_iter):
+            for _ in range(n_iter):
+                qp.RX(x, 0)
+            return qp.expval(qp.Z(0))
+
+        return _circuit
+
+    def test_specs_partial_positional_args(self, circuit):
+        """specs works when positional args are pre-bound via partial."""
+        from functools import partial
+
+        fixed = partial(circuit, 0.5)
+        result = qp.specs(fixed)(3)
+        assert result.resources.gate_types["RX"] == 3
+
+    def test_specs_partial_keyword_args(self, circuit):
+        """specs works when keyword args are pre-bound via partial."""
+        from functools import partial
+
+        fixed = partial(circuit, n_iter=3)
+        result = qp.specs(fixed)(0.5)
+        assert result.resources.gate_types["RX"] == 3
+
+    def test_specs_partial_nested(self, circuit):
+        """specs works with nested partial(partial(...))."""
+        from functools import partial
+
+        fixed = partial(partial(circuit, 0.5), n_iter=2)
+        result = qp.specs(fixed)()
+        assert result.resources.gate_types["RX"] == 2
+
+    def test_specs_partial_mixed(self, circuit):
+        """specs works when both positional and keyword args are pre-bound."""
+        from functools import partial
+
+        fixed = partial(circuit, 0.5, n_iter=4)
+        result = qp.specs(fixed)()
+        assert result.resources.gate_types["RX"] == 4
+
+    def test_specs_plain_qnode_unaffected(self, circuit):
+        """Non-partial QNode still works correctly (regression check)."""
+        result = qp.specs(circuit)(0.5, 2)
+        assert result.resources.gate_types["RX"] == 2
+
+    def test_specs_partial_raises_for_non_qnode(self):
+        """specs still raises ValueError if inner callable is not a QNode."""
+        from functools import partial
+
+        def plain_fn(x):
+            return x
+
+        fixed = partial(plain_fn, 1.0)
+        with pytest.raises(
+            ValueError, match="qp.specs can only be applied to a QNode or qjit'd QNode"
+        ):
+            qp.specs(fixed)()
+
 
 @pytest.mark.usefixtures("enable_graph_decomposition")
 class TestSpecsGraphModeExclusive:
@@ -672,3 +737,4 @@ class TestSpecsGraphModeExclusive:
         # No work wires available (2 device wires - 2 tape wires = 0)
         assert specs["num_device_wires"] == 2
         assert specs["resources"].num_allocs == 2
+

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -633,6 +633,8 @@ class TestSpecsPartialSupport:
         ):
             qp.specs(fixed)()
 
+    @pytest.mark.catalyst
+    @pytest.mark.external
     def test_specs_partial_qjit(self):
         """specs works with partial wrapping a qjit\'d QNode."""
         catalyst = pytest.importorskip("catalyst")

--- a/tests/resource/test_specs.py
+++ b/tests/resource/test_specs.py
@@ -20,6 +20,7 @@ import pennylane as qp
 from pennylane import numpy as pnp
 from pennylane.measurements import Shots
 from pennylane.resource import SpecsResources
+from functools import partial
 from pennylane.resource.specs import (
     _get_last_tape_transform_level,
     _preprocess_level_input,
@@ -587,7 +588,6 @@ class TestSpecsPartialSupport:
 
     def test_specs_partial_positional_args(self, circuit):
         """specs works when positional args are pre-bound via partial."""
-        from functools import partial
 
         fixed = partial(circuit, 0.5)
         result = qp.specs(fixed)(3)
@@ -595,7 +595,6 @@ class TestSpecsPartialSupport:
 
     def test_specs_partial_keyword_args(self, circuit):
         """specs works when keyword args are pre-bound via partial."""
-        from functools import partial
 
         fixed = partial(circuit, n_iter=3)
         result = qp.specs(fixed)(0.5)
@@ -603,7 +602,6 @@ class TestSpecsPartialSupport:
 
     def test_specs_partial_nested(self, circuit):
         """specs works with nested partial(partial(...))."""
-        from functools import partial
 
         fixed = partial(partial(circuit, 0.5), n_iter=2)
         result = qp.specs(fixed)()
@@ -611,7 +609,6 @@ class TestSpecsPartialSupport:
 
     def test_specs_partial_mixed(self, circuit):
         """specs works when both positional and keyword args are pre-bound."""
-        from functools import partial
 
         fixed = partial(circuit, 0.5, n_iter=4)
         result = qp.specs(fixed)()
@@ -624,7 +621,6 @@ class TestSpecsPartialSupport:
 
     def test_specs_partial_raises_for_non_qnode(self):
         """specs still raises ValueError if inner callable is not a QNode."""
-        from functools import partial
 
         def plain_fn(x):
             return x
@@ -634,6 +630,23 @@ class TestSpecsPartialSupport:
             ValueError, match="qp.specs can only be applied to a QNode or qjit'd QNode"
         ):
             qp.specs(fixed)()
+
+    def test_specs_partial_qjit(self):
+        """specs works with partial wrapping a qjit\'d QNode."""
+        catalyst = pytest.importorskip("catalyst")
+
+        dev = qp.device("lightning.qubit", wires=1)
+
+        @catalyst.qjit
+        @qp.qnode(dev)
+        def circuit(x, n_iter: int):
+            for _ in range(n_iter):
+                qp.RX(x, 0)
+            return qp.expval(qp.Z(0))
+
+        fixed = partial(circuit, n_iter=3)
+        result = qp.specs(fixed, level="device")(0.5)
+        assert result is not None
 
 
 @pytest.mark.usefixtures("enable_graph_decomposition")


### PR DESCRIPTION
Context:
qml.draw, qml.draw_mpl, and qml.specs all blow up when you pass them a functools.partial-wrapped QNode. The tools look for a QNode directly and can't see through the wrapper, so you get either an empty result or a ValueError. Pre-binding some circuit arguments with partial before inspecting is a pretty normal thing to want to do:

pythonfixed = partial(circuit, n_iter=3)
qml.draw(fixed)(0.5)   # TypeError before this fix
qml.specs(fixed)(0.5)  # ValueError before this fix

Description of the Change:
Added _unwrap_partial in draw.py and specs.py. It loops through functools.partial layers collecting positional and keyword args at each level until it finds the actual QNode. At the entry of each inspection tool, if the input is a partial it gets unwrapped and the bound args get merged with whatever the user passes at call time. Nested partials work fine — inner kwargs take precedence, which matches how Python's own partial resolution works.
For draw_mpl specifically, the unwrapped args flow through _draw_mpl_qnode via two new keyword params bound_args and bound_kwargs so the merge happens inside the wrapper where construct_batch is called.
When no partial is involved nothing changes — bound_args is empty, bound_kwargs is empty, call is identical to before.

Benefits:
All three inspection tools now work with partial-wrapped QNodes. Nested partials with any mix of positional and keyword bindings work too.

Possible Drawbacks:
If the unwrapped inner callable isn't a QNode, validation fires exactly as it did before. No change there.

Related GitHub Issues:
Closes #9394