### PR TITLE
Fix a small bug in the way gate types in specs are accumulated

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -464,6 +464,9 @@
   with the multi-wire case, matching the existing behavior of :func:`~pennylane.draw_mpl`.
   [(#9532)](https://github.com/PennyLaneAI/pennylane/pull/9532)
 
+* Fixed a bug where gate types are overwritten in ``qp.specs`` on the MLIR level.
+  [(#9574)](https://github.com/PennyLaneAI/pennylane/pull/9574)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/resource/mlir_specs.py
+++ b/pennylane/resource/mlir_specs.py
@@ -128,7 +128,7 @@ def _mlir_resources_to_specs_resources(
             # Separate out PPMs and PPRs by weight
             gate_name += f"-w{gate_size}"
 
-        gate_types[gate_name] = +count
+        gate_types[gate_name] += count
         gate_sizes[int(gate_size)] += count
 
     # Recurse through all function calls and combine resources with the appropriate multiplicative factors

--- a/pennylane/resource/mlir_specs.py
+++ b/pennylane/resource/mlir_specs.py
@@ -128,7 +128,7 @@ def _mlir_resources_to_specs_resources(
             # Separate out PPMs and PPRs by weight
             gate_name += f"-w{gate_size}"
 
-        gate_types[gate_name] = count
+        gate_types[gate_name] = +count
         gate_sizes[int(gate_size)] += count
 
     # Recurse through all function calls and combine resources with the appropriate multiplicative factors

--- a/tests/resource/test_mlir_specs.py
+++ b/tests/resource/test_mlir_specs.py
@@ -224,6 +224,42 @@ class TestAnalysisPassConversion:
             ),
         ]
 
+    def test_same_op_name_multiple_widths(self):
+        """A single op name at multiple qubit widths must accumulate in gate_types,
+        not overwrite. Regression for the 'Inconsistent gate counts' ValueError."""
+        actual = _get_resources_from_analysis_pass(
+            {
+                "circuit": {
+                    "auto_qubit_management": False,
+                    "classical_instructions": {},
+                    "device_name": "NullQubit",
+                    "function_calls": {},
+                    "has_branches": False,
+                    "measurements": {},
+                    "num_alloc_qubits": 4,
+                    "num_arg_qubits": 0,
+                    "num_qubits": 4,
+                    "operations": {
+                        "MultiControlledX(2)": 5,
+                        "MultiControlledX(3)": 7,
+                        "Hadamard(1)": 2,
+                    },
+                    "qnode": True,
+                    "var_function_calls": {},
+                }
+            }
+        )
+
+        assert actual == [
+            SpecsResources(
+                gate_types={"Hadamard": 2, "MultiControlledX": 12},
+                gate_sizes={1: 2, 2: 5, 3: 7},
+                measurements={},
+                num_allocs=4,
+                depth=None,
+            )
+        ]
+
     def test_mlir_resources_to_specs_resources(self, example_loop_analysis_pass_result):
         fn_resources = {}
         display_names = {}


### PR DESCRIPTION

**Context:**
Fix a small bug in the way gate types in specs are accumulated

Test is co-written by yours truly, Jukebox (Claude)

**Description of the Change:**

Small fix so same gate types don't get overwritten

**Benefits:**

Fixes bug

**Possible Drawbacks:**

**Related GitHub Issues:**
