### PR TITLE
Add __repr__ to Tracker

### DIFF
--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -179,6 +179,18 @@ class Tracker:
                 raise ValueError(f"Device '{dev.short_name}' does not support device tracking")
             dev.tracker = self
 
+    def __repr__(self):
+        return(
+            f"<"
+            f"{self.__class__.__name__}("
+            f"active={self.active!r}, "
+            f"persistent={self.persistent!r}, "
+            f"totals={self.totals!r}, "
+            f"history={self.history!r}, "
+            f"latest={self.latest!r}"
+            f")>"
+        ) 
+    
     def __enter__(self):
         if not self.persistent:
             self.reset()

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -41,6 +41,34 @@ class TestTrackerCoreBehavior:
 
         assert tracker.active is False
 
+    def test_repr(self):
+        """Test repr functionality"""
+        tracker = Tracker()
+        default_repr = (
+            "<Tracker(active=False, persistent=False, "
+            "totals={}, history={}, latest={})>"
+        )
+        assert default_repr == repr(tracker)
+        tracker.active = True
+        tracker.update(a=1, b=2, c="c")
+        updated_repr = (
+            "<Tracker(active=True, persistent=False, "
+            "totals={'a': 1, 'b': 2}, "
+            "history={'a': [1], 'b': [2], 'c': ['c']}, " 
+            "latest={'a': 1, 'b': 2, 'c': 'c'})>"
+        )
+        assert updated_repr == repr(tracker)
+        tracker.update(a=2, b=3, c=0)
+        tracker.persistent=True
+        updated_repr = (
+            "<Tracker(active=True, persistent=True, "
+            "totals={'a': 3, 'b': 5, 'c': 0}, "
+            "history={'a': [1, 2], 'b': [2, 3], 'c': ['c', 0]}, " 
+            "latest={'a': 2, 'b': 3, 'c': 0})>"
+        )
+        assert updated_repr == repr(tracker)
+
+
     def test_device_assignment(self):
         """Assert gets assigned to device"""
 


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Context:**
Since the Tracker class lacks __repr__ function, debugging is messy. In order to overcome this __repr__ needs to be introduced.

**Description of the Change:**
Added __repr__ to Tracker class together with unit tests..

**Benefits:**
Improves 'debugability' of code.

**Possible Drawbacks:**
I would say none.

**Related GitHub Issues:**
[This](https://github.com/pennylaneai/pennylane/issues/9389)

**AI used**
None