### PR TITLE
Add documentation testing support for pennylane/shadows

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -84,7 +84,6 @@ jobs:
           --ignore=pennylane/math
           --ignore=pennylane/compiler
           --ignore=pennylane/capture
-          --ignore=pennylane/shadows
           --ignore=pennylane/gradients
           --ignore=pennylane/optimize
           --ignore=pennylane/pulse

--- a/pennylane/shadows/__init__.py
+++ b/pennylane/shadows/__init__.py
@@ -97,10 +97,22 @@ The easiest way of computing expectation values with classical shadows in PennyL
 
 The big advantage of this way of computing expectation values is that it is differentiable.
 
+>>> H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.Z(1)])
+>>> dev = qp.device("default.qubit")
+>>> @qp.defer_measurements
+... @qp.set_shots(shots=10000)
+... @qp.qnode(dev)
+... def qnode(x):
+...     qp.Hadamard(0)
+...     qp.CNOT((0,1))
+...     qp.RX(x, wires=0)
+...     qp.measure(1)
+...     return qp.shadow_expval(H)
+>>> x = qp.numpy.array(0.5, requires_grad=True)
 >>> qnode(x)
-array(0.8406)
+array(...)
 >>> qp.grad(qnode)(x)
--0.49680000000000013
+np.float64(-0...)
 
 There are more options for post-processing classical shadows in :class:`ClassicalShadow`.
 """

--- a/pennylane/shadows/classical_shadow.py
+++ b/pennylane/shadows/classical_shadow.py
@@ -81,14 +81,24 @@ class ClassicalShadow:
     After recording these ``T=1000`` quantum measurements, we can post-process the results to arbitrary local expectation values of Pauli strings.
     For example, we can compute the expectation value of a Pauli string
 
+    >>> dev = qp.device("default.qubit", wires=range(2))
+    >>> @qp.set_shots(shots=1000)
+    ... @qp.qnode(dev)
+    ... def qnode(x):
+    ...     qp.Hadamard(0)
+    ...     qp.CNOT((0,1))
+    ...     qp.RX(x, wires=0)
+    ...     return qp.classical_shadow(wires=range(2))
+    >>> bits, recipes = qnode(0)
+    >>> shadow = qp.ClassicalShadow(bits, recipes)
     >>> shadow.expval(qp.X(0) @ qp.X(1), k=1)
-    array(0.972)
+    array(...)
 
     or of a Hamiltonian:
 
     >>> H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.X(1)])
     >>> shadow.expval(H, k=1)
-    array(1.917)
+    array(...)
 
     The parameter ``k`` is used to estimate the expectation values via the `median of means` algorithm (see `2002.08953 <https://arxiv.org/abs/2002.08953>`_). The case ``k=1`` corresponds to simply taking the mean
     value over all local snapshots. ``k>1`` corresponds to splitting the ``T`` local snapshots into ``k`` equal parts, and taking the median of their individual means. For the case of measuring only in the Pauli basis,
@@ -211,6 +221,17 @@ class ClassicalShadow:
 
             bell_state = np.array([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
 
+        >>> dev = qp.device("default.qubit", wires=range(2))
+        >>> @qp.set_shots(shots=1000)
+        ... @qp.qnode(dev)
+        ... def qnode():
+        ...     qp.Hadamard(0)
+        ...     qp.CNOT((0,1))
+        ...     return qp.classical_shadow(wires=range(2))
+        >>> bits, recipes = qnode()
+        >>> shadow = qp.ClassicalShadow(bits, recipes)
+        >>> shadow_state = np.mean(shadow.global_snapshots(), axis=0)
+        >>> bell_state = np.array([[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]])
         >>> np.allclose(bell_state, shadow_state, atol=1e-1)
         True
 
@@ -316,14 +337,24 @@ class ClassicalShadow:
 
         Compute Pauli string observables
 
+        >>> dev = qp.device("default.qubit", wires=range(2))
+        >>> @qp.set_shots(shots=1000)
+        ... @qp.qnode(dev)
+        ... def qnode(x):
+        ...     qp.Hadamard(0)
+        ...     qp.CNOT((0,1))
+        ...     qp.RX(x, wires=0)
+        ...     return qp.classical_shadow(wires=range(2))
+        >>> bits, recipes = qnode(0)
+        >>> shadow = qp.ClassicalShadow(bits, recipes)
         >>> shadow.expval(qp.X(0) @ qp.X(1), k=1)
-        array(1.116)
+        array(...)
 
         or of a Hamiltonian using `the same` measurement results
 
         >>> H = qp.Hamiltonian([1., 1.], [qp.Z(0) @ qp.Z(1), qp.X(0) @ qp.X(1)])
         >>> shadow.expval(H, k=1)
-        array(1.9980000000000002)
+        array(...)
         """
         if not isinstance(H, (list, tuple)):
             H = [H]
@@ -405,6 +436,18 @@ class ClassicalShadow:
 
             entropies = [shadow.entropy(wires=[0], alpha=alpha) for alpha in [1., 2., 3.]]
 
+        >>> wires = 4
+        >>> dev = qp.device("default.qubit", wires=range(wires))
+        >>> @qp.set_shots(shots=1000)
+        ... @qp.qnode(dev)
+        ... def max_entangled_circuit():
+        ...     qp.Hadamard(wires=0)
+        ...     for i in range(1, wires):
+        ...         qp.CNOT(wires=[0, i])
+        ...     return qp.classical_shadow(wires=range(wires))
+        >>> bits, recipes = max_entangled_circuit()
+        >>> shadow = qp.ClassicalShadow(bits, recipes)
+        >>> entropies = [shadow.entropy(wires=[0], alpha=alpha) for alpha in [1., 2., 3.]]
         >>> print(np.isclose(entropies, entropies[0], atol=5e-2))
         [ True  True  True]
 
@@ -426,8 +469,21 @@ class ClassicalShadow:
             bitstrings, recipes = qnode(x)
             shadow = qp.ClassicalShadow(bitstrings, recipes)
 
+        >>> wires = 4
+        >>> dev = qp.device("default.qubit", wires=range(wires))
+        >>> @qp.set_shots(shots=1000)
+        ... @qp.qnode(dev)
+        ... def qnode(x):
+        ...     for i in range(wires):
+        ...         qp.RY(x[i], wires=i)
+        ...     for i in range(wires - 1):
+        ...         qp.CNOT((i, i + 1))
+        ...     return qp.classical_shadow(wires=range(wires))
+        >>> x = np.linspace(0.5, 1.5, num=wires)
+        >>> bitstrings, recipes = qnode(x)
+        >>> shadow = qp.ClassicalShadow(bitstrings, recipes)
         >>> [shadow.entropy(wires=wires, alpha=alpha) for alpha in [1., 2., 3.]]
-        [1.5419292874423107, 1.1537924276625828, 0.9593638767763727]
+        [...]
 
         """
 

--- a/pennylane/shadows/transforms.py
+++ b/pennylane/shadows/transforms.py
@@ -158,17 +158,20 @@ def shadow_state(
             qp.RX(x, wires=0)
             return qp.classical_shadow(wires=[0, 1])
 
-    >>> x = np.array(1.2)
+    >>> dev = qp.device("default.qubit", wires=2)
+    >>> @qp.set_shots(shots=10000)
+    ... @qp.shadows.shadow_state(wires=[0, 1], diffable=True)
+    ... @qp.qnode(dev)
+    ... def circuit(x):
+    ...     qp.Hadamard(wires=0)
+    ...     qp.CNOT(wires=[0, 1])
+    ...     qp.RX(x, wires=0)
+    ...     return qp.classical_shadow(wires=[0, 1])
+    >>> x = qp.numpy.array(1.2, requires_grad=True)
     >>> circuit(x)
-    array([[ 0.33835   +0.j     , -0.01215   +0.2241j , -0.00465   +0.237j  ,  0.35504997-0.01755j],
-       [-0.01215   -0.2241j ,  0.1528    +0.j     ,  0.16919999-0.0036j , -0.00285   -0.22065j],
-       [-0.00465   -0.237j  ,  0.16919999+0.0036j ,  0.17529999+0.j     ,  0.0099    -0.2358j ],
-       [ 0.35504997+0.01755j, -0.00285   +0.22065j,  0.0099    +0.2358j ,  0.33355   +0.j     ]], dtype=complex64)
+    array(...)
     >>> qp.jacobian(lambda x: np.real(circuit(x)))(x)
-    array([[-0.245025, -0.005325,  0.004275, -0.2358  ],
-           [-0.005325,  0.235275,  0.2358  , -0.004275],
-           [ 0.004275,  0.2358  ,  0.244875, -0.002175],
-           [-0.2358  , -0.004275, -0.002175, -0.235125]])
+    array(...)
     """
     tapes, fn = (
         _shadow_state_diffable(tape, wires) if diffable else _shadow_state_undiffable(tape, wires)


### PR DESCRIPTION
- Fix doctest examples in __init__.py, classical_shadow.py, transforms.py
- Convert code-block examples to testable >>> doctest format
- Use ellipsis wildcards for stochastic outputs
- Remove pennylane/shadows from CI ignore list

Closes #9396

## AI disclosure
I used Claude as a co-pilot to help identify doctest patterns and debug failures, which I then manually verified by running pytest locally.

## Summary:
- Fixed doctest examples in '__init__py', 'classical_shadow.py', and 'transforms.py'
- Converted '.. code-block::' setups into testable '>>>' doctest format so Sybil can run them
- Used '...' ellipsis wildcards for stochastic shot-based outputs
- Made 'x' trainable with 'qp.numpy.array(..., requires_grad=True)' where needed
- removed 'penny lane/shadows' from the CI ignore list in 'documentation-tests.yml'

All 46 doctests now pass locally ('pytest pennylane/shadows').

