### PR TITLE
Add __repr__ to qp.Tracker to improve readability

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -103,6 +103,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Added a custom ``__repr__`` method to :class:`~.Tracker` for improved readability and debugging.
+  [(#9389)](https://github.com/PennyLaneAI/pennylane/issues/9389)
+
 * Instances of `C(Prod)` now have a significantly more efficient decomposition in terms of `TemporaryAND` operators when work wires are provided.
 
   For example, a controlled multi-target-``X`` operation previously decomposed as

--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -242,6 +242,19 @@ class Tracker:
         self.history = {}
         self.latest = {}
 
+    def __repr__(self):
+        callback_info = "custom" if self.callback is not None else None
+        return (
+            f"Tracker("
+            f"active={self.active}, "
+            f"totals={self.totals}, "
+            f"persistent={self.persistent}, "
+            f"history={self.history}, "
+            f"latest={self.latest}, "
+            f"callback={callback_info}"
+            f")"
+        )
+
     def record(self):
         """This method allows users to interact with the stored data.  While it's intended purpose
         is monitoring large jobs through ``print`` statements or logging, the function is

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -143,6 +143,29 @@ class TestTrackerCoreBehavior:
 
         assert tracker.latest == {"a": 2, "b": "b2", "c": 1}
 
+    def test_repr(self):
+        """Tests that __repr__ displays relevant information"""
+        tracker = Tracker()
+
+        repr_str = repr(tracker)
+        assert repr_str.startswith("Tracker(")
+        assert "active=False" in repr_str
+        assert "totals={}" in repr_str
+        assert "persistent=False" in repr_str
+        assert "history={}" in repr_str
+        assert "latest={}" in repr_str
+        assert "callback=None" in repr_str
+
+        tracker.update(a=1, b="b")
+        repr_str = repr(tracker)
+        assert "a" in repr_str
+        assert "b" in repr_str
+        assert "callback=None" in repr_str
+
+        tracker.callback = lambda **kwargs: None
+        repr_str = repr(tracker)
+        assert "callback=custom" in repr_str
+
     def test_record_callback(self, mocker):
         # pylint: disable=too-few-public-methods
         class callback_wrapper:


### PR DESCRIPTION
**Context:**
Currently, the `Tracker` object has no defined `__repr__`, which makes it hard to interact with and debug. Printing a tracker just shows the default object representation with a memory address.

```python
>>> from pennylane import Tracker
>>> tracker = Tracker()
>>> tracker.update(a=2, b="b2", c=1)
>>> print(tracker)
<pennylane.devices.tracker.Tracker object at 0x1304e3a50>
```

**Description of the Change:**
Added a custom `__repr__` method to the `Tracker` class that displays all relevant internal state:
- `active` - whether tracking is currently enabled
- `totals` - running sum per keyword (numeric values)
- `persistent` - whether tracking persists across contexts
- `history` - list of all values recorded per keyword
- `latest` - most recently recorded values
- `callback` - shows `None` or `custom` if a callback function exists

Example output after the change:
```python
>>> print(tracker)
Tracker(active=False, totals={'a': 2, 'c': 1}, persistent=False, history={'a': [2], 'b': ['b2'], 'c': [1]}, latest={'a': 2, 'b': 'b2', 'c': 1}, callback=None)
```

Added corresponding unit tests in `tests/devices/test_tracker.py` to verify the `__repr__` output for default state, populated state, and callback presence.

**Benefits:**
- Improved debugging experience when working with trackers
- Easier to inspect tracker state during interactive development
- Clear visibility into what data the tracker has collected

**Possible Drawbacks:**
- None expected. The `__repr__` is purely additive and does not change any existing behavior.

**Related GitHub Issues:**
Closes #9389
