### PR TITLE
Use different seed for classical shadow in the doc

### DIFF
--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -738,7 +738,7 @@ def classical_shadow(wires: WiresLike, seed=None) -> ClassicalShadowMP:
         def circuit():
             qp.Hadamard(wires=0)
             qp.CNOT(wires=[0, 1])
-            return qp.classical_shadow(wires=[0, 1], seed=42)
+            return qp.classical_shadow(wires=[0, 1], seed=89)
 
     Executing this QNode produces the sampled bits and the Pauli measurements used:
 

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -745,16 +745,16 @@ def classical_shadow(wires: WiresLike, seed=None) -> ClassicalShadowMP:
     >>> bits, recipes = circuit()
     >>> bits
     array([[1, 1],
-           [0, 0],
+           [0, 1],
            [1, 1],
            [1, 0],
            [0, 0]], dtype=int8)
     >>> recipes
     array([[2, 0],
-           [2, 2],
-           [0, 0],
-           [2, 1],
-           [2, 2]], dtype=int8)
+           [1, 2],
+           [1, 2],
+           [0, 2],
+           [0, 1]], dtype=int8)
 
     .. details::
         :title: Usage Details
@@ -766,15 +766,15 @@ def classical_shadow(wires: WiresLike, seed=None) -> ClassicalShadowMP:
         >>> bits
         array([[0, 0],
            [1, 1],
+           [1, 0],
            [1, 1],
-           [1, 1],
-           [0, 0]], dtype=int8)
+           [0, 1]], dtype=int8)
         >>> recipes
         array([[2, 0],
-           [2, 2],
-           [0, 0],
-           [2, 1],
-           [2, 2]], dtype=int8)
+           [1, 2],
+           [1, 2],
+           [0, 2],
+           [0, 1]], dtype=int8)
 
         To use the same Pauli recipes for different executions, the :class:`~.tape.QuantumTape`
         interface should be used instead:


### PR DESCRIPTION
Noticed this while reviewing the rendered page of https://github.com/PennyLaneAI/pennylane/pull/9566
Note that, `pennylane.classical_shadow.html` uses not the code from `pennylane/shadow` but that from `pennylane/measurements/classical_shadow.py`.

More context: for shadow to work properly, one needs different seeds for device and shadow function.

[sc-121481]

Let's trigger the doctest and see what is gonna be the new result, and then fix as well.