### PR TITLE
 update imports to pennylane.core

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -403,7 +403,8 @@ Completed deprecation cycles
 
 .. code-block:: python
 
-    from pennylane.operation import TermsUndefinedError, Operator
+    from pennylane.core.operator import Operator
+    from pennylane.operation import TermsUndefinedError
 
     def not_tape(obj):
         return not isinstance(obj, qml.tape.QuantumScript)

--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -404,7 +404,7 @@ Completed deprecation cycles
 .. code-block:: python
 
     from pennylane.core.operator import Operator
-    from pennylane.operation import TermsUndefinedError
+    from pennylane.exceptions import TermsUndefinedError
 
     def not_tape(obj):
         return not isinstance(obj, qml.tape.QuantumScript)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -356,6 +356,7 @@
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.
   [(#9508)](https://github.com/PennyLaneAI/pennylane/pull/9508)
+  [(#9583)](https://github.com/PennyLaneAI/pennylane/pull/9583)
 
 * ``assert_valid`` will now correctly raise an ``ImportError`` if `skip_capture=False` and JAX is not installed.
   [(#9567)](https://github.com/PennyLaneAI/pennylane/pull/9567)

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -26,6 +26,7 @@ from pennylane.queuing import QueuingManager, apply
 from pennylane import compiler
 from pennylane.compiler import qjit
 from pennylane import capture
+from pennylane import core
 from pennylane import control_flow
 from pennylane.control_flow import for_loop, while_loop
 from pennylane import kernels

--- a/pennylane/allocation.py
+++ b/pennylane/allocation.py
@@ -20,8 +20,8 @@ from enum import StrEnum
 from typing import Literal
 
 from pennylane.capture import enabled as capture_enabled
+from pennylane.core.operator import Operator
 from pennylane.math import is_abstract
-from pennylane.operation import Operator
 from pennylane.wires import DynamicWire, Wires
 
 has_jax = True

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -23,8 +23,8 @@ from functools import cached_property
 import numpy as np
 import rustworkx as rx
 
+from pennylane.core.operator import Operator
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Operator
 from pennylane.ops.identity import I
 from pennylane.ops.mid_measure import MidMeasure, PauliMeasure
 from pennylane.ops.op_math.condition import Conditional

--- a/pennylane/data/attributes/operator/operator.py
+++ b/pennylane/data/attributes/operator/operator.py
@@ -22,9 +22,9 @@ from typing import Generic, TypeVar
 import numpy as np
 
 from pennylane import ops as qops
+from pennylane.core.operator import Operator
 from pennylane.data.base.attribute import DatasetAttribute
 from pennylane.data.base.hdf5 import HDF5Group, h5py
-from pennylane.operation import Operator
 from pennylane.queuing import QueuingManager
 
 from ._wires import wires_to_json

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -35,9 +35,9 @@ import rustworkx as rx
 from rustworkx.visit import DijkstraVisitor, PruneSearch, StopSearch
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.decomposition.gate_set import GateSet
 from pennylane.exceptions import DecompositionError, DecompositionWarning
-from pennylane.operation import Operator
 
 from .decomposition_rule import DecompositionRule, WorkWireSpec, list_decomps, null_decomp
 from .reconstruct import decomps_use_reconstructor

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -27,7 +27,7 @@ from typing import overload
 
 import pennylane as qp
 from pennylane import queuing
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 from .reconstruct import get_decomp_kwargs
 from .resources import Resources, auto_wrap, resource_rep

--- a/pennylane/decomposition/gate_set.py
+++ b/pennylane/decomposition/gate_set.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Set
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 from .utils import to_name
 

--- a/pennylane/decomposition/reconstruct.py
+++ b/pennylane/decomposition/reconstruct.py
@@ -17,8 +17,8 @@
 from collections.abc import Callable
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.decomposition.resources import resource_rep
-from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 _reconstructors = {}

--- a/pennylane/decomposition/resources.py
+++ b/pennylane/decomposition/resources.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 from .utils import to_name
 

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import singledispatch
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 OP_NAME_ALIASES = {
     "X": "PauliX",

--- a/pennylane/devices/_legacy_device.py
+++ b/pennylane/devices/_legacy_device.py
@@ -25,6 +25,7 @@ from functools import lru_cache
 import numpy as np
 
 from pennylane.boolean_fn import BooleanFn
+from pennylane.core.operator import Operation, Operator, StatePrepBase
 from pennylane.decomposition.gate_set import GateSet
 from pennylane.exceptions import DeviceError, QuantumFunctionError, WireError
 from pennylane.measurements import (
@@ -37,7 +38,6 @@ from pennylane.measurements import (
     StateMP,
     VarianceMP,
 )
-from pennylane.operation import Operation, Operator, StatePrepBase
 from pennylane.ops import LinearCombination, MidMeasure, Prod, Projector, SProd, Sum
 from pennylane.tape import QuantumScript
 from pennylane.transforms import broadcast_expand, decompose, split_non_commuting

--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from pennylane import math
 from pennylane import numpy as pnp
+from pennylane.core.operator import Operation, Operator
 from pennylane.exceptions import DeviceError, EigvalsUndefinedError, QuantumFunctionError
 from pennylane.math import multiply as qpmul
 from pennylane.math import sum as qpsum
@@ -48,7 +49,7 @@ from pennylane.measurements import (
     VarianceMP,
     VnEntropyMP,
 )
-from pennylane.operation import Operation, Operator, operation_derivative
+from pennylane.operation import operation_derivative
 from pennylane.ops import MeasurementValue, MidMeasure, Rot, X, Y, Z, adjoint
 from pennylane.tape import QuantumScript
 from pennylane.wires import Wires

--- a/pennylane/devices/capabilities.py
+++ b/pennylane/devices/capabilities.py
@@ -23,8 +23,8 @@ from itertools import repeat
 
 import tomlkit as toml
 
+from pennylane.core.operator import Operator
 from pennylane.exceptions import InvalidCapabilitiesError, QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.ops import CompositeOp, SymbolicOp
 
 from .execution_config import MCM_METHOD

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -25,6 +25,7 @@ from functools import partial
 import numpy as np
 
 from pennylane import math, ops
+from pennylane.core.operator import Channel, Operator, StatePrepBase
 from pennylane.exceptions import DeviceError, QuantumFunctionError
 from pennylane.measurements import (
     ClassicalShadowMP,
@@ -40,7 +41,6 @@ from pennylane.measurements import (
     VarianceMP,
     VnEntropyMP,
 )
-from pennylane.operation import Channel, Operator, StatePrepBase
 from pennylane.ops.qubit.observables import BasisStateProjector
 from pennylane.pauli import PauliWord, pauli_decompose
 from pennylane.pauli.utils import _binary_matrix_from_pws

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -81,7 +81,7 @@ if TYPE_CHECKING:
 
     from jax.extend.core import Jaxpr
 
-    from pennylane.operation import Operator
+    from pennylane.core.operator import Operator
 
 
 # Base gate set for DefaultQubit

--- a/pennylane/devices/default_tensor.py
+++ b/pennylane/devices/default_tensor.py
@@ -27,6 +27,7 @@ from typing import Union
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operation, Operator
 from pennylane.devices import Device, ExecutionConfig
 from pennylane.devices.modifiers import simulator_tracking, single_tape_support
 from pennylane.devices.preprocess import (
@@ -43,7 +44,6 @@ from pennylane.measurements import (
     StateMP,
     VarianceMP,
 )
-from pennylane.operation import Operation, Operator
 from pennylane.ops import LinearCombination, Prod, SProd, Sum
 from pennylane.tape import QuantumScript, QuantumScriptOrBatch
 from pennylane.templates.subroutines.time_evolution.trotter import _recursive_expression

--- a/pennylane/devices/legacy_facade.py
+++ b/pennylane/devices/legacy_facade.py
@@ -24,6 +24,7 @@ from copy import copy, deepcopy
 from dataclasses import replace
 
 from pennylane import math, ops
+from pennylane.core.operator import Operator
 from pennylane.decomposition.gate_sets import ROTATIONS_PLUS_CNOT
 from pennylane.devices.capabilities import DeviceCapabilities
 from pennylane.exceptions import (
@@ -34,7 +35,6 @@ from pennylane.exceptions import (
 )
 from pennylane.math import Interface, requires_grad
 from pennylane.measurements import ExpectationMP, Shots
-from pennylane.operation import Operator
 from pennylane.ops import MidMeasure
 from pennylane.tape import QuantumScript
 from pennylane.transforms import broadcast_expand, defer_measurements, dynamic_one_shot

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -22,6 +22,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from copy import copy
 
+from pennylane.core.operator import Operator, StatePrepBase
 from pennylane.decomposition import enabled_graph
 from pennylane.exceptions import (
     AllocationError,
@@ -37,7 +38,6 @@ from pennylane.measurements import (
     counts,
     sample,
 )
-from pennylane.operation import Operator, StatePrepBase
 from pennylane.ops import Snapshot
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import (

--- a/pennylane/devices/qubit/apply_operation.py
+++ b/pennylane/devices/qubit/apply_operation.py
@@ -23,7 +23,7 @@ import scipy as sp
 
 import pennylane as qp
 from pennylane import math, ops
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import Conditional, MidMeasure
 
 EINSUM_OP_WIRECOUNT_PERF_THRESHOLD = 3

--- a/pennylane/devices/qubit/simulate.py
+++ b/pennylane/devices/qubit/simulate.py
@@ -24,6 +24,7 @@ from numpy.random import default_rng
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import StatePrepBase
 from pennylane.logging import debug_logger
 from pennylane.math.interface_utils import Interface
 from pennylane.measurements import (
@@ -35,7 +36,6 @@ from pennylane.measurements import (
     Shots,
     VarianceMP,
 )
-from pennylane.operation import StatePrepBase
 from pennylane.ops import MidMeasure
 from pennylane.tape import QuantumScript
 from pennylane.transforms.dynamic_one_shot import gather_mcm

--- a/pennylane/devices/qubit_mixed/apply_operation.py
+++ b/pennylane/devices/qubit_mixed/apply_operation.py
@@ -22,8 +22,8 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Channel, Operator
 from pennylane.devices.qubit.apply_operation import _apply_grover_without_matrix
-from pennylane.operation import Channel, Operator
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 from pennylane.typing import TensorLike
 

--- a/pennylane/devices/qutrit_mixed/apply_operation.py
+++ b/pennylane/devices/qutrit_mixed/apply_operation.py
@@ -21,7 +21,7 @@ from string import ascii_letters as alphabet
 import pennylane as qp
 from pennylane import math
 from pennylane import numpy as np
-from pennylane.operation import Channel
+from pennylane.core.operator import Channel
 
 from .utils import QUDIT_DIM, get_einsum_mapping, get_new_state_einsum_indices
 

--- a/pennylane/devices/qutrit_mixed/initialize_state.py
+++ b/pennylane/devices/qutrit_mixed/initialize_state.py
@@ -16,7 +16,7 @@
 from collections.abc import Iterable
 
 import pennylane as qp
-from pennylane.operation import StatePrepBase
+from pennylane.core.operator import StatePrepBase
 
 from .utils import QUDIT_DIM
 

--- a/pennylane/devices/reference_qubit.py
+++ b/pennylane/devices/reference_qubit.py
@@ -19,7 +19,7 @@ and plugin development purposes.
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.tape import QuantumScript
 from pennylane.transforms import (
     broadcast_expand,

--- a/pennylane/drawer/_add_obj.py
+++ b/pennylane/drawer/_add_obj.py
@@ -27,6 +27,7 @@ The `_add_obj` function is automatically invoked by the text drawer when renderi
 
 from functools import singledispatch
 
+from pennylane.core.operator import Operator
 from pennylane.measurements import (
     CountsMP,
     DensityMatrixMP,
@@ -37,7 +38,6 @@ from pennylane.measurements import (
     StateMP,
     VarianceMP,
 )
-from pennylane.operation import Operator
 from pennylane.ops import (
     Adjoint,
     Conditional,

--- a/pennylane/drawer/label.py
+++ b/pennylane/drawer/label.py
@@ -17,8 +17,8 @@ Contains the 'label' function for customizing operator labels.
 
 # pylint: disable=unused-argument
 
+from pennylane.core.operator import Operator
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operator
 from pennylane.ops.functions.equal import (
     BASE_OPERATION_MISMATCH_ERROR_MESSAGE,
     _equal,

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -41,7 +41,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from pennylane.operation import Operator
+    from pennylane.core.operator import Operator
     from pennylane.tape import QuantumScript
 
 

--- a/pennylane/estimator/estimate.py
+++ b/pennylane/estimator/estimate.py
@@ -17,9 +17,9 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from functools import singledispatch, wraps
 
+from pennylane.core.operator import Operation, Operator
 from pennylane.estimator.ops.op_math.symbolic import Adjoint, Controlled, Pow
 from pennylane.measurements.measurements import MeasurementProcess
-from pennylane.operation import Operation, Operator
 from pennylane.queuing import AnnotatedQueue, QueuingManager
 from pennylane.wires import Wires
 from pennylane.workflow.qnode import QNode

--- a/pennylane/estimator/qpe_resources/first_quantization.py
+++ b/pennylane/estimator/qpe_resources/first_quantization.py
@@ -20,8 +20,8 @@ non-Clifford gates for quantum algorithms in first quantization using a plane-wa
 import numpy as np
 import scipy as sp
 
+from pennylane.core.operator import Operation
 from pennylane.math import ceil_log2
-from pennylane.operation import Operation
 
 
 class FirstQuantization(Operation):

--- a/pennylane/estimator/qpe_resources/second_quantization.py
+++ b/pennylane/estimator/qpe_resources/second_quantization.py
@@ -19,8 +19,8 @@ method.
 # pylint: disable=no-self-use, too-many-arguments, too-many-instance-attributes, too-many-positional-arguments
 import numpy as np
 
+from pennylane.core.operator import Operation
 from pennylane.math import ceil_log2
-from pennylane.operation import Operation
 from pennylane.qchem import factorize
 
 

--- a/pennylane/estimator/resource_mapping.py
+++ b/pennylane/estimator/resource_mapping.py
@@ -25,7 +25,7 @@ import pennylane.estimator.templates as re_temps
 import pennylane.ops as qops
 import pennylane.templates as qtemps
 from pennylane import math as pl_math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops.functions import simplify
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 from pennylane.ops.op_math.controlled import Controlled, ControlledOp

--- a/pennylane/fermi/conversion.py
+++ b/pennylane/fermi/conversion.py
@@ -26,7 +26,7 @@ from pennylane.pauli import PauliSentence, PauliWord
 from .fermionic import FermiSentence, FermiWord
 
 if TYPE_CHECKING:
-    from pennylane.operation import Operator
+    from pennylane.core.operator import Operator
 
 
 def jordan_wigner(

--- a/pennylane/fourier/mark.py
+++ b/pennylane/fourier/mark.py
@@ -17,8 +17,8 @@ Contains the 'label' function for customizing operator labels.
 
 # pylint: disable=unused-argument
 
+from pennylane.core.operator import Operator
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operator
 from pennylane.ops.functions.equal import (
     BASE_OPERATION_MISMATCH_ERROR_MESSAGE,
     _equal,

--- a/pennylane/ftqc/graph_state_preparation.py
+++ b/pennylane/ftqc/graph_state_preparation.py
@@ -17,7 +17,7 @@ r"""This module contains the GraphStatePrep template."""
 import networkx as nx
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.wires import Wires
 
 from .qubit_graph import QubitGraph

--- a/pennylane/ftqc/operations.py
+++ b/pennylane/ftqc/operations.py
@@ -15,8 +15,8 @@
 Contains FTQC/MBQC-specific operations
 """
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import RX, RZ
 
 

--- a/pennylane/ftqc/pauli_tracker.py
+++ b/pennylane/ftqc/pauli_tracker.py
@@ -21,7 +21,7 @@ import itertools
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import CNOT, RZ, H, I, S, X, Y, Z
 from pennylane.tape import QuantumScript
 

--- a/pennylane/gradients/finite_difference.py
+++ b/pennylane/gradients/finite_difference.py
@@ -29,12 +29,12 @@ from scipy.linalg import solve as linalg_solve
 from scipy.special import factorial
 
 from pennylane import math, pytrees
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.devices.preprocess import decompose
 from pennylane.exceptions import DecompositionUndefinedError
 from pennylane.gradients.gradient_transform import contract_qjac_with_cjac
 from pennylane.measurements import ProbabilityMP
-from pennylane.operation import Operator
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn

--- a/pennylane/gradients/hadamard_gradient.py
+++ b/pennylane/gradients/hadamard_gradient.py
@@ -23,9 +23,9 @@ from typing import Literal
 import numpy as np
 
 from pennylane import math, ops
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.measurements import ProbabilityMP, expval
-from pennylane.operation import Operator
 from pennylane.ops import Sum
 from pennylane.pauli import PauliWord, pauli_decompose
 from pennylane.tape import QuantumScript, QuantumScriptBatch

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -22,10 +22,10 @@ from functools import partial
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.exceptions import OperatorPropertyUndefined, ParameterFrequenciesUndefinedError
 from pennylane.measurements import ExpectationMP, VarianceMP, expval
-from pennylane.operation import Operator
 from pennylane.ops import Prod, prod
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import decompose, split_to_single_terms

--- a/pennylane/io/qasm_interpreter.py
+++ b/pennylane/io/qasm_interpreter.py
@@ -17,7 +17,7 @@ from openqasm3.visitor import QASMNode
 
 from pennylane import ops
 from pennylane.control_flow import for_loop, while_loop
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import MeasurementValue, MidMeasure, measure
 
 NON_PARAMETERIZED_GATES = {

--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -24,9 +24,9 @@ import pennylane.measurements as qmeas
 import pennylane.ops as qops
 import pennylane.templates as qtemps
 from pennylane import math
+from pennylane.core.operator import Operation, Operator
 from pennylane.estimator.estimate import estimate
 from pennylane.exceptions import DecompositionUndefinedError, MatrixUndefinedError
-from pennylane.operation import Operation, Operator
 from pennylane.queuing import AnnotatedQueue, QueuingManager
 from pennylane.registers import registers
 from pennylane.tape import make_qscript

--- a/pennylane/io/to_openqasm.py
+++ b/pennylane/io/to_openqasm.py
@@ -19,8 +19,8 @@ from collections.abc import Callable
 from functools import singledispatch, wraps
 from typing import Any, overload
 
+from pennylane.core.operator import Operator
 from pennylane.devices.preprocess import decompose
-from pennylane.operation import Operator
 from pennylane.ops import Conditional, MidMeasure
 from pennylane.tape import QuantumScript
 from pennylane.transforms import convert_to_numpy_parameters

--- a/pennylane/labs/dla/dense_util.py
+++ b/pennylane/labs/dla/dense_util.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import sqrtm
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.qubit.matrix_ops import _walsh_hadamard_transform
 from pennylane.pauli import PauliSentence, PauliVSpace, PauliWord, trace_inner_product
 from pennylane.typing import TensorLike

--- a/pennylane/labs/dla/variational_kak.py
+++ b/pennylane/labs/dla/variational_kak.py
@@ -21,8 +21,8 @@ from functools import partial
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.liealg import adjvec_to_op, op_to_adjvec
-from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence
 
 try:

--- a/pennylane/labs/estimator_beta/estimate.py
+++ b/pennylane/labs/estimator_beta/estimate.py
@@ -17,11 +17,11 @@ from collections import defaultdict
 from collections.abc import Callable
 from functools import singledispatch, wraps
 
+from pennylane.core.operator import Operation
 from pennylane.estimator.estimate import _get_resource_decomposition, _ops_to_compressed_reps
 from pennylane.estimator.resource_mapping import _map_to_resource_op
 from pennylane.estimator.resource_operator import CompressedResourceOp, GateCount, ResourceOperator
 from pennylane.estimator.resources_base import DefaultGateSet, Resources
-from pennylane.operation import Operation
 from pennylane.queuing import AnnotatedQueue
 from pennylane.workflow.qnode import QNode
 

--- a/pennylane/labs/estimator_beta/wires_manager/wire_counting.py
+++ b/pennylane/labs/estimator_beta/wires_manager/wire_counting.py
@@ -16,6 +16,7 @@
 from collections.abc import Iterable
 
 from pennylane.allocation import AllocateState
+from pennylane.core.operator import Operator
 from pennylane.estimator.estimate import _get_resource_decomposition
 from pennylane.estimator.resource_mapping import _map_to_resource_op
 from pennylane.estimator.resource_operator import GateCount, ResourceOperator
@@ -30,7 +31,6 @@ from pennylane.labs.estimator_beta.wires_manager.base_classes import (
     MarkQubits,
 )
 from pennylane.measurements.measurements import MeasurementProcess
-from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 
@@ -300,7 +300,7 @@ def estimate_wires_from_circuit(
             for w in active_wires:
                 state_circuit_wires[w] = 0
 
-            num_clean_logical_wires = sum((state_circuit_wires[w_i] for w_i in circuit_wires))
+            num_clean_logical_wires = sum(state_circuit_wires[w_i] for w_i in circuit_wires)
             num_any_state_logical_wires = (
                 len(circuit_wires) - num_clean_logical_wires
             )  # Note this contains the wires that circuit_element acts on

--- a/pennylane/labs/templates/left_classical_comparator.py
+++ b/pennylane/labs/templates/left_classical_comparator.py
@@ -15,11 +15,11 @@
 test of a quantum register and a classical integer."""
 
 from pennylane import capture, compiler, cond, for_loop, math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
 )
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, X
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply
 from pennylane.templates.subroutines import Elbow

--- a/pennylane/labs/templates/left_quantum_comparator.py
+++ b/pennylane/labs/templates/left_quantum_comparator.py
@@ -14,11 +14,11 @@
 """Contains the LeftQuantumComparator template for performing inequality test of two quantum registers."""
 
 from pennylane import capture, compiler, for_loop, math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
 )
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, X
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply
 from pennylane.templates.subroutines import Elbow

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -19,13 +19,13 @@ Decomposition rule for SelectPauliRot in terms of `phase gradient states <https:
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.decomposition import (
     adjoint_resource_rep,
     change_op_basis_resource_rep,
     controlled_resource_rep,
     resource_rep,
 )
-from pennylane.operation import Operator
 from pennylane.ops import Prod
 from pennylane.ops.op_math import change_op_basis
 from pennylane.wires import WireError, Wires

--- a/pennylane/liealg/cartan_decomp.py
+++ b/pennylane/liealg/cartan_decomp.py
@@ -14,7 +14,7 @@
 """Functionality for Cartan decomposition"""
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import PauliSentence, PauliVSpace
 from pennylane.typing import TensorLike
 

--- a/pennylane/liealg/center.py
+++ b/pennylane/liealg/center.py
@@ -18,7 +18,7 @@ from itertools import combinations
 import numpy as np
 from scipy.linalg import norm, null_space
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 
 from .structure_constants import structure_constants

--- a/pennylane/liealg/horizontal_cartan_subalgebra.py
+++ b/pennylane/liealg/horizontal_cartan_subalgebra.py
@@ -21,8 +21,8 @@ from itertools import combinations, combinations_with_replacement
 from scipy.linalg import null_space, sqrtm
 
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.liealg.center import _intersect_bases
-from pennylane.operation import Operator
 from pennylane.ops import Identity
 from pennylane.ops.functions import commutator, equal, matrix, simplify
 from pennylane.pauli import PauliSentence, trace_inner_product

--- a/pennylane/liealg/involutions.py
+++ b/pennylane/liealg/involutions.py
@@ -18,7 +18,7 @@ from functools import singledispatch
 import numpy as np
 
 import pennylane.ops.functions as op_func
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import Y, Z, op_math
 from pennylane.pauli import PauliSentence
 

--- a/pennylane/liealg/lie_closure.py
+++ b/pennylane/liealg/lie_closure.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import pennylane.ops.functions as op_func
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import (
     PauliSentence,
     PauliVSpace,

--- a/pennylane/liealg/structure_constants.py
+++ b/pennylane/liealg/structure_constants.py
@@ -19,7 +19,7 @@ import numpy as np
 
 import pennylane.ops.functions as op_func
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires

--- a/pennylane/measurements/classical_shadow.py
+++ b/pennylane/measurements/classical_shadow.py
@@ -22,8 +22,8 @@ from string import ascii_letters
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import MeasurementShapeError
-from pennylane.operation import Operator
 from pennylane.ops import RZ, Hadamard, I, X, Y, Z
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/measurements/counts.py
+++ b/pennylane/measurements/counts.py
@@ -21,8 +21,8 @@ from collections.abc import Sequence
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.ops import MeasurementValue
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires

--- a/pennylane/measurements/expval.py
+++ b/pennylane/measurements/expval.py
@@ -18,7 +18,7 @@ This module contains the qp.expval measurement.
 from collections.abc import Sequence
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import I, MeasurementValue
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires

--- a/pennylane/measurements/sample.py
+++ b/pennylane/measurements/sample.py
@@ -20,8 +20,8 @@ from collections.abc import Sequence
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import MeasurementShapeError, QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.ops import MeasurementValue
 from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike

--- a/pennylane/measurements/var.py
+++ b/pennylane/measurements/var.py
@@ -19,7 +19,7 @@ This module contains the qp.var measurement.
 from collections.abc import Sequence
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import MeasurementValue
 from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike

--- a/pennylane/noise/add_noise.py
+++ b/pennylane/noise/add_noise.py
@@ -16,10 +16,10 @@ from copy import copy
 from functools import lru_cache
 
 from pennylane import math, templates
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.devices.preprocess import decompose, null_postprocessing
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operator
 from pennylane.ops.functions import equal
 from pennylane.ops.op_math import Adjoint
 from pennylane.tape import make_qscript

--- a/pennylane/noise/conditionals.py
+++ b/pennylane/noise/conditionals.py
@@ -22,8 +22,8 @@ from inspect import isclass, signature
 from pennylane import math, measurements
 from pennylane import ops as qops
 from pennylane.boolean_fn import BooleanFn
+from pennylane.core.operator import Operation
 from pennylane.exceptions import WireError
-from pennylane.operation import Operation
 from pennylane.ops import (
     Adjoint,
     Controlled,

--- a/pennylane/noise/insert_ops.py
+++ b/pennylane/noise/insert_ops.py
@@ -19,10 +19,10 @@ from collections.abc import Callable, Sequence
 from types import FunctionType
 
 from pennylane import templates
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import gate_sets
 from pennylane.devices.preprocess import decompose
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operation, Operator
 from pennylane.ops.op_math import Adjoint
 from pennylane.tape import QuantumScript, QuantumScriptBatch, make_qscript
 from pennylane.transforms import transform

--- a/pennylane/noise/mitigate.py
+++ b/pennylane/noise/mitigate.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from pennylane import math
-from pennylane.operation import Channel
+from pennylane.core.operator import Channel
 from pennylane.ops.op_math import adjoint
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms import transform

--- a/pennylane/ops/channel.py
+++ b/pennylane/ops/channel.py
@@ -22,7 +22,7 @@ from collections.abc import Hashable, Iterable
 from typing import Any
 
 from pennylane import math as np
-from pennylane.operation import Channel
+from pennylane.core.operator import Channel
 from pennylane.wires import Wires, WiresLike
 
 #: Small epsilon added to sqrt to prevent floating-point errors during qubit channel normalization.

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -41,7 +41,7 @@ import numpy as np
 from scipy.linalg import block_diag
 
 from pennylane import math
-from pennylane.operation import CVObservable, CVOperation
+from pennylane.core.operator import CVObservable, CVOperation
 
 _two_term_shift_rule = [[0.5, 1, np.pi / 2], [-0.5, 1, -np.pi / 2]]
 

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from functools import singledispatch
 
 from pennylane import ops
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import (
     Adjoint,
     CompositeOp,

--- a/pennylane/ops/functions/dot.py
+++ b/pennylane/ops/functions/dot.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 from collections.abc import Callable, Sequence
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.pulse import ParametrizedHamiltonian
 

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -22,12 +22,12 @@ from functools import singledispatch
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.measurements import MeasurementProcess
 from pennylane.measurements.classical_shadow import ShadowExpvalMP
 from pennylane.measurements.counts import CountsMP
 from pennylane.measurements.mutual_info import MutualInfoMP
 from pennylane.measurements.vn_entropy import VnEntropyMP
-from pennylane.operation import Operator
 from pennylane.ops import (
     Adjoint,
     CompositeOp,

--- a/pennylane/ops/functions/evolve.py
+++ b/pennylane/ops/functions/evolve.py
@@ -18,7 +18,7 @@ This module contains the qp.evolve function.
 from functools import singledispatch
 from typing import overload
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import Evolution
 from pennylane.pulse import ParametrizedEvolution, ParametrizedHamiltonian
 from pennylane.typing import TensorLike

--- a/pennylane/ops/functions/is_hermitian.py
+++ b/pennylane/ops/functions/is_hermitian.py
@@ -24,7 +24,7 @@ from pennylane.ops import adjoint
 from pennylane.ops.functions.matrix import matrix
 
 if TYPE_CHECKING:
-    from pennylane.operation import Operator
+    from pennylane.core.operator import Operator
 
 
 def is_hermitian(op: Operator):

--- a/pennylane/ops/functions/is_unitary.py
+++ b/pennylane/ops/functions/is_unitary.py
@@ -16,7 +16,7 @@ This module contains the qp.is_unitary function.
 """
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 
 def is_unitary(op: Operator):

--- a/pennylane/ops/functions/map_wires.py
+++ b/pennylane/ops/functions/map_wires.py
@@ -22,8 +22,8 @@ from typing import overload
 
 import pennylane as qp
 from pennylane import transform
+from pennylane.core.operator import Operator
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Operator
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.typing import PostprocessingFn

--- a/pennylane/ops/functions/matrix.py
+++ b/pennylane/ops/functions/matrix.py
@@ -20,8 +20,8 @@ from functools import partial
 
 import pennylane as qp
 from pennylane import transform
+from pennylane.core.operator import Operator
 from pennylane.exceptions import MatrixUndefinedError, TransformError
-from pennylane.operation import Operator
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch

--- a/pennylane/ops/functions/simplify.py
+++ b/pennylane/ops/functions/simplify.py
@@ -22,8 +22,8 @@ from copy import copy
 from typing import TYPE_CHECKING
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Operator
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.typing import PostprocessingFn

--- a/pennylane/ops/functions/single_qubit_zyz_angles.py
+++ b/pennylane/ops/functions/single_qubit_zyz_angles.py
@@ -18,8 +18,8 @@ from functools import singledispatch
 
 import numpy as np
 
+from pennylane.core.operator import Operator
 from pennylane.math.decomposition import zyz_rotation_angles
-from pennylane.operation import Operator
 from pennylane.ops.op_math.adjoint import AdjointOperation
 from pennylane.ops.qubit import (
     RX,

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from scipy import sparse
 
 import pennylane as qp
+from pennylane.core.operator import CVObservable, Operation
 from pennylane.decomposition import add_decomps, controlled_resource_rep, register_resources
 from pennylane.decomposition.decomposition_rule import null_decomp
 from pennylane.decomposition.symbolic_decomposition import (
@@ -29,7 +30,6 @@ from pennylane.decomposition.symbolic_decomposition import (
     qjit_compatible_pow_rotation,
 )
 from pennylane.exceptions import SparseMatrixUndefinedError
-from pennylane.operation import CVObservable, Operation
 from pennylane.wires import WiresLike
 
 

--- a/pennylane/ops/meta.py
+++ b/pennylane/ops/meta.py
@@ -23,7 +23,7 @@ from copy import copy
 from typing import Literal
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.wires import Wires, WiresLike
 
 

--- a/pennylane/ops/mid_measure/mid_measure.py
+++ b/pennylane/ops/mid_measure/mid_measure.py
@@ -21,8 +21,8 @@ from functools import lru_cache
 
 from pennylane.capture import enabled as capture_enabled
 from pennylane.compiler import compiler
+from pennylane.core.operator import Operator
 from pennylane.exceptions import QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.wires import Wires
 
 from .measurement_value import MeasurementValue

--- a/pennylane/ops/mid_measure/pauli_measure.py
+++ b/pennylane/ops/mid_measure/pauli_measure.py
@@ -25,7 +25,7 @@ import pennylane as qp
 from pennylane import math
 from pennylane.capture import enabled as capture_enabled
 from pennylane.compiler import compiler
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.wires import Wires, WiresLike
 
 from .measurement_value import MeasurementValue

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -24,9 +24,9 @@ import pennylane as qp
 from pennylane import pytrees
 from pennylane.capture.autograph import wraps
 from pennylane.compiler import compiler
+from pennylane.core.operator import Operation, Operator
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.math import conj, moveaxis, transpose
-from pennylane.operation import Operation, Operator
 from pennylane.queuing import QueuingManager
 
 from .symbolicop import SymbolicOp

--- a/pennylane/ops/op_math/change_op_basis.py
+++ b/pennylane/ops/op_math/change_op_basis.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from functools import reduce
 
 from pennylane import capture, math, pytrees, queuing
+from pennylane.core.operator import Operator
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
@@ -34,7 +35,6 @@ from pennylane.exceptions import (
     MatrixUndefinedError,
     SparseMatrixUndefinedError,
 )
-from pennylane.operation import Operator
 from pennylane.ops.op_math import adjoint, ctrl, prod
 
 from .composite import CompositeOp, handle_recursion_error

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -24,8 +24,9 @@ from warnings import warn
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import _UNSET_BATCH_SIZE, Operator
+from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.wires import Wires
 
 # pylint: disable=too-many-instance-attributes

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -25,8 +25,8 @@ from warnings import warn
 import pennylane as qp
 from pennylane import math
 from pennylane.core.operator import Operator
+from pennylane.core.operator.base import _UNSET_BATCH_SIZE  # tach-ignore
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.wires import Wires
 
 # pylint: disable=too-many-instance-attributes

--- a/pennylane/ops/op_math/condition.py
+++ b/pennylane/ops/op_math/condition.py
@@ -24,8 +24,8 @@ from pennylane import QueuingManager, math
 from pennylane.capture import FlatFn
 from pennylane.capture.autograph import wraps
 from pennylane.compiler import compiler
+from pennylane.core.operator import Operation, Operator
 from pennylane.exceptions import ConditionalTransformError
-from pennylane.operation import Operation, Operator
 from pennylane.ops.op_math.symbolicop import SymbolicOp
 
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -33,13 +33,13 @@ from pennylane import math, pytrees
 from pennylane._class_property import classproperty
 from pennylane.capture.autograph import wraps
 from pennylane.compiler import compiler
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition.resources import resolve_work_wire_type
 from pennylane.exceptions import (
     GeneratorUndefinedError,
     ParameterFrequenciesUndefinedError,
     SparseMatrixUndefinedError,
 )
-from pennylane.operation import Operation, Operator
 from pennylane.wires import Wires, WiresLike
 
 from .decompositions.controlled_decompositions import ctrl_decomp_bisect, ctrl_decomp_zyz

--- a/pennylane/ops/op_math/controlled_decompositions.py
+++ b/pennylane/ops/op_math/controlled_decompositions.py
@@ -20,7 +20,7 @@ from typing import Literal
 import numpy as np
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.wires import Wires, WiresLike
 
 from .decompositions.controlled_decompositions import (

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import allocation, compiler, control_flow, math, ops, queuing
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
     adjoint_resource_rep,
     controlled_resource_rep,
@@ -28,7 +29,6 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.decomposition.symbolic_decomposition import flip_zero_control
-from pennylane.operation import Operation, Operator
 from pennylane.ops.op_math.decompositions.unitary_decompositions import two_qubit_decomp_rule
 from pennylane.wires import Wires
 

--- a/pennylane/ops/op_math/exp.py
+++ b/pennylane/ops/op_math/exp.py
@@ -23,6 +23,7 @@ from scipy.sparse.linalg import expm as sparse_expm
 
 import pennylane as qp
 from pennylane import math, queuing
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
     add_decomps,
     register_condition,
@@ -34,7 +35,6 @@ from pennylane.exceptions import (
     GeneratorUndefinedError,
     OperatorPropertyUndefined,
 )
-from pennylane.operation import Operation, Operator
 from pennylane.wires import Wires
 
 from .linear_combination import LinearCombination

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -22,7 +22,7 @@ import numbers
 from copy import copy
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 from .sprod import SProd
 from .sum import Sum

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -22,13 +22,13 @@ from scipy.linalg import fractional_matrix_power
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operation, Operator
 from pennylane.exceptions import (
     AdjointUndefinedError,
     DecompositionUndefinedError,
     PowUndefinedError,
     SparseMatrixUndefinedError,
 )
-from pennylane.operation import Operation, Operator
 from pennylane.ops.identity import Identity
 from pennylane.queuing import QueuingManager, apply
 

--- a/pennylane/ops/op_math/prod.py
+++ b/pennylane/ops/op_math/prod.py
@@ -28,13 +28,13 @@ from scipy.sparse import kron as sparse_kron
 import pennylane as qp
 from pennylane import compiler, control_flow, math
 from pennylane.capture.autograph import wraps
+from pennylane.core.operator import Operator
 from pennylane.decomposition import (
     adjoint_resource_rep,
     controlled_resource_rep,
     resource_rep,
 )
 from pennylane.decomposition.symbolic_decomposition import flip_zero_control
-from pennylane.operation import Operator
 from pennylane.ops.op_math.pow import Pow
 from pennylane.ops.op_math.sprod import SProd
 from pennylane.ops.op_math.sum import Sum

--- a/pennylane/ops/op_math/sprod.py
+++ b/pennylane/ops/op_math/sprod.py
@@ -18,8 +18,8 @@ computing the scalar product of operations.
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import DecompositionUndefinedError, TermsUndefinedError
-from pennylane.operation import Operator
 from pennylane.ops.op_math.pow import Pow
 from pennylane.ops.op_math.sum import Sum
 from pennylane.queuing import QueuingManager

--- a/pennylane/ops/op_math/sum.py
+++ b/pennylane/ops/op_math/sum.py
@@ -23,7 +23,7 @@ from copy import copy
 
 import pennylane as qp
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.queuing import QueuingManager
 
 from .composite import CompositeOp, handle_recursion_error

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -23,8 +23,8 @@ import numpy as np
 
 import pennylane as qp
 from pennylane.core.operator import Operator
+from pennylane.core.operator.base import _UNSET_BATCH_SIZE  # tach-ignore
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.queuing import QueuingManager
 
 from .composite import handle_recursion_error

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -22,8 +22,9 @@ from warnings import warn
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import _UNSET_BATCH_SIZE, Operator
+from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.queuing import QueuingManager
 
 from .composite import handle_recursion_error

--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -24,6 +24,7 @@ from copy import copy
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     register_condition,
@@ -34,7 +35,6 @@ from pennylane.decomposition.symbolic_decomposition import (
     pow_involutory,
     qjit_compatible_self_adjoint,
 )
-from pennylane.operation import Operation
 from pennylane.typing import FlatPytree, TensorLike
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/ops/qubit/attributes.py
+++ b/pennylane/ops/qubit/attributes.py
@@ -18,7 +18,7 @@ and lists all operators satisfying those criteria.
 
 from inspect import isclass
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 
 class Attribute(set):

--- a/pennylane/ops/qubit/matrix_ops.py
+++ b/pennylane/ops/qubit/matrix_ops.py
@@ -27,10 +27,10 @@ from scipy.sparse import csr_matrix
 import pennylane as qp
 from pennylane import math
 from pennylane import numpy as pnp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
 from pennylane.decomposition.symbolic_decomposition import is_integer
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operation
 from pennylane.ops.op_math.decompositions.unitary_decompositions import (
     multi_qubit_decomp_rule,
     rot_decomp_rule,

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -29,6 +29,7 @@ from scipy import sparse
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -44,7 +45,6 @@ from pennylane.decomposition.symbolic_decomposition import (
     qjit_compatible_self_adjoint,
 )
 from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import Operation
 from pennylane.wires import Wires, WiresLike
 
 INV_SQRT2 = 1 / qp.math.sqrt(2)

--- a/pennylane/ops/qubit/observables.py
+++ b/pennylane/ops/qubit/observables.py
@@ -24,7 +24,7 @@ import numpy as np
 from scipy.sparse import csr_matrix, spmatrix
 
 import pennylane as qp
-from pennylane.operation import Operation, Operator
+from pennylane.core.operator import Operation, Operator
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/ops/qubit/parametric_ops_multi_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_multi_qubit.py
@@ -29,6 +29,7 @@ import numpy as np
 import pennylane as qp
 from pennylane import compiler, math, queuing
 from pennylane.capture.autograph import disable_autograph
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
@@ -42,7 +43,6 @@ from pennylane.decomposition.symbolic_decomposition import (
 )
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.math.decomposition import decomp_int_to_powers_of_two
-from pennylane.operation import Operation, Operator
 from pennylane.typing import FlatPytree, TensorLike
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy as sp
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -42,7 +43,6 @@ from pennylane.decomposition.symbolic_decomposition import (
     qjit_compatible_pow_rotation,
 )
 from pennylane.exceptions import DecompositionUndefinedError, PennyLaneDeprecationWarning
-from pennylane.operation import Operation
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 

--- a/pennylane/ops/qubit/qchem_ops.py
+++ b/pennylane/ops/qubit/qchem_ops.py
@@ -23,13 +23,13 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.decomposition.resources import resource_rep
 from pennylane.decomposition.symbolic_decomposition import (
     qjit_compatible_adjoint_rotation,
     qjit_compatible_pow_rotation,
 )
-from pennylane.operation import Operation
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 

--- a/pennylane/ops/qubit/special_unitary.py
+++ b/pennylane/ops/qubit/special_unitary.py
@@ -24,8 +24,8 @@ from typing import Literal
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops.qubit.parametric_ops_multi_qubit import PauliRot
 from pennylane.typing import FlatPytree, TensorLike
 from pennylane.wires import WiresLike

--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -27,6 +27,7 @@ from scipy.sparse import csr_array, csr_matrix
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operation, Operator, StatePrepBase
 from pennylane.decomposition import (
     add_decomps,
     pow_resource_rep,
@@ -34,7 +35,6 @@ from pennylane.decomposition import (
     register_resources,
 )
 from pennylane.exceptions import WireError
-from pennylane.operation import Operation, Operator, StatePrepBase
 from pennylane.templates.state_preparations import MottonenStatePreparation
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/ops/qutrit/channel.py
+++ b/pennylane/ops/qutrit/channel.py
@@ -20,7 +20,7 @@ quantum channels supported by PennyLane, as well as their conventions.
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Channel
+from pennylane.core.operator import Channel
 
 QUDIT_DIM = 3
 

--- a/pennylane/ops/qutrit/matrix_ops.py
+++ b/pennylane/ops/qutrit/matrix_ops.py
@@ -19,9 +19,9 @@ accept a unitary matrix as a parameter.
 import warnings
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.decomposition.resources import resource_rep
-from pennylane.operation import Operation
 from pennylane.wires import Wires
 
 

--- a/pennylane/ops/qutrit/non_parametric_ops.py
+++ b/pennylane/ops/qutrit/non_parametric_ops.py
@@ -19,10 +19,10 @@ that do not depend on any parameters.
 # pylint:disable=arguments-differ
 import numpy as np
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps
 from pennylane.decomposition.symbolic_decomposition import self_adjoint
 from pennylane.exceptions import AdjointUndefinedError
-from pennylane.operation import Operation
 from pennylane.wires import Wires
 
 from .parametric_ops import validate_subspace

--- a/pennylane/ops/qutrit/observables.py
+++ b/pennylane/ops/qutrit/observables.py
@@ -18,7 +18,7 @@ This submodule contains the qutrit quantum observables.
 import numpy as np
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.qubit import Hermitian
 from pennylane.ops.qutrit import QutritUnitary
 

--- a/pennylane/ops/qutrit/parametric_ops.py
+++ b/pennylane/ops/qutrit/parametric_ops.py
@@ -22,9 +22,9 @@ import functools
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps
 from pennylane.decomposition.symbolic_decomposition import adjoint_rotation
-from pennylane.operation import Operation
 
 stack_last = functools.partial(qp.math.stack, axis=-1)
 

--- a/pennylane/ops/qutrit/state_preparation.py
+++ b/pennylane/ops/qutrit/state_preparation.py
@@ -20,8 +20,8 @@ with preparing a certain state on the qutrit device.
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import StatePrepBase
 from pennylane.exceptions import WireError
-from pennylane.operation import StatePrepBase
 from pennylane.templates.state_preparations import QutritBasisStatePreparation
 from pennylane.wires import Wires
 

--- a/pennylane/pauli/grouping/optimize_measurements.py
+++ b/pennylane/pauli/grouping/optimize_measurements.py
@@ -16,7 +16,7 @@ The main function for measurement reduction, ``optimize_measurements`` returns t
 corresponding necessary circuit post-rotations for a given list of Pauli words.
 """
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli.utils import diagonalize_qwc_groupings
 from pennylane.typing import Sequence
 

--- a/pennylane/pauli/pauli_vspace.py
+++ b/pennylane/pauli/pauli_vspace.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 from .pauli_arithmetic import PauliSentence
 

--- a/pennylane/pauli/trace_inner_product.py
+++ b/pennylane/pauli/trace_inner_product.py
@@ -16,7 +16,7 @@
 from collections.abc import Iterable
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.pauli import PauliSentence
 from pennylane.typing import TensorLike
 

--- a/pennylane/pulse/hardware_hamiltonian.py
+++ b/pennylane/pulse/hardware_hamiltonian.py
@@ -21,7 +21,7 @@ from typing import Union
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import Identity, LinearCombination, SProd, X, Y
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires

--- a/pennylane/pulse/parametrized_evolution.py
+++ b/pennylane/pulse/parametrized_evolution.py
@@ -21,7 +21,7 @@ import warnings
 from collections.abc import Sequence
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops import functions
 from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike

--- a/pennylane/pulse/parametrized_hamiltonian.py
+++ b/pennylane/pulse/parametrized_hamiltonian.py
@@ -19,7 +19,7 @@ This submodule contains the ParametrizedHamiltonian class
 from copy import copy
 
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import LinearCombination, SProd, Sum, op_math
 from pennylane.queuing import QueuingManager
 from pennylane.typing import TensorLike

--- a/pennylane/qaoa/cycle.py
+++ b/pennylane/qaoa/cycle.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import rustworkx as rx
 
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import Identity, LinearCombination, X, Y, Z
 
 if TYPE_CHECKING:

--- a/pennylane/qcut/kahypar.py
+++ b/pennylane/qcut/kahypar.py
@@ -23,7 +23,7 @@ from typing import Any
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 
 
 # pylint: disable=too-many-positional-arguments

--- a/pennylane/qcut/ops.py
+++ b/pennylane/qcut/ops.py
@@ -17,7 +17,7 @@ Nodes for use in qcut.
 
 import uuid
 
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 
 
 class PrepareNode(Operation):

--- a/pennylane/qcut/tapes.py
+++ b/pennylane/qcut/tapes.py
@@ -20,9 +20,9 @@ from collections.abc import Callable, Sequence
 from itertools import product
 
 from pennylane import ops
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.measurements import ExpectationMP, MeasurementProcess, SampleMP, expval, sample
-from pennylane.operation import Operator
 from pennylane.ops.meta import WireCut
 from pennylane.pauli import partition_pauli_group, string_to_pauli_word
 from pennylane.queuing import QueuingManager, WrappedObj

--- a/pennylane/resource/error/error.py
+++ b/pennylane/resource/error/error.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from functools import partial
 
 import pennylane as qp
-from pennylane.operation import Operation, Operator
+from pennylane.core.operator import Operation, Operator
 
 
 class AlgorithmicError(ABC):

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -26,8 +26,8 @@ from functools import lru_cache
 from string import ascii_lowercase
 from typing import Any
 
+from pennylane.core.operator import Operation
 from pennylane.measurements import MeasurementProcess, Shots, add_shots
-from pennylane.operation import Operation
 from pennylane.ops.op_math import Controlled, ControlledOp
 from pennylane.tape import QuantumScript
 

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -37,7 +37,7 @@ from pennylane.capture.primitives import (
     value_and_grad_prim,
     vjp_prim,
 )
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.mid_measure import (
     MeasurementValue,
     MidMeasure,

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -28,10 +28,10 @@ from typing import Any, ParamSpec, TypeVar
 
 import pennylane as qp
 from pennylane.core.operator import Operation, Operator
+from pennylane.core.operator.base import _UNSET_BATCH_SIZE  # tach-ignore
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.measurements import MeasurementProcess
 from pennylane.measurements.shots import Shots, ShotsLike
-from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.operation2 import Operator2
 from pennylane.pytrees import register_pytree
 from pennylane.queuing import AnnotatedQueue

--- a/pennylane/tape/qscript.py
+++ b/pennylane/tape/qscript.py
@@ -27,10 +27,11 @@ from functools import cached_property
 from typing import Any, ParamSpec, TypeVar
 
 import pennylane as qp
+from pennylane.core.operator import Operation, Operator
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.measurements import MeasurementProcess
 from pennylane.measurements.shots import Shots, ShotsLike
-from pennylane.operation import _UNSET_BATCH_SIZE, Operation, Operator
+from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.operation2 import Operator2
 from pennylane.pytrees import register_pytree
 from pennylane.queuing import AnnotatedQueue

--- a/pennylane/templates/core.py
+++ b/pennylane/templates/core.py
@@ -42,6 +42,7 @@ import numpy as np
 
 from pennylane import capture, math, queuing
 from pennylane.capture import subroutine as capture_subroutine
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
     CompressedResourceOp,
     add_decomps,
@@ -50,7 +51,6 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.decomposition.resources import auto_wrap
-from pennylane.operation import Operation, Operator
 from pennylane.ops import ChangeOpBasis
 from pennylane.pytrees import flatten, unflatten
 from pennylane.wires import Wires, is_abstract_qubit

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -17,8 +17,8 @@ Contains the ``AngleEmbedding`` template.
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import RX, RY, RZ
 from pennylane.wires import WiresLike
 

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -16,7 +16,7 @@ Contains the ``DisplacementEmbedding`` template.
 """
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops.cv import Displacement
 
 

--- a/pennylane/templates/embeddings/iqp.py
+++ b/pennylane/templates/embeddings/iqp.py
@@ -21,8 +21,8 @@ from itertools import combinations
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop, while_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import RZ, H, MultiRZ
 from pennylane.wires import Wires
 

--- a/pennylane/templates/embeddings/qaoaembedding.py
+++ b/pennylane/templates/embeddings/qaoaembedding.py
@@ -19,8 +19,8 @@ from collections import defaultdict
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import RX, RY, RZ, H, MultiRZ, cond
 from pennylane.wires import Wires
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -18,7 +18,7 @@ Contains the SqueezingEmbedding template.
 from pennylane import math
 
 # pylint: disable=too-many-arguments
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops.cv import Squeezing
 
 

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -17,8 +17,8 @@ Contains the BasicEntanglerLayers template.
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, RX, cond
 
 

--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -18,7 +18,7 @@ Contains the CVNeuralNetLayers template.
 from pennylane import math
 
 # pylint: disable=too-many-arguments
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops.cv import Displacement, Kerr, Squeezing
 from pennylane.templates.subroutines import Interferometer
 

--- a/pennylane/templates/layers/gate_fabric.py
+++ b/pennylane/templates/layers/gate_fabric.py
@@ -20,8 +20,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import DoubleExcitation, OrbitalRotation, cond
 from pennylane.templates.embeddings import BasisEmbedding
 from pennylane.wires import Wires

--- a/pennylane/templates/layers/particle_conserving_u1.py
+++ b/pennylane/templates/layers/particle_conserving_u1.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, CZ, CRot, PhaseShift
 from pennylane.templates.embeddings import BasisEmbedding
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/layers/particle_conserving_u2.py
+++ b/pennylane/templates/layers/particle_conserving_u2.py
@@ -17,8 +17,8 @@ Contains the hardware-efficient ParticleConservingU2 template.
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, CRX, RZ
 from pennylane.templates.embeddings import BasisEmbedding
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -20,7 +20,7 @@ Contains the RandomLayers template.
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops import CNOT, RX, RY, RZ
 from pennylane.wires import Wires
 

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -17,8 +17,8 @@ Contains the SimplifiedTwoDesign template.
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import CZ, RY
 
 has_jax = True

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -18,8 +18,8 @@ Contains the StronglyEntanglingLayers template.
 # pylint: disable=too-many-arguments
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, Rot
 from pennylane.ops.op_math import cond
 from pennylane.wires import Wires

--- a/pennylane/templates/state_preparations/arbitrary_state_preparation.py
+++ b/pennylane/templates/state_preparations/arbitrary_state_preparation.py
@@ -21,8 +21,8 @@ from collections import Counter
 import pennylane as qp
 from pennylane import register_resources
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, resource_rep
-from pennylane.operation import Operation
 
 
 @functools.lru_cache

--- a/pennylane/templates/state_preparations/basis_qutrit.py
+++ b/pennylane/templates/state_preparations/basis_qutrit.py
@@ -18,7 +18,7 @@ Contains the QutritBasisStatePreparation template.
 import numpy as np
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 
 
 class QutritBasisStatePreparation(Operation):

--- a/pennylane/templates/state_preparations/cosine_window.py
+++ b/pennylane/templates/state_preparations/cosine_window.py
@@ -20,9 +20,9 @@ import numpy as np
 import pennylane as qp
 from pennylane import capture, math, register_resources
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import StatePrepBase
 from pennylane.decomposition import add_decomps, adjoint_resource_rep, resource_rep
 from pennylane.exceptions import WireError
-from pennylane.operation import StatePrepBase
 from pennylane.wires import Wires
 
 

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -18,7 +18,7 @@ Contains the MottonenStatePreparation template.
 import numpy as np
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.typing import TensorLike
 
 

--- a/pennylane/templates/state_preparations/multiplexer_state_prep.py
+++ b/pennylane/templates/state_preparations/multiplexer_state_prep.py
@@ -17,8 +17,8 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import math, queuing
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.wires import Wires
 
 

--- a/pennylane/templates/state_preparations/qrom_state_prep.py
+++ b/pennylane/templates/state_preparations/qrom_state_prep.py
@@ -16,7 +16,7 @@ r"""Contains the QROMStatePreparation template."""
 import numpy as np
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.wires import Wires
 
 #: Small constant to prevent division by zero in state preparation.

--- a/pennylane/templates/state_preparations/state_prep_mps.py
+++ b/pennylane/templates/state_preparations/state_prep_mps.py
@@ -18,8 +18,8 @@ Contains the MPSPrep template.
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.wires import Wires
 
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import allocate, for_loop, math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -27,7 +28,6 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operation
 
 
 def _columns_differ(bits: np.ndarray) -> bool:

--- a/pennylane/templates/state_preparations/superposition.py
+++ b/pennylane/templates/state_preparations/superposition.py
@@ -20,13 +20,13 @@ from functools import reduce
 
 import pennylane as qp
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 
 
 def order_states(basis_states: list[list[int]]) -> dict[tuple[int], tuple[int]]:

--- a/pennylane/templates/subroutines/amplitude_amplification.py
+++ b/pennylane/templates/subroutines/amplitude_amplification.py
@@ -22,13 +22,13 @@ import copy
 import numpy as np
 
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import Hadamard, PhaseShift
 from pennylane.ops.op_math import ctrl
 from pennylane.queuing import QueuingManager, apply

--- a/pennylane/templates/subroutines/aqft.py
+++ b/pennylane/templates/subroutines/aqft.py
@@ -21,13 +21,13 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import SWAP, ControlledPhaseShift, Hadamard, PhaseShift, cond
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/arbitrary_unitary.py
+++ b/pennylane/templates/subroutines/arbitrary_unitary.py
@@ -16,8 +16,8 @@ Contains the ArbitraryUnitary template.
 """
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import PauliRot
 from pennylane.wires import WiresLike
 

--- a/pennylane/templates/subroutines/arithmetic/adder.py
+++ b/pennylane/templates/subroutines/arithmetic/adder.py
@@ -15,13 +15,13 @@
 Contains the Adder template.
 """
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     change_op_basis_resource_rep,
     register_resources,
 )
 from pennylane.decomposition.resources import resource_rep
-from pennylane.operation import Operation
 from pennylane.ops.op_math import change_op_basis
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/arithmetic/mod_exp.py
+++ b/pennylane/templates/subroutines/arithmetic/mod_exp.py
@@ -17,8 +17,8 @@ Contains the ModExp template.
 
 import numpy as np
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -17,6 +17,7 @@ Contains the Multiplier template.
 
 import numpy as np
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -24,7 +25,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import SWAP, Prod, adjoint, change_op_basis, prod
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT

--- a/pennylane/templates/subroutines/arithmetic/out_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/out_adder.py
@@ -17,13 +17,13 @@ Contains the OutAdder template.
 
 from collections import defaultdict
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import Prod, change_op_basis
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -17,6 +17,7 @@ Contains the OutMultiplier template.
 
 from collections import defaultdict
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -26,7 +27,6 @@ from pennylane.decomposition import (
     register_resources,
 )
 from pennylane.decomposition.resources import resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import (
     CNOT,
     BasisState,

--- a/pennylane/templates/subroutines/arithmetic/out_poly.py
+++ b/pennylane/templates/subroutines/arithmetic/out_poly.py
@@ -18,6 +18,7 @@ Contains the OutPoly template.
 from collections import Counter
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -25,7 +26,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import adjoint, ctrl
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/arithmetic/phase_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/phase_adder.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from pennylane import math, ops
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -28,7 +29,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.templates.subroutines.qft import QFT
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/arithmetic/semi_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/semi_adder.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 """Contains the SemiAdder template for performing the semi-out-place addition."""
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
     controlled_resource_rep,
     register_resources,
 )
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, adjoint, ctrl
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/arithmetic/temporary_and.py
+++ b/pennylane/templates/subroutines/arithmetic/temporary_and.py
@@ -18,6 +18,7 @@ Contains the TemporaryAND template, which also is known as Elbow.
 from functools import lru_cache
 
 from pennylane import math, ops
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -25,7 +26,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.wires import Wires, WiresLike
 
 

--- a/pennylane/templates/subroutines/controlled_sequence.py
+++ b/pennylane/templates/subroutines/controlled_sequence.py
@@ -18,13 +18,13 @@ Contains the ControlledSequence template.
 from copy import copy
 
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     pow_resource_rep,
     register_resources,
 )
-from pennylane.operation import Operation
 from pennylane.ops.op_math import SymbolicOp, ctrl
 from pennylane.ops.op_math import pow as qp_pow
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -23,8 +23,8 @@ import numpy as np
 
 from pennylane import math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, RY, SWAP, Hadamard, cond
 from pennylane.templates.state_preparations.mottonen import compute_theta, gray_code
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/ffft.py
+++ b/pennylane/templates/subroutines/ffft.py
@@ -21,8 +21,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop, while_loop
+from pennylane.core.operator import Operator
 from pennylane.decomposition import add_decomps, pow_resource_rep, register_resources, resource_rep
-from pennylane.operation import Operator
 from pennylane.ops import FermionicSWAP, PauliZ, pow
 from pennylane.wires import WiresLike
 

--- a/pennylane/templates/subroutines/flip_sign.py
+++ b/pennylane/templates/subroutines/flip_sign.py
@@ -17,13 +17,13 @@ Contains the FlipSign template.
 
 from functools import reduce
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import X, Z, cond, ctrl
 
 

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -18,8 +18,8 @@ Contains the GQSP template.
 import copy
 
 from pennylane import capture, ops
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, controlled_resource_rep, register_resources
-from pennylane.operation import Operation
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires
 

--- a/pennylane/templates/subroutines/grover.py
+++ b/pennylane/templates/subroutines/grover.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import GlobalPhase, Hadamard, MultiControlledX, PauliZ
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
     CompressedResourceOp,
     add_decomps,
@@ -28,7 +29,6 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.math import is_abstract
-from pennylane.operation import Operation, Operator
 from pennylane.ops import CNOT, Hadamard, QubitUnitary
 from pennylane.queuing import QueuingManager, apply
 from pennylane.typing import TensorLike

--- a/pennylane/templates/subroutines/interferometer.py
+++ b/pennylane/templates/subroutines/interferometer.py
@@ -18,7 +18,7 @@ Contains the ``Interferometer`` template.
 from itertools import product
 
 from pennylane import math
-from pennylane.operation import CVOperation
+from pennylane.core.operator import CVOperation
 
 # pylint: disable-msg=too-many-branches,too-many-arguments
 from pennylane.ops import Beamsplitter, Rotation

--- a/pennylane/templates/subroutines/iqp.py
+++ b/pennylane/templates/subroutines/iqp.py
@@ -21,13 +21,13 @@ from functools import reduce
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
     resource_rep,
 )
 from pennylane.math import expand_matrix
-from pennylane.operation import Operation
 from pennylane.ops import Hadamard, MultiRZ, PauliRot, PauliX
 from pennylane.typing import TensorLike
 

--- a/pennylane/templates/subroutines/permute.py
+++ b/pennylane/templates/subroutines/permute.py
@@ -19,8 +19,8 @@ import copy
 from collections import Counter
 
 from pennylane import capture
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import SWAP
 from pennylane.wires import Wires
 

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -19,13 +19,13 @@ Contains the PrepSelPrep template.
 import copy
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import GlobalPhase, Prod, StatePrep, change_op_basis, prod
 from pennylane.ops.op_math.composite import CompositeOp
 from pennylane.ops.op_math.symbolicop import SymbolicOp

--- a/pennylane/templates/subroutines/qchem/all_singles_doubles.py
+++ b/pennylane/templates/subroutines/qchem/all_singles_doubles.py
@@ -23,8 +23,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import BasisState, DoubleExcitation, SingleExcitation
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/qchem/basis_rotation.py
+++ b/pennylane/templates/subroutines/qchem/basis_rotation.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from pennylane import capture, compiler, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import PhaseShift, SingleExcitation, cond
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/qchem/fermionic_double_excitation.py
+++ b/pennylane/templates/subroutines/qchem/fermionic_double_excitation.py
@@ -22,8 +22,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, RX, RZ, Hadamard
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/qchem/fermionic_single_excitation.py
+++ b/pennylane/templates/subroutines/qchem/fermionic_single_excitation.py
@@ -19,8 +19,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, RX, RZ, Hadamard
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/qchem/kupccgsd.py
+++ b/pennylane/templates/subroutines/qchem/kupccgsd.py
@@ -25,8 +25,8 @@ import numpy as np
 
 from pennylane import math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.templates.embeddings import BasisEmbedding
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/qchem/uccsd.py
+++ b/pennylane/templates/subroutines/qchem/uccsd.py
@@ -24,8 +24,8 @@ import numpy as np
 
 from pennylane import capture, math
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import BasisState
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -22,8 +22,8 @@ import numpy as np
 from pennylane import math
 from pennylane.capture import enabled
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources
-from pennylane.operation import Operation
 from pennylane.ops import SWAP, ControlledPhaseShift, Hadamard
 from pennylane.wires import Wires, WiresLike
 

--- a/pennylane/templates/subroutines/qmc.py
+++ b/pennylane/templates/subroutines/qmc.py
@@ -21,8 +21,8 @@ import copy
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import QubitUnitary
 from pennylane.wires import Wires
 

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -19,6 +19,7 @@ Contains the QuantumPhaseEstimation template.
 import copy
 
 from pennylane import math, ops
+from pennylane.core.operator import Operator
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -27,7 +28,6 @@ from pennylane.decomposition import (
     resource_rep,
 )
 from pennylane.exceptions import QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.ops import pow as qp_pow
 from pennylane.queuing import QueuingManager
 from pennylane.resource.error import ErrorOperation, SpectralNormError

--- a/pennylane/templates/subroutines/qram.py
+++ b/pennylane/templates/subroutines/qram.py
@@ -18,13 +18,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import (
     CNOT,
     CSWAP,

--- a/pennylane/templates/subroutines/qrom.py
+++ b/pennylane/templates/subroutines/qrom.py
@@ -23,13 +23,13 @@ import numpy as np
 
 import pennylane.math as pl_math
 from pennylane import ops as qp_ops
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
     resource_rep,
 )
 from pennylane.math import ceil_log2
-from pennylane.operation import Operation
 from pennylane.queuing import QueuingManager, apply
 from pennylane.templates.embeddings import BasisEmbedding
 from pennylane.typing import TensorLike

--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -28,9 +28,9 @@ import scipy
 from numpy.polynomial import Polynomial, chebyshev
 
 from pennylane import math, ops, pytrees
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
 from pennylane.decomposition.resources import change_op_basis_resource_rep
-from pennylane.operation import Operation, Operator
 from pennylane.queuing import QueuingManager, apply
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/qubitization.py
+++ b/pennylane/templates/subroutines/qubitization.py
@@ -17,8 +17,8 @@ This submodule contains the template for Qubitization.
 
 import copy
 
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import I, Prod, prod
 from pennylane.queuing import QueuingManager
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/reflection.py
+++ b/pennylane/templates/subroutines/reflection.py
@@ -21,6 +21,7 @@ import copy
 import numpy as np
 
 from pennylane import ops, pytrees
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -28,7 +29,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.queuing import QueuingManager, apply
 from pennylane.wires import Wires
 

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -22,6 +22,7 @@ from itertools import product
 import numpy as np
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -30,7 +31,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, X, adjoint, ctrl
 from pennylane.queuing import QueuingManager, apply
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/select_pauli_rot.py
+++ b/pennylane/templates/subroutines/select_pauli_rot.py
@@ -18,6 +18,7 @@ Contains the SelectPauliRot template.
 from collections import defaultdict
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,
@@ -25,7 +26,6 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.operation import Operation
 from pennylane.ops import CNOT, RZ, Hadamard, S, adjoint, change_op_basis, prod
 from pennylane.ops.op_math import Prod
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply

--- a/pennylane/templates/subroutines/time_evolution/approx_time_evolution.py
+++ b/pennylane/templates/subroutines/time_evolution/approx_time_evolution.py
@@ -20,8 +20,8 @@ import copy
 from collections import defaultdict
 
 from pennylane.control_flow import for_loop
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops import PauliRot
 from pennylane.ops.op_math.linear_combination import Hamiltonian
 from pennylane.pauli import PauliWord

--- a/pennylane/templates/subroutines/time_evolution/commuting_evolution.py
+++ b/pennylane/templates/subroutines/time_evolution/commuting_evolution.py
@@ -19,8 +19,8 @@ Contains the CommutingEvolution template.
 import copy
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation
 from pennylane.ops.op_math.linear_combination import Hamiltonian
 from pennylane.pauli import PauliWord
 from pennylane.queuing import QueuingManager

--- a/pennylane/templates/subroutines/time_evolution/qdrift.py
+++ b/pennylane/templates/subroutines/time_evolution/qdrift.py
@@ -16,8 +16,8 @@
 import copy
 
 from pennylane import math
+from pennylane.core.operator import Operation
 from pennylane.exceptions import QuantumFunctionError
-from pennylane.operation import Operation
 from pennylane.ops import Evolution, LinearCombination, Sum
 from pennylane.queuing import QueuingManager, apply
 from pennylane.wires import Wires

--- a/pennylane/templates/subroutines/time_evolution/trotter.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter.py
@@ -21,8 +21,8 @@ from collections import defaultdict
 from pennylane import math
 from pennylane import ops as qp_ops
 from pennylane.capture.autograph import wraps
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import add_decomps, register_resources, resource_rep
-from pennylane.operation import Operation, Operator
 from pennylane.queuing import QueuingManager, apply
 from pennylane.resource import Resources, ResourcesOperation
 from pennylane.resource.error import (

--- a/pennylane/templates/swapnetworks/ccl2.py
+++ b/pennylane/templates/swapnetworks/ccl2.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops import SWAP, FermionicSWAP
 
 

--- a/pennylane/templates/tensornetworks/mera.py
+++ b/pennylane/templates/tensornetworks/mera.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.queuing import QueuingManager, apply
 from pennylane.tape import make_qscript
 

--- a/pennylane/templates/tensornetworks/mps.py
+++ b/pennylane/templates/tensornetworks/mps.py
@@ -19,7 +19,7 @@ Contains the MPS template.
 import warnings
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.queuing import QueuingManager, apply
 from pennylane.tape import make_qscript
 

--- a/pennylane/templates/tensornetworks/ttn.py
+++ b/pennylane/templates/tensornetworks/ttn.py
@@ -22,7 +22,7 @@ import warnings
 import numpy as np
 
 from pennylane import math
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.queuing import QueuingManager, apply
 from pennylane.tape import make_qscript
 

--- a/pennylane/transforms/core/transform.py
+++ b/pennylane/transforms/core/transform.py
@@ -26,9 +26,9 @@ from inspect import Parameter, signature
 
 from pennylane import capture, math
 from pennylane.capture import autograph
+from pennylane.core.operator import Operator
 from pennylane.exceptions import TransformError
 from pennylane.measurements import MeasurementProcess
-from pennylane.operation import Operator
 from pennylane.pytrees import flatten
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply
 from pennylane.tape import QuantumScript

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -19,11 +19,11 @@ from functools import partial
 
 from typing_extensions import override
 
+from pennylane.core.operator import Operator
 from pennylane.decomposition import DecompGraphSolution, DecompositionGraph, enabled_graph
 from pennylane.decomposition.decomposition_graph import _DecompositionNode, _OperatorNode
 from pennylane.decomposition.decomposition_rule import _DecompInfo, _DecompInfoCollection
 from pennylane.decomposition.resources import resource_rep
-from pennylane.operation import Operator
 from pennylane.tape import QuantumScript, QuantumScriptBatch
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -24,6 +24,7 @@ from functools import lru_cache, partial
 
 from pennylane import math, ops, queuing
 from pennylane.allocation import Allocate, Deallocate
+from pennylane.core.operator import Operator
 from pennylane.decomposition import (
     DecompositionGraph,
     GateSet,
@@ -33,7 +34,6 @@ from pennylane.decomposition import (
 from pennylane.decomposition.decomposition_graph import DecompGraphSolution
 from pennylane.decomposition.reconstruct import get_decomp_kwargs
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operator
 from pennylane.ops import Conditional, GlobalPhase
 from pennylane.templates import SubroutineOp
 from pennylane.transforms.core import transform

--- a/pennylane/transforms/optimization/cancel_inverses.py
+++ b/pennylane/transforms/optimization/cancel_inverses.py
@@ -15,8 +15,8 @@
 
 from functools import lru_cache, partial
 
+from pennylane.core.operator import Operator
 from pennylane.math import is_abstract
-from pennylane.operation import Operator
 from pennylane.ops.op_math import Adjoint
 from pennylane.ops.qubit.attributes import (
     self_inverses,

--- a/pennylane/transforms/optimization/merge_amplitude_embedding.py
+++ b/pennylane/transforms/optimization/merge_amplitude_embedding.py
@@ -38,7 +38,7 @@ def _get_plxpr_merge_amplitude_embedding():
         from pennylane.capture import PlxprInterpreter
         from pennylane.capture.base_interpreter import jaxpr_to_jaxpr
         from pennylane.capture.primitives import cond_prim, measure_prim
-        from pennylane.operation import Operator
+        from pennylane.core.operator import Operator
     except ImportError:  # pragma: no cover
         return None, None
 

--- a/pennylane/transforms/optimization/merge_rotations.py
+++ b/pennylane/transforms/optimization/merge_rotations.py
@@ -37,7 +37,7 @@ def _get_plxpr_merge_rotations():
 
         from pennylane.capture import PlxprInterpreter
         from pennylane.capture.primitives import measure_prim
-        from pennylane.operation import Operator
+        from pennylane.core.operator import Operator
     except ImportError:  # pragma: no cover
         return None, None
 

--- a/pennylane/transforms/rz_phase_gradient.py
+++ b/pennylane/transforms/rz_phase_gradient.py
@@ -21,7 +21,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.op_math import change_op_basis
 from pennylane.queuing import QueuingManager
 from pennylane.tape import QuantumScript, QuantumScriptBatch

--- a/pennylane/transforms/unitary_to_rot.py
+++ b/pennylane/transforms/unitary_to_rot.py
@@ -18,7 +18,7 @@ A transform for decomposing arbitrary single-qubit QubitUnitary gates into eleme
 from functools import lru_cache, partial
 
 from pennylane import capture, math
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.op_math.decompositions import one_qubit_decomposition, two_qubit_decomposition
 from pennylane.ops.qubit.matrix_ops import QubitUnitary
 from pennylane.queuing import QueuingManager

--- a/pennylane/transforms/zx/converter.py
+++ b/pennylane/transforms/zx/converter.py
@@ -22,10 +22,10 @@ from functools import partial
 import numpy as np
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.decomposition import gate_sets
 from pennylane.decomposition.decomposition_rule import null_decomp
 from pennylane.exceptions import QuantumFunctionError
-from pennylane.operation import Operator
 from pennylane.tape import QuantumScript
 from pennylane.transforms import transform
 from pennylane.wires import Wires

--- a/tach.toml
+++ b/tach.toml
@@ -333,6 +333,10 @@ cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 path = "pennylane.operation"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
+[[interfaces]]
+expose = ["operation_derivative", "is_trainable"]
+from = ["pennylane.operation"]
+
 [[modules]]
 path = "pennylane.core.operator"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]

--- a/tests/capture/transforms/test_capture_graph_decompose.py
+++ b/tests/capture/transforms/test_capture_graph_decompose.py
@@ -24,8 +24,8 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition.decomposition_rule import null_decomp
-from pennylane.operation import Operation
 from pennylane.ops import Conditional, MidMeasure, PauliMeasure
 
 jax = pytest.importorskip("jax")

--- a/tests/core/test_core_operator.py
+++ b/tests/core/test_core_operator.py
@@ -23,12 +23,14 @@ from gate_data import CNOT, I, Toffoli, X
 
 import pennylane as qp
 from pennylane import numpy as pnp
-from pennylane.exceptions import PennyLaneDeprecationWarning
-from pennylane.operation import (
-    _UNSET_BATCH_SIZE,
+from pennylane.core.operator import (
     Operation,
     Operator,
     StatePrepBase,
+)
+from pennylane.exceptions import PennyLaneDeprecationWarning
+from pennylane.operation import (
+    _UNSET_BATCH_SIZE,
     operation_derivative,
 )
 from pennylane.ops import Prod, SProd, Sum

--- a/tests/data/attributes/operator/test_operator.py
+++ b/tests/data/attributes/operator/test_operator.py
@@ -22,9 +22,9 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.data.attributes import DatasetOperator, DatasetPyTree
 from pennylane.data.base.typing_util import get_type_str
-from pennylane.operation import Operator
 
 pytestmark = pytest.mark.data
 

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -22,6 +22,7 @@ import pytest
 
 import pennylane as qp
 from conftest import decompositions, to_resources  # pylint: disable=no-name-in-module
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     DecompositionGraph,
     adjoint_resource_rep,
@@ -32,7 +33,6 @@ from pennylane.decomposition import (
 from pennylane.decomposition.reconstruct import get_decomp_kwargs
 from pennylane.decomposition.utils import to_name
 from pennylane.exceptions import DecompositionError, DecompositionWarning
-from pennylane.operation import Operation
 
 # pylint: disable=protected-access,no-name-in-module
 

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -19,6 +19,7 @@ from textwrap import dedent
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.decomposition.decomposition_rule import (
     DecompCollection,
     DecompositionRule,
@@ -28,7 +29,6 @@ from pennylane.decomposition.decomposition_rule import (
     register_resources,
 )
 from pennylane.decomposition.resources import CompressedResourceOp, Resources
-from pennylane.operation import Operator
 
 
 class CustomOp(Operator):  # pylint: disable=too-few-public-methods

--- a/tests/default_qubit_legacy.py
+++ b/tests/default_qubit_legacy.py
@@ -29,11 +29,11 @@ from scipy.sparse import coo_matrix, csr_matrix
 import pennylane as qp
 from pennylane import BasisState, Snapshot, StatePrep
 from pennylane._version import __version__
+from pennylane.core.operator import Operation
 from pennylane.devices._qubit_device import QubitDevice
 from pennylane.devices.qubit import measure
 from pennylane.exceptions import DeviceError, WireError
 from pennylane.measurements import ExpectationMP
-from pennylane.operation import Operation
 from pennylane.ops import Sum
 from pennylane.ops.qubit.attributes import diagonal_in_z_basis
 from pennylane.pulse import ParametrizedEvolution

--- a/tests/devices/qubit/test_apply_operation.py
+++ b/tests/devices/qubit/test_apply_operation.py
@@ -26,13 +26,14 @@ from scipy.sparse import csr_matrix, kron
 from scipy.stats import unitary_group
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.devices.qubit.apply_operation import (
     apply_operation,
     apply_operation_csr_matrix,
     apply_operation_einsum,
     apply_operation_tensordot,
 )
-from pennylane.operation import _UNSET_BATCH_SIZE, Operation
+from pennylane.operation import _UNSET_BATCH_SIZE
 
 apply_operation_module = importlib.import_module("pennylane.devices.qubit.apply_operation")
 

--- a/tests/devices/qubit/test_initialize_state.py
+++ b/tests/devices/qubit/test_initialize_state.py
@@ -18,8 +18,8 @@ import scipy as sp
 
 import pennylane as qp
 from pennylane import numpy as np
+from pennylane.core.operator import StatePrepBase
 from pennylane.devices.qubit import create_initial_state
-from pennylane.operation import StatePrepBase
 
 
 class TestInitializeState:

--- a/tests/devices/qubit_mixed/test_qubit_mixed_initialize_state.py
+++ b/tests/devices/qubit_mixed/test_qubit_mixed_initialize_state.py
@@ -18,8 +18,8 @@ import pytest
 import pennylane as qp
 from pennylane import BasisState, StatePrep, math
 from pennylane import numpy as np
+from pennylane.core.operator import StatePrepBase
 from pennylane.devices.qubit_mixed import create_initial_state
-from pennylane.operation import StatePrepBase
 
 ml_interfaces = ["numpy", "autograd", "jax", "torch"]
 

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_apply_operation.py
@@ -22,8 +22,8 @@ from scipy.stats import unitary_group
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Channel
 from pennylane.devices.qutrit_mixed import apply_operation, measure
-from pennylane.operation import Channel
 
 # Small additive constant to prevent negative sqrt arguments from floating-point errors
 _SQRT_STABILITY_EPS = 1e-14

--- a/tests/devices/qutrit_mixed/test_qutrit_mixed_initialize_state.py
+++ b/tests/devices/qutrit_mixed/test_qutrit_mixed_initialize_state.py
@@ -18,8 +18,8 @@ import pytest
 import pennylane as qp
 from pennylane import QutritBasisState
 from pennylane import numpy as np
+from pennylane.core.operator import StatePrepBase
 from pennylane.devices.qutrit_mixed import create_initial_state
-from pennylane.operation import StatePrepBase
 
 
 class TestInitializeState:

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.devices.preprocess import (
     _operator_decomposition_gen,
     decompose,
@@ -36,7 +37,6 @@ from pennylane.devices.preprocess import (
 )
 from pennylane.exceptions import DeviceError, QuantumFunctionError
 from pennylane.measurements import CountsMP, SampleMP
-from pennylane.operation import Operation
 from pennylane.tape import QuantumScript
 
 # pylint: disable=too-few-public-methods

--- a/tests/estimator/test_estimator_mapping.py
+++ b/tests/estimator/test_estimator_mapping.py
@@ -24,8 +24,8 @@ import pennylane.estimator as re_ops
 import pennylane.estimator.templates as re_temps
 import pennylane.ops as qops
 import pennylane.templates as qtemps
+from pennylane.core.operator import Operation
 from pennylane.estimator.resource_mapping import _map_term_trotter, _map_to_resource_op
-from pennylane.operation import Operation
 
 # pylint: disable= no-self-use,too-few-public-methods
 

--- a/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
+++ b/tests/gradients/finite_diff/test_spsa_gradient_shot_vec.py
@@ -23,10 +23,10 @@ from default_qubit_legacy import DefaultQubitLegacy
 
 import pennylane as qp
 from pennylane import numpy as pnp
+from pennylane.core.operator import Operator
 from pennylane.exceptions import QuantumFunctionError
 from pennylane.gradients import spsa_grad
 from pennylane.measurements import Shots
-from pennylane.operation import Operator
 
 h_val = 0.1
 spsa_shot_vec_tol = 0.33

--- a/tests/measurements/test_sample.py
+++ b/tests/measurements/test_sample.py
@@ -17,8 +17,8 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.exceptions import EigvalsUndefinedError, MeasurementShapeError, QuantumFunctionError
-from pennylane.operation import Operator
 
 # pylint: disable=protected-access, no-member, too-many-public-methods
 

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -23,10 +23,10 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Channel, Operation, Operator, StatePrepBase
 from pennylane.drawer.label import LabelledOp
 from pennylane.exceptions import DeviceError
 from pennylane.fourier.mark import MarkedOp
-from pennylane.operation import Channel, Operation, Operator, StatePrepBase
 from pennylane.ops.op_math import ChangeOpBasis
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 from pennylane.ops.op_math.pow import PowOperation

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.functions import assert_valid
 from pennylane.ops.functions.assert_valid import _check_capture, _test_decomposition_rule
 

--- a/tests/ops/functions/test_commutator.py
+++ b/tests/ops/functions/test_commutator.py
@@ -19,7 +19,7 @@ Unit tests for the comm function
 import pytest
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops import SProd
 from pennylane.pauli import PauliSentence, PauliWord
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -28,11 +28,11 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as npp
+from pennylane.core.operator import Operator
 from pennylane.drawer.label import LabelledOp
 from pennylane.fourier.mark import MarkedOp
 from pennylane.measurements import ExpectationMP
 from pennylane.measurements.probs import ProbabilityMP
-from pennylane.operation import Operator
 from pennylane.ops import Conditional, PauliMeasure
 from pennylane.ops.functions.equal import (
     BASE_OPERATION_MISMATCH_ERROR_MESSAGE,

--- a/tests/ops/functions/test_is_hermitian.py
+++ b/tests/ops/functions/test_is_hermitian.py
@@ -18,7 +18,7 @@ Unit tests for the qp.is_hermitian function
 import pytest
 
 import pennylane as qp
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 
 hermitian_ops = (
     qp.Identity(0),

--- a/tests/ops/op_math/test_condition.py
+++ b/tests/ops/op_math/test_condition.py
@@ -27,8 +27,8 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operator
 from pennylane.exceptions import ConditionalTransformError
-from pennylane.operation import Operator
 from pennylane.ops.op_math.condition import Conditional
 
 terminal_meas = [

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -38,10 +38,10 @@ from scipy import sparse
 
 import pennylane as qp
 from pennylane import numpy as pnp
+from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import gate_sets
 from pennylane.decomposition.decomposition_rule import register_resources
 from pennylane.exceptions import DecompositionUndefinedError
-from pennylane.operation import Operation, Operator
 from pennylane.ops.op_math.controlled import Controlled, ControlledOp, ctrl
 from pennylane.tape import QuantumScript
 from pennylane.transforms import decompose

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -23,8 +23,8 @@ import pytest
 import pennylane as qp
 import pennylane.numpy as qnp
 from pennylane import math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import DeviceError, MatrixUndefinedError
-from pennylane.operation import Operator
 from pennylane.ops.op_math.prod import Prod, _swappable_ops, prod
 from pennylane.wires import Wires
 

--- a/tests/ops/op_math/test_sum.py
+++ b/tests/ops/op_math/test_sum.py
@@ -25,8 +25,8 @@ import pytest
 import pennylane as qp
 import pennylane.numpy as qnp
 from pennylane import X, Y, Z, math
+from pennylane.core.operator import Operator
 from pennylane.exceptions import MatrixUndefinedError
-from pennylane.operation import Operator
 from pennylane.ops.op_math import Prod, Sum
 from pennylane.wires import Wires
 

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -19,7 +19,7 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as np
-from pennylane.operation import Operator
+from pennylane.core.operator import Operator
 from pennylane.ops.op_math import ScalarSymbolicOp, SymbolicOp
 from pennylane.wires import Wires
 

--- a/tests/resource/test_error/test_error.py
+++ b/tests/resource/test_error/test_error.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.resource.error import (
     AlgorithmicError,
     ErrorOperation,

--- a/tests/resource/test_resource.py
+++ b/tests/resource/test_resource.py
@@ -22,8 +22,8 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.measurements import Shots
-from pennylane.operation import Operation
 from pennylane.resource.expression import Expression
 from pennylane.resource.resource import (
     CircuitSpecs,

--- a/tests/templates/embeddings/test_basis.py
+++ b/tests/templates/embeddings/test_basis.py
@@ -20,8 +20,8 @@ import pytest
 
 import pennylane as qp
 from pennylane import numpy as pnp
+from pennylane.core.operator import Operator
 from pennylane.decomposition.decomposition_graph import DecompositionGraph
-from pennylane.operation import Operator
 
 
 @pytest.mark.jax

--- a/tests/transforms/test_decompose_transform.py
+++ b/tests/transforms/test_decompose_transform.py
@@ -21,7 +21,7 @@ import pytest
 
 import pennylane as qp
 import pennylane.numpy as qnp
-from pennylane.operation import Operation
+from pennylane.core.operator import Operation
 from pennylane.ops import Conditional, MidMeasure
 from pennylane.queuing import AnnotatedQueue
 from pennylane.transforms.decompose import _operator_decomposition_gen, decompose

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -20,10 +20,10 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core.operator import Operation
 from pennylane.decomposition.decomposition_rule import null_decomp
 from pennylane.decomposition.gate_set import GateSet
 from pennylane.exceptions import DecompositionWarning
-from pennylane.operation import Operation
 from pennylane.ops.mid_measure import MidMeasure
 from pennylane.ops.mid_measure.pauli_measure import PauliMeasure
 from pennylane.ops.op_math.condition import Conditional


### PR DESCRIPTION

**Context:**

In #9508  ,  we created a `core` module and moved all the Operator interfaces into it, but left all the imports in our code base untouched. This PR strictly updates all the imports.

Updates performed by Cursor

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-121185]
