### PR TITLE
[TEST] fixture: `preserve_jax_x64`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -365,6 +365,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Adds a new test fixture `preserve_jax_x64` to help automatically restore the `jax.config.jax_enable_x64` to prevent
+  accidental context contamination.
+  [(#9590)](https://github.com/PennyLaneAI/pennylane/pull/9590)
+
 * New, experimental abstractions for creating PennyLane operators have been added, built around a new
   base class, `Operator2`. This is an internal, work-in-progress effort that is being incrementally
   integrated into the PennyLane ecosystem. Supported functionality so far:

--- a/tests/capture/workflow/test_capture_finite_diff.py
+++ b/tests/capture/workflow/test_capture_finite_diff.py
@@ -26,6 +26,7 @@ jax = pytest.importorskip("jax")
 jnp = pytest.importorskip("jax.numpy")
 
 
+@pytest.mark.usefixtures("preserve_jax_x64")
 def test_warning_float32():
     """Test that a warning is raised if trainable inputs are float32."""
 
@@ -40,11 +41,8 @@ def test_warning_float32():
         jax.grad(circuit)(jnp.array(0.5, dtype=jnp.float32))
 
     jax.config.update("jax_enable_x64", False)
-    try:
-        with pytest.warns(UserWarning, match="Detected 32 bits precision with finite differences."):
-            jax.grad(circuit)(0.5)
-    finally:
-        jax.config.update("jax_enable_x64", True)
+    with pytest.warns(UserWarning, match="Detected 32 bits precision with finite differences."):
+        jax.grad(circuit)(0.5)
 
 
 class TestGradients:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,21 @@ def pytest_generate_tests(metafunc):
         jax.config.update("jax_enable_x64", True)
 
 
+@pytest.fixture
+def preserve_jax_x64():
+    """Save and restore jax_enable_x64 around a test.
+
+    Use this fixture on any test that sets ``jax_enable_x64`` to ``False`` so
+    that subsequent tests in the same xdist worker are not contaminated.
+    """
+    if not jax_available:
+        yield
+        return
+    original = jax.config.jax_enable_x64
+    yield
+    jax.config.update("jax_enable_x64", original)
+
+
 @pytest.fixture(
     params=[
         pytest.param("autograd", marks=pytest.mark.autograd),

--- a/tests/devices/default_qubit/test_default_qubit.py
+++ b/tests/devices/default_qubit/test_default_qubit.py
@@ -2334,6 +2334,7 @@ def test_broadcasted_parameter(max_workers):
 
 
 @pytest.mark.jax
+@pytest.mark.usefixtures("preserve_jax_x64")
 def test_renomalization_issue():
     """Test that no normalization error occurs with the following workflow in float32 mode.
     Just tests executes without error.  Not producing a more minimal example due to difficulty
@@ -2342,7 +2343,6 @@ def test_renomalization_issue():
     import jax
     from jax import numpy as jnp
 
-    initial_mode = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", False)
 
     def gaussian_fn(p, t):
@@ -2376,4 +2376,3 @@ def test_renomalization_issue():
     circuit_qp = qp.QNode(circuit, qp.device("default.qubit"), interface="jax", shots=1000)
 
     circuit_qp(params)
-    jax.config.update("jax_enable_x64", initial_mode)

--- a/tests/devices/test_default_qutrit.py
+++ b/tests/devices/test_default_qutrit.py
@@ -1532,6 +1532,7 @@ class TestDtypePreservedJax:
     """Test that the user-defined dtype of the device is preserved for QNode
     evaluation"""
 
+    @pytest.mark.usefixtures("preserve_jax_x64")
     @pytest.mark.parametrize("enable_x64, r_dtype", [(False, np.float32), (True, np.float64)])
     @pytest.mark.parametrize(
         "measurement",
@@ -1563,6 +1564,7 @@ class TestDtypePreservedJax:
         res = circuit(p)
         assert res.dtype == r_dtype
 
+    @pytest.mark.usefixtures("preserve_jax_x64")
     @pytest.mark.parametrize("enable_x64, c_dtype", [(False, np.complex64), (True, np.complex128)])
     def test_complex_dtype(self, enable_x64, c_dtype, use_jit):
         """Test that the user-defined dtype of the device is preserved

--- a/tests/templates/subroutines/test_qsvt_optax.py
+++ b/tests/templates/subroutines/test_qsvt_optax.py
@@ -72,17 +72,15 @@ def generate_polynomial_coeffs(degree, parity=None):
 pytestmark = pytest.mark.external
 
 
+@pytest.mark.usefixtures("preserve_jax_x64")
 def test_jax_x64_warning():
     """Ensures a warning is raised if running in 32-bit JAX."""
 
-    initial_mode = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", False)
 
     poly = generate_polynomial_coeffs(4, 0)
     with pytest.warns(UserWarning, match="JAX 64-bit mode is recommended"):
         _ = qp.poly_to_angles(list(poly), "QSP", angle_solver="iterative-optax")
-
-    jax.config.update("jax_enable_x64", initial_mode)
 
 
 class TestOptaxAngleSolver:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -106,6 +106,7 @@ class TestCatalyst:
         assert jnp.allclose(circuit(jnp.pi, jnp.pi / 2), 1.0)
         assert jnp.allclose(qp.qjit(circuit)(jnp.pi, jnp.pi / 2), -1.0)
 
+    @pytest.mark.usefixtures("preserve_jax_x64")
     @pytest.mark.parametrize("jax_enable_x64", [False, True])
     def test_jax_enable_x64(self, jax_enable_x64):
         """Test whether `qp.compiler.active` changes `jax_enable_x64`."""

--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -3364,64 +3364,52 @@ class TestSinglePrecision:
 
         assert _jax_dtype(bool) == jax.numpy.dtype(bool)
 
+    @pytest.mark.usefixtures("preserve_jax_x64")
     @pytest.mark.parametrize("diff_method", ("adjoint", "parameter-shift"))
     def test_float32_return(self, diff_method):
         """Test that jax jit works when float64 mode is disabled."""
         jax.config.update("jax_enable_x64", False)
 
-        try:
+        @jax.jit
+        @qp.qnode(qp.device("default.qubit"), diff_method=diff_method)
+        def circuit(x):
+            qp.RX(x, wires=0)
+            return qp.expval(qp.PauliZ(0))
 
-            @jax.jit
-            @qp.qnode(qp.device("default.qubit"), diff_method=diff_method)
-            def circuit(x):
-                qp.RX(x, wires=0)
-                return qp.expval(qp.PauliZ(0))
+        grad = jax.grad(circuit)(jax.numpy.array(0.1))
+        assert qp.math.allclose(grad, -np.sin(0.1))
 
-            grad = jax.grad(circuit)(jax.numpy.array(0.1))
-            assert qp.math.allclose(grad, -np.sin(0.1))
-        finally:
-            jax.config.update("jax_enable_x64", True)
-        jax.config.update("jax_enable_x64", True)
-
+    @pytest.mark.usefixtures("preserve_jax_x64")
     @pytest.mark.parametrize("diff_method", ("adjoint", "finite-diff"))
     def test_complex64_return(self, diff_method):
         """Test that jax jit works with differentiating the state."""
         jax.config.update("jax_enable_x64", False)
 
-        try:
-            # finite diff with float32 ...
-            tol = 5e-2 if diff_method == "finite-diff" else 1e-6
+        # finite diff with float32 ...
+        tol = 5e-2 if diff_method == "finite-diff" else 1e-6
 
-            @jax.jit
-            @qp.qnode(qp.device("default.qubit", wires=1), diff_method=diff_method)
-            def circuit(x):
-                qp.RX(x, wires=0)
-                return qp.state()
+        @jax.jit
+        @qp.qnode(qp.device("default.qubit", wires=1), diff_method=diff_method)
+        def circuit(x):
+            qp.RX(x, wires=0)
+            return qp.state()
 
-            j = jax.jacobian(circuit, holomorphic=True)(jax.numpy.array(0.1 + 0j))
-            assert qp.math.allclose(j, [-np.sin(0.05) / 2, -np.cos(0.05) / 2 * 1j], atol=tol)
+        j = jax.jacobian(circuit, holomorphic=True)(jax.numpy.array(0.1 + 0j))
+        assert qp.math.allclose(j, [-np.sin(0.05) / 2, -np.cos(0.05) / 2 * 1j], atol=tol)
 
-        finally:
-            jax.config.update("jax_enable_x64", True)
-        jax.config.update("jax_enable_x64", True)
-
+    @pytest.mark.usefixtures("preserve_jax_x64")
     def test_int32_return(self):
         """Test that jax jit forward execution works with samples and int32"""
 
         jax.config.update("jax_enable_x64", False)
 
-        try:
+        @jax.jit
+        @qp.qnode(qp.device("default.qubit"), diff_method=qp.gradients.param_shift, shots=10)
+        def circuit(x):
+            qp.RX(x, wires=0)
+            return qp.sample(wires=0)
 
-            @jax.jit
-            @qp.qnode(qp.device("default.qubit"), diff_method=qp.gradients.param_shift, shots=10)
-            def circuit(x):
-                qp.RX(x, wires=0)
-                return qp.sample(wires=0)
-
-            _ = circuit(jax.numpy.array(0.1))
-        finally:
-            jax.config.update("jax_enable_x64", True)
-        jax.config.update("jax_enable_x64", True)
+        _ = circuit(jax.numpy.array(0.1))
 
 
 def test_no_inputs_jitting():


### PR DESCRIPTION
**Context:**
Spawned from https://github.com/PennyLaneAI/pennylane/pull/9519 
There are cases where we would like to test the x32 compatibilty. But sometimes we forgot to reset back to the original x64 which supposed to be true. To completely resolve similar issues now and forever, let's have a new fixture to automatically maintain this status for all such tests, including those who used to be using the correct `try ... finally` structure.

This did not become an issue in the past because our test split algorithm preserved the locality of tests and local context of problematic tests "auto-corrected" these mistakes.

**Description of the Change:**
New fixture: `preserve_jax_x64`
 - If `jax` is not available, exit
 - If `jax` is available, always reset the value of `preserve_jax_x64`

**Benefits:**
jax x64 flags won't contaminate among runners with distributed way of testing.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
[sc-121576]