### PR TITLE
Added __repr__ to qp.Tracker and appropriate test functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -530,4 +530,5 @@ Jay Soni,
 Paul Haochen Wang,
 Dennis Wayo,
 David Wierichs,
-Jake Zaia.
+Jake Zaia,
+Pranavi Jain.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -176,6 +176,10 @@
   now formatted for clearer visual inspection when used in a Jupyter notebook environment.
   [(#9518)](https://github.com/PennyLaneAI/pennylane/pull/9518)
 
+* `qp.Tracker` now has a `__repr__` that displays all instance state (`active`, `totals`,
+  `persistent`, `latest`, `history`, `callback`) for easier inspection by its users.
+  [(#9591)](https://github.com/PennyLaneAI/pennylane/pull/9591)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * Added a variant of `SumOfSlatersPrep` to labs, accessible as `labs.templates.SumOfSlatersPrep2`.

--- a/pennylane/devices/tracker.py
+++ b/pennylane/devices/tracker.py
@@ -179,6 +179,13 @@ class Tracker:
                 raise ValueError(f"Device '{dev.short_name}' does not support device tracking")
             dev.tracker = self
 
+    def __repr__(self):
+        """Return a string representation of the Tracker with all its current state."""
+        return (
+            f"Tracker(active={self.active}, totals={self.totals}, persistent={self.persistent}, "
+            f"latest={self.latest}, history={self.history}, callback={self.callback})"
+        )
+
     def __enter__(self):
         if not self.persistent:
             self.reset()

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -99,6 +99,22 @@ class TestTrackerCoreBehavior:
         assert tracker.history == {}
         assert tracker.latest == {}
 
+    def test_repr(self):
+        """Assert __repr__ includes all tracker attributes with correct values."""
+
+        tracker = Tracker()
+
+        tracker.totals = {"a": 1}
+        tracker.history = {"a": [1]}
+        tracker.latest = {"a": 1}
+
+        expected = (
+            f"Tracker(active={tracker.active}, totals={tracker.totals}, persistent= {tracker.persistent}, "
+            f"latest={tracker.latest}, history={tracker.history}, callback={tracker.callback})"
+        )
+
+        assert repr(tracker) == expected
+
     def test_enter_and_exit(self):
         """Assert entering and exit work as expected"""
 

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -111,13 +111,12 @@ class TestTrackerCoreBehavior:
         assert "history={}" in repr(tracker)
         assert "callback=None" in repr(tracker)
 
-        tracker.totals = {"a": 1}
-        tracker.latest = {"a": 1}
-        tracker.history = {"a": [1]}
+        tracker.update(a=1, b="b", c=None)
+        tracker.update(a=2, b="b2", c=1)
 
-        assert "totals={'a': 1}" in repr(tracker)
-        assert "latest={'a': 1}" in repr(tracker)
-        assert "history={'a': [1]}" in repr(tracker)
+        assert "totals={'a': 3, 'c': 1}" in repr(tracker)
+        assert "latest={'a': 2, 'b': 'b2', 'c': 1}" in repr(tracker)
+        assert "history={'a': [1, 2], 'b': ['b', 'b2'], 'c': [None, 1]}" in repr(tracker)
         assert "callback=None" in repr(tracker)
 
     def test_enter_and_exit(self):

--- a/tests/devices/test_tracker.py
+++ b/tests/devices/test_tracker.py
@@ -104,16 +104,21 @@ class TestTrackerCoreBehavior:
 
         tracker = Tracker()
 
+        assert "active=False" in repr(tracker)
+        assert "totals={}" in repr(tracker)
+        assert "persistent=False" in repr(tracker)
+        assert "latest={}" in repr(tracker)
+        assert "history={}" in repr(tracker)
+        assert "callback=None" in repr(tracker)
+
         tracker.totals = {"a": 1}
-        tracker.history = {"a": [1]}
         tracker.latest = {"a": 1}
+        tracker.history = {"a": [1]}
 
-        expected = (
-            f"Tracker(active={tracker.active}, totals={tracker.totals}, persistent= {tracker.persistent}, "
-            f"latest={tracker.latest}, history={tracker.history}, callback={tracker.callback})"
-        )
-
-        assert repr(tracker) == expected
+        assert "totals={'a': 1}" in repr(tracker)
+        assert "latest={'a': 1}" in repr(tracker)
+        assert "history={'a': [1]}" in repr(tracker)
+        assert "callback=None" in repr(tracker)
 
     def test_enter_and_exit(self):
         """Assert entering and exit work as expected"""


### PR DESCRIPTION
**Context:**
`qp.Tracker` had no `__repr__`, so inspecting a tracker instance showed an unhelpful default object string to its users.

**Description of the Change:**
Added `__repr__` to `pennylane.Tracker` that returns a human-readable string listing all instance attributes: `active`, `totals`, `persistent`, `latest`, `history`, and `callback`. A unit test `test_repr` was added to `TestTrackerCoreBehavior` to verify the output against expected values.

**Benefits:**
Makes `Tracker` instances easier to inspect interactively; printing or evaluating a tracker now shows its full state at a glance.

**Possible Drawbacks:**
`history` can be large; the string representation will be verbose if many updates have been recorded.

**Related GitHub Issues:**
#9389 for unitaryHack26
