### PR TITLE
Refactor iteration patterns and remove redundant conversions

### DIFF
--- a/Zaraki4707s_Contribution.md
+++ b/Zaraki4707s_Contribution.md
@@ -1,0 +1,81 @@
+I gave the performance impact only 4/10, it's because most of these changes improve the source code much more than they improve runtime.
+
+For example:
+
+range(len(seq)) → enumerate(seq)
+
+Old:
+
+for i in range(len(seq)):
+    x = seq[i]
+
+New:
+
+for i, x in enumerate(seq):
+
+The new version is cleaner and avoids explicit indexing, but the runtime difference is usually extremely small in CPython. Both are implemented efficiently in C.
+
+sorted(list(set(x))) → sorted(set(x))
+
+This one does save an unnecessary list allocation:
+
+sorted(list(set(x)))
+
+creates:
+
+a set
+a list from that set
+then sorted() creates another list
+
+while:
+
+sorted(set(x))
+
+skips step 2.
+
+That's a real improvement, but unless the collection is huge or called frequently, the gain is still small.
+
+Why maintainers may still like the PR
+
+Because software engineering isn't only about speed.
+
+Your changes improve:
+
+readability
+maintainability
+consistency
+linting compliance
+removal of redundant operations
+
+Those are valuable.
+
+In fact, if I were a maintainer, I'd view this more as:
+
+"This code is now cleaner and more idiomatic Python"
+
+than
+
+"This code is now significantly faster."
+
+When I'd give 9/10 performance impact
+
+Something like:
+
+for item in data:
+    if item not in lst:
+
+becoming
+
+lookup = set(lst)
+for item in data:
+    if item not in lookup:
+
+because that changes complexity from roughly O(n²) to O(n).
+
+Or removing repeated expensive computations inside hot loops.
+
+Or vectorizing Python loops with NumPy.
+
+Those can produce 10x, 100x, or even 1000x improvements.
+
+Your changes are mostly micro-optimizations and code cleanup, which is why I rated the performance impact modestly while rating the overall contribution much higher. 

--- a/pennylane/devices/tests/test_measurements.py
+++ b/pennylane/devices/tests/test_measurements.py
@@ -760,7 +760,7 @@ class TestSample:
         # res should only contain the eigenvalues of
         # the hermitian matrix
         eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol)
+        assert np.allclose(sorted(set(res.tolist())), sorted(eigvals), atol=tol)
         # the analytic mean is 2*sin(theta)+0.5*cos(theta)+0.5
         assert np.allclose(np.mean(res), 2 * np.sin(theta) + 0.5 * np.cos(theta) + 0.5, atol=tol)
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
@@ -790,8 +790,8 @@ class TestSample:
         res_basis = circuit([0]).flatten()
         res_state = circuit([1, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
         assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol)
@@ -801,8 +801,8 @@ class TestSample:
         res_basis = circuit([1]).flatten()
         res_state = circuit([0, 1]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
         assert np.allclose(np.var(res_basis), expected - (expected) ** 2, atol=tol)
@@ -810,7 +810,7 @@ class TestSample:
 
         expected = 0.5
         res = circuit(np.array([1, 1]) / np.sqrt(2)).flatten()
-        assert np.allclose(sorted(list(set(res.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res), expected, atol=tol)
         assert np.allclose(np.var(res), expected - (expected) ** 2, atol=tol)
 
@@ -849,7 +849,7 @@ class TestSample:
         # res should only contain the eigenvalues of
         # the hermitian matrix
         eigvals = np.linalg.eigvalsh(A_)
-        assert np.allclose(sorted(list(set(res.tolist()))), sorted(eigvals), atol=tol)
+        assert np.allclose(sorted(set(res.tolist())), sorted(eigvals), atol=tol)
 
         # make sure the mean matches the analytic mean
         expected = (
@@ -889,32 +889,32 @@ class TestSample:
         res_basis = circuit([0, 0]).flatten()
         res_state = circuit([1, 0, 0, 0]).flatten()
         # res should only contain 0 or 1, the eigenvalues of the projector
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.cos(theta / 2) * np.sin(theta)) ** 2
         res_basis = circuit([0, 1]).flatten()
         res_state = circuit([0, 1, 0, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.sin(theta / 2) * np.sin(theta)) ** 2
         res_basis = circuit([1, 0]).flatten()
         res_state = circuit([0, 0, 1, 0]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
 
         expected = (np.sin(theta / 2) * np.cos(theta)) ** 2
         res_basis = circuit([1, 1]).flatten()
         res_state = circuit([0, 0, 0, 1]).flatten()
-        assert np.allclose(sorted(list(set(res_basis.tolist()))), [0, 1], atol=tol)
-        assert np.allclose(sorted(list(set(res_state.tolist()))), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_basis.tolist())), [0, 1], atol=tol)
+        assert np.allclose(sorted(set(res_state.tolist())), [0, 1], atol=tol)
         assert np.allclose(np.mean(res_basis), expected, atol=tol)
         assert np.allclose(np.mean(res_state), expected, atol=tol)
 

--- a/pennylane/gradients/gradient_transform.py
+++ b/pennylane/gradients/gradient_transform.py
@@ -108,7 +108,7 @@ def assert_no_trainable_tape_batching(tape, transform_name):
         return
 
     # Iterate over trainable parameters and check the affiliated operations for batching
-    for idx in range(len(tape.trainable_params)):
+    for idx, _ in enumerate(tape.trainable_params):
         if tape.get_operation(idx)[0].batch_size is not None:
             raise NotImplementedError(
                 "Computing the gradient of broadcasted tapes with respect to the broadcasted "
@@ -293,13 +293,13 @@ def _no_trainable_grad(tape):
         if len(tape.measurements) == 1:
             return [], lambda _: tuple(math.zeros([0]) for _ in range(tape.shots.num_copies))
         return [], lambda _: tuple(
-            tuple(math.zeros([0]) for _ in range(len(tape.measurements)))
+            tuple(math.zeros([0]) for _ in tape.measurements)
             for _ in range(tape.shots.num_copies)
         )
 
     if len(tape.measurements) == 1:
         return [], lambda _: math.zeros([0])
-    return [], lambda _: tuple(math.zeros([0]) for _ in range(len(tape.measurements)))
+    return [], lambda _: tuple(math.zeros([0]) for _ in tape.measurements)
 
 
 def _swap_first_two_axes(grads, first_axis_size, second_axis_size, squeeze=True):

--- a/pennylane/gradients/jvp.py
+++ b/pennylane/gradients/jvp.py
@@ -438,7 +438,7 @@ def batch_jvp(tapes, tangents, gradient_fn, reduction="append", gradient_kwargs=
         jvps = []
         start = 0
 
-        for t_idx in range(len(tapes)):
+        for t_idx, _ in enumerate(tapes):
             # extract the correct results from the flat list
             res_len = reshape_info[t_idx]
             res_t = results[start : start + res_len]

--- a/pennylane/gradients/parameter_shift.py
+++ b/pennylane/gradients/parameter_shift.py
@@ -495,7 +495,7 @@ def _put_zeros_in_pdA2_involutory(tape, pdA2, involutory_indices):
     variables).
     """
     new_pdA2 = []
-    for i in range(len(tape.measurements)):
+    for i, _ in enumerate(tape.measurements):
         if i in involutory_indices:
             num_params = len(tape.trainable_params)
             item = (
@@ -707,7 +707,7 @@ def var_param_shift(tape, argnum, shifts=None, gradient_recipes=None, f0=None, b
         new_measurements[i] = expval(op=obs)
         if obs.name in ["LinearCombination", "Sum"]:
             first_obs_idx = len(tape.operations)
-            for t_idx in reversed(range(len(tape.trainable_params))):
+            for t_idx in range(len(tape.trainable_params) - 1, -1, -1):
                 op, op_idx, _ = tape.get_operation(t_idx)
                 if op_idx < first_obs_idx:
                     break  # already seen all observables

--- a/pennylane/gradients/vjp.py
+++ b/pennylane/gradients/vjp.py
@@ -519,7 +519,7 @@ def batch_vjp(tapes, dys, gradient_fn, reduction="append", gradient_kwargs=None)
         if nums is None:
             nums = [None] * len(tapes)
 
-        for t_idx in range(len(tapes)):
+        for t_idx, _ in enumerate(tapes):
             # extract the correct results from the flat list
             res_len = reshape_info[t_idx]
             res_t = results[start : start + res_len]

--- a/pennylane/labs/phox/utils.py
+++ b/pennylane/labs/phox/utils.py
@@ -104,7 +104,7 @@ def create_random_gates(
 
     for i in range(n_gates):
         weight = rng.integers(min_weight, max_weight + 1)
-        gate = sorted(list(rng.choice(range(n_qubits), size=weight, replace=False)))
+        gate = sorted(rng.choice(range(n_qubits), size=weight, replace=False))
         gates_dict[i] = [[int(q) for q in gate]]
 
     return gates_dict

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -150,7 +150,7 @@ class AngleEmbedding(Operation):
         # If the leading dimension is a batch dimension, exchange the wire and batching axes.
         features = math.T(features) if batched else features
 
-        return [rotation(features[i], wires=wires[i]) for i in range(len(wires))]
+        return [rotation(features[i], wires=w) for i, w in enumerate(wires)]
 
 
 def _angle_embedding_resources(rotation: Operation, num_wires: int) -> dict:

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -159,5 +159,5 @@ class DisplacementEmbedding(Operation):
          Displacement(tensor(2.), tensor(0.), wires=[1])]
         """
         return [
-            Displacement(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i in range(len(wires))
+            Displacement(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i, _ in enumerate(wires)
         ]

--- a/pennylane/templates/embeddings/iqp.py
+++ b/pennylane/templates/embeddings/iqp.py
@@ -265,9 +265,9 @@ class IQPEmbedding(Operation):
             features = math.T(features)
 
         for _ in range(n_repeats):
-            for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-                op_list.append(H(wires=wires[i]))
-                op_list.append(RZ(features[i], wires=wires[i]))
+            for i, w in enumerate(wires):
+                op_list.append(H(wires=w))
+                op_list.append(RZ(features[i], wires=w))
 
             for wire_pair in pattern:
                 # get the position of the wire indices in the array

--- a/pennylane/templates/embeddings/qaoaembedding.py
+++ b/pennylane/templates/embeddings/qaoaembedding.py
@@ -302,16 +302,16 @@ class QAOAEmbedding(Operation):
                 )
                 op_list.extend(multirz_gates)
                 local_field_gates = (
-                    local_field(weights[l][len(wires) + i], wires=wires[i])
-                    for i in range(len(wires))
+                    local_field(weights[l][len(wires) + i], wires=w)
+                    for i, w in enumerate(wires)
                 )
                 op_list.extend(local_field_gates)
 
         # repeat the feature encoding once more at the end
         for i in range(n_features):
             op_list.append(RX(features[i], wires=wires[i]))
-        for i in range(n_features, len(wires)):
-            op_list.append(H(wires=wires[i]))
+        for _, w in enumerate(wires[n_features:]):
+            op_list.append(H(wires=w))
 
         return op_list
 

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -162,5 +162,5 @@ class SqueezingEmbedding(Operation):
         Squeezing(tensor(2.), tensor(0.), wires=['b'])]
         """
         return [
-            Squeezing(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i in range(len(wires))
+            Squeezing(pars[i, 0], pars[i, 1], wires=wires[i : i + 1]) for i, _ in enumerate(wires)
         ]

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -194,14 +194,14 @@ class BasicEntanglerLayers(Operation):
 
         op_list = []
         for layer in range(repeat):
-            for i in range(len(wires)):
+            for i, _ in enumerate(wires):
                 op_list.append(rotation(weights[..., layer, i], wires=wires[i : i + 1]))
 
             if len(wires) == 2:
                 op_list.append(CNOT(wires=wires))
 
             elif len(wires) > 2:
-                for i in range(len(wires)):
+                for i, _ in enumerate(wires):
                     w = wires.subset([i, i + 1], periodic_boundary=True)
                     op_list.append(CNOT(wires=w))
 
@@ -251,9 +251,9 @@ def _basic_entangler_decomposition(weights, wires, rotation):
         wires_loop()  # pylint: disable=no-value-for-parameter
 
         def elif_body():
-            for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-                j = (i + 1) % len(wires)
-                CNOT(wires=[wires[i], wires[j]])
+            for j, wire in enumerate(wires):
+                k = (j + 1) % len(wires)
+                CNOT(wires=[wire, wires[k]])
 
         def true_body():
             CNOT(wires=wires)

--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -208,8 +208,8 @@ class CVNeuralNetLayers(Operation):
                 )
             )
 
-            for i in range(len(wires)):  # pylint:disable=consider-using-enumerate
-                op_list.append(Squeezing(r[m, i], phi_r[m, i], wires=wires[i]))
+            for i, w in enumerate(wires):
+                op_list.append(Squeezing(r[m, i], phi_r[m, i], wires=w))
 
             op_list.append(
                 Interferometer(
@@ -220,11 +220,11 @@ class CVNeuralNetLayers(Operation):
                 )
             )
 
-            for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-                op_list.append(Displacement(a[m, i], phi_a[m, i], wires=wires[i]))
+            for i, w in enumerate(wires):
+                op_list.append(Displacement(a[m, i], phi_a[m, i], wires=w))
 
-            for i in range(len(wires)):  # pylint:disable=consider-using-enumerate
-                op_list.append(Kerr(k[m, i], wires=wires[i]))
+            for i, w in enumerate(wires):
+                op_list.append(Kerr(k[m, i], wires=w))
 
         return op_list
 

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -198,8 +198,8 @@ class SimplifiedTwoDesign(Operation):
         op_list = []
 
         # initial rotations
-        for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
-            op_list.append(RY(initial_layer_weights[i], wires=wires[i]))
+        for i, w in enumerate(wires):
+            op_list.append(RY(initial_layer_weights[i], wires=w))
 
         for layer in range(n_layers):
             # even layer of entanglers

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -226,18 +226,18 @@ class StronglyEntanglingLayers(Operation):
         op_list = []
 
         for l in range(n_layers):
-            for i in range(len(wires)):  # pylint: disable=consider-using-enumerate
+            for i, w in enumerate(wires):
                 op_list.append(
                     Rot(
                         weights[..., l, i, 0],
                         weights[..., l, i, 1],
                         weights[..., l, i, 2],
-                        wires=wires[i],
+                        wires=w,
                     )
                 )
 
             if len(wires) > 1:
-                for i in range(len(wires)):
+                for i, _ in enumerate(wires):
                     act_on = wires.subset([i, i + ranges[l]], periodic_boundary=True)
                     op_list.append(imprimitive(wires=act_on))
 

--- a/pennylane/templates/subroutines/fable.py
+++ b/pennylane/templates/subroutines/fable.py
@@ -227,7 +227,7 @@ def _fable_resources(wires, thetas, control_wires, tol):
         else:
             nots[wire_map[control_index]] = 1
 
-    for _ in range(len(nots.keys())):
+    for _ in nots:
         resources[resource_rep(CNOT)] += 1
 
     resources[resource_rep(SWAP)] = min(len(wires_i), len(wires_j))

--- a/pennylane/transforms/optimization/pattern_matching.py
+++ b/pennylane/transforms/optimization/pattern_matching.py
@@ -1773,4 +1773,4 @@ class TemplateSubstitution:  # pylint: disable=too-few-public-methods
             circuit_list = circuit_list + elem.circuit_config + elem.pred_block
 
         # Unmatched gates that are not predecessors of any group of matches.
-        self.unmatched_list = sorted(list(set(range(0, self.circuit_dag.size)) - set(circuit_list)))
+        self.unmatched_list = sorted(set(range(self.circuit_dag.size)) - set(circuit_list))


### PR DESCRIPTION
## Context

This PR introduces small refactoring improvements across several modules, focusing on modern Python iteration patterns and removal of redundant container constructions.

The goal is to improve readability and maintainability of the codebase while preserving full backward compatibility and behavior.

## Description of the Change

This contribution focuses on modernizing Pythonic patterns in iteration and container usage.

### 1. Replace `range(len(seq))` with `enumerate(seq)`

When both the index and element are used, `enumerate()` is used instead of manual indexing.

Example:

Old:
```python
for i in range(len(seq)): 
	x = seq[i]
	# ...
```

New:
```python
for i, x in enumerate(seq):
	# ...
```

This improves readability and reduces manual index handling. The runtime difference in CPython is typically negligible since both approaches are implemented efficiently.

### 2. Replace `sorted(list(set(x)))` with `sorted(set(x))`

Remove an unnecessary intermediate list creation step.

Old:
```python
sorted(list(set(x)))
```

New:
```python
sorted(set(x))
```

This avoids redundant memory allocation while preserving identical output behavior.

## Benefits

- Improved readability and clarity
- More idiomatic Python usage
- Removal of redundant container constructions
- Better consistency across modules
- Slight reduction in unnecessary intermediate allocations

These changes mainly improve maintainability rather than providing significant runtime performance gains.

## Possible Drawbacks

- Performance improvements are minimal and may not be measurable in most cases
- Some may prefer explicit indexing in certain contexts
- Changes are stylistic and should be evaluated for consistency with project conventions

## Related GitHub Issues

N/A

