### PR TITLE
Improve ExecutionConfig print readability

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -157,7 +157,7 @@
 
 * Calling ``print`` on :class:`~.devices.ExecutionConfig` now displays a readable multi-line
   output matching ``pprint``.
-  [(#9602)](https://github.com/PennyLaneAI/pennylane/pull/9602)
+  [(#9603)](https://github.com/PennyLaneAI/pennylane/pull/9603)
 
 * Instances of `C(Prod)` now have a significantly more efficient decomposition in terms of `TemporaryAND` operators when work wires are provided.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -155,6 +155,10 @@
   phases are purely real, i.e. :math:`\pm 1`.
   [(#9561)](https://github.com/PennyLaneAI/pennylane/pull/9561)
 
+* Calling ``print`` on :class:`~.devices.ExecutionConfig` now displays a readable multi-line
+  output matching ``pprint``.
+  [(#9602)](https://github.com/PennyLaneAI/pennylane/pull/9602)
+
 * Instances of `C(Prod)` now have a significantly more efficient decomposition in terms of `TemporaryAND` operators when work wires are provided.
 
   For example, a controlled multi-target-``X`` operation previously decomposed as

--- a/pennylane/devices/execution_config.py
+++ b/pennylane/devices/execution_config.py
@@ -21,6 +21,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pprint import pformat
 from typing import TYPE_CHECKING
 
 from pennylane.concurrency.executors.backends import ExecBackends, get_executor
@@ -242,6 +243,10 @@ class ExecutionConfig:
     """
     Defines the class for the executor backend.
     """
+
+    def __str__(self):
+        """Display the execution configuration in a readable multi-line format."""
+        return pformat(self)
 
     def __post_init__(self):
         """

--- a/pennylane/workflow/jacobian_products.py
+++ b/pennylane/workflow/jacobian_products.py
@@ -419,7 +419,7 @@ class DeviceDerivatives(JacobianProductCalculator):
     """
 
     def __repr__(self):
-        return f"<DeviceDerivatives: {self._device.name}, {self._execution_config}>"
+        return f"<DeviceDerivatives: {self._device.name}, {self._execution_config!r}>"
 
     def __init__(
         self,
@@ -668,7 +668,7 @@ class DeviceJacobianProducts(JacobianProductCalculator):
     """
 
     def __repr__(self):
-        return f"<DeviceJacobianProducts: {self._device.name}, {self._execution_config}>"
+        return f"<DeviceJacobianProducts: {self._device.name}, {self._execution_config!r}>"
 
     def __init__(self, device: qp.devices.Device, execution_config: qp.devices.ExecutionConfig):
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover

--- a/tests/devices/test_execution_config.py
+++ b/tests/devices/test_execution_config.py
@@ -17,6 +17,7 @@ Unit tests for the :class:`~pennylane.devices.ExecutionConfig` class.
 
 from copy import copy, deepcopy
 from dataclasses import replace
+from pprint import pformat
 
 import pytest
 
@@ -270,6 +271,27 @@ class TestExecutionConfig:
             mcm_config={"mcm_method": "deferred", "postselect_mode": "hw-like"},
         )
         assert isinstance(hash(config), int)
+
+    def test_str_pretty_prints_config(self):
+        """Test that printing an ExecutionConfig uses a readable multi-line format."""
+        config = ExecutionConfig()
+
+        assert str(config) == pformat(config)
+        assert str(config) != repr(config)
+        assert str(config).splitlines() == [
+            "ExecutionConfig(grad_on_execution=None,",
+            "                use_device_gradient=None,",
+            "                use_device_jacobian_product=None,",
+            "                gradient_method=None,",
+            "                gradient_keyword_arguments={},",
+            "                device_options={},",
+            "                interface=<Interface.NUMPY: 'numpy'>,",
+            "                derivative_order=1,",
+            "                mcm_config=MCMConfig(mcm_method=None, postselect_mode=None),",
+            "                convert_to_numpy=True,",
+            "                executor_backend=<class "
+            "'pennylane.concurrency.executors.native.multiproc.MPPoolExec'>)",
+        ]
 
 
 class TestMCMConfig:


### PR DESCRIPTION
# Improve readability when printing ExecutionConfig

**Context:**

`ExecutionConfig` contains enough fields that its default dataclass string representation is difficult to read when printed directly. This came up in #7007, where the current `print(config)` output is a single long line, while `pprint(config)` is much easier to scan.

**Description of the Change:**

This PR adds a custom `ExecutionConfig.__str__` implementation that delegates to `pprint.pformat(self)`. As a result, `print(config)` now produces the same readable multi-line format users previously needed to call `pprint` for explicitly.

The dataclass `repr(config)` is intentionally left unchanged. Two repr methods that embed an `ExecutionConfig`, `DeviceDerivatives.__repr__` and `DeviceJacobianProducts.__repr__`, now use `!r` explicitly so their compact one-line diagnostic output remains stable.

A regression test was added for the new `str(config)` behavior.

Focused tests run:

```text
.venv/bin/python -m pytest tests/devices/test_execution_config.py
```

Result: `62 passed, 1 warning`

```text
.venv/bin/python -m pytest tests/workflow/interfaces/test_jacobian_products.py::TestBasics::test_device_jacobians_repr tests/workflow/interfaces/test_jacobian_products.py::TestBasics::test_device_jacobian_products_repr
```

Result: `2 passed, 1 warning`

The warning is the existing pytest config warning for unknown option `rng_salt`.

**Benefits:**

`ExecutionConfig` is easier to inspect in debugging and exploratory workflows. Users can now rely on `print(config)` for readable output instead of importing and calling `pprint`.

Keeping `repr(config)` unchanged preserves compact representations where `ExecutionConfig` is embedded inside other objects or logs.

**Possible Drawbacks:**

Any code that asserted the exact output of `str(config)` will need to be updated for the new multi-line formatting. Code using `repr(config)` should be unaffected.

**AI Tool Use:**

This contribution was carefully assisted by Codex. I reviewed the codes and text before submitting and remain responsible for the contribution.

**Related GitHub Issues:**

Fixes #7007.
