### PR TITLE
Improve assert_equal messages for measurements

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -139,7 +139,7 @@
 
 * :func:`~.assert_equal` now provides informative error messages when comparing
   unequal measurement processes.
-  [(#7354)](https://github.com/PennyLaneAI/pennylane/issues/7354)
+  [(#9605)](https://github.com/PennyLaneAI/pennylane/pull/9605)
 
 * `Tracker` now has a readable `__repr__` that displays all relevant internals
   (`active`, `totals`, `history`, `latest`, `persistent`, `callback`).

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -137,6 +137,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* :func:`~.assert_equal` now provides informative error messages when comparing
+  unequal measurement processes.
+  [(#7354)](https://github.com/PennyLaneAI/pennylane/issues/7354)
+
 * `Tracker` now has a readable `__repr__` that displays all relevant internals
   (`active`, `totals`, `history`, `latest`, `persistent`, `callback`).
   [(#9575)](https://github.com/PennyLaneAI/pennylane/pull/9575)

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -759,7 +759,12 @@ def _equal_conditional(op1: Conditional, op2: Conditional, **kwargs):
 @_equal_dispatch.register
 def _equal_measurement_value(op1: MeasurementValue, op2: MeasurementValue, **kwargs):
     """Determine whether two MeasurementValue objects are equal"""
-    return op1.measurements == op2.measurements
+    if op1.measurements != op2.measurements:
+        return (
+            "op1 and op2 have different measurements. "
+            f"Got {op1.measurements} and {op2.measurements}."
+        )
+    return True
 
 
 @_equal_dispatch.register
@@ -885,7 +890,7 @@ def _equal_measurements(
     """Determine whether two MeasurementProcess objects are equal"""
 
     if op1.obs is not None and op2.obs is not None:
-        return equal(
+        obs_equal_check = _equal(
             op1.obs,
             op2.obs,
             check_interface=check_interface,
@@ -893,45 +898,96 @@ def _equal_measurements(
             rtol=rtol,
             atol=atol,
         )
+        if isinstance(obs_equal_check, str):
+            return f"op1 and op2 have different observables because {obs_equal_check}"
+        return True
 
     if op1.mv is not None and op2.mv is not None:
         if isinstance(op1.mv, MeasurementValue) and isinstance(op2.mv, MeasurementValue):
-            return qp.equal(op1.mv, op2.mv)
+            mv_equal_check = _equal(
+                op1.mv,
+                op2.mv,
+                check_interface=check_interface,
+                check_trainability=check_trainability,
+                rtol=rtol,
+                atol=atol,
+            )
+            if isinstance(mv_equal_check, str):
+                return f"op1 and op2 have different measurement values because {mv_equal_check}"
+            return True
 
         if math.is_abstract(op1.mv) or math.is_abstract(op2.mv):
-            return op1.mv is op2.mv
+            if op1.mv is not op2.mv:
+                return "op1 and op2 have different abstract measurement values."
+            return True
 
         if isinstance(op1.mv, Iterable) and isinstance(op2.mv, Iterable):
-            if len(op1.mv) == len(op2.mv):
-                return all(
-                    mv1.measurements == mv2.measurements
-                    for mv1, mv2 in zip(op1.mv, op2.mv, strict=True)
+            if len(op1.mv) != len(op2.mv):
+                return (
+                    "op1 and op2 collect different numbers of measurement values. "
+                    f"Got {len(op1.mv)} and {len(op2.mv)}."
                 )
 
-        return False
+            for i, (mv1, mv2) in enumerate(zip(op1.mv, op2.mv, strict=True)):
+                if mv1.measurements != mv2.measurements:
+                    return (
+                        f"op1 and op2 have different measurement values at index {i}. "
+                        f"Got measurements {mv1.measurements} and {mv2.measurements}."
+                    )
+
+            return True
+
+        return (
+            "op1 and op2 have incompatible measurement values. "
+            f"Got {op1.mv} and {op2.mv}."
+        )
+
+    if op1.mv is not None or op2.mv is not None:
+        return (
+            "Only one measurement process has a measurement value. "
+            f"Got {op1.mv} and {op2.mv}."
+        )
 
     if op1.wires != op2.wires:
-        return False
+        return f"op1 and op2 have different wires. Got {op1.wires} and {op2.wires}."
 
     if op1.obs is None and op2.obs is None:
         # only compare eigvals if both observables are None.
         # Can be expensive to compute for large observables
-        if op1.eigvals() is not None and op2.eigvals() is not None:
-            return math.allclose(op1.eigvals(), op2.eigvals(), rtol=rtol, atol=atol)
+        op1_eigvals = op1.eigvals()
+        op2_eigvals = op2.eigvals()
+        if op1_eigvals is not None and op2_eigvals is not None:
+            if not math.allclose(op1_eigvals, op2_eigvals, rtol=rtol, atol=atol):
+                return (
+                    "op1 and op2 have different eigenvalues. "
+                    f"Got {op1_eigvals} and {op2_eigvals}."
+                )
+            return True
 
-        return op1.eigvals() is None and op2.eigvals() is None
+        if op1_eigvals is not None or op2_eigvals is not None:
+            return (
+                "op1 and op2 have different eigenvalues. "
+                f"Got {op1_eigvals} and {op2_eigvals}."
+            )
+        return True
 
-    return False
+    return f"Only one measurement process has an observable. Got {op1.obs} and {op2.obs}."
 
 
 @_equal_dispatch.register
 def _equal_mid_measure(op1: MidMeasure, op2: MidMeasure, **_):
-    return (
-        op1.wires == op2.wires
-        and op1.meas_uid == op2.meas_uid
-        and op1.reset == op2.reset
-        and op1.postselect == op2.postselect
-    )
+    if op1.wires != op2.wires:
+        return f"op1 and op2 have different wires. Got {op1.wires} and {op2.wires}."
+    if op1.meas_uid != op2.meas_uid:
+        return f"op1 and op2 have different identifiers. Got {op1.meas_uid} and {op2.meas_uid}."
+    if op1.reset != op2.reset:
+        return f"op1 and op2 have different reset values. Got {op1.reset} and {op2.reset}."
+    if op1.postselect != op2.postselect:
+        return (
+            "op1 and op2 have different postselect values. "
+            f"Got {op1.postselect} and {op2.postselect}."
+        )
+    return True
 
 
 @_equal_dispatch.register
@@ -951,41 +1007,71 @@ def _equal_pauli_measure(op1: PauliMeasure, op2: PauliMeasure, **_):
 def _(op1: VnEntropyMP, op2: VnEntropyMP, **kwargs):
     """Determine whether two MeasurementProcess objects are equal"""
     eq_m = _equal_measurements(op1, op2, **kwargs)
-    log_base_match = op1.log_base == op2.log_base
-    return eq_m and log_base_match
+    if isinstance(eq_m, str):
+        return eq_m
+    if op1.log_base != op2.log_base:
+        return f"op1 and op2 have different log bases. Got {op1.log_base} and {op2.log_base}."
+    return True
 
 
 @_equal_dispatch.register
 def _(op1: MutualInfoMP, op2: MutualInfoMP, **kwargs):
     """Determine whether two MeasurementProcess objects are equal"""
     eq_m = _equal_measurements(op1, op2, **kwargs)
-    log_base_match = op1.log_base == op2.log_base
-    return eq_m and log_base_match
+    if isinstance(eq_m, str):
+        return eq_m
+    if op1.log_base != op2.log_base:
+        return f"op1 and op2 have different log bases. Got {op1.log_base} and {op2.log_base}."
+    return True
 
 
 @_equal_dispatch.register
-def _equal_shadow_measurements(op1: ShadowExpvalMP, op2: ShadowExpvalMP, **_):
+def _equal_shadow_measurements(op1: ShadowExpvalMP, op2: ShadowExpvalMP, **kwargs):
     """Determine whether two ShadowExpvalMP objects are equal"""
 
-    wires_match = op1.wires == op2.wires
+    if op1.wires != op2.wires:
+        return f"op1 and op2 have different wires. Got {op1.wires} and {op2.wires}."
 
     if isinstance(op1.H, Operator) and isinstance(op2.H, Operator):
-        H_match = equal(op1.H, op2.H)
+        H_equal_check = _equal(op1.H, op2.H, **kwargs)
+        if isinstance(H_equal_check, str):
+            return f"op1 and op2 have different H observables because {H_equal_check}"
     elif isinstance(op1.H, Iterable) and isinstance(op2.H, Iterable):
         if len(op1.H) != len(op2.H):
-            return False
-        H_match = all(equal(o1, o2) for o1, o2 in zip(op1.H, op2.H, strict=True))
+            return (
+                "op1 and op2 have different numbers of H observables. "
+                f"Got {len(op1.H)} and {len(op2.H)}."
+            )
+        for i, (o1, o2) in enumerate(zip(op1.H, op2.H, strict=True)):
+            H_equal_check = _equal(o1, o2, **kwargs)
+            if isinstance(H_equal_check, str):
+                return (
+                    f"op1 and op2 have different H observables at index {i} "
+                    f"because {H_equal_check}"
+                )
     else:
-        return False
+        return (
+            "op1 and op2 have incompatible H observable types. "
+            f"Got {type(op1.H)} and {type(op2.H)}."
+        )
 
-    k_match = op1.k == op2.k
+    if op1.k != op2.k:
+        return f"op1 and op2 have different k values. Got {op1.k} and {op2.k}."
 
-    return wires_match and H_match and k_match
+    return True
 
 
 @_equal_dispatch.register
 def _equal_counts(op1: CountsMP, op2: CountsMP, **kwargs):
-    return _equal_measurements(op1, op2, **kwargs) and op1.all_outcomes == op2.all_outcomes
+    eq_m = _equal_measurements(op1, op2, **kwargs)
+    if isinstance(eq_m, str):
+        return eq_m
+    if op1.all_outcomes != op2.all_outcomes:
+        return (
+            "op1 and op2 have different all_outcomes values. "
+            f"Got {op1.all_outcomes} and {op2.all_outcomes}."
+        )
+    return True
 
 
 @_equal_dispatch.register

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1801,6 +1801,71 @@ class TestMeasurementsEqual:
         m2 = qp.shadow_expval(H=[op])
         assert qp.equal(m1, m2) is False
 
+    @pytest.mark.parametrize(
+        "op1, op2, match",
+        [
+            (
+                qp.expval(qp.Z(0)),
+                qp.expval(qp.X(0)),
+                "different observables because op1 and op2 are of different types",
+            ),
+            (
+                qp.expval(qp.X(1)),
+                qp.expval(qp.X(0)),
+                "different observables because op1 and op2 have different wires",
+            ),
+            (
+                qp.probs(wires=0),
+                qp.probs(wires=1),
+                "op1 and op2 have different wires",
+            ),
+            (
+                ProbabilityMP(eigvals=(1, 1e-3)),
+                ProbabilityMP(eigvals=(1, 0)),
+                "op1 and op2 have different eigenvalues",
+            ),
+            (
+                qp.shadow_expval(qp.X(0)),
+                qp.shadow_expval([qp.X(0)]),
+                "op1 and op2 have incompatible H observable types",
+            ),
+            (
+                qp.shadow_expval([qp.X(0)]),
+                qp.shadow_expval([qp.Z(0)]),
+                "op1 and op2 have different H observables at index 0",
+            ),
+            (
+                qp.counts(wires=0, all_outcomes=True),
+                qp.counts(wires=0, all_outcomes=False),
+                "op1 and op2 have different all_outcomes values",
+            ),
+            (
+                qp.vn_entropy(wires=0, log_base=2),
+                qp.vn_entropy(wires=0, log_base=None),
+                "op1 and op2 have different log bases",
+            ),
+            (
+                qp.mutual_info(wires0=0, wires1=1, log_base=2),
+                qp.mutual_info(wires0=0, wires1=1, log_base=None),
+                "op1 and op2 have different log bases",
+            ),
+        ],
+    )
+    def test_assert_equal_measurement_process_error_messages(self, op1, op2, match):
+        """Test that assert_equal gives informative errors for measurement processes."""
+        assert qp.equal(op1, op2) is False
+        with pytest.raises(AssertionError, match=match):
+            qp.assert_equal(op1, op2)
+
+    def test_assert_equal_measurement_value_error_message(self):
+        """Test that assert_equal gives informative errors for mid-circuit measurement values."""
+        m1 = qp.measure(0)
+        m2 = qp.measure(1)
+
+        assert qp.equal(m1, m2) is False
+        with pytest.raises(AssertionError, match="op1 and op2 have different measurements"):
+            qp.assert_equal(m1, m2)
+
 
 def test_unsupported_object_type_not_implemented():
     dev = qp.device("default.qubit", wires=1)


### PR DESCRIPTION

**Summary:**

`qml.assert_equal` is intended to explain why two PennyLane objects differ. For measurement processes, several comparison paths still returned plain `False`, which caused fallback errors such as:

```text
expval(Z(0)) and expval(X(0)) are not equal for an unspecified reason.
```

Issue #7354 requests that measurement-process `_equal_dispatch` implementations return useful error strings instead of `True`/`False` only.

Previous PR attempts for this issue were closed without merging, mostly due to staleness, unrelated changes, or missing tests/changelog coverage. This PR keeps the scope limited to measurement equality diagnostics.

**Description of the Change:**

This PR updates measurement-related equality dispatchers to return explanatory mismatch strings for `qml.assert_equal`, while preserving the public boolean behavior of `qml.equal`.

The updated paths include:

- Measurement-process observable mismatches, e.g. `expval(Z(0))` vs `expval(X(0))`.
- Measurement-process wire mismatches.
- Mid-circuit `MeasurementValue` mismatches.
- Measurement-value lists used by sample/probs/counts.
- Eigenvalue mismatches.
- `VnEntropyMP` and `MutualInfoMP` log-base mismatches.
- `ShadowExpvalMP` `H`, wire, and `k` mismatches.
- `CountsMP.all_outcomes` mismatches.

For example:

```python
qml.assert_equal(qml.expval(qml.Z(0)), qml.expval(qml.X(0)))
```

now raises:

```text
AssertionError: op1 and op2 have different observables because op1 and op2 are of different types. Got <class 'pennylane.ops.qubit.non_parametric_ops.PauliZ'> and <class 'pennylane.ops.qubit.non_parametric_ops.PauliX'>.
```

Focused tests run:

```text
MPLCONFIGDIR=/private/tmp/mpl .venv/bin/python -m pytest tests/ops/functions/test_equal.py -q
```

Result: `2455 passed, 2 warnings`

The warnings were an existing `autoray` runtime warning and the existing pytest config warning for unknown option `rng_salt`.

**Benefits:**

Users and contributors get actionable assertion failures when measurement objects are unequal, which is especially useful for tests involving measurements, mid-circuit measurements, and classical shadows.

**Possible Drawbacks:**

Exact `AssertionError` messages for unequal measurement processes change from the generic fallback to specific diagnostics. Code asserting the old generic text will need to update its expected message.

**AI Tool Use:**

This contribution was carefully assisted by Codex. I reviewed the generated code and text before submitting and remain responsible for the contribution.

**Related GitHub Issues:**

Fixes #7354.
