### PR TITLE
fix: bump `codecov-action` to `v7` to fix GPG key verification

### DIFF
--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -739,7 +739,7 @@ jobs:
         uses: actions/download-artifact@v8
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true  # upload errors should be caught early

--- a/.github/workflows/interface-unit-tests.yml
+++ b/.github/workflows/interface-unit-tests.yml
@@ -739,7 +739,7 @@ jobs:
         uses: actions/download-artifact@v8
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true  # upload errors should be caught early

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -411,7 +411,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Bump `codecov-action` to `v6`.
+* Bump `codecov-action` to `v7`.
   [(#9615)](https://github.com/PennyLaneAI/pennylane/pull/9615)
 
 * :func:`~.parameter_frequencies` added that allows a user to retrieve `parameter_frequencies` from an

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -411,6 +411,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Bump `codecov-action` to `v6`.
+  [(#9615)](https://github.com/PennyLaneAI/pennylane/pull/9615)
+
 * :func:`~.parameter_frequencies` added that allows a user to retrieve `parameter_frequencies` from an
   :class:`~.Operation` or calculate them for an :class:`~.Operator2`.
   [(#9569)](https://github.com/PennyLaneAI/pennylane/pull/9569)


### PR DESCRIPTION
**Context:**

Encountering signature verification issues in our upload to codecov workflow which hardblocks any merges to `main`.

Looking at https://github.com/codecov/codecov-action/issues/1956 , it seems that the solution is bumping our version to v7.

**Description of the Change:**

Bumps our `codecov-action` workflow to `v7` (latest)

**Benefits:** CI is unblocked

**Possible Drawbacks:** None identified
