### PR TITLE
lazily dispatch adjoint and ctrl of functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -516,6 +516,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
+  [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 
 * Fixed a bug in `change_op_basis` where `TypeError` raised within the body of callable inputs were
   accidentally being masked by internal try/except logic.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -515,6 +515,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
+
 * Fixed a bug in `change_op_basis` where `TypeError` raised within the body of callable inputs were
   accidentally being masked by internal try/except logic.
   [(#9552)](https://github.com/PennyLaneAI/pennylane/pull/9552)

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -184,8 +184,6 @@ def create_adjoint_op(fn, lazy):
     if isinstance(fn, Operator):
         return Adjoint(fn) if lazy else _single_op_eager(fn, update_queue=True)
     if callable(fn):
-        if qp.capture.enabled():
-            return _capture_adjoint_transform(fn, lazy=lazy)
         return _adjoint_transform(fn, lazy=lazy)
     if fn is None:
         raise ValueError(
@@ -259,6 +257,9 @@ def _adjoint_transform(qfunc: Callable, lazy=True) -> Callable:
     # default adjoint transform when capture is not enabled.
     @wraps(qfunc)
     def wrapper(*args, **kwargs):
+        if qp.capture.enabled():
+            return _capture_adjoint_transform(qfunc, lazy=lazy)(*args, **kwargs)
+
         qscript = qp.tape.make_qscript(qfunc)(*args, **kwargs)
 
         leaves, _ = qp.pytrees.flatten((args, kwargs), lambda obj: isinstance(obj, Operator))

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -254,14 +254,15 @@ def create_controlled_op(
             "This error might occur if you apply ctrl to a list "
             "of operations instead of a function or Operator."
         )
-    if qp.capture.enabled():
-        return _capture_ctrl_transform(op, control, control_values, work_wires)
     return _ctrl_transform(op, control, control_values, work_wires)
 
 
 def _ctrl_transform(op, control, control_values, work_wires):
     @wraps(op)
     def wrapper(*args, **kwargs):
+        if qp.capture.enabled():
+            return _capture_ctrl_transform(op, control, control_values, work_wires)(*args, **kwargs)
+
         qscript = qp.tape.make_qscript(op)(*args, **kwargs)
 
         leaves, _ = qp.pytrees.flatten((args, kwargs), lambda obj: isinstance(obj, Operator))

--- a/tests/capture/test_nested_plxpr.py
+++ b/tests/capture/test_nested_plxpr.py
@@ -32,6 +32,19 @@ from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 class TestAdjointQfunc:
     """Tests for the adjoint transform."""
 
+    def test_lazy_dispatch(self):
+        """Test that the dispatch to capture happens at call time."""
+
+        qp.capture.disable()
+
+        adj_qfunc = qp.adjoint(qp.S)
+
+        qp.capture.enable()
+
+        jaxpr = jax.make_jaxpr(adj_qfunc)(0)
+        assert jaxpr.eqns[0].primitive == adjoint_transform_prim
+        assert jaxpr.eqns[0].params["jaxpr"].eqns[0].primitive == qp.S._primitive
+
     def test_adjoint_qfunc(self):
         """Test that the adjoint qfunc transform can be captured."""
 
@@ -284,6 +297,20 @@ class TestAdjointDynamicShapes:
 
 class TestCtrlQfunc:
     """Tests for the ctrl primitive."""
+
+    def test_lazy_dispatch_ctrl(self):
+        """Test that the dispatch to capture happens at call time."""
+
+        qp.capture.disable()
+
+        adj_qfunc = qp.ctrl(qp.S, 1)
+
+        qp.capture.enable()
+
+        jaxpr = jax.make_jaxpr(adj_qfunc)(0)
+        assert jaxpr.eqns[0].primitive == ctrl_transform_prim
+        assert jaxpr.eqns[0].invars[1].val == 1
+        assert jaxpr.eqns[0].params["jaxpr"].eqns[0].primitive == qp.S._primitive
 
     def test_operator_type_input(self):
         """Test that an operator type can be the callable."""


### PR DESCRIPTION

**Context:**

[sc-121641]

Bug reported for:
```
gate = qp.adjoint(qp.S)

@qp.qjit(capture=True, target="mlir")
@qp.qnode(qp.device("lightning.qubit", wires=1))
def test_circ():
    gate(0)
    return qp.expval(qp.Z(0))
print(test_circ.mlir)
```

We need to lazily dispatch capturing the adjoint of a function.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
