### PR TITLE
fix: update `core/__init__.py` to include `Operator2` and `StatePrepBase2`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -438,6 +438,7 @@
   [(#9527)](https://github.com/PennyLaneAI/pennylane/pull/9527)
   [(#9562)](https://github.com/PennyLaneAI/pennylane/pull/9562)
   [(#9607)](https://github.com/PennyLaneAI/pennylane/pull/9607)
+  [(#9627)](https://github.com/PennyLaneAI/pennylane/pull/9627)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/core/__init__.py
+++ b/pennylane/core/__init__.py
@@ -35,10 +35,20 @@ Operator Types
 
 """
 
-from .operator import Operator, Operation, Channel, CV, CVOperation, CVObservable, StatePrepBase
+from .operator import (
+    CV,
+    Channel,
+    CVObservable,
+    CVOperation,
+    Operation,
+    Operator,
+    Operator2,
+    StatePrepBase,
+)
 
 __all__ = [
     "Operator",
+    "Operator2",
     "Operation",
     "Channel",
     "CV",

--- a/pennylane/core/__init__.py
+++ b/pennylane/core/__init__.py
@@ -44,6 +44,7 @@ from .operator import (
     Operator,
     Operator2,
     StatePrepBase,
+    StatePrepBase2,
 )
 
 __all__ = [
@@ -55,4 +56,5 @@ __all__ = [
     "CVOperation",
     "CVObservable",
     "StatePrepBase",
+    "StatePrepBase2",
 ]

--- a/pennylane/core/operator/__init__.py
+++ b/pennylane/core/operator/__init__.py
@@ -182,7 +182,7 @@ these objects are located in ``pennylane.ops.qubit.attributes``, not ``pennylane
 """
 
 from .base import Operator, Operation
-from .operator2 import Operator2
+from .operator2 import Operator2, StatePrepBase2
 from .channel import Channel
 from .cv import CV, CVObservable, CVOperation
 from .state_prep import StatePrepBase
@@ -196,4 +196,5 @@ __all__ = [
     "CVObservable",
     "CVOperation",
     "StatePrepBase",
+    "StatePrepBase2",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -342,7 +342,7 @@ path = "pennylane.core.operator"
 cannot_depend_on = ["pennylane.ftqc", "pennylane.labs"]
 
 [[interfaces]]
-expose = ["Operator", "Operator2", "Operation", "CV", "CVObservable", "CVOperation", "Channel", "StatePrepBase"]
+expose = ["Operator", "Operator2", "Operation", "CV", "CVObservable", "CVOperation", "Channel", "StatePrepBase", "StatePrepBase2"]
 from = ["pennylane.core.operator"]
 
 [[modules]]


### PR DESCRIPTION
**Context:**

@mudit2812 noticed that we cannot import `Operator2/StatePrepBase2` from `qp.core`. This PR fixes that.
