### PR TITLE
RS decomp no longer queries cond operator in catalyst for static predicates

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,7 +230,7 @@
 * The Ross-Selinger decomposition method :func:`~.ops.rs_decomposition` when used Catalyst no longer
   queues a Catalyst conditional operator when the conditional predicate is static. Instead, the
   static conditional will be evaluated at trace time, and only the correct branch will be queued.
-  [(#????)](https://github.com/PennyLaneAI/pennylane/pull/????)
+  [(#9630)](https://github.com/PennyLaneAI/pennylane/pull/9630)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,10 +151,10 @@
   >>> tracker.update(a=2, b="b2", c=1)
   >>> print(tracker)
   Tracker(active=False, totals={'a': 2, 'c': 1}, history={'a': [2], 'b': ['b2'], 'c': [1]}, latest={'a': 2, 'b': 'b2', 'c': 1}, persistent=False, callback=None)
-  
+
   ```
 
-* Updated the preprocessing of target state vectors for `MottonenStatePreparation` and 
+* Updated the preprocessing of target state vectors for `MottonenStatePreparation` and
   `MultiplexerStatePreparation` to produce only `RY` rotation angles for real target state vectors
   that contain negative signs. This allows the preparation circuits to skip phase gates when the
   phases are purely real, i.e. :math:`\pm 1`.
@@ -227,11 +227,16 @@
   now formatted for clearer visual inspection when used in a Jupyter notebook environment.
   [(#9518)](https://github.com/PennyLaneAI/pennylane/pull/9518)
 
+* The Ross-Selinger decomposition method :func:`~.ops.rs_decomposition` when used Catalyst no longer
+  queues a Catalyst conditional operator when the conditional predicate is static. Instead, the
+  static conditional will be evaluated at trace time, and only the correct branch will be queued.
+  [(#????)](https://github.com/PennyLaneAI/pennylane/pull/????)
+
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
 * Added a variant of `SumOfSlatersPrep` to labs, accessible as `labs.templates.SumOfSlatersPrep2`.
   This variant handles work wires explicitly instead of allocating them dynamically in the
-  decomposition. This enables usage of `SumOfSlatersPrep2` with `qp.qjit` with 
+  decomposition. This enables usage of `SumOfSlatersPrep2` with `qp.qjit` with
   capture _disabled_ (`qp.capture.disable()`).
   [(#9539)](https://github.com/PennyLaneAI/pennylane/pull/9539)
 
@@ -510,7 +515,7 @@
 * Added examples to the documentation for the :class:`~.CNOT`, :class:`~.Toffoli`, and :class:`~.CCZ` operators.
   [(#9555)](https://github.com/PennyLaneAI/pennylane/pull/9555)
 
-* Clarified the documentation for the :class:`~.QNode` to apply to more than just variational circuits. 
+* Clarified the documentation for the :class:`~.QNode` to apply to more than just variational circuits.
   [(#9599)](https://github.com/PennyLaneAI/pennylane/pull/9599)
 
 <h3>Bug fixes 🐛</h3>
@@ -562,7 +567,7 @@
   ``compiler.active()`` is ``True``. Both ``two_qubit_decomposition`` and
   ``two_qubit_decomp_rule`` are fixed.
   [(#9520)](https://github.com/PennyLaneAI/pennylane/pull/9520)
-  
+
 * Fixed a bug in the :mod:`~.pennylane.qchem.vibrational` submodule to properly account for the number of modes.
   [(#9522)](https://github.com/PennyLaneAI/pennylane/pull/9522)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -228,8 +228,9 @@
   [(#9518)](https://github.com/PennyLaneAI/pennylane/pull/9518)
 
 * The Ross-Selinger decomposition method :func:`~.ops.rs_decomposition` when used Catalyst no longer
-  queues a Catalyst conditional operator when the conditional predicate is static. Instead, the
-  static conditional will be evaluated at trace time, and only the correct branch will be queued.
+  queues a Catalyst conditional operator when the conditional predicate for whether a leading T gate
+  exists is static. Instead, the static conditional will be evaluated at trace time, and only the
+  correct branch will be queued.
   [(#9630)](https://github.com/PennyLaneAI/pennylane/pull/9630)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -227,10 +227,10 @@
   now formatted for clearer visual inspection when used in a Jupyter notebook environment.
   [(#9518)](https://github.com/PennyLaneAI/pennylane/pull/9518)
 
-* The Ross-Selinger decomposition method :func:`~.ops.rs_decomposition` when used Catalyst no longer
-  queues a Catalyst conditional operator when the conditional predicate for whether a leading T gate
-  exists is static. Instead, the static conditional will be evaluated at trace time, and only the
-  correct branch will be queued.
+* The Ross-Selinger decomposition method :func:`~.ops.rs_decomposition` when used with Catalyst
+  no longer queues a Catalyst conditional operator, if the conditional predicate for whether a
+  leading T gate exists is statically known. Instead, the static conditional will be evaluated at
+  trace time, and only the correct branch will be queued.
   [(#9630)](https://github.com/PennyLaneAI/pennylane/pull/9630)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>

--- a/pennylane/ops/op_math/decompositions/ross_selinger.py
+++ b/pennylane/ops/op_math/decompositions/ross_selinger.py
@@ -150,7 +150,8 @@ def _jit_rs_decomposition(wire, decomposition_info):
     # Optional leading T gate
     leading_t_cond = qp.cond(has_leading_t, qp.T)
     leading_t_cond(wire)
-    ops.append(leading_t_cond.operation)
+    if qp.math.is_abstract(has_leading_t):
+        ops.append(leading_t_cond.operation)
 
     active_jit = active_compiler()
     compilers = AvailableCompilers.names_entrypoints


### PR DESCRIPTION
**Context:**
Recently Catalyst [started evaluating static conditionals at tracing time in legacy path](https://github.com/PennyLaneAI/catalyst/pull/2912). This means in cases where the conditional predicate is static, only the correct branch will be taken, and no catalyst `cond` operators will be traced.

In RS decomp, there is one place where the catalyst `cond` operator was unconditionally queried and queued into a new tape. 

**Description of the Change:**
Only query the catalyst `cond` operator when the predicate is not static.

**Benefits:**
Unblocks work by fixing a test.
