### PR TITLE
fix(math): track state_indices across iterations in partial trace for multiple wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -549,6 +549,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug in _batched_partial_trace_nonrep_indices where state_indices was reset
+  to its initial value on each iteration of the wire-tracing loop, causing incorrect einsum index
+  mappings when tracing out multiple wires. The fix tracks state_indices across iterations.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
   [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 

--- a/pennylane/math/quantum.py
+++ b/pennylane/math/quantum.py
@@ -341,10 +341,10 @@ def _batched_partial_trace_nonrep_indices(matrix, is_batched, indices, batch_dim
 
     kraus = math.convert_like(kraus, matrix)
     kraus_dagger = math.convert_like(kraus_dagger, matrix)
+    # Tensor indices of density matrix (tracked across iterations)
+    state_indices = ascii_letters[1 : rho_dim + 1]
     # For loop over wires
     for target_wire in indices:
-        # Tensor indices of density matrix
-        state_indices = ascii_letters[1 : rho_dim + 1]
         # row indices of the quantum state affected by this operation
         row_wires_list = [target_wire + 1]
         row_indices = "".join(ascii_letter_arr[row_wires_list].tolist())
@@ -373,6 +373,7 @@ def _batched_partial_trace_nonrep_indices(matrix, is_batched, indices, batch_dim
             f"{kraus_index}{col_indices}{new_col_indices}->a{new_state_indices}"
         )
         matrix = math.einsum(einsum_indices, kraus, matrix, kraus_dagger)
+        state_indices = new_state_indices
 
     number_wires_sub = num_indices - len(indices)
     reduced_density_matrix = np.reshape(


### PR DESCRIPTION
### Context

The `_batched_partial_trace_nonrep_indices` function in `pennylane/math/quantum.py` contains a bug where `state_indices` is reset to its initial value on each iteration of the wire-tracing loop. When tracing out multiple wires, this causes incorrect einsum index mappings after the first wire is traced, because the tensor's index structure has changed but the code still references the original index letters.

### Description of the Change

Move `state_indices = ascii_letters[1 : rho_dim + 1]` from inside the for-loop to before the loop, and add `state_indices = new_state_indices` after each einsum contraction to track the updated tensor index structure across iterations.

**Before (buggy):**
```python
for target_wire in indices:
    state_indices = ascii_letters[1 : rho_dim + 1]  # reset every iteration!
    ...
    matrix = math.einsum(einsum_indices, kraus, matrix, kraus_dagger)
```

**After (fixed):**
```python
state_indices = ascii_letters[1 : rho_dim + 1]
for target_wire in indices:
    ...
    matrix = math.einsum(einsum_indices, kraus, matrix, kraus_dagger)
    state_indices = new_state_indices  # track updated indices
```

### Benefits

- Correct partial trace computation when tracing out 2 or more wires
- The single-wire case is unaffected (loop runs once)
- Minimal change (2 lines moved, 1 line added)

### Possible Drawbacks

None. This is a local fix within an internal helper function. All existing tests for `partial_trace` (including `test_partial_trace_over_all_wires`) should continue to pass, as the bug only manifests in specific multi-wire tracing scenarios not currently covered by tests.

### Related GitHub Issues

N/A (found by automated bug detection)

---

🤖 Assisted-by: Claude Code