### PR TITLE
fix(devices): use total_shots for MCM shot-by-shot loop iteration

### DIFF
--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -260,7 +260,7 @@ class QubitDevice(Device):
             # and hence we update `self.shots` temporarily for this loop
             shots_copy = self.shots
             self.shots = 1
-            for _ in circuit.shots:
+            for _ in range(circuit.shots.total_shots):
                 kwargs["mid_measurements"] = {}
                 self.reset()
                 results.append(self.execute(aux_circ, **kwargs))


### PR DESCRIPTION
### Context

When a circuit contains mid-circuit measurements and uses a shot vector
(e.g. `shots=[100, 200]`), `QubitDevice.execute()` runs the circuit
shot-by-shot. The loop `for _ in circuit.shots` delegates to
`Shots.__iter__`, which for shot vectors yields per-copy shot counts
rather than individual shots. For `[100, 200]` this produces 2
iterations instead of 300.

### Description of the Change

Change `for _ in circuit.shots` to `for _ in range(circuit.shots.total_shots)`.

### Benefits

- Correct MCM simulation results when using shot vectors
- No change in behavior for integer shot counts

### Possible Drawbacks

None. For integer shots, `range(Shots.total_shots)` produces the same
number of iterations as iterating the Shots object directly.