### PR TITLE
[Labs] Registers2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/gitleaks/gitleaks
-    rev: v8.28.0
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         name: "🔒 gitleaks · Detect hardcoded secrets"
 -   repo: https://github.com/psf/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
     - id: black
       name: "🐍 black · Format code"
@@ -15,7 +15,7 @@ repos:
             ]
       exclude: ^doc/
 -   repo: https://github.com/PyCQA/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
     - id: isort
       name: "🐍 isort · Sort imports"
@@ -31,7 +31,7 @@ repos:
     -   id: tach
         name: "🐍 tach · Check module dependencies"
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         name: "🐍 pyupgrade · Check language features"

--- a/pennylane/labs/registers/__init__.py
+++ b/pennylane/labs/registers/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+This subpackage contains experimental registers
+
+.. currentmodule:: pennylane.labs.registers
+
+Registers
+~~~~~~~~~~
+
+.. autosummary::
+    :toctree: api
+
+    ~registers
+
+"""
+
+from .registers import registers

--- a/pennylane/labs/registers/registers.py
+++ b/pennylane/labs/registers/registers.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A drop-in, extended replacement for ``qp.registers``
+
+The stock ``qml.registers`` returns a plain ``dict[str, Wires]``. This subclass
+preserves that exact behaviour/return value but adds wire-reindexing arithmetic:
+``reg1 + reg2`` concatenates the two register sets, offsetting the second set's
+integer wire labels so they don't collide with the first.
+
+Register-name clashes (the same key in both operands) are resolved rather than
+blindly offset; see ``__add__`` for the rules.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pennylane as qml
+from pennylane.wires import Wires
+
+
+class registers(dict):
+    """``dict[str, Wires]`` produced like ``qml.registers`` plus concatenation.
+
+    Parameters
+    ----------
+    register_dict : dict | None
+        Same as ``qml.registers``: name -> int (n wires) or nested dict. May also
+        be an already-built name -> ``Wires`` mapping (used internally).
+    verbose : bool
+        If ``True`` (default), emit a ``UserWarning`` when a name clash is resolved
+        by merging differing-but-same-size wire sets.
+    """
+
+    def __init__(self, register_dict=None, verbose: bool = True):
+        self.verbose = verbose
+        if register_dict is None:
+            super().__init__()
+        elif isinstance(register_dict, dict) and all(
+            isinstance(v, Wires) for v in register_dict.values()
+        ):
+            # Already a mapping of name -> Wires (e.g. produced internally by __add__).
+            super().__init__(register_dict)
+        elif isinstance(register_dict, dict):
+            # Spec dict (int / nested dict values): defer to PennyLane for the
+            # canonical flattening / nesting semantics.
+            super().__init__(qml.registers(register_dict))
+        else:
+            raise ValueError(f"Expected a dict, got {type(register_dict).__name__}.")
+
+    # -- helpers --------------------------------------------------------------
+    @property
+    def n_wires(self) -> int:
+        """Number of distinct wires spanned by this register set."""
+        return len({l for w in self.values() for l in w.labels})
+
+    def _offset(self) -> int:
+        """Smallest non-negative offset that clears all existing int labels."""
+        int_labels = [l for w in self.values() for l in w.labels if isinstance(l, int)]
+        return (max(int_labels) + 1) if int_labels else 0
+
+    @staticmethod
+    def _labels(wires) -> set:
+        return set(wires.labels)
+
+    # -- clash resolution -----------------------------------------------------
+    def _resolve_clash(self, name, existing, incoming, others: set):
+        """Resolve a register-name clash on ``name``.
+
+        ``existing`` = self[name], ``incoming`` = other[name] (both raw, un-offset).
+        ``others`` is the set of wire labels used by every *other* register in the
+        merged result. Returns the chosen ``Wires`` (or ``None`` to drop the key,
+        which only happens when an identical entry already exists).
+        """
+        if len(existing) != len(incoming):
+            raise ValueError(
+                f"Register {name!r} clashes with different sizes "
+                f"({len(existing)} vs {len(incoming)}); refusing to merge."
+            )
+
+        if self._labels(existing) == self._labels(incoming):
+            return existing  # identical -> keep one, drop the duplicate silently
+
+        # Same size, different wires: keep whichever does not collide with the rest.
+        e_ok = self._labels(existing).isdisjoint(others)
+        i_ok = self._labels(incoming).isdisjoint(others)
+
+        if e_ok and not i_ok:
+            chosen = existing
+        elif i_ok and not e_ok:
+            chosen = incoming
+        elif e_ok and i_ok:
+            chosen = existing  # both safe -> prefer the left/existing operand
+        else:
+            raise ValueError(
+                f"Register {name!r} clashes ({list(existing.labels)} vs "
+                f"{list(incoming.labels)}); neither is disjoint from the other "
+                "registers, so the merge is ambiguous."
+            )
+
+        if self.verbose:
+            warnings.warn(
+                f"Register {name!r} appears in both operands with different but "
+                f"same-size wires ({list(existing.labels)} vs {list(incoming.labels)}); "
+                f"merged by keeping {list(chosen.labels)}.",
+                UserWarning,
+                stacklevel=3,
+            )
+        return chosen
+
+    # -- arithmetic -----------------------------------------------------------
+    def __add__(self, other) -> registers:
+        if not isinstance(other, dict):
+            return NotImplemented
+        offset = self._offset()
+        merged = dict(self)
+        for name, wires in other.items():
+            if name not in merged:
+                # Disjoint name: reindex so it can't collide with the left operand.
+                merged[name] = Wires(
+                    [l + offset if isinstance(l, int) else l for l in wires.labels]
+                )
+            else:
+                # Name clash: compare RAW wires (no offset) per the resolution rules.
+                others = {l for k, w in merged.items() if k != name for l in w.labels}
+                chosen = self._resolve_clash(name, merged[name], wires, others)
+                merged[name] = chosen
+        return registers(merged, verbose=self.verbose)
+
+    def __radd__(self, other):
+        # Enables sum([...], start=registers()) and 0 + reg.
+        if other == 0 or other is None:
+            return registers(self, verbose=self.verbose)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return f"registers({super().__repr__()})"

--- a/pennylane/labs/tests/registers/test_registers.py
+++ b/pennylane/labs/tests/registers/test_registers.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the extended ``registers`` class.
+"""
+
+# pylint: disable=use-implicit-booleaness-not-comparison
+
+import pytest
+
+from pennylane.labs.registers import registers
+from pennylane.wires import Wires
+
+
+class TestConstruction:
+    """Construction parity with ``qml.registers`` plus the Wires-mapping path."""
+
+    def test_flat_spec(self):
+        """A flat int spec allocates contiguous, non-overlapping wire ranges."""
+        reg = registers({"a": 2, "b": 2})
+        assert isinstance(reg, dict)
+        assert reg["a"].tolist() == [0, 1]
+        assert reg["b"].tolist() == [2, 3]
+
+    def test_nested_spec(self):
+        """A nested spec flattens children while the parent spans their wires."""
+        reg = registers({"x": {"a": 2, "b": 2}, "c": 3})
+        assert reg["a"].tolist() == [0, 1]
+        assert reg["b"].tolist() == [2, 3]
+        assert reg["x"].tolist() == [0, 1, 2, 3]
+        assert reg["c"].tolist() == [4, 5, 6]
+
+    def test_wires_mapping_passthrough(self):
+        """An already-built name->Wires mapping is stored verbatim."""
+        reg = registers({"a": Wires([0, 1]), "b": Wires([2, 3])})
+        assert reg["a"].tolist() == [0, 1]
+        assert reg["b"].tolist() == [2, 3]
+
+    def test_none_is_empty(self):
+        """Constructing with ``None`` yields an empty register set."""
+        assert registers(None) == {}
+
+    def test_non_dict_raises(self):
+        """A non-dict argument raises ``ValueError``."""
+        with pytest.raises(ValueError, match="Expected a dict"):
+            registers([("a", 2)])
+
+    def test_verbose_default_true(self):
+        """``verbose`` defaults to ``True`` and is overridable."""
+        assert registers({"a": 2}).verbose is True
+        assert registers({"a": 2}, verbose=False).verbose is False
+
+
+class TestHelpers:
+    """Internal helpers: distinct-wire count and the reindex offset."""
+
+    def test_n_wires_flat(self):
+        """``n_wires`` counts the distinct wires of a flat register set."""
+        assert registers({"a": 2, "b": 2}).n_wires == 4
+
+    def test_n_wires_nested_counts_distinct(self):
+        """``n_wires`` counts distinct wires, not summed register lengths."""
+        # Parent key 'x' shares wires with its children; distinct count is 7.
+        assert registers({"x": {"a": 2, "b": 2}, "c": 3}).n_wires == 7
+
+    def test_offset_empty(self):
+        """An empty register set has a zero reindex offset."""
+        assert registers(None)._offset() == 0  # pylint: disable=protected-access
+
+    def test_offset_flat(self):
+        """The offset clears the largest existing integer wire label."""
+        assert registers({"a": 2, "b": 2})._offset() == 4  # pylint: disable=protected-access
+
+
+class TestAddDisjoint:
+    """The headline behaviour: reindex the right operand on concatenation."""
+
+    def test_basic_reindex(self):
+        """Adding disjoint register sets offsets the right operand's wires."""
+        reg1 = registers({"a": 2, "b": 2})
+        reg2 = registers({"c": 2, "d": 2})
+        out = reg1 + reg2
+        assert {k: v.tolist() for k, v in out.items()} == {
+            "a": [0, 1],
+            "b": [2, 3],
+            "c": [4, 5],
+            "d": [6, 7],
+        }
+
+    def test_returns_registers_instance(self):
+        """The sum is itself a ``registers`` instance, not a plain dict."""
+        out = registers({"a": 2}) + registers({"b": 2})
+        assert isinstance(out, registers)
+
+    def test_operands_unmodified(self):
+        """Addition does not mutate either operand."""
+        reg1 = registers({"a": 2, "b": 2})
+        reg2 = registers({"c": 2, "d": 2})
+        _ = reg1 + reg2
+        assert reg1["a"].tolist() == [0, 1]
+        assert reg2["c"].tolist() == [0, 1]  # right operand untouched
+
+    def test_add_non_dict_returns_notimplemented(self):
+        """Adding a non-dict falls back to a ``TypeError`` via NotImplemented."""
+        with pytest.raises(TypeError):
+            _ = registers({"a": 2}) + 5
+
+    def test_radd_supports_sum(self):
+        """``__radd__`` enables ``sum`` with a ``registers`` start value."""
+        regs = [registers({"a": 2}), registers({"b": 2}), registers({"c": 3})]
+        out = sum(regs, start=registers())
+        assert {k: v.tolist() for k, v in out.items()} == {"a": [0, 1], "b": [2, 3], "c": [4, 5, 6]}
+
+
+class TestAddNameClash:
+    """Resolution rules when the same register name appears in both operands."""
+
+    def test_identical_wires_kept_once_no_warning(self, recwarn):
+        """Identical clashing wires are kept once and emit no warning."""
+        left = registers({"a": 2, "b": 2})
+        right = registers({"a": 2, "x": 3})
+        out = left + right
+        assert out["a"].tolist() == [0, 1]  # identical -> kept once
+        assert out["b"].tolist() == [2, 3]
+        assert out["x"].tolist() == [6, 7, 8]  # non-clashing key still offset
+        assert len(recwarn) == 0
+
+    def test_different_size_raises(self):
+        """Clashing names with different sizes raise ``ValueError``."""
+        with pytest.raises(ValueError, match="different sizes"):
+            _ = registers({"a": 2}) + registers({"a": 3})
+
+    def test_different_wires_keep_disjoint_and_warn(self):
+        """A same-size clash keeps the wire set disjoint from the rest, with a warning."""
+        left = registers({"a": Wires([0, 1]), "b": Wires([2, 3])})
+        right = registers({"a": Wires([2, 3])})  # collides with left['b']
+        with pytest.warns(UserWarning, match="merged by keeping"):
+            out = left + right
+        assert out["a"].tolist() == [0, 1]  # existing is disjoint -> kept
+
+    def test_both_disjoint_prefers_left(self):
+        """When both clashing wire sets are safe, the left operand wins."""
+        left = registers({"a": Wires([0, 1])})
+        right = registers({"a": Wires([5, 6])})  # both disjoint (no other regs)
+        with pytest.warns(UserWarning, match="merged by keeping"):
+            out = left + right
+        assert out["a"].tolist() == [0, 1]
+
+    def test_ambiguous_raises(self):
+        """A clash where neither wire set is disjoint raises ``ValueError``."""
+        # For key 'a', others={1,2}; existing [0,1] hits 1, incoming [2,3] hits 2.
+        left = registers({"a": Wires([0, 1]), "b": Wires([1, 2])})
+        right = registers({"a": Wires([2, 3])})
+        with pytest.raises(ValueError, match="ambiguous"):
+            _ = left + right
+
+    def test_verbose_false_silences_warning(self, recwarn):
+        """``verbose=False`` suppresses the merge warning."""
+        left = registers({"a": Wires([0, 1]), "b": Wires([2, 3])}, verbose=False)
+        right = registers({"a": Wires([2, 3])})
+        out = left + right
+        assert out["a"].tolist() == [0, 1]
+        assert len(recwarn) == 0
+
+
+class TestRepr:  # pylint: disable=too-few-public-methods
+    """String representation of a register set."""
+
+    def test_repr_roundtrips_dict(self):
+        """``repr`` is prefixed with the class name."""
+        reg = registers({"a": 2})
+        assert repr(reg).startswith("registers(")

--- a/pennylane/labs/tests/registers/test_registers.py
+++ b/pennylane/labs/tests/registers/test_registers.py
@@ -16,8 +16,6 @@
 Unit tests for the extended ``registers`` class.
 """
 
-# pylint: disable=use-implicit-booleaness-not-comparison
-
 import pytest
 
 from pennylane.labs.registers import registers
@@ -50,7 +48,7 @@ class TestConstruction:
 
     def test_none_is_empty(self):
         """Constructing with ``None`` yields an empty register set."""
-        assert registers(None) == {}
+        assert not registers(None)  # same as asserting = {}
 
     def test_non_dict_raises(self):
         """A non-dict argument raises ``ValueError``."""


### PR DESCRIPTION

**Context:**

We want to create registers at different times in a workflow, but eventually combine them to one collection of registers, but that doesnt work so easily because it needs reindexing. This class takes care of this with a custom `__add__` method

Disclaimer: This was vibe coded with jukebox

**Description of the Change:**

**Benefits:**

```
from pennylane.labs.registers import registers as registers2

reg1 = registers2({"a": 2, "b": 2})
reg2 = registers2({"c": 2, "d": 2})
>>> reg1 + reg2
{'a': Wires([0, 1]), 'b': Wires([2, 3]), 'c': Wires([4, 5]), 'd': Wires([6, 7])}
```

**Possible Drawbacks:**

**Related GitHub Issues:**
