### PR TITLE
Improve `Hadamard` decompositions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -144,6 +144,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* Updated the decompositions of :class:`~.Hadamard` to take advantage of the used 
+  angles that are multiples of :math:`\pi/2`.
+  [(#9645)](https://github.com/PennyLaneAI/pennylane/pull/9645)
+
 * :func:`~pennylane.draw` now renders :class:`~.SelectPauliRot` with multiplexer selector
   symbols on the control wires and a Pauli rotation label on the target wire.
   [(#9604)](https://github.com/PennyLaneAI/pennylane/pull/9604)

--- a/pennylane/decomposition/__init__.py
+++ b/pennylane/decomposition/__init__.py
@@ -175,7 +175,7 @@ among ``my_cnot1``, ``my_cnot2``, and all existing decomposition rules defined f
         qp.Z(wires[1])
 
     @qp.decompose(
-        gate_set={"RX", "RZ", "CZ", "GlobalPhase"},
+        gate_set={"RX", "RY", "RZ", "CZ", "GlobalPhase"},
         alt_decomps={qp.CNOT: [my_cnot1, my_cnot2]},
         fixed_decomps={qp.IsingXX: isingxx_decomp},
     )
@@ -186,7 +186,7 @@ among ``my_cnot1``, ``my_cnot2``, and all existing decomposition rules defined f
         return qp.state()
 
 >>> qp.specs(circuit)()["resources"].gate_types
-{'RZ': 12, 'RX': 7, 'GlobalPhase': 6, 'CZ': 3}
+{'RZ': 6, 'GlobalPhase': 6, 'RY': 6, 'CZ': 3, 'RX': 1}
 
 To register alternative decomposition rules under an operator to be used globally, use
 :func:`~pennylane.add_decomps`. See :ref:`Inspecting and Managing Decomposition Rules <decomps_management>`

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -825,7 +825,7 @@ class DecompGraphSolution:
             op = qp.CRY(0.2, wires=[0, 2])
             graph = DecompositionGraph(
                 operations=[op],
-                gate_set={"RZ", "RX", "CNOT", "GlobalPhase"},
+                gate_set={"RZ", "RX", "Z", "CNOT", "GlobalPhase"},
             )
             solution = graph.solve()
             rule = solution.decomposition(op)

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -238,15 +238,14 @@ Args:
 
 
 def _hadamard_s_sx_resources():
-    return {qp.S: 2, qp.SX: 1, qp.GlobalPhase: 1}
+    return {qp.S: 2, qp.RX: 1}
 
 
 @register_resources(_hadamard_s_sx_resources)
-def _hadamard_to_s_sx(wires: WiresLike, **__):
+def _hadamard_to_s_rx(wires: WiresLike, **__):
     qp.S(wires=wires)
-    qp.SX(wires=wires)
+    qp.RX(np.pi / 2, wires=wires)
     qp.S(wires=wires)
-    qp.GlobalPhase(np.pi / 4, wires=wires)
 
 
 def _hadamard_z_ry_resources():
@@ -259,7 +258,7 @@ def _hadamard_to_z_ry(wires: WiresLike, **__):
     qp.RY(np.pi / 2, wires=wires)
 
 
-add_decomps(Hadamard, _hadamard_to_s_sx, _hadamard_to_z_ry)
+add_decomps(Hadamard, _hadamard_to_s_rx, _hadamard_to_z_ry)
 add_decomps("Adjoint(Hadamard)", qjit_compatible_self_adjoint)
 add_decomps("Pow(Hadamard)", pow_involutory)
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -237,16 +237,16 @@ Args:
 """
 
 
-def _hadamard_rz_rx_resources():
-    return {qp.RZ: 2, qp.RX: 1, qp.GlobalPhase: 1}
+def _hadamard_s_sx_resources():
+    return {qp.S: 2, qp.SX: 1, qp.GlobalPhase: 1}
 
 
-@register_resources(_hadamard_rz_rx_resources)
-def _hadamard_to_rz_rx(wires: WiresLike, **__):
-    qp.RZ(np.pi / 2, wires=wires)
-    qp.RX(np.pi / 2, wires=wires)
-    qp.RZ(np.pi / 2, wires=wires)
-    qp.GlobalPhase(-np.pi / 2, wires=wires)
+@register_resources(_hadamard_s_sx_resources)
+def _hadamard_to_s_sx(wires: WiresLike, **__):
+    qp.S(wires=wires)
+    qp.SX(wires=wires)
+    qp.S(wires=wires)
+    qp.GlobalPhase(np.pi / 4, wires=wires)
 
 
 def _hadamard_z_ry_resources():
@@ -259,7 +259,7 @@ def _hadamard_to_z_ry(wires: WiresLike, **__):
     qp.RY(np.pi / 2, wires=wires)
 
 
-add_decomps(Hadamard, _hadamard_to_rz_rx, _hadamard_to_z_ry)
+add_decomps(Hadamard, _hadamard_to_s_sx, _hadamard_to_z_ry)
 add_decomps("Adjoint(Hadamard)", qjit_compatible_self_adjoint)
 add_decomps("Pow(Hadamard)", pow_involutory)
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -249,18 +249,17 @@ def _hadamard_to_rz_rx(wires: WiresLike, **__):
     qp.GlobalPhase(-np.pi / 2, wires=wires)
 
 
-def _hadamard_rz_ry_resources():
-    return {qp.RZ: 1, qp.RY: 1, qp.GlobalPhase: 1}
+def _hadamard_z_ry_resources():
+    return {qp.Z: 1, qp.RY: 1}
 
 
-@register_resources(_hadamard_rz_ry_resources)
-def _hadamard_to_rz_ry(wires: WiresLike, **__):
-    qp.RZ(np.pi, wires=wires)
+@register_resources(_hadamard_z_ry_resources)
+def _hadamard_to_z_ry(wires: WiresLike, **__):
+    qp.Z(wires)
     qp.RY(np.pi / 2, wires=wires)
-    qp.GlobalPhase(-np.pi / 2)
 
 
-add_decomps(Hadamard, _hadamard_to_rz_rx, _hadamard_to_rz_ry)
+add_decomps(Hadamard, _hadamard_to_rz_rx, _hadamard_to_z_ry)
 add_decomps("Adjoint(Hadamard)", qjit_compatible_self_adjoint)
 add_decomps("Pow(Hadamard)", pow_involutory)
 

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -407,7 +407,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
 
         qp.decomposition.enable_graph()
 
-        @qp.decomp_inspector(gate_set={"RZ", "RX", "CNOT", "S", "SX"}, num_work_wires=2)
+        @qp.decomp_inspector(gate_set={"RZ", "RX", "CNOT"}, num_work_wires=2)
         @qp.qnode(qp.device("default.qubit"))
         def circuit():
             qp.PauliRot(0.5, "XYZ", [0, 1, 2])
@@ -432,13 +432,13 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     First-Level Expansion Gates: {PauliZ: 1, RY: 1}
     Missing Ops: {PauliZ}
     <BLANKLINE>
-    Decomposition 1 (name: _hadamard_to_s_sx)
-    0: ──S──SX──S──GlobalPhase(0.79)─┤
-    First-Level Expansion Gates: {S: 2, SX: 1, GlobalPhase: 1}
-    Missing Ops: {GlobalPhase}
+    Decomposition 1 (name: _hadamard_to_s_rx)
+    0: ──S──RX(1.57)──S─┤
+    First-Level Expansion Gates: {S: 2, RX: 1}
+    Missing Ops: {S}
 
     Now it's finally clear that the reason why ``PauliRot`` could not be decomposed was that
-    ``Z``, or alternatively ``GlobalPhase``, is missing from the target gate set.
+    ``Z``, or alternatively ``S``, is missing from the target gate set.
 
     .. details::
         :title: Working with a dynamic work wire allocation budget
@@ -486,7 +486,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     1: ──────────────╰MultiRZ(0.50)────────────────┤
         First-Level Expansion Gates: {MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {RZ: 96, CNOT: 60, GlobalPhase: 102, RY: 22, RX: 12, MidMeasure: 2}
+        Full Expansion Gates: {RZ: 94, CNOT: 58, GlobalPhase: 104, RY: 26, RX: 12, MidMeasure: 2}
         Weighted Cost: 192.0
         <BLANKLINE>
         Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -500,7 +500,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ─├●─├●────────├●─┤
         6: ─╰●─╰●────────╰●─┤
         First-Level Expansion Gates: {Controlled(RZ, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-        Full Expansion Gates: {GlobalPhase: 194, RX: 32, MidMeasure: 6, RY: 42, RZ: 176, CNOT: 102}
+        Full Expansion Gates: {GlobalPhase: 200, RX: 32, MidMeasure: 6, RY: 54, RZ: 170, CNOT: 96}
         Weighted Cost: 358.0
 
         Similarly, for the ``MultiControlledX`` in the circuit:
@@ -532,7 +532,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ────────────────────╰X───────────────────────┤
         First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 42, RX: 6, MidMeasure: 1, RY: 9, RZ: 38, CNOT: 23}
+        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)
@@ -569,7 +569,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ─────────────────╰X─────────────────────┤
         First-Level Expansion Gates: {TemporaryAND: 2, Adjoint(TemporaryAND): 2, Toffoli: 1}
         Wire Allocations: {'zero': 2}
-        Full Expansion Gates: {MidMeasure: 2, GlobalPhase: 35, RX: 8, RY: 8, RZ: 31, CNOT: 16}
+        Full Expansion Gates: {MidMeasure: 2, GlobalPhase: 37, RX: 8, RY: 12, RZ: 29, CNOT: 14}
         Weighted Cost: 65.0
         <BLANKLINE>
         Decomposition 9 (name: many_borrowed_workers)
@@ -626,7 +626,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ────────────────────╰X───────────────────────┤
         First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 42, RX: 6, MidMeasure: 1, RY: 9, RZ: 38, CNOT: 23}
+        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -360,7 +360,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                 1: ──────────────╰MultiRZ(0.50)────────────────┤
     First-Level Expansion Gates: {MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
     Wire Allocations: {'zero': 1}
-    Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, RX: 8, MidMeasure: 2}
+    Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, MidMeasure: 2, RX: 8}
     Weighted Cost: 120.0
     <BLANKLINE>
     Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -373,7 +373,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     4: ─├●─├●────────├●─┤
     5: ─╰●─╰●────────╰●─┤
     First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-    Full Expansion Gates: {GlobalPhase: 76, RX: 16, MidMeasure: 4, RY: 24, RZ: 80, CNOT: 72}
+    Full Expansion Gates: {MidMeasure: 4, GlobalPhase: 76, RX: 16, RY: 24, RZ: 80, CNOT: 72}
     Weighted Cost: 196.0
 
     For applicable decompositions, the "First-Level Expansion" label refers to the operators immediately produced by the decomposition rule,
@@ -407,7 +407,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
 
         qp.decomposition.enable_graph()
 
-        @qp.decomp_inspector(gate_set={"RZ", "RX", "CNOT"}, num_work_wires=2)
+        @qp.decomp_inspector(gate_set={"RZ", "RX", "CNOT", "S", "SX"}, num_work_wires=2)
         @qp.qnode(qp.device("default.qubit"))
         def circuit():
             qp.PauliRot(0.5, "XYZ", [0, 1, 2])
@@ -427,18 +427,18 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     to find a decomposition for ``Hadamard``. We can investigate further:
 
     >>> inspector.inspect_decomps(qp.Hadamard(0))
-    Decomposition 0 (name: _hadamard_to_rz_ry)
-    0: ──RZ(3.14)──RY(1.57)──GlobalPhase(-1.57)─┤
-    First-Level Expansion Gates: {RZ: 1, RY: 1, GlobalPhase: 1}
-    Missing Ops: {GlobalPhase}
+    Decomposition 0 (name: _hadamard_to_z_ry)
+    0: ──Z──RY(1.57)─┤
+    First-Level Expansion Gates: {PauliZ: 1, RY: 1}
+    Missing Ops: {PauliZ}
     <BLANKLINE>
-    Decomposition 1 (name: _hadamard_to_rz_rx)
-    0: ──RZ(1.57)──RX(1.57)──RZ(1.57)──GlobalPhase(-1.57)─┤
-    First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
+    Decomposition 1 (name: _hadamard_to_s_sx)
+    0: ──S──SX──S──GlobalPhase(0.79)─┤
+    First-Level Expansion Gates: {S: 2, SX: 1, GlobalPhase: 1}
     Missing Ops: {GlobalPhase}
 
     Now it's finally clear that the reason why ``PauliRot`` could not be decomposed was that
-    ``GlobalPhase`` is missing from the target gate set.
+    ``Z``, or alternatively ``GlobalPhase``, is missing from the target gate set.
 
     .. details::
         :title: Working with a dynamic work wire allocation budget
@@ -486,7 +486,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     1: ──────────────╰MultiRZ(0.50)────────────────┤
         First-Level Expansion Gates: {MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {RZ: 94, CNOT: 58, GlobalPhase: 104, RY: 26, RX: 12, MidMeasure: 2}
+        Full Expansion Gates: {RZ: 96, CNOT: 60, GlobalPhase: 102, RY: 22, RX: 12, MidMeasure: 2}
         Weighted Cost: 192.0
         <BLANKLINE>
         Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -500,7 +500,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ─├●─├●────────├●─┤
         6: ─╰●─╰●────────╰●─┤
         First-Level Expansion Gates: {Controlled(RZ, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-        Full Expansion Gates: {GlobalPhase: 200, RX: 32, MidMeasure: 6, RY: 54, RZ: 170, CNOT: 96}
+        Full Expansion Gates: {GlobalPhase: 194, RX: 32, MidMeasure: 6, RY: 42, RZ: 176, CNOT: 102}
         Weighted Cost: 358.0
 
         Similarly, for the ``MultiControlledX`` in the circuit:
@@ -520,7 +520,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-        Full Expansion Gates: {GlobalPhase: 43, RY: 14, RZ: 57, RX: 4, CNOT: 58}
+        Full Expansion Gates: {RY: 14, GlobalPhase: 43, RZ: 61, CNOT: 58}
         Weighted Cost: 133.0
         <BLANKLINE>
         Decomposition 2 (name: one_zeroed_worker)
@@ -532,7 +532,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ────────────────────╰X───────────────────────┤
         First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
+        Full Expansion Gates: {GlobalPhase: 42, RX: 6, MidMeasure: 1, RY: 9, RZ: 38, CNOT: 23}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)
@@ -569,7 +569,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ─────────────────╰X─────────────────────┤
         First-Level Expansion Gates: {TemporaryAND: 2, Adjoint(TemporaryAND): 2, Toffoli: 1}
         Wire Allocations: {'zero': 2}
-        Full Expansion Gates: {GlobalPhase: 37, RX: 8, MidMeasure: 2, RY: 12, RZ: 29, CNOT: 14}
+        Full Expansion Gates: {MidMeasure: 2, GlobalPhase: 35, RX: 8, RY: 8, RZ: 31, CNOT: 16}
         Weighted Cost: 65.0
         <BLANKLINE>
         Decomposition 9 (name: many_borrowed_workers)
@@ -614,7 +614,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-        Full Expansion Gates: {GlobalPhase: 43, RY: 14, RZ: 57, RX: 4, CNOT: 58}
+        Full Expansion Gates: {RY: 14, GlobalPhase: 43, RZ: 61, CNOT: 58}
         Weighted Cost: 133.0
         <BLANKLINE>
         CHOSEN: Decomposition 2 (name: one_zeroed_worker)
@@ -626,7 +626,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
                     6: ────────────────────╰X───────────────────────┤
         First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
+        Full Expansion Gates: {GlobalPhase: 42, RX: 6, MidMeasure: 1, RY: 9, RZ: 38, CNOT: 23}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)

--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -724,7 +724,7 @@ def decompose(
                 qp.Z(wires[1])
 
             @qp.decompose(
-                gate_set={"RX", "RZ", "CZ", "GlobalPhase"},
+                gate_set={"RX", "RY", "RZ", "CZ", "GlobalPhase"},
                 alt_decomps={qp.CNOT: [my_cnot1, my_cnot2]},
                 fixed_decomps={qp.IsingXX: isingxx_decomp},
             )
@@ -735,7 +735,7 @@ def decompose(
                 return qp.state()
 
         >>> qp.specs(circuit)()["resources"].gate_types
-        {'RZ': 12, 'RX': 7, 'GlobalPhase': 6, 'CZ': 3}
+        {'RZ': 6, 'GlobalPhase': 6, 'RY': 6, 'CZ': 3, 'RX': 1}
         >>> qp.decomposition.disable_graph()
 
         **Degenerate Graph Solutions**

--- a/tests/capture/transforms/test_capture_graph_decompose.py
+++ b/tests/capture/transforms/test_capture_graph_decompose.py
@@ -168,52 +168,43 @@ class TestDecomposeInterpreterGraphEnabled:
             qp.CNOT(wires=[2, 1]),
         ]
 
-        decomposed_f = DecomposeInterpreter(gate_set={"RY", "RZ", "CZ", "GlobalPhase"})(f)
+        decomposed_f = DecomposeInterpreter(gate_set={"Z", "RY", "RZ", "CZ", "GlobalPhase"})(f)
         jaxpr = jax.make_jaxpr(decomposed_f)(0.1, 0.2, 0.3)
         collector = CollectOpsandMeas()
         collector.eval(jaxpr.jaxpr, jaxpr.consts, 0.1, 0.2, 0.3)
         assert collector.state["ops"] == [
             # The H decomposes to RZ and RY
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             # Rot decomposes to ZYZ
             qp.RZ(0.1, wires=[0]),
             qp.RY(0.2, wires=[0]),
             qp.RZ(0.3, wires=[0]),
             # CNOT decomposes to H and CZ, where H decomposes to RZ and RY
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[2, 1]),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             # second CNOT
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[1, 0]),
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             # The middle RZ
             qp.RZ(0.1, wires=[0]),
             # The last two CNOTs
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[1, 0]),
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[2, 1]),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
         ]
 
     @pytest.mark.integration

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -50,6 +50,7 @@ import pennylane as qp
 from pennylane.decomposition.reconstruct import get_decomp_kwargs
 from pennylane.ops.functions.assert_valid import (
     _test_decomposition_rule,
+    assert_valid,
 )
 from pennylane.transforms import decompose
 from pennylane.wires import Wires
@@ -126,6 +127,13 @@ def test_alias_XYZI(wire):
 
 
 class TestOperations:
+
+    @pytest.mark.parametrize("op_cls, _", NON_PARAMETRIZED_OPERATIONS)
+    def test_assert_valid(self, op_cls, _):
+        """Test that the operation is valid, using standard assert_valid test."""
+        op = op_cls(wires=0 if op_cls.num_wires is None else range(op_cls.num_wires))
+        assert_valid(op)
+
     @pytest.mark.parametrize("op_cls, _", NON_PARAMETRIZED_OPERATIONS)
     def test_op_copy(self, op_cls, _, tol):
         """Tests that copied nonparametrized ops function as expected"""

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -128,6 +128,7 @@ def test_alias_XYZI(wire):
 
 class TestOperations:
 
+    @pytest.mark.jax
     @pytest.mark.parametrize("op_cls, _", NON_PARAMETRIZED_OPERATIONS)
     def test_assert_valid(self, op_cls, _):
         """Test that the operation is valid, using standard assert_valid test."""

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -115,13 +115,13 @@ class TestInspectDecompGraph:
             Not applicable (provided operator instance does not meet all conditions for this rule).
 
             CHOSEN: Decomposition 2 (name: controlled(_multi_rz_decomposition))
-            0: ─╭X─╭RZ(0.50)─╭X─┤  
-            1: ─├●─│─────────├●─┤  
-            3: ─├●─├●────────├●─┤  
-            4: ─├●─├●────────├●─┤  
-            5: ─╰●─╰●────────╰●─┤  
+            0: ─╭X─╭RZ(0.50)─╭X─┤
+            1: ─├●─│─────────├●─┤
+            3: ─├●─├●────────├●─┤
+            4: ─├●─├●────────├●─┤
+            5: ─╰●─╰●────────╰●─┤
             First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-            Full Expansion Gates: {GlobalPhase: 88, RZ: 136, CNOT: 160, RY: 28, RX: 8}
+            Full Expansion Gates: {GlobalPhase: 88, RZ: 144, CNOT: 160, RY: 28}
             Weighted Cost: 332.0
             """).strip()
 
@@ -141,11 +141,11 @@ class TestInspectDecompGraph:
             #### **CHOSEN:** Decomposition 2 (name: controlled(_multi_rz_decomposition))
 
             ```
-            0: ─╭X─╭RZ(0.50)─╭X─┤  
-            1: ─├●─│─────────├●─┤  
-            3: ─├●─├●────────├●─┤  
-            4: ─├●─├●────────├●─┤  
-            5: ─╰●─╰●────────╰●─┤  
+            0: ─╭X─╭RZ(0.50)─╭X─┤
+            1: ─├●─│─────────├●─┤
+            3: ─├●─├●────────├●─┤
+            4: ─├●─├●────────├●─┤
+            5: ─╰●─╰●────────╰●─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -158,9 +158,8 @@ class TestInspectDecompGraph:
             | :--- | :--- |
             | CNOT | 160 |
             | GlobalPhase | 88 |
-            | RX | 8 |
             | RY | 28 |
-            | RZ | 136 |
+            | RZ | 144 |
             | **Weighted Cost** | 332.0 |
             </details>
             """).strip()
@@ -180,28 +179,28 @@ class TestInspectDecompGraph:
         result = inspector.inspect_decomps(op, num_work_wires=2)
         assert str(result) == dedent("""
             CHOSEN: Decomposition 0 (name: flip_zero_ctrl_values(_ctrl_single_work_wire))
-            <DynamicWire>: ──Allocate─╭X─╭●─────────────╭X──Deallocate─┤  
-                        3: ───────────├●─│──────────────├●─────────────┤  
-                        4: ───────────├●─│──────────────├●─────────────┤  
-                        5: ───────────╰●─│──────────────╰●─────────────┤  
-                        0: ──────────────├MultiRZ(0.50)────────────────┤  
-                        1: ──────────────╰MultiRZ(0.50)────────────────┤  
+            <DynamicWire>: ──Allocate─╭X─╭●─────────────╭X──Deallocate─┤
+                        3: ───────────├●─│──────────────├●─────────────┤
+                        4: ───────────├●─│──────────────├●─────────────┤
+                        5: ───────────╰●─│──────────────╰●─────────────┤
+                        0: ──────────────├MultiRZ(0.50)────────────────┤
+                        1: ──────────────╰MultiRZ(0.50)────────────────┤
             First-Level Expansion Gates: {MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, RX: 8, MidMeasure: 2}
+            Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, MidMeasure: 2, RX: 8}
             Weighted Cost: 120.0
 
             Decomposition 1 (name: to_controlled_qubit_unitary)
             Not applicable (provided operator instance does not meet all conditions for this rule).
 
             Decomposition 2 (name: controlled(_multi_rz_decomposition))
-            0: ─╭X─╭RZ(0.50)─╭X─┤  
-            1: ─├●─│─────────├●─┤  
-            3: ─├●─├●────────├●─┤  
-            4: ─├●─├●────────├●─┤  
-            5: ─╰●─╰●────────╰●─┤  
+            0: ─╭X─╭RZ(0.50)─╭X─┤
+            1: ─├●─│─────────├●─┤
+            3: ─├●─├●────────├●─┤
+            4: ─├●─├●────────├●─┤
+            5: ─╰●─╰●────────╰●─┤
             First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-            Full Expansion Gates: {GlobalPhase: 76, RX: 16, MidMeasure: 4, RY: 24, RZ: 80, CNOT: 72}
+            Full Expansion Gates: {MidMeasure: 4, GlobalPhase: 76, RX: 16, RY: 24, RZ: 80, CNOT: 72}
             Weighted Cost: 196.0
             """).strip()
 
@@ -209,12 +208,12 @@ class TestInspectDecompGraph:
             #### **CHOSEN:** Decomposition 0 (name: flip_zero_ctrl_values(_ctrl_single_work_wire))
 
             ```
-            <DynamicWire>: ──Allocate─╭X─╭●─────────────╭X──Deallocate─┤  
-                        3: ───────────├●─│──────────────├●─────────────┤  
-                        4: ───────────├●─│──────────────├●─────────────┤  
-                        5: ───────────╰●─│──────────────╰●─────────────┤  
-                        0: ──────────────├MultiRZ(0.50)────────────────┤  
-                        1: ──────────────╰MultiRZ(0.50)────────────────┤  
+            <DynamicWire>: ──Allocate─╭X─╭●─────────────╭X──Deallocate─┤
+                        3: ───────────├●─│──────────────├●─────────────┤
+                        4: ───────────├●─│──────────────├●─────────────┤
+                        5: ───────────╰●─│──────────────╰●─────────────┤
+                        0: ──────────────├MultiRZ(0.50)────────────────┤
+                        1: ──────────────╰MultiRZ(0.50)────────────────┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -249,11 +248,11 @@ class TestInspectDecompGraph:
             #### Decomposition 2 (name: controlled(_multi_rz_decomposition))
 
             ```
-            0: ─╭X─╭RZ(0.50)─╭X─┤  
-            1: ─├●─│─────────├●─┤  
-            3: ─├●─├●────────├●─┤  
-            4: ─├●─├●────────├●─┤  
-            5: ─╰●─╰●────────╰●─┤  
+            0: ─╭X─╭RZ(0.50)─╭X─┤
+            1: ─├●─│─────────├●─┤
+            3: ─├●─├●────────├●─┤
+            4: ─├●─├●────────├●─┤
+            5: ─╰●─╰●────────╰●─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -280,34 +279,34 @@ class TestInspectDecompGraph:
             Not applicable (provided operator instance does not meet all conditions for this rule).
 
             Decomposition 1 (name: no_workers)
-            0: ────╭●───────────────────╭●──────────────────────╭●──────────────────┤  
-            1: ────├●───────────────────├●──────────────────────├●──────────────────┤  
-            2: ────│─────────╭●─────────│─────────╭●────────────├●──────────────────┤  
-            3: ──H─╰X──U(M0)─╰X──U(M0)†─╰X──U(M0)─╰X──U(M0)†──H─╰GlobalPhase(-1.57)─┤  
-            M0 = 
+            0: ────╭●───────────────────╭●──────────────────────╭●──────────────────┤
+            1: ────├●───────────────────├●──────────────────────├●──────────────────┤
+            2: ────│─────────╭●─────────│─────────╭●────────────├●──────────────────┤
+            3: ──H─╰X──U(M0)─╰X──U(M0)†─╰X──U(M0)─╰X──U(M0)†──H─╰GlobalPhase(-1.57)─┤
+            M0 =
             [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
              [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
             First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, CNOT: 2, MultiControlledX(num_control_wires=2, num_work_wires=1, num_zero_control_values=0, work_wire_type=borrowed): 2, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 25, RY: 10, RZ: 31, RX: 4}
+            Full Expansion Gates: {CNOT: 24, RY: 10, GlobalPhase: 25, RZ: 35}
             Weighted Cost: 69.0
 
             CHOSEN: Decomposition 2 (name: one_zeroed_worker)
-            <DynamicWire>: ──Allocate─╭⊕─╭●──⊕╮──Deallocate─┤  
-                        0: ───────────├●─│───●┤─────────────┤  
-                        1: ───────────╰●─│───●╯─────────────┤  
-                        2: ──────────────├●─────────────────┤  
-                        3: ──────────────╰X─────────────────┤  
+            <DynamicWire>: ──Allocate─╭⊕─╭●──⊕╮──Deallocate─┤
+                        0: ───────────├●─│───●┤─────────────┤
+                        1: ───────────╰●─│───●╯─────────────┤
+                        2: ──────────────├●─────────────────┤
+                        3: ──────────────╰X─────────────────┤
             First-Level Expansion Gates: {Toffoli: 1, TemporaryAND: 1, Adjoint(TemporaryAND): 1}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {GlobalPhase: 23, RX: 4, MidMeasure: 1, RY: 7, RZ: 19, CNOT: 10}
+            Full Expansion Gates: {MidMeasure: 1, GlobalPhase: 23, RX: 4, RY: 7, RZ: 19, CNOT: 10}
             Weighted Cost: 41.0
 
             Decomposition 3 (name: one_borrowed_worker)
-            <DynamicWire>: ──Allocate─╭X─╭●─╭X─╭●──Deallocate─┤  
-                        0: ───────────├●─│──├●─│──────────────┤  
-                        1: ───────────╰●─│──╰●─│──────────────┤  
-                        2: ──────────────├●────├●─────────────┤  
-                        3: ──────────────╰X────╰X─────────────┤  
+            <DynamicWire>: ──Allocate─╭X─╭●─╭X─╭●──Deallocate─┤
+                        0: ───────────├●─│──├●─│──────────────┤
+                        1: ───────────╰●─│──╰●─│──────────────┤
+                        2: ──────────────├●────├●─────────────┤
+                        3: ──────────────╰X────╰X─────────────┤
             First-Level Expansion Gates: {Toffoli: 4}
             Wire Allocations: {'any': 1}
             Full Expansion Gates: {CNOT: 24, GlobalPhase: 36, RZ: 36, RY: 8}
@@ -352,9 +351,9 @@ class TestInspectDecompGraph:
         result = inspector.inspect_decomps(op)
         assert str(result) == dedent("""
             Decomposition 0 (name: _pauli_rot_decomposition)
-            0: ──H────────╭MultiRZ(0.50)──H─────────┤  
-            1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤  
-            2: ───────────╰MultiRZ(0.50)────────────┤  
+            0: ──H────────╭MultiRZ(0.50)──H─────────┤
+            1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤
+            2: ───────────╰MultiRZ(0.50)────────────┤
             First-Level Expansion Gates: {Hadamard: 2, RX: 2, MultiRZ(num_wires=3): 1}
             Missing Ops: {Hadamard}
             """).strip()
@@ -363,9 +362,9 @@ class TestInspectDecompGraph:
             #### Decomposition 0 (name: _pauli_rot_decomposition)
 
             ```
-            0: ──H────────╭MultiRZ(0.50)──H─────────┤  
-            1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤  
-            2: ───────────╰MultiRZ(0.50)────────────┤  
+            0: ──H────────╭MultiRZ(0.50)──H─────────┤
+            1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤
+            2: ───────────╰MultiRZ(0.50)────────────┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -381,16 +380,16 @@ class TestInspectDecompGraph:
             | Hadamard |
             """).strip()
 
-        assert str(inspector.inspect_decomps(qp.H(0))) == dedent("""
-            Decomposition 0 (name: _hadamard_to_rz_ry)
-            0: ──RZ(3.14)──RY(1.57)──GlobalPhase(-1.57)─┤  
-            First-Level Expansion Gates: {RZ: 1, RY: 1, GlobalPhase: 1}
-            Missing Ops: {GlobalPhase}
+        assert str(inspector.inspect_decomps(qp.H(0))) == dedent(r"""
+            Decomposition 0 (name: _hadamard_to_z_ry)
+            0: ──Z──RY(1.57)─┤
+            First-Level Expansion Gates: {PauliZ: 1, RY: 1}
+            Missing Ops: {PauliZ}
 
-            Decomposition 1 (name: _hadamard_to_rz_rx)
-            0: ──RZ(1.57)──RX(1.57)──RZ(1.57)──GlobalPhase(-1.57)─┤  
-            First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
-            Missing Ops: {GlobalPhase}
+            Decomposition 1 (name: _hadamard_to_s_rx)
+            0: ──S──RX(1.57)──S─┤
+            First-Level Expansion Gates: {S: 2, RX: 1}
+            Missing Ops: {S}
             """).strip()
 
     def test_inexact_count(self):
@@ -413,35 +412,35 @@ class TestInspectDecompGraph:
             Not applicable (provided operator instance does not meet all conditions for this rule).
 
             Decomposition 2 (name: rot)
-            0: ──RZ(0.00)─┤  
+            0: ──RZ(0.00)─┤
             Estimated First-Level Expansion Gates: {Rot: 1, RZ: 1, GlobalPhase: 1}
             Actual First-Level Expansion Gates: {RZ: 1}
             Full Expansion Gates: {GlobalPhase: 1, RZ: 5, RX: 1}
             Weighted Cost: 7.0
 
             Decomposition 3 (name: xyx)
-            0: ──RX(0.00)──RY(0.00)──RX(0.00)─┤  
+            0: ──RX(0.00)──RY(0.00)──RX(0.00)─┤
             Estimated First-Level Expansion Gates: {RX: 2, RY: 1, GlobalPhase: 1}
             Actual First-Level Expansion Gates: {RX: 2, RY: 1}
             Full Expansion Gates: {GlobalPhase: 1, RX: 3, RZ: 2}
             Weighted Cost: 6.0
 
             CHOSEN: Decomposition 4 (name: xzx)
-            0: ──RX(0.00)──RZ(0.00)──RX(0.00)─┤  
+            0: ──RX(0.00)──RZ(0.00)──RX(0.00)─┤
             Estimated First-Level Expansion Gates: {RX: 2, RZ: 1, GlobalPhase: 1}
             Actual First-Level Expansion Gates: {RX: 2, RZ: 1}
             Full Expansion Gates: {GlobalPhase: 1, RX: 2, RZ: 1}
             Weighted Cost: 4.0
 
             Decomposition 5 (name: zxz)
-            0: ──RZ(0.00)──RX(0.00)──RZ(0.00)─┤  
+            0: ──RZ(0.00)──RX(0.00)──RZ(0.00)─┤
             Estimated First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
             Actual First-Level Expansion Gates: {RZ: 2, RX: 1}
             Full Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 2}
             Weighted Cost: 4.0
 
             Decomposition 6 (name: zyz)
-            0: ──RZ(0.00)──RY(0.00)──RZ(0.00)─┤  
+            0: ──RZ(0.00)──RY(0.00)──RZ(0.00)─┤
             Estimated First-Level Expansion Gates: {RZ: 2, RY: 1, GlobalPhase: 1}
             Actual First-Level Expansion Gates: {RZ: 2, RY: 1}
             Full Expansion Gates: {GlobalPhase: 1, RZ: 4, RX: 1}
@@ -464,7 +463,7 @@ class TestInspectDecompGraph:
             #### Decomposition 2 (name: rot)
 
             ```
-            0: ──RZ(0.00)─┤  
+            0: ──RZ(0.00)─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -487,7 +486,7 @@ class TestInspectDecompGraph:
             #### Decomposition 3 (name: xyx)
 
             ```
-            0: ──RX(0.00)──RY(0.00)──RX(0.00)─┤  
+            0: ──RX(0.00)──RY(0.00)──RX(0.00)─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -510,7 +509,7 @@ class TestInspectDecompGraph:
             #### **CHOSEN:** Decomposition 4 (name: xzx)
 
             ```
-            0: ──RX(0.00)──RZ(0.00)──RX(0.00)─┤  
+            0: ──RX(0.00)──RZ(0.00)──RX(0.00)─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -533,7 +532,7 @@ class TestInspectDecompGraph:
             #### Decomposition 5 (name: zxz)
 
             ```
-            0: ──RZ(0.00)──RX(0.00)──RZ(0.00)─┤  
+            0: ──RZ(0.00)──RX(0.00)──RZ(0.00)─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 
@@ -556,7 +555,7 @@ class TestInspectDecompGraph:
             #### Decomposition 6 (name: zyz)
 
             ```
-            0: ──RZ(0.00)──RY(0.00)──RZ(0.00)─┤  
+            0: ──RZ(0.00)──RY(0.00)──RZ(0.00)─┤
             ```
             <details><summary>Gate Counts and Wire Allocations</summary>
 

--- a/tests/transforms/test_decompose_transform_graph.py
+++ b/tests/transforms/test_decompose_transform_graph.py
@@ -192,49 +192,42 @@ class TestDecomposeGraphEnabled:
             qp.CNOT(wires=[2, 1]),
         ]
 
-        [new_tape], _ = qp.transforms.decompose(tape, gate_set={"RY", "RZ", "CZ", "GlobalPhase"})
+        [new_tape], _ = qp.transforms.decompose(
+            tape, gate_set={"RY", "RZ", "CZ", "Z", "GlobalPhase"}
+        )
         assert new_tape.operations == [
             # The H decomposes to RZ and RY
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             # Rot decomposes to ZYZ
             qp.RZ(0.1, wires=[0]),
             qp.RY(0.2, wires=[0]),
             qp.RZ(0.3, wires=[0]),
             # CNOT decomposes to H and CZ, where H decomposes to RZ and RY
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[2, 1]),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             # second CNOT
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[1, 0]),
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             # The middle RZ
             qp.RZ(0.5, wires=[0]),
             # The last two CNOTs
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[1, 0]),
-            qp.RZ(np.pi, wires=[0]),
+            qp.Z(wires=[0]),
             qp.RY(np.pi / 2, wires=[0]),
-            qp.GlobalPhase(-np.pi / 2),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
             qp.CZ(wires=[2, 1]),
-            qp.RZ(np.pi, wires=[1]),
+            qp.Z(wires=[1]),
             qp.RY(np.pi / 2, wires=[1]),
-            qp.GlobalPhase(-np.pi / 2),
         ]
 
     @pytest.mark.integration


### PR DESCRIPTION
**Context:**
We're decomposing `Hadamard` in a very "NISQy" way, currently.

**Description of the Change:**
Make the decompositions smarter about the specific angles they contain.

**Benefits:**
Cheaper FTQC decompositions.

**Possible Drawbacks:**

**Related GitHub Issues:**
