### PR TITLE
Clean up pytest markers related to Catalyst-dependent tests

### DIFF
--- a/tests/drawer/test_draw_catalyst.py
+++ b/tests/drawer/test_draw_catalyst.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Test the pennylane drawer with Catalyst."""
 
-# pylint: disable=protected-access,wrong-import-position,wrong-import-order
+# pylint: disable=protected-access,wrong-import-position
 import pytest
 
 pytestmark = [pytest.mark.external, pytest.mark.catalyst]

--- a/tests/drawer/test_draw_catalyst.py
+++ b/tests/drawer/test_draw_catalyst.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 """Test the pennylane drawer with Catalyst."""
 
-# pylint: disable=import-outside-toplevel,protected-access
+# pylint: disable=protected-access,wrong-import-position,wrong-import-order
 import pytest
 
+pytestmark = [pytest.mark.external, pytest.mark.catalyst]
+
+import catalyst
+import matplotlib as mpl
+
 import pennylane as qp
-
-catalyst = pytest.importorskip("catalyst")
-mpl = pytest.importorskip("matplotlib")
-
-pytestmark = pytest.mark.external
 
 
 class TestCatalystDraw:
@@ -45,8 +45,6 @@ class TestCatalystDraw:
     @pytest.mark.parametrize("c", [0, 1])
     def test_cond_circuit(self, c):
         """Test a circuit with a Catalyst conditional."""
-
-        import catalyst  # pylint: disable=redefined-outer-name
 
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=(0, "a", 1.234)))
@@ -73,8 +71,6 @@ class TestCatalystDraw:
     def test_for_loop_circuit(self, c):
         """Test a circuit with a Catalyst for_loop"""
 
-        import catalyst  # pylint: disable=redefined-outer-name
-
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit(x, y, z, c):
@@ -99,8 +95,6 @@ class TestCatalystDraw:
     @pytest.mark.parametrize("c", [0, 1])
     def test_while_loop_circuit(self, c):
         """Test a circuit with a Catalyst while_loop"""
-
-        import catalyst  # pylint: disable=redefined-outer-name
 
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=3))
@@ -150,8 +144,6 @@ class TestCatalystDrawMpl:
     def test_cond_circuit(self, c):
         """Test a circuit with a Catalyst conditional."""
 
-        import catalyst  # pylint: disable=redefined-outer-name
-
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=(0, "a", 1.234)))
         def circuit(x, y, z, c):
@@ -175,8 +167,6 @@ class TestCatalystDrawMpl:
     def test_for_loop_circuit(self, c):
         """Test a circuit with a Catalyst for_loop"""
 
-        import catalyst  # pylint: disable=redefined-outer-name
-
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit(x, y, z, c):
@@ -199,8 +189,6 @@ class TestCatalystDrawMpl:
     @pytest.mark.parametrize("c", [0, 1])
     def test_while_loop_circuit(self, c):
         """Test a circuit with a Catalyst while_loop"""
-
-        import catalyst  # pylint: disable=redefined-outer-name
 
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=3))

--- a/tests/gradients/core/test_metric_tensor.py
+++ b/tests/gradients/core/test_metric_tensor.py
@@ -977,6 +977,7 @@ def autodiff_metric_tensor(ansatz, num_wires):
 class TestFullMetricTensor:
     num_wires = 3
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     def test_catalyst_compatibility(self):
         """Test that the metric tensor can be executed with catalyst."""

--- a/tests/math/test_catalyst_math.py
+++ b/tests/math/test_catalyst_math.py
@@ -20,6 +20,7 @@ import pytest
 import pennylane as qp
 
 
+@pytest.mark.catalyst
 @pytest.mark.external
 def test_catalyst_integration():
     """Test that scatter_element_add can be used with catalyst by specifying indices_are_sorted and unique_indices."""

--- a/tests/math/test_givens_rotations.py
+++ b/tests/math/test_givens_rotations.py
@@ -153,22 +153,22 @@ def test_givens_decomposition(shape, seed):
         pytest.param("qjit", marks=[pytest.mark.external, pytest.mark.catalyst]),
     ],
 )
-@pytest.mark.jax
-@pytest.mark.external
 def test_givens_decomposition_jax_qjit(shape, compiler, seed):
     r"""Test that `givens_decomposition` performs a correct Givens decomposition."""
-    import jax
-    from jax import numpy as jnp
-
-    matrix = jnp.array(unitary_group.rvs(shape, random_state=seed))
     if compiler == "jit":
+        import jax
+        from jax import numpy as flex_np
+
         func = jax.jit(givens_decomposition)
     elif compiler == "qjit":
-        catalyst = pytest.importorskip("catalyst")
-        func = catalyst.qjit(givens_decomposition)
+        from jax import numpy as flex_np
+
+        func = qp.qjit(givens_decomposition)
     else:
+        flex_np = onp
         func = givens_decomposition
 
+    matrix = flex_np.array(unitary_group.rvs(shape, random_state=seed))
     copied_matrix = matrix.copy()
     phase_mat, ordered_rotations = func(matrix)
     assert qp.math.allclose(copied_matrix, matrix)
@@ -348,29 +348,32 @@ def test_givens_matrix_jaxpr():
 )
 @pytest.mark.parametrize(
     "compiler",
-    [None, "jit", pytest.param("qjit", marks=[pytest.mark.external, pytest.mark.catalyst])],
+    [
+        None,
+        pytest.param("jit", marks=[pytest.mark.jax]),
+        pytest.param("qjit", marks=[pytest.mark.external, pytest.mark.catalyst]),
+    ],
 )
-@pytest.mark.jax
 def test_set_unitary_matrix_real(
     use_jax, unitary_matrix, index, value, like, expected_matrix, compiler
 ):
     """Test the _set_unitary function on different interfaces with real-valued matrices."""
     if like == "numpy" and compiler is not None:
         pytest.skip(reason="Can't use numpy interface with jit compilation.")
-    import jax
-    import jax.numpy as jnp
-
     if use_jax:
+        import jax.numpy as jnp
+
         unitary_matrix = jnp.array(unitary_matrix)
         value = jnp.array(value)
     else:
         value = onp.array(value)
 
     if compiler == "jit":
+        import jax
+
         fn = jax.jit(_set_unitary_matrix, static_argnums=[1, 3, 4])
     elif compiler == "qjit":
-        catalyst = pytest.importorskip("catalyst")
-        fn = catalyst.qjit(_set_unitary_matrix, static_argnums=[1, 3, 4])
+        fn = qp.qjit(_set_unitary_matrix, static_argnums=[1, 3, 4])
     else:
         fn = _set_unitary_matrix
     copied_matrix = unitary_matrix.copy()
@@ -446,9 +449,12 @@ def test_set_unitary_matrix_real(
 )
 @pytest.mark.parametrize(
     "compiler",
-    [None, "jit", pytest.param("qjit", marks=[pytest.mark.external, pytest.mark.catalyst])],
+    [
+        None,
+        pytest.param("jit", marks=[pytest.mark.jax]),
+        pytest.param("qjit", marks=[pytest.mark.external, pytest.mark.catalyst]),
+    ],
 )
-@pytest.mark.jax
 def test_set_unitary_matrix_complex(
     use_jax, unitary_matrix, index, value, like, expected_matrix, compiler
 ):
@@ -456,20 +462,20 @@ def test_set_unitary_matrix_complex(
     if like == "numpy" and compiler is not None:
         pytest.skip(reason="Can't use numpy interface with jit compilation.")
 
-    import jax
-    import jax.numpy as jnp
-
     if use_jax:
+        import jax.numpy as jnp
+
         unitary_matrix = jnp.array(unitary_matrix)
         value = jnp.array(value)
     else:
         value = onp.array(value)
 
     if compiler == "jit":
+        import jax
+
         fn = jax.jit(_set_unitary_matrix, static_argnums=[1, 3, 4])
     elif compiler == "qjit":
-        catalyst = pytest.importorskip("catalyst")
-        fn = catalyst.qjit(_set_unitary_matrix, static_argnums=[1, 3, 4])
+        fn = qp.qjit(_set_unitary_matrix, static_argnums=[1, 3, 4])
     else:
         fn = _set_unitary_matrix
     copied_matrix = unitary_matrix.copy()

--- a/tests/ops/op_math/decompositions/test_ross_selinger.py
+++ b/tests/ops/op_math/decompositions/test_ross_selinger.py
@@ -75,7 +75,6 @@ def test_ross_selinger(op, epsilon):
 
 
 @pytest.mark.catalyst
-@pytest.mark.jax
 @pytest.mark.external
 @pytest.mark.parametrize(
     ("op", "epsilon", "wires"),
@@ -93,7 +92,6 @@ def test_ross_selinger(op, epsilon):
 @pytest.mark.filterwarnings("ignore::pennylane.exceptions.PennyLaneDeprecationWarning")
 def test_ross_selinger_qjit(op, epsilon, wires):
     """Test Ross-Selinger decomposition method with specified max-depth"""
-    pytest.importorskip("catalyst")
     dev = qp.device("lightning.qubit", wires=wires)
 
     @qp.qjit(static_argnums=0)
@@ -135,7 +133,6 @@ def test_exception():
 
 
 @pytest.mark.catalyst
-@pytest.mark.jax
 @pytest.mark.external
 @pytest.mark.parametrize(
     ("decomposition_info"),
@@ -151,9 +148,8 @@ def test_exception():
 @pytest.mark.filterwarnings("ignore::pennylane.exceptions.PennyLaneDeprecationWarning")
 def test_jit_rs_decomposition(decomposition_info):
     """Test that the qjit rs decomposition is working."""
-    catalyst = pytest.importorskip("catalyst")
-    jax = pytest.importorskip("jax")
-    jnp = jax.numpy
+    import catalyst
+    from jax import numpy as jnp
 
     # Create decomposition info using jnp
     has_leading_t = jnp.int32(decomposition_info[0])  # First element

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -1130,7 +1130,9 @@ class TestMCXDecomposition:
                 control_wires, target_wire, work_wires, work_wire_type="zeroed"
             )
 
+    @pytest.mark.catalyst
     @pytest.mark.external
+    @pytest.mark.usefixtures("enable_graph_decomposition")
     @pytest.mark.parametrize(
         "num_control_wires, num_work_wires",
         [(4, 1), (4, 2)],
@@ -1138,11 +1140,8 @@ class TestMCXDecomposition:
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_mcx_qjit(self, num_control_wires, num_work_wires, work_wire_type):
         """Test that MultiControlledX decomposition is QJIT compatible with JAX-traced wires."""
-        jax = pytest.importorskip("jax")
         from catalyst.device.decomposition import catalyst_decompose
-
-        jnp = jax.numpy
-        qp.decomposition.enable_graph()
+        from jax import numpy as jnp
 
         gate_set = {
             "X",

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1231,13 +1231,11 @@ class TestTwoQubitUnitaryDecompositionInterfaces:
 
         assert check_matrix_equivalence(U, jitted_matrix, atol=1e-7)
 
-    @pytest.mark.jax
     @pytest.mark.catalyst
     @pytest.mark.external
     def test_two_qubit_decomposition_2_cnots_qjit(self):
         """Test that two_qubit_decomposition does not raise TracerArrayConversionError
         under qjit. Regression test for #9016."""
-        pytest.importorskip("catalyst")
         import jax.numpy as jnp
         from catalyst import grad as catalyst_grad
         from catalyst.utils.exceptions import DifferentiableCompileError

--- a/tests/ops/op_math/test_prod.py
+++ b/tests/ops/op_math/test_prod.py
@@ -1744,11 +1744,13 @@ class TestDecomposition:
         for rule in qp.list_decomps("C(Prod)"):
             _test_decomposition_rule(op, rule)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize(
         "num_control_wires, num_work_wires",
         [(3, 1), (3, 2), (4, 1), (5, 3)],
     )
+    @pytest.mark.usefixtures("enable_graph_decomposition")
     @pytest.mark.parametrize("work_wire_type", ["zeroed"])
     def test_controlled_prod_qjit(self, num_control_wires, num_work_wires, work_wire_type):
         """Test that the ``C(Prod)`` decompositions* is QJIT-compatible with JAX-traced wires.
@@ -1765,8 +1767,6 @@ class TestDecomposition:
         """
 
         from catalyst.device.decomposition import catalyst_decompose
-
-        qp.decomposition.enable_graph()
 
         gate_set = {
             "X": 1,

--- a/tests/ops/qubit/test_matrix_ops.py
+++ b/tests/ops/qubit/test_matrix_ops.py
@@ -835,6 +835,7 @@ class TestDiagonalQubitUnitary:  # pylint: disable=too-many-public-methods
         assert qp.math.allclose(orig_mat, decomp_mat)
         assert qp.math.allclose(orig_mat, decomp_mat2)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("n", [1, 2, 3])
     def test_decomposition_matrix_match_jit(self, n, seed):
@@ -903,6 +904,7 @@ class TestDiagonalQubitUnitary:  # pylint: disable=too-many-public-methods
         for rule in qp.list_decomps(qp.DiagonalQubitUnitary):
             _test_decomposition_rule(op, rule)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("op", standard_case_ops)
     def test_decomposition_rule_new_qjit(self, op):
@@ -953,6 +955,7 @@ class TestDiagonalQubitUnitary:  # pylint: disable=too-many-public-methods
         for rule in qp.list_decomps(qp.DiagonalQubitUnitary):
             _test_decomposition_rule(op, rule)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("op", edge_case_ops)
     def test_decomposition_rule_edge_cases_qjit(self, op):

--- a/tests/ops/qubit/test_parametric_ops.py
+++ b/tests/ops/qubit/test_parametric_ops.py
@@ -17,7 +17,7 @@ Unit tests for the available built-in parametric qubit operations.
 
 # pylint: disable=too-few-public-methods,too-many-public-methods
 import copy
-from functools import partial, reduce
+from functools import reduce
 
 import numpy as np
 import pytest
@@ -3321,6 +3321,7 @@ class TestMultiRZ:
         op = qp.MultiRZ(0.123, wires=[0, 1, 2, 3])
         qp.ops.functions.assert_valid(op)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("n", [1, 2, 3, 4])
     def test_MultiRZ_decomposition_qjit_old(self, n):
@@ -3333,6 +3334,7 @@ class TestMultiRZ:
         exp_mat = qp.MultiRZ.compute_matrix(theta, n)
         assert np.allclose(mat, exp_mat)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("n", [1, 2, 3, 4])
     def test_MultiRZ_decomposition_qjit_new(self, n):
@@ -3343,7 +3345,7 @@ class TestMultiRZ:
         exp_state = np.diag(qp.MultiRZ.compute_matrix(theta, n)) / 2 ** (n / 2)
         for rule in qp.list_decomps(qp.MultiRZ):
 
-            @partial(qp.qjit, static_argnums=[1])
+            @qp.qjit(static_argnums=[1])
             @qp.qnode(qp.device("lightning.qubit", wires=n))
             def node(theta, rule):
                 _ = [qp.H(w) for w in range(n)]

--- a/tests/optimize/test_momentum_qng_qjit.py
+++ b/tests/optimize/test_momentum_qng_qjit.py
@@ -202,14 +202,11 @@ class TestOptimize:
         assert np.allclose(state2, state2_jit)
         assert np.allclose(cost, cost_jit)
 
-    @pytest.mark.jax
     @pytest.mark.catalyst
     @pytest.mark.external
     def test_qjit(self):
         """Test optimizer compatibility with qp.qjit compilation."""
         import jax.numpy as jnp
-
-        pytest.importorskip("catalyst")
 
         device = qp.device("lightning.qubit", wires=2)
         qnode = qp.QNode(circuit, device=device)

--- a/tests/optimize/test_qng_qjit.py
+++ b/tests/optimize/test_qng_qjit.py
@@ -379,14 +379,11 @@ class TestOptimize:
         assert state2_jit is None
         assert np.allclose(cost, cost_jit)
 
-    @pytest.mark.jax
     @pytest.mark.catalyst
     @pytest.mark.external
     def test_qjit(self):
         """Test optimizer compatibility with qp.qjit compilation."""
         import jax.numpy as jnp
-
-        pytest.importorskip("catalyst")
 
         device = qp.device("lightning.qubit", wires=2)
         qnode = qp.QNode(circuit, device=device)

--- a/tests/qchem/test_factorization.py
+++ b/tests/qchem/test_factorization.py
@@ -149,7 +149,7 @@ def test_factorize_reproduce(two_tensor):
 @pytest.mark.parametrize("regularization", [None, "L1", "L2"])
 def test_factorize_compressed_reproduce(two_tensor, cholesky, regularization):
     r"""Test that factors returned by the factorize function reproduce the two-electron tensor."""
-    optax = pytest.importorskip("optax")
+    import optax
 
     factors, cores, leaves = qp.qchem.factorize(
         two_tensor,
@@ -193,8 +193,6 @@ def test_factorize_compressed_reproduce(two_tensor, cholesky, regularization):
 )
 def test_regularization_error(two_tensor):
     r"""Test that the factorize function raises an error when incorrect regularization is provided."""
-    _ = pytest.importorskip("optax")
-
     with pytest.raises(ValueError, match="Supported regularization types include"):
         qp.qchem.factorize(two_tensor, compressed=True, regularization=True)
 

--- a/tests/templates/layers/test_strongly_entangling.py
+++ b/tests/templates/layers/test_strongly_entangling.py
@@ -28,7 +28,6 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
 @pytest.mark.jax
-@pytest.mark.external
 def test_standard_validity():
     """Check the operation using the assert_valid function."""
 

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -611,6 +611,7 @@ class TestSumOfSlatersPrep:
                 out_state = out_state[::2]
             assert np.allclose([out_state[key] for key in indices], coefficients)
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     def test_qjit_on_subroutine(self, seed):
         """Test that the subroutine of the SumOfSlatersPrep decomposition

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -412,6 +412,7 @@ class TestOutMultiplier:
         wires = qp.OutMultiplier(x_wires=[1, 2], y_wires=[3, 4], output_wires=[5, 6]).wires
         assert wires == qp.wires.Wires([1, 2, 3, 4, 5, 6])
 
+    @pytest.mark.catalyst
     @pytest.mark.external
     def test_qjit_compatible(self):
         """Test that the template is compatible with the QJIT compiler."""

--- a/tests/templates/subroutines/arithmetic/test_temporary_and.py
+++ b/tests/templates/subroutines/arithmetic/test_temporary_and.py
@@ -287,6 +287,7 @@ class TestTemporaryAND:
         assert qp.math.allclose(circuit(), jit_circuit())
 
     @pytest.mark.usefixtures("enable_graph_decomposition")
+    @pytest.mark.catalyst
     @pytest.mark.external
     @pytest.mark.parametrize("cvals", [(0, 0), (0, 1), (1, 1), (True, False)])
     def test_jax_qjit_control_values(self, cvals):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -15,25 +15,24 @@
 Unit tests for the compiler subpackage.
 """
 
-# pylint: disable=import-outside-toplevel
+# pylint: disable=wrong-import-position
 from unittest.mock import patch
 
 import mcm_utils
 import numpy as np
 import pytest
 
+pytestmark = [pytest.mark.external, pytest.mark.catalyst]
+
+import catalyst
+import jax
+from jax import numpy as jnp
+from jax.core import ShapedArray
+
 import pennylane as qp
 from pennylane import numpy as np
 from pennylane.exceptions import CompileError
 from pennylane.transforms.dynamic_one_shot import fill_in_value
-
-catalyst = pytest.importorskip("catalyst")
-jax = pytest.importorskip("jax")
-
-pytestmark = pytest.mark.external
-
-from jax import numpy as jnp  # pylint:disable=wrong-import-order, wrong-import-position
-from jax.core import ShapedArray  # pylint:disable=wrong-import-order, wrong-import-position
 
 # pylint: disable=too-few-public-methods, too-many-public-methods
 

--- a/tests/transforms/intermediate_reps/test_rowcol.py
+++ b/tests/transforms/intermediate_reps/test_rowcol.py
@@ -173,7 +173,6 @@ def assert_respects_connectivity(cnots, connectivity):
     assert unique_undirected_cnots.issubset(edges)
 
 
-@pytest.mark.external
 class TestRowCol:
     """Tests for rowcol."""
 

--- a/tests/transforms/test_cliffordt_transform.py
+++ b/tests/transforms/test_cliffordt_transform.py
@@ -220,15 +220,10 @@ class TestCliffordCompile:
         qp.math.isclose(res1, tape_fn([res2]), atol=1e-2)
 
     @pytest.mark.catalyst
-    @pytest.mark.jax
     @pytest.mark.external
     @pytest.mark.parametrize("circuit", [circuit_7, circuit_8, circuit_10])
     def test_decomposition_with_rs_qjit(self, circuit):
         """Test decomposition for the Clifford transform with Ross-Selinger method with QJIT enabled."""
-
-        pytest.importorskip("jax")
-        pytest.importorskip("catalyst")
-
         dev = qp.device("lightning.qubit", wires=4)
         qnode_cir = qp.qnode(dev)(circuit)
         decomp_cir = clifford_t_decomposition(qnode_cir, method="gridsynth")
@@ -238,14 +233,10 @@ class TestCliffordCompile:
         assert qp.math.isclose(res1, res2, atol=1e-2)
 
     @pytest.mark.catalyst
-    @pytest.mark.jax
     @pytest.mark.external
     @pytest.mark.parametrize("circuit", [circuit_1, circuit_10])
     def test_decomposition_with_rs_qjit_repeated_decomp(self, circuit):
         """Test decomposition for multiple Clifford transforms with Ross-Selinger method with QJIT enabled with repeated parameters."""
-
-        pytest.importorskip("jax")
-        pytest.importorskip("catalyst")
 
         dev = qp.device("lightning.qubit", wires=4)
         qnode_cir = qp.qnode(dev)(circuit)
@@ -742,13 +733,9 @@ class TestCatalyst:
         assert results[0] and not results[1]
 
     @pytest.mark.catalyst
-    @pytest.mark.jax
     @pytest.mark.external
     def test_decomposition_with_rs_qjit_dynamic_param(self):
         """Test clifford T decomposition with qjit and dynamic parameters."""
-
-        pytest.importorskip("jax")
-        pytest.importorskip("catalyst")
 
         def circuit(angle, qb):
             qp.H(qb)


### PR DESCRIPTION
**Context:**
- We have pytest markers `jax`, `external` and `catalyst`.
- The latter does not do anything in CI.
- The former is not installing Catalyst in CI but defines a group of runners, so that all tests with `jax` marker that use Catalyst need to do `importorskip("catalyst")`.
- Similarly, anything marked with `external` already will run in the external dependencies CI runner and have JAX installed, so marking with `jax` in addition only requires `importorskip("external_package")` but does not add any value.

**Description of the Change:**
Remove the marker `jax` from all tests that are marked with `external` and/or `catalyst`. 

**Benefits:**
Clearer precedence of marker usage.

**Possible Drawbacks:**

**Related GitHub Issues:**
