### PR TITLE
Fix BoseWord.__mul__ for factors built from non-sorted dicts

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -634,6 +634,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug in `BoseWord.__mul__` where multiplying by a `BoseWord` built from a non-sorted
+  dictionary returned the wrong operator, because the right factor's sorted keys were paired with
+  its insertion-order values.
+  [(#9660)](https://github.com/PennyLaneAI/pennylane/pull/9660)
+
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
   [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 
@@ -708,6 +713,7 @@ This release contains contributions from (in alphabetical order):
 Usman Ahmed,
 Guillermo Alonso,
 Abdullah Al Omar Galib,
+Booyaka101,
 Astral Cai,
 Daniel Casota,
 Yushao Chen,

--- a/pennylane/bose/bosonic.py
+++ b/pennylane/bose/bosonic.py
@@ -232,7 +232,8 @@ class BoseWord(dict):
             dict_other = dict(
                 zip(
                     [(order_idx, other_wires[i]) for i, order_idx in enumerate(order_final)],
-                    other.values(),
+                    # sorted_dic values to stay paired with the sorted keys above (#9650)
+                    other.sorted_dic.values(),
                     strict=True,
                 )
             )

--- a/tests/bose/test_bosonic.py
+++ b/tests/bose/test_bosonic.py
@@ -377,6 +377,16 @@ class TestBoseWordArithmetic:
         assert f1 * f2 == result_bw_right
         assert f2 * f1 == result_bw_left
 
+    def test_mul_with_non_sorted_dict_factor(self):
+        """Test that multiplying by a BoseWord built from a non-sorted dict matches the
+        equivalent sorted word, since the two are equal operators (#9650)."""
+        # same operator as bw1, but with a non-sorted insertion order
+        unsorted = BoseWord({(1, 1): "-", (0, 0): "+"})
+        assert unsorted == bw1
+        assert bw1 * unsorted == bw1 * bw1
+        assert unsorted * bw1 == bw1 * bw1
+        assert unsorted * bw3 == bw1 * bw3
+
     WORDS_AND_SENTENCES_MUL = (
         (
             bw1,


### PR DESCRIPTION
**Context:** Fixes #9650.

### Motivation

A `BoseWord` canonicalises its operators on construction (it stores a `sorted_dic`), so two words built from dictionaries with the same key/value pairs but different insertion order are equal:

```python
w1 = BoseWord({(0, 0): '+', (1, 1): '-'})   # b⁺(0) b(1)
w2 = BoseWord({(1, 1): '-', (0, 0): '+'})   # same operator, scrambled insertion order
assert w1 == w2
```

Because they are equal operators, `w1 * w1` and `w1 * w2` must give the same result. They did not:

```text
w1 * w1 = b⁺(0) b(1) b⁺(0) b(1)   # correct
w1 * w2 = b⁺(0) b(1) b(0) b⁺(1)   # wrong: last two symbols swapped
```

The corruption is stored in the returned object's `sorted_dic`, so it propagates to normal ordering, `qml.matrix`, Hamiltonian construction, etc.

### Implementation

In `BoseWord.__mul__`, the right factor's positions and wires are taken from `other.sorted_dic.keys()` (sorted), but they were zipped with `other.values()`, which follows the original **insertion** order. When `other` was built from a non-sorted dict, the operator symbols were paired with the wrong positions.

The fix pairs the sorted keys with `other.sorted_dic.values()` so values and keys come from the same ordering.

### Verification

- Reproduced the issue and confirmed the fix makes `w1 * w2 == w1 * w1` for non-sorted factors, on both left and right multiplication.
- Normal (already-sorted) multiplication, multi-operator words, and empty-word identity are unaffected.
- Added a regression test `test_mul_with_non_sorted_dict_factor`; `ruff` and `black` are clean.

### AI disclosure

Per the PennyLane AI Tool Use Policy, this change was prepared with AI assistance (Claude Code), reviewed by me; the commit carries an `Assisted-by:` trailer.
