### PR TITLE
Remove deprecated branch in `generator.py`

### DIFF
--- a/doc/development/deprecations.rst
+++ b/doc/development/deprecations.rst
@@ -107,6 +107,11 @@ for details on how to port your legacy code to the new system. The following fun
 Completed deprecation cycles
 ----------------------------
 
+* Implementing ``Operator.generator`` as a property is no longer supported. Instead, define a ``generator()`` method for your operator that returns an ``Operator`` instance.
+
+  - Deprecated in v0.22
+  - Removed in v0.46
+
 * Specifying ``shots`` as a keyword argument when executing a :class:`~.QNode` has been removed.
   Instead, please set shots on ``QNode`` initialization, or use the :func:`~.workflow.set_shots` transform to set the number of shots.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -509,6 +509,8 @@
   Instead, `Operator.queue` can be overwritten if needed.
   [(#9470)](https://github.com/PennyLaneAI/pennylane/pull/9470)
 
+* Implementing ``Operator.generator`` as a property is no longer supported. Instead, define a ``generator()`` method for your operator that returns an ``Operator`` instance.
+
 <h3>Deprecations 👋</h3>
 
 * The ``simplify`` method in ``PauliSentence``, ``FermiSentence``, and ``BoseSentence`` are deprecated in favour of ``prune``, and will be removed in v0.47.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -510,6 +510,7 @@
   [(#9470)](https://github.com/PennyLaneAI/pennylane/pull/9470)
 
 * Implementing ``Operator.generator`` as a property is no longer supported. Instead, define a ``generator()`` method for your operator that returns an ``Operator`` instance.
+  [(#9662)](https://github.com/PennyLaneAI/pennylane/pull/9662)
 
 <h3>Deprecations 👋</h3>
 

--- a/pennylane/ops/functions/generator.py
+++ b/pennylane/ops/functions/generator.py
@@ -15,13 +15,8 @@
 This module contains the qp.generator function.
 """
 
-import inspect
-import warnings
-
-import numpy as np
-
 import pennylane as qp
-from pennylane.exceptions import PennyLaneDeprecationWarning, QuantumFunctionError
+from pennylane.exceptions import QuantumFunctionError
 from pennylane.ops import LinearCombination, Prod, SProd, Sum
 
 
@@ -86,28 +81,6 @@ def _generator_prefactor(gen):
         return gen.base, gen.scalar
 
     return gen, prefactor
-
-
-def _generator_backcompatibility(op):
-    r"""Preserve backwards compatibility behaviour for PennyLane
-    versions <=0.22, where generators returned List[type or ndarray, float].
-    This function raises a deprecation warning, and converts to the new
-    format where an instantiated Operator is returned."""
-    warnings.warn(
-        "The Operator.generator property is deprecated. Please update the operator so that "
-        "\n\t1. Operator.generator() is a method, and"
-        "\n\t2. Operator.generator() returns an Operator instance representing the operator.",
-        PennyLaneDeprecationWarning,
-    )
-    gen = op.generator
-
-    if inspect.isclass(gen[0]):
-        return gen[1] * gen[0](wires=op.wires)
-
-    if isinstance(gen[0], np.ndarray) and len(gen[0].shape) == 2:
-        return gen[1] * qp.Hermitian(gen[0], wires=op.wires)
-
-    raise qp.operation.GeneratorUndefinedError
 
 
 def generator(op: qp.operation.Operator, format="prefactor"):
@@ -187,12 +160,7 @@ def generator(op: qp.operation.Operator, format="prefactor"):
                 f"Operation {gen_op.name} is not written in terms of a single parameter"
             )
 
-        try:
-            gen = gen_op.generator()
-        except TypeError:
-            # For backwards compatibility with PennyLane
-            # versions <=0.22, assume gen_op.generator is a property
-            gen = _generator_backcompatibility(gen_op)
+        gen = gen_op.generator()
 
         if not gen.is_verified_hermitian:
             raise QuantumFunctionError(

--- a/tests/ops/functions/test_generator.py
+++ b/tests/ops/functions/test_generator.py
@@ -195,59 +195,6 @@ class TestValidation:
             qp.generator(qp.RX, format=None)(0.5, wires=0)
 
 
-class TestBackwardsCompatibility:
-    """Test that operators that provide the old style generator property
-    continue to work with a deprecation warning."""
-
-    def test_return_class(self):
-        """Test that an old-style Operator that has a generator property,
-        and that returns a list containing (a) operator class and (b) prefactor,
-        continues to work but also raises a deprecation warning."""
-
-        class DeprecatedClassOp(CustomOp):
-            generator = [qp.PauliX, -0.6]
-
-        op = DeprecatedClassOp(0.5, wires="a")
-
-        with pytest.warns(UserWarning, match=r"The Operator\.generator property is deprecated"):
-            gen, prefactor = qp.generator(op)
-
-        assert isinstance(gen, qp.operation.Operator)
-        assert prefactor == -0.6
-        assert gen.name == "PauliX"
-        assert gen.wires.tolist() == ["a"]
-
-    def test_return_array(self):
-        """Test that an old-style Operator that has a generator property,
-        and that returns a list containing (a) array and (b) prefactor,
-        continues to work but also raises a deprecation warning."""
-
-        class DeprecatedClassOp(CustomOp):
-            generator = [np.diag([0, 1]), -0.6]
-
-        op = DeprecatedClassOp(0.5, wires="a")
-
-        with pytest.warns(UserWarning, match=r"The Operator\.generator property is deprecated"):
-            gen, prefactor = qp.generator(op)
-
-        assert isinstance(gen, qp.operation.Operator)
-        assert prefactor == -0.6
-        assert gen.name == "Hermitian"
-        assert gen.wires.tolist() == ["a"]
-
-    def test_generator_property_old_default(self):
-        """Test that if the old-style generator property is the default,
-        a GeneratorUndefinedError is raised and a warning is raised about the old syntax."""
-
-        class DeprecatedClassOp(CustomOp):
-            generator = [None, 1]
-
-        op = DeprecatedClassOp(0.5, wires="a")
-        with pytest.warns(UserWarning, match=r"The Operator\.generator property is deprecated"):
-            with pytest.raises(qp.operation.GeneratorUndefinedError):
-                qp.generator(op)
-
-
 class TestPrefactorReturn:
     """Tests for format="prefactor". This format attempts to isolate a prefactor
     (if possible) from the generator, which is useful if the generator is a Pauli word."""


### PR DESCRIPTION
**Context:**
There's a backwards compatibility branch in `generator` that has been deprecated for four years, removing it now.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
