### PR TITLE
Use standard PL interface casting

### DIFF
--- a/pennylane/ops/qubit/state_preparation.py
+++ b/pennylane/ops/qubit/state_preparation.py
@@ -237,13 +237,8 @@ def _basis_state_decomp(state, wires, **__):
     if qp.capture.enabled() or qp.compiler.active():
         # This branch makes sure that state and wires are cast to objects into which
         # a traced loop index is allowed to index (if they aren't already traced)
-        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
-
-        if not qp.math.is_abstract(state):
-            state = jnp.array(state)
-
-        if not qp.math.is_abstract(wires):
-            wires = jnp.array(wires)
+        state = qp.math.array(state, like="jax")
+        wires = qp.math.array(wires, like="jax")
 
     @qp.for_loop(len(state))
     def _loop(i):


### PR DESCRIPTION
Encountered this in the wild, but it's better to use the standard method already available in PL.