### PR TITLE
Fix mutual information on default.clifford (missing S(AB) term)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1086,6 +1086,11 @@
 * Fixed a bug in :class:`~.SumOfSlatersPrep` with `qjit` compilation and non-identity encoding.
   [(#9747)](https://github.com/PennyLaneAI/pennylane/pull/9747)
 
+* Fixed a bug in `default.clifford` where `qml.mutual_info` omitted the joint-subsystem entropy
+  term, returning `S(A) + S(B)` instead of `S(A) + S(B) - S(AB)` and therefore double the correct
+  value for correlated subsystems.
+  [(#9668)](https://github.com/PennyLaneAI/pennylane/pull/9668)
+
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
   [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 
@@ -1185,6 +1190,7 @@ Miguel Cárdenas,
 Yushao Chen,
 Diksha Dhawan,
 Marcus Edwards,
+Vincent Gao,
 Austin Huang,
 Harshal Janjani,
 Jacob Kitchen,

--- a/pennylane/devices/default_clifford.py
+++ b/pennylane/devices/default_clifford.py
@@ -840,9 +840,16 @@ class DefaultClifford(Device):
         tableau = tableau_simulator.current_inverse_tableau().inverse()
         z_stabs = math.array([tableau.z_output(wire) for wire in range(len(wires))])
         indices0, indices1 = getattr(meas, "_wires")
-        return self._measure_stabilizer_entropy(
-            z_stabs, list(indices0), meas.log_base
-        ) + self._measure_stabilizer_entropy(z_stabs, list(indices1), meas.log_base)
+        # Mutual information is I(A:B) = S(A) + S(B) - S(AB); the joint-subsystem
+        # entropy S(AB) must be subtracted (previously omitted, so the result was
+        # double the correct value for maximally correlated subsystems).
+        return (
+            self._measure_stabilizer_entropy(z_stabs, list(indices0), meas.log_base)
+            + self._measure_stabilizer_entropy(z_stabs, list(indices1), meas.log_base)
+            - self._measure_stabilizer_entropy(
+                z_stabs, list(indices0) + list(indices1), meas.log_base
+            )
+        )
 
     def _measure_purity(self, meas, tableau_simulator, **kwargs):
         r"""Measure the purity of the state of simulator device.

--- a/tests/devices/test_default_clifford.py
+++ b/tests/devices/test_default_clifford.py
@@ -181,6 +181,30 @@ def test_meas_qinfo_clifford(meas_op):
     assert np.allclose(qnode_clfrd(), qnode_qubit())
 
 
+def test_mutual_info_clifford_subtracts_joint_entropy():
+    """Mutual information on ``default.clifford`` must subtract the joint entropy.
+
+    Regression test for a bug where ``I(A:B)`` was computed as ``S(A) + S(B)``
+    without the ``- S(AB)`` term, giving double the correct value for correlated
+    subsystems (PennyLaneAI/pennylane#9610). For a GHZ state the mutual
+    information between two qubits is ``ln(2)``, not ``2 * ln(2)``.
+    """
+    dev_c = qp.device("default.clifford", wires=3)
+    dev_q = qp.device("default.qubit", wires=3)
+
+    def circuit_fn():
+        qp.Hadamard(0)
+        qp.CNOT(wires=[0, 1])
+        qp.CNOT(wires=[1, 2])
+        return qp.mutual_info(wires0=[0], wires1=[1])
+
+    clifford_mi = qp.QNode(circuit_fn, dev_c)()
+    qubit_mi = qp.QNode(circuit_fn, dev_q)()
+
+    assert np.allclose(clifford_mi, np.log(2))
+    assert np.allclose(clifford_mi, qubit_mi)
+
+
 @pytest.mark.parametrize("shots", [None, 1_000_000])
 @pytest.mark.parametrize(
     "ops",


### PR DESCRIPTION
**Context:** Fixes #9610.

### Problem

`qml.mutual_info` returns incorrect results on `default.clifford`. For a state
where the two subsystems are correlated, the device returns double the correct
value. The reproducer from the issue (a 3-qubit GHZ state) returns `2*ln(2) ≈
1.3863` for the mutual information between qubits 0 and 1, where the correct
answer is `ln(2) ≈ 0.6931`. `default.qubit` is unaffected because it uses a
different code path.

### Cause

`DefaultClifford._measure_mutual_info` (`pennylane/devices/default_clifford.py`)
computed `S(A) + S(B)` and never subtracted the joint-subsystem entropy. Mutual
information is `I(A:B) = S(A) + S(B) - S(AB)`, so the `S(AB)` term was missing.
This was invisible whenever the subsystems are uncorrelated (`S(AB) = 0`), which
is why the existing `test_meas_qinfo_clifford` parametrizations did not catch
it.

### Fix

Subtract the entropy of the joint subsystem, computed with the existing
`_measure_stabilizer_entropy` helper over the concatenated wire indices
(`list(indices0) + list(indices1)`). After the fix `default.clifford` agrees
with `default.qubit`.

### Test

Adds `test_mutual_info_clifford_subtracts_joint_entropy`, which runs the GHZ
reproducer and asserts the mutual information equals `ln(2)` and matches
`default.qubit`. The existing uncorrelated-subsystem tests still pass unchanged.
Without the fix the new test fails with `1.3863 != 0.6931`.

I reviewed and verified this change myself: I reproduced the bug, confirmed the
fix yields `ln(2)`, and checked the regression test fails without it. Tool usage
is disclosed via an `Assisted-by` trailer per the AI policy.
