### PR TITLE
Fix serial perturbation error accumulation across BCH orders

### DIFF
--- a/pennylane/labs/tests/trotter_error/product_formulas/test_error_trotter.py
+++ b/pennylane/labs/tests/trotter_error/product_formulas/test_error_trotter.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 from pennylane.labs.trotter_error import (
+    generic_fragments,
     HOState,
     ProductFormula,
     perturbation_error,
@@ -65,6 +66,23 @@ def test_perturbation_error(backend, parallel_mode, mpi4py_support):
 
     assert isinstance(errors, list)
     assert len(errors) == 2
+
+
+def test_perturbation_error_serial_accumulates_each_order_independently():
+    """Test that serial execution stores independent scalar expectation values by order."""
+
+    x_mat = np.array([[0, 1], [1, 0]], dtype=complex)
+    z_mat = np.array([[1, 0], [0, -1]], dtype=complex)
+    frags = dict(enumerate(generic_fragments([x_mat, z_mat])))
+    pf = ProductFormula([0, 1, 1, 0], coeffs=[0.5, 0.5, 0.5, 0.5])
+    state = np.array([1, 0], dtype=complex)
+
+    errors = perturbation_error(pf, frags, [state], max_order=5, backend="serial")
+
+    assert len(errors) == 1
+    assert set(errors[0]) == {3, 5}
+    assert np.allclose(errors[0][3], 1j / 6)
+    assert np.allclose(errors[0][5], -0.025j)
 
 
 def test_perturbation_error_invalid_parallel_mode():

--- a/pennylane/labs/trotter_error/product_formulas/error.py
+++ b/pennylane/labs/trotter_error/product_formulas/error.py
@@ -211,16 +211,19 @@ def perturbation_error(
         assert num_workers == 1, "num_workers must be set to 1 for serial execution."
         expectations = []
         for state in states:
-            expectation = 0
+            state_expectations = {}
             for commutators in commutator_lists:
                 if len(commutators) == 0:
                     continue
 
                 order = len(commutators[0])
-                for commutator in commutators:
-                    expectation += _compute_expectation(commutator, fragments, state)
+                expectation = sum(
+                    _compute_expectation(commutator, fragments, state)
+                    for commutator in commutators
+                )
+                state_expectations[order] = (1j * timestep) ** order * expectation
 
-                expectations.append({order: (1j * timestep) ** order * expectation})
+            expectations.append(state_expectations)
 
         return expectations
 


### PR DESCRIPTION
**Context:**

PR #8226 updated `perturbation_error` to accumulate scalar expectation values rather than intermediate state vectors, addressing the main issue described in #8152.

While checking the current implementation, I found a remaining serial-mode inconsistency for cases where the BCH expansion has multiple non-empty orders. The serial path was appending one result per order and reusing the accumulated scalar across orders, while the parallel paths returned one dictionary per input state with each order accumulated independently.

**Description of the Change:**

This updates the serial `perturbation_error` path to:

- compute a fresh scalar expectation value for each BCH order,
- store each order in a per-state dictionary,
- append exactly one result dictionary per input state.

A regression test was added using a small two-Pauli matrix example with non-empty order 3 and order 5 BCH terms. The test verifies that serial execution returns independent scalar contributions for each order.

**Benefits:**

This makes serial execution consistent with the existing parallel `state` and `commutator` modes for multi-order perturbation error estimates.

**Possible Drawbacks:**

None expected. The change is limited to the serial accumulation path and preserves the existing return shape used by the parallel paths.

**Related GitHub Issues:**

Refs #8152

Follows up #8226

**Testing:**

```bash
.venv/bin/python -m pytest pennylane/labs/tests/trotter_error/product_formulas/test_error_trotter.py::test_perturbation_error_serial_accumulates_each_order_independently -q
.venv/bin/python -m pytest pennylane/labs/tests/trotter_error/product_formulas/test_error_trotter.py -q
.venv/bin/python -m pytest pennylane/labs/tests/trotter_error/product_formulas/test_pt_integration.py -q
git diff --check
```

Results:

- `1 passed`
- `10 passed, 4 skipped`
- `8 passed, 4 skipped`
- `git diff --check` clean
