### PR TITLE
Improve estimator gate set error message

### DIFF
--- a/pennylane/estimator/estimate.py
+++ b/pennylane/estimator/estimate.py
@@ -20,6 +20,7 @@ from functools import singledispatch, wraps
 from pennylane.core.measurements import MeasurementProcess
 from pennylane.core.operator import Operation, Operator
 from pennylane.estimator.ops.op_math.symbolic import Adjoint, Controlled, Pow
+from pennylane.exceptions import ResourcesUndefinedError
 from pennylane.queuing import AnnotatedQueue, QueuingManager
 from pennylane.wires import Wires
 from pennylane.workflow.qnode import QNode
@@ -37,6 +38,33 @@ _SYMBOLIC_DECOMP_MAP = {
     Controlled: ("ctrl_custom_decomps", "controlled_resource_decomp"),
     Pow: ("pow_custom_decomps", "pow_resource_decomp"),
 }
+
+
+def _gate_set_to_str(gate_set: Iterable) -> str:
+    """Return a deterministic display string for a requested gate set."""
+    gate_names = [
+        gate if isinstance(gate, str) else getattr(gate, "__name__", str(gate))
+        for gate in gate_set
+    ]
+    return "{" + ", ".join(repr(gate_name) for gate_name in sorted(gate_names)) + "}"
+
+
+def _resources_undefined_error_message(
+    comp_res_op: CompressedResourceOp, gate_set: Iterable, original_error: ResourcesUndefinedError
+) -> str:
+    """Return an actionable error for operators that cannot target a requested gate set."""
+    message = (
+        f"Resources for {comp_res_op.name} cannot be expressed in the requested gate_set "
+        f"{_gate_set_to_str(gate_set)}. {comp_res_op.name} is not in the gate_set and does "
+        "not define a resource decomposition to continue decomposing it. To estimate this "
+        f"workflow, add {comp_res_op.name!r} to gate_set or provide a custom resource "
+        "decomposition with ResourceConfig.set_decomp."
+    )
+
+    if str(original_error):
+        message += f" Original error: {original_error}"
+
+    return message
 
 
 def estimate(
@@ -481,7 +509,13 @@ def _update_counts_from_compressed_res_op(
         gate_counts_dict[comp_res_op] += scalar
         return
 
-    resource_decomp = _get_resource_decomposition(comp_res_op, config)
+    try:
+        resource_decomp = _get_resource_decomposition(comp_res_op, config)
+    except ResourcesUndefinedError as exc:
+        raise ResourcesUndefinedError(
+            _resources_undefined_error_message(comp_res_op, gate_set, exc)
+        ) from exc
+
     qubit_alloc_sum = _sum_allocated_wires(resource_decomp)
 
     for action in resource_decomp:

--- a/tests/estimator/test_estimate.py
+++ b/tests/estimator/test_estimate.py
@@ -336,9 +336,33 @@ class TestEstimateResources:
         """Test that a ResourcesUndefinedError is raised when obtaining resources for
         a resource operator which has no resource_decomp defined"""
         with pytest.raises(
-            ResourcesUndefinedError, match=".* does not have a resource decomposition defined"
+            ResourcesUndefinedError,
+            match=(
+                "Resources for DummyT cannot be expressed in the requested gate_set "
+                ".*add 'DummyT' to gate_set.*ResourceConfig.set_decomp"
+            ),
         ):
             estimate(workflow=DummyT(), gate_set={DummyCNOT})
+
+    def test_estimate_resources_from_qfunc_with_untargetable_gate_set(self):
+        """Test that qfunc resource estimation explains how to fix an untargetable gate set."""
+
+        def circuit(num_wires):
+            qp.estimator.Hadamard()
+            qp.estimator.BasisRotation(num_wires)
+            mrx = qp.estimator.MultiRZ(2)
+            qp.estimator.Controlled(mrx, num_ctrl_wires=1, num_zero_ctrl=1)
+            qp.estimator.PhaseShift()
+
+        with pytest.raises(ResourcesUndefinedError) as exc_info:
+            estimate(circuit, gate_set={"RZ", "CNOT"})(3)
+
+        message = str(exc_info.value)
+        assert "Resources for Hadamard cannot be expressed in the requested gate_set" in message
+        assert "'CNOT'" in message
+        assert "'RZ'" in message
+        assert "add 'Hadamard' to gate_set" in message
+        assert "ResourceConfig.set_decomp" in message
 
     def test_estimate_resources_from_scaled_resource_operator(self):
         """Test that we can accurately obtain resources from resource operator"""


### PR DESCRIPTION
**Summary**

When `qml.estimator.estimate` cannot express a workflow in terms of the requested `gate_set`, the current error can be hard to act on. In the example from #8530, the estimator eventually reaches `Hadamard`, sees that it is not in `{"RZ", "CNOT"}`, and raises a low-level resource decomposition error.

That tells the user which gate failed, but not why it failed in the context of their `gate_set` or what they can change to keep going.

**What changed**

This wraps `ResourcesUndefinedError` at the estimator boundary when an operator cannot be decomposed toward the requested gate set. The new message explains:

- which operator could not be expressed,
- which `gate_set` was requested,
- that the operator is not in the gate set and has no further resource decomposition,
- how to proceed by adding the operator to `gate_set` or providing a custom decomposition with `ResourceConfig.set_decomp`.

The underlying decomposition behavior is unchanged.

**Why**

This makes the estimator failure mode much more direct for users. Instead of seeing only that a fundamental resource operator has no decomposition, they now get the gate-set context and a concrete next step.

**Testing**

```bash
.venv/bin/python -m pytest tests/estimator/test_estimate.py::TestEstimateResources::test_estimate_resources_from_resource_operator_no_decomp tests/estimator/test_estimate.py::TestEstimateResources::test_estimate_resources_from_qfunc_with_untargetable_gate_set -q
.venv/bin/python -m pytest tests/estimator/test_estimate.py -q
git diff --check
```

Results:

- `2 passed`
- `25 passed`
- `git diff --check` clean

Fixes #8530
