### PR TITLE
Support collapsible tables in specs IPython output

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -245,6 +245,7 @@
 
 * Data from :func:`~.specs` now have markdown formatting for IPython, improving their readability;
   particularly :class:`~.resource.CircuitSpecs` and :class:`~.resource.SpecsResources`.
+  [(#9679)](https://github.com/PennyLaneAI/pennylane/pull/9679)
   [(#9585)](https://github.com/PennyLaneAI/pennylane/pull/9585)
 
 * Added a decomposition of `DiagonalQubitUnitary` into a single `RZ` multiplexer, i.e.

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -964,6 +964,9 @@ class CircuitSpecs:
 
             https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
         """
+        #pylint: disable=too-many-branches
+        # Ignore pylint on this one, this is not better served by splitting into even
+        # smaller functions than it already has
         lines = []
         if collapsible:
             lines.append("<details open>")

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -964,7 +964,7 @@ class CircuitSpecs:
 
             https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
         """
-        #pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches
         # Ignore pylint on this one, this is not better served by splitting into even
         # smaller functions than it already has
         lines = []

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -950,7 +950,7 @@ class CircuitSpecs:
             )
         return "\n".join(lines)
 
-    def _repr_markdown_(self) -> str:
+    def _repr_markdown_(self, collapsible: bool = True) -> str:
         """
         Return a Markdown representation of the :class:`CircuitSpecs` for Jupyter notebook display.
 
@@ -959,7 +959,11 @@ class CircuitSpecs:
             https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
         """
         lines = []
-        lines.append("**Circuit Specs:**")
+        if collapsible:
+            lines.append("<details open>")
+            lines.append("<summary>Circuit Specs</summary>")
+        else:
+            lines.append("**Circuit Specs:**")
         lines.append("")
         lines.append("| Metric | Value |")
         lines.append("| :--- | ---: |")
@@ -974,19 +978,35 @@ class CircuitSpecs:
             lines.append(f"| **Level** | {self.level} |")
 
         lines.append("")
-        lines.append("**Resources:**")
+
+        if collapsible:
+            lines.append("</details>")
+            lines.append("<details open>")
+            lines.append("<summary>Resources</summary>")
+        else:
+            lines.append("**Resources:**")
         lines.append("")
 
         if isinstance(self.resources, SpecsResources):
             lines.append(self.resources._repr_markdown_())  # pylint: disable=protected-access
         elif isinstance(self.resources, list):
             for i, r in enumerate(self.resources):
-                lines.append(f"**Batched tape {num_to_letters(i)}:**")
+                if collapsible:
+                    lines.append("<details open>")
+                    lines.append(f"<summary>Batched tape {num_to_letters(i)}</summary>")
+                else:
+                    lines.append(f"**Batched tape {num_to_letters(i)}:**")
                 lines.append("")
                 lines.append(r._repr_markdown_())  # pylint: disable=protected-access
                 lines.append("")
+                if collapsible:
+                    lines.append("</details>")
         elif isinstance(self.resources, dict):
             lines.append(self._to_markdown_tabular())
+
+        if collapsible:
+            lines.append("")
+            lines.append("</details>")
 
         return "\n".join(lines)
 

--- a/pennylane/resource/resource.py
+++ b/pennylane/resource/resource.py
@@ -954,6 +954,12 @@ class CircuitSpecs:
         """
         Return a Markdown representation of the :class:`CircuitSpecs` for Jupyter notebook display.
 
+        Args:
+            collapsible (bool): Whether to display the resources in collapsible sections.
+
+        Returns:
+            str: A Markdown representation of this object for Jupyter notebooks.
+
         .. seealso::
 
             https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods

--- a/tests/resource/test_resource.py
+++ b/tests/resource/test_resource.py
@@ -1449,7 +1449,7 @@ class TestIPythonDisplays:
             level=2,
             resources=example_specs_resource,
         )
-        actual = s._repr_markdown_()
+        actual = s._repr_markdown_(collapsible=False)
         expected = textwrap.dedent("""\
             **Circuit Specs:**
 
@@ -1476,6 +1476,47 @@ class TestIPythonDisplays:
 
         assert actual.strip() == expected.strip()
 
+    def test_single_level_circuit_specs_ipython_display_collapsible(self, example_specs_resource):
+        """Test the IPython display of a single-level CircuitSpecs instance."""
+        s = CircuitSpecs(
+            device_name="default.qubit",
+            num_device_wires=5,
+            shots=Shots(1000),
+            level=2,
+            resources=example_specs_resource,
+        )
+        actual = s._repr_markdown_(collapsible=True)
+        expected = textwrap.dedent("""\
+            <details open>
+            <summary>Circuit Specs</summary>
+
+            | Metric | Value |
+            | :--- | ---: |
+            | **Device** | default.qubit |
+            | **Device wires** | 5 |
+            | **Shots** | Shots(total=1000) |
+            | **Level** | 2 |
+
+            </details>
+            <details open>
+            <summary>Resources</summary>
+
+            | **Metric** | **Value** |
+            | :--- | ---: |
+            | **Wire allocations** | 2 |
+            | **Total gates** | 1.000E+5 |
+            | **Gate counts:** | |
+            | Hadamard | 1 |
+            | CNOT | 1.000E+5 |
+            | **Measurements:** | |
+            | expval(PauliZ) | 1 |
+            | **Depth** | 2 |
+
+            </details>
+        """)
+
+        assert actual.strip() == expected.strip()
+
     def test_batched_circuit_specs_ipython_display(self, example_specs_resource):
         """Test the IPython display of a single-level CircuitSpecs instance."""
         s = CircuitSpecs(
@@ -1485,7 +1526,7 @@ class TestIPythonDisplays:
             level=2,
             resources=[example_specs_resource, example_specs_resource],
         )
-        actual = s._repr_markdown_()
+        actual = s._repr_markdown_(collapsible=False)
         expected = textwrap.dedent("""\
             **Circuit Specs:**
 
@@ -1527,6 +1568,67 @@ class TestIPythonDisplays:
 
         assert actual.strip() == expected.strip()
 
+    def test_batched_circuit_specs_ipython_display_collapsible(self, example_specs_resource):
+        """Test the IPython display of a single-level CircuitSpecs instance."""
+        s = CircuitSpecs(
+            device_name="default.qubit",
+            num_device_wires=5,
+            shots=Shots(1000),
+            level=2,
+            resources=[example_specs_resource, example_specs_resource],
+        )
+        actual = s._repr_markdown_(collapsible=True)
+        expected = textwrap.dedent("""\
+            <details open>
+            <summary>Circuit Specs</summary>
+
+            | Metric | Value |
+            | :--- | ---: |
+            | **Device** | default.qubit |
+            | **Device wires** | 5 |
+            | **Shots** | Shots(total=1000) |
+            | **Level** | 2 |
+
+            </details>
+            <details open>
+            <summary>Resources</summary>
+
+            <details open>
+            <summary>Batched tape a</summary>
+
+            | **Metric** | **Value** |
+            | :--- | ---: |
+            | **Wire allocations** | 2 |
+            | **Total gates** | 1.000E+5 |
+            | **Gate counts:** | |
+            | Hadamard | 1 |
+            | CNOT | 1.000E+5 |
+            | **Measurements:** | |
+            | expval(PauliZ) | 1 |
+            | **Depth** | 2 |
+
+            </details>
+            <details open>
+            <summary>Batched tape b</summary>
+
+            | **Metric** | **Value** |
+            | :--- | ---: |
+            | **Wire allocations** | 2 |
+            | **Total gates** | 1.000E+5 |
+            | **Gate counts:** | |
+            | Hadamard | 1 |
+            | CNOT | 1.000E+5 |
+            | **Measurements:** | |
+            | expval(PauliZ) | 1 |
+            | **Depth** | 2 |
+
+            </details>
+
+            </details>
+            """)
+
+        assert actual.strip() == expected.strip()
+
     def test_multi_level_circuit_specs_ipython_display(
         self, example_symbolic_specs_resource, example_specs_resource
     ):
@@ -1541,7 +1643,7 @@ class TestIPythonDisplays:
                 1: [example_specs_resource, example_specs_resource],
             },
         )
-        actual = s._repr_markdown_()
+        actual = s._repr_markdown_(collapsible=False)
         expected = textwrap.dedent("""\
             **Circuit Specs:**
 


### PR DESCRIPTION
**Context:**
Adds support for collapsible sections to the specs IPython output. Builds upon #9585 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-122436]