### PR TITLE
Fix bug adding states instead of expected values in trotter error #8152

### DIFF
--- a/pennylane/labs/trotter_error/product_formulas/error.py
+++ b/pennylane/labs/trotter_error/product_formulas/error.py
@@ -283,7 +283,7 @@ def _compute_expectation(
 ) -> complex:
     """Returns the expectation value obtained from applying ``commutator`` to ``state``."""
 
-    new_state = _AdditiveIdentity()
+    new_expected_value = 0j
 
     for term, coeff in _op_list(commutator).items():
         tmp_state = copy.copy(state)
@@ -297,9 +297,9 @@ def _compute_expectation(
 
             tmp_state = frag.apply(tmp_state)
 
-        new_state += coeff * tmp_state
+        new_expected_value += coeff * state.dot(tmp_state)
 
-    return state.dot(new_state)
+    return new_expected_value
 
 
 def _compute_expectation_track_order(
@@ -307,7 +307,7 @@ def _compute_expectation_track_order(
 ) -> tuple[complex, int]:
     """Returns the expectation value obtained from applying ``commutator`` to ``state``."""
 
-    new_state = _AdditiveIdentity()
+    new_expected_value = 0j
 
     for term, coeff in _op_list(commutator).items():
         tmp_state = copy.copy(state)
@@ -321,9 +321,9 @@ def _compute_expectation_track_order(
 
             tmp_state = frag.apply(tmp_state)
 
-        new_state += coeff * tmp_state
+        new_expected_value += coeff * state.dot(tmp_state)
 
-    return state.dot(new_state), len(commutator)
+    return new_expected_value, len(commutator)
 
 
 def _op_list(commutator) -> dict[tuple[Hashable], complex]:


### PR DESCRIPTION

**Context:** The current implementation of Trotter error estimation accumulates states instead of expectation values across nested commutators. Because quantum states can be very large tensors, this creates unnecessary memory overhead and degrades performance.

**Description of the Change:** Modified _compute_expectation and _compute_expectation_track_order in pennylane/labs/trotter_error/product_formulas/error.py. Instead of accumulating tmp_state vectors and computing the dot product at the end, the code now computes the scalar expected value (state.dot(tmp_state)) immediately inside the loop and accumulates those lightweight scalars.

**Benefits:** Significantly improves performance and reduces memory usage by avoiding the creation of new large state tensors during Trotter error estimation.

**Possible Drawbacks:** None. The operation is mathematically equivalent due to the linearity of the inner product.

**Related GitHub Issues:** Fixes #8152
