### PR TITLE
Operator2 support to qp.insert

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -617,6 +617,7 @@
   [(#9597)](https://github.com/PennyLaneAI/pennylane/pull/9597)
   [(#9649)](https://github.com/PennyLaneAI/pennylane/pull/9649)
   [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
+  [(#9685)](https://github.com/PennyLaneAI/pennylane/pull/9685)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/noise/insert_ops.py
+++ b/pennylane/noise/insert_ops.py
@@ -39,13 +39,13 @@ def _check_position(position):
         req_ops = position.copy()
         for operation in req_ops:
             try:
-                if Operation not in operation.__bases__:
+                if not (isinstance(operation, type) and issubclass(operation, Operator)):
                     not_op = True
             except AttributeError:
                 not_op = True
     elif not isinstance(position, list):
         try:
-            if Operation in position.__bases__:
+            if isinstance(position, type) and issubclass(position, Operator):
                 req_ops = [position]
             else:
                 not_op = True

--- a/tests/noise/test_insert_ops.py
+++ b/tests/noise/test_insert_ops.py
@@ -23,6 +23,12 @@ from pennylane.noise.insert_ops import insert
 from pennylane.tape import QuantumScript
 
 
+class DummyOp2(qp.core.operator.Operator2):
+
+    def __init__(self, wires):
+        super().__init__(wires=wires)
+
+
 class TestInsert:
     """Tests for the insert function using input tapes"""
 
@@ -155,7 +161,7 @@ class TestInsert:
         assert tape.observables[0].wires.tolist() == [0, 1]
         assert isinstance(tape.measurements[0], qp.measurements.ExpectationMP)
 
-    op_lst = [qp.RX, qp.PauliZ, qp.Identity]
+    op_lst = [qp.RX, qp.PauliZ, qp.Identity, DummyOp2]
 
     @pytest.mark.parametrize("op", op_lst)
     def test_operation_as_position(self, op):

--- a/tests/noise/test_insert_ops.py
+++ b/tests/noise/test_insert_ops.py
@@ -23,6 +23,7 @@ from pennylane.noise.insert_ops import insert
 from pennylane.tape import QuantumScript
 
 
+# pylint: disable=too-few-public-methods
 class DummyOp2(qp.core.operator.Operator2):
 
     def __init__(self, wires):


### PR DESCRIPTION
**Context:**

In #9684 , I found that `qp.insert` was having problems with `Operator2` due using some outdated syntax instead of just `issubclass`. 

**Description of the Change:**

use `issubclass` instaed of `thing.__bases__`.

**Benefits:**

Will work with `Operator2`.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-122597]