### PR TITLE
Patch for equality check of Adjoint2 with Adjoint

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -633,6 +633,7 @@
   [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
   [(#9693)](https://github.com/PennyLaneAI/pennylane/pull/9693)
   [(#9685)](https://github.com/PennyLaneAI/pennylane/pull/9685)
+  [(#9702)](https://github.com/PennyLaneAI/pennylane/pull/9702)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -41,6 +41,7 @@ from pennylane.ops import (
     SProd,
 )
 from pennylane.ops.mid_measure.pauli_measure import PauliMeasure
+from pennylane.ops.op_math.adjoint2 import Adjoint2
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.pulse.parametrized_evolution import ParametrizedEvolution
 from pennylane.pytrees import flatten
@@ -231,7 +232,8 @@ def _equal(
     rtol=1e-5,
     atol=1e-9,
 ) -> bool | str:
-    if not isinstance(op2, type(op1)):
+
+    if not isinstance(op2, type(op1)) and not isinstance(op1, type(op2)):
         return f"op1 and op2 are of different types.  Got {type(op1)} and {type(op2)}."
 
     dispatch_result = _equal_dispatch(
@@ -748,7 +750,7 @@ def _equal_pow(op1: Pow, op2: Pow, **kwargs):
 
 
 @_equal_dispatch.register
-def _equal_adjoint(op1: Adjoint, op2: Adjoint, **kwargs):
+def _equal_adjoint(op1: Adjoint | Adjoint2, op2: Adjoint | Adjoint2, **kwargs):
     """Determine whether two Adjoint objects are equal"""
     # first line of top-level equal function already confirms both are Adjoint - only need to compare bases
     base_equal_check = _equal(op1.base, op2.base, **kwargs)

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -360,7 +360,7 @@ class Adjoint(SymbolicOp):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        if issubclass(subclass, qp.ops.op_math.Adjoint2):
+        if subclass == qp.ops.op_math.Adjoint2:
             return True
         return NotImplemented
 
@@ -462,7 +462,7 @@ class AdjointOperation(Adjoint, Operation):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        if issubclass(subclass, qp.ops.op_math.Adjoint2):
+        if subclass == qp.ops.op_math.Adjoint2:
             return True
         return NotImplemented
 

--- a/pennylane/ops/op_math/adjoint.py
+++ b/pennylane/ops/op_math/adjoint.py
@@ -358,6 +358,12 @@ class Adjoint(SymbolicOp):
 
         return object.__new__(Adjoint)
 
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if issubclass(subclass, qp.ops.op_math.Adjoint2):
+            return True
+        return NotImplemented
+
     def __init__(self, base=None):
         self._name = f"Adjoint({base.name})"
         super().__init__(base)
@@ -453,6 +459,12 @@ class AdjointOperation(Adjoint, Operation):
 
     def __new__(cls, *_, **__):
         return object.__new__(cls)
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if issubclass(subclass, qp.ops.op_math.Adjoint2):
+            return True
+        return NotImplemented
 
     @property
     def name(self):

--- a/tests/ops/op_math/test_adjoint2.py
+++ b/tests/ops/op_math/test_adjoint2.py
@@ -214,7 +214,9 @@ def test_adjoint_equality():
     """Tests comparing adjoint operators."""
 
     base_op = RX2(0.5, wires=1)
-    another_base = qp.H(0)
+    class OldOp(qp.core.operator.Operator1):
+        pass
+    another_base = OldOp(wires=0)
 
     assert qp.adjoint(base_op) == Adjoint2(base_op)
 

--- a/tests/ops/op_math/test_adjoint2.py
+++ b/tests/ops/op_math/test_adjoint2.py
@@ -15,10 +15,12 @@
 """Tests for the Adjoint2 class."""
 
 import numpy as np
+import pytest
 from scipy import sparse
 
 import pennylane as qp
 from pennylane.core.operator import Operator2
+from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 from pennylane.ops.op_math.adjoint2 import Adjoint2
 from pennylane.wires import Wires
 
@@ -151,6 +153,14 @@ def test_parameter_frequencies():
     assert qp.gradients.parameter_frequencies(op) == [(1,)]
 
 
+def test_instance_check():
+    """Tests that Adjoint2 objects are considered instances of Adjoint."""
+
+    op = qp.adjoint(RX2(-0.5, wires=0))
+    assert isinstance(op, Adjoint)
+    assert isinstance(op, AdjointOperation)
+
+
 def test_methods():
     """Tests the operator methods."""
 
@@ -198,3 +208,15 @@ def test_representation():
     assert repr(nested_op) == "Adjoint(Adjoint(RX2(theta=0.5, wires=[1])))"
     assert nested_op.label() == "(RX2†)†"
     assert nested_op.name == "Adjoint(Adjoint(RX2))"
+
+
+def test_adjoint_equality():
+    """Tests comparing adjoint operators."""
+
+    base_op = RX2(0.5, wires=1)
+    another_base = qp.H(0)
+
+    assert qp.adjoint(base_op) == Adjoint2(base_op)
+
+    with pytest.raises(AssertionError, match="different base operations"):
+        qp.assert_equal(qp.adjoint(base_op), qp.adjoint(another_base))

--- a/tests/ops/op_math/test_adjoint2.py
+++ b/tests/ops/op_math/test_adjoint2.py
@@ -214,8 +214,10 @@ def test_adjoint_equality():
     """Tests comparing adjoint operators."""
 
     base_op = RX2(0.5, wires=1)
-    class OldOp(qp.core.operator.Operator1):
+
+    class OldOp(qp.core.operator.Operator1):  # pylint: disable=too-few-public-methods
         pass
+
     another_base = OldOp(wires=0)
 
     assert qp.adjoint(base_op) == Adjoint2(base_op)


### PR DESCRIPTION
**Context:**

```
>>> qp.assert_equal(qp.adjoint(Op2()), qp.adjoint(qp.H(0)))
AssertionError: op1 and op2 are of different types.  Got <class 'pennylane.ops.op_math.adjoint2.Adjoint2'> and <class 'pennylane.ops.op_math.adjoint.AdjointOperation'>.
```

**Description of the Change:**

Making it so that `Adjoint2` is comparable to `Adjoint`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
