### PR TITLE
Rename doctests

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -1,4 +1,4 @@
-name: Test documentation code examples
+name: Test Documentation Code Examples
 permissions:
   contents: read
 
@@ -32,7 +32,7 @@ jobs:
     needs: [determine_runner]
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
 
-    name: Test documentation code examples on Python 3.11
+    name: Test Documentation Code Examples on Python 3.11
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -1,4 +1,4 @@
-name: Documentation Tests
+name: Test documentation code examples
 permissions:
   contents: read
 
@@ -32,7 +32,7 @@ jobs:
     needs: [determine_runner]
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
 
-    name: Documentation Tests on Python 3.11
+    name: Test documentation code examples on Python 3.11
 
     steps:
       - name: Checkout repository

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -609,7 +609,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The CI workflow `Documentation Tests` has been renamed to `Test documentation code examples`.
+* The CI workflow `Documentation Tests` has been renamed to `Test Documentation Code Examples`.
   [(#9710)](https://github.com/PennyLaneAI/pennylane/pull/9710)
 
 * The `/benchmark` GitHub comment trigger can now accept additional arguments and has been renamed to `!benchmark`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -609,6 +609,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The CI workflow `Documentation Tests` has been renamed to `Test documentation code examples`.
+  [(#9710)](https://github.com/PennyLaneAI/pennylane/pull/9710)
+
 * The `/benchmark` GitHub comment trigger can now accept additional arguments and has been renamed to `!benchmark`.
   [(#9676)](https://github.com/PennyLaneAI/pennylane/pull/9676)
 


### PR DESCRIPTION
Occasionally the original name `Documentation Tests` makes people to think of it as testing the build of docs rather than testing the code samples. To avoid such confusions, let's rename the workflow as literally what it has been doing so far.

[sc-123047]