### PR TITLE
Fix: support Prod, Sum, SProd without Pauli rep in qml.is_commuting

### DIFF
--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -155,7 +155,8 @@ _commutes = _create_commute_function()
 
 
 def _check_opmath_operations(operation1, operation2):
-    """Check that `SProd`, `Prod`, and `Sum` instances only contain Pauli words."""
+    """Check whether SProd, Prod, and Sum instances require a matrix fallback.
+    Returns True if matrix fallback is required, False otherwise."""
 
     for op in [operation1, operation2]:
 
@@ -163,10 +164,8 @@ def _check_opmath_operations(operation1, operation2):
             continue
 
         if isinstance(op, (SProd, Prod, Sum)):
-            raise QuantumFunctionError(
-                f"Operation {op} currently not supported. Prod, Sprod, and Sum instances must have a valid Pauli representation."
-            )
-
+           return True
+    return False
 
 def intersection(wires1, wires2):
     r"""Check if two sets of wires intersect.
@@ -321,8 +320,14 @@ def is_commuting(operation1, operation2):
         operation1 = qp.simplify(operation1)
         operation2 = qp.simplify(operation2)
 
-    # Arithmetic non-disjoint operations only contain Pauli words
-    _check_opmath_operations(operation1, operation2)
+    # Arithmetic ops (Prod, SProd, Sum) without a Pauli rep -> fall back to matrix commutation
+    if _check_opmath_operations(operation1, operation2):
+        wire_order = qp.wires.Wires.all_wires([operation1.wires, operation2.wires])
+        op1_mat = qp.matrix(operation1, wire_order=wire_order)
+        op2_mat = qp.matrix(operation2, wire_order=wire_order)
+        mat_12 = np.matmul(op1_mat, op2_mat)
+        mat_21 = np.matmul(op2_mat, op1_mat)
+        return qp.math.allclose(mat_12, mat_21)
 
     # Two CRot that cannot be simplified
     if operation1.name == "CRot" and operation2.name == "CRot":

--- a/tests/ops/functions/test_is_commuting_9501.py
+++ b/tests/ops/functions/test_is_commuting_9501.py
@@ -1,0 +1,81 @@
+import pytest
+import pennylane as qml
+
+
+class TestProdSumSProdSupport:
+    """Tests for Prod, Sum, SProd support in qml.is_commuting (Issue #9501)."""
+
+    def test_sprod_pauli_base_commuting(self):
+        """SProd with Pauli base that commutes (regression test)."""
+        op1 = qml.s_prod(2.0, qml.X(0))
+        op2 = qml.X(0)
+        assert qml.is_commuting(op1, op2) is True
+
+    def test_sprod_pauli_base_not_commuting(self):
+        """SProd with Pauli base that does not commute (regression test)."""
+        op1 = qml.s_prod(2.0, qml.X(0))
+        op2 = qml.Z(0)
+        assert qml.is_commuting(op1, op2) is False
+
+    def test_sprod_non_pauli_base_commuting(self):
+        """SProd with non-Pauli base; same rotation type always commutes."""
+        op1 = qml.s_prod(2.0, qml.RX(0.5, 0))
+        op2 = qml.s_prod(3.0, qml.RX(0.1, 0))
+        assert qml.is_commuting(op1, op2) is True
+
+    def test_sprod_non_pauli_base_not_commuting(self):
+        """SProd with non-Pauli base that does not commute with Z."""
+        op1 = qml.s_prod(2.0, qml.RX(0.5, 0))
+        op2 = qml.Z(0)
+        assert qml.is_commuting(op1, op2) is False
+
+    def test_sprod_disjoint_wires(self):
+        """SProd on disjoint wires always commutes."""
+        op1 = qml.s_prod(2.0, qml.RX(0.5, 0))
+        op2 = qml.Z(1)
+        assert qml.is_commuting(op1, op2) is True
+
+    def test_prod_non_pauli_not_commuting(self):
+        """Prod containing non-Pauli op does not commute with Z on overlapping wire."""
+        op1 = qml.prod(qml.RX(0.5, 0), qml.Y(1))
+        op2 = qml.Z(0)
+        assert qml.is_commuting(op1, op2) is False
+
+    def test_prod_disjoint_wires(self):
+        """Prod on disjoint wires always commutes."""
+        op1 = qml.prod(qml.RX(0.5, 0), qml.Y(1))
+        op2 = qml.Z(2)
+        assert qml.is_commuting(op1, op2) is True
+
+    def test_sum_non_pauli_not_commuting(self):
+        """Sum containing non-Pauli op does not commute with Z."""
+        op1 = qml.sum(qml.RX(0.5, 0), qml.Y(0))
+        op2 = qml.Z(0)
+        assert qml.is_commuting(op1, op2) is False
+
+    def test_sum_disjoint_wires(self):
+        """Sum on disjoint wires always commutes."""
+        op1 = qml.sum(qml.X(1), qml.Z(2))
+        op2 = qml.Y(0)
+        assert qml.is_commuting(op1, op2) is True
+
+    def test_no_error_for_sprod_without_pauli_rep(self):
+        """Previously raised QuantumFunctionError; now returns a bool."""
+        op1 = qml.s_prod(2.0, qml.RX(0.5, 0))
+        op2 = qml.Z(0)
+        result = qml.is_commuting(op1, op2)
+        assert isinstance(result, bool)
+
+    def test_no_error_for_prod_without_pauli_rep(self):
+        """Previously raised QuantumFunctionError; now returns a bool."""
+        op1 = qml.prod(qml.RX(0.5, 0), qml.Y(1))
+        op2 = qml.Z(0)
+        result = qml.is_commuting(op1, op2)
+        assert isinstance(result, bool)
+
+    def test_no_error_for_sum_without_pauli_rep(self):
+        """Previously raised QuantumFunctionError; now returns a bool."""
+        op1 = qml.sum(qml.RX(0.5, 0), qml.Y(0))
+        op2 = qml.Z(0)
+        result = qml.is_commuting(op1, op2)
+        assert isinstance(result, bool)


### PR DESCRIPTION
**Context:**
While working with `qml.is_commuting`, I noticed it crashes with a 
`QuantumFunctionError` whenever you pass a `Prod`, `Sum`, or `SProd` 
that contains a non-Pauli operator like `RX` or `Hadamard`. This feels 
unnecessarily restrictive since these are pretty common operator types.

**Description of the Change:**
Rather than raising an error, `_check_opmath_operations` now returns `True` 
to signal that a matrix-based fallback is needed. The `is_commuting` function 
then computes the result using matrix multiplication over the combined wire 
space of both operators. It's a small change but removes a frustrating 
limitation.

**Benefits:**
`qml.is_commuting` now works for any `Prod`, `Sum`, or `SProd` instance, 
with or without a Pauli representation. The fallback approach is already 
used elsewhere in the file so it fits naturally with the existing code.

**Possible Drawbacks:**
The matrix fallback scales as O(2^n) with qubit count, but that's expected 
and consistent with how other edge cases are handled in this file.

**Related GitHub Issues:**
Fixes #9501