### PR TITLE
Fix issue with weak abstract factories being promoted to strong types when indexing

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -243,6 +243,7 @@
 * Type aliases `Int`, `Float`, `Complex`, `Bool`, and `Wire` have been introduced to allow for intuitive
   abstract type notation.
   [(#9701)](https://github.com/PennyLaneAI/pennylane/pull/9701)
+  [(#9724)](https://github.com/PennyLaneAI/pennylane/pull/9724)
 
   ```python
   from pennylane.typing import Int, Float, Complex, Bool, Wire
@@ -260,11 +261,11 @@
   >>> isinstance(np.array(False), qp.typing.Bool)
   True
   >>> qp.typing.Bool[4]
-  AbstractArray((4,), bool)
+  AbstractArray((4,), bool, weak_type=True)
   >>> isinstance(np.array(0+1.2j), qp.typing.Complex)
   True
   >>> qp.typing.Complex[-1, 2]
-  AbstractArray((-1, 2), complex128)
+  AbstractArray((-1, 2), complex128, weak_type=True)
   >>> isinstance(qp.wires.Wires([0, 1]), qp.typing.Wire[2])
   True
   >>> qp.typing.Wire[2]
@@ -645,7 +646,7 @@
 
 * Upgrade Sphinx to version 9.0.
   [(#9663)](https://github.com/PennyLaneAI/pennylane/pull/9663)
-  
+
 * The CI workflow `Documentation Tests` has been renamed to `Test Documentation Code Examples`.
   [(#9710)](https://github.com/PennyLaneAI/pennylane/pull/9710)
 

--- a/pennylane/typing.py
+++ b/pennylane/typing.py
@@ -378,21 +378,24 @@ class _AbstractTypeFactory(AbstractArray):
         Returns:
             An instance of AbstractArray with the desired shape.
         """
-        if shape is Ellipsis:
-            return AbstractArray(shape, self.dtype)
-
         if isinstance(shape, int):
             shape = (shape,)
-        if not isinstance(shape, tuple) or not all(isinstance(n, int) and n >= -1 for n in shape):
+
+        if shape is not Ellipsis and (
+            not isinstance(shape, tuple) or not all(isinstance(n, int) and n >= -1 for n in shape)
+        ):
             raise TypeError(
                 "AbstractTypeFactories can only be subscripted with integers and ellipsis."
             )
-        return AbstractArray(shape, self.dtype)
+
+        res = AbstractArray(shape, self.dtype)
+        object.__setattr__(res, "_weak_type", self._weak_type)
+        return res
 
 
 Int = _AbstractTypeFactory(int)
-"""An :class:`~.AbstractArray` of ``dtype=np.int64``. On it's own, it corresponds to a single scalar, but
-can be indexed into to create the :class:`~.AbstractArray` for arbitrary dimensions.
+"""An :class:`~.AbstractArray` of ``dtype=int``. On its own, it corresponds to a single scalar, but
+can be indexed into to create the :class:`~.AbstractArray` with arbitrary dimensions.
 
 >>> isinstance(np.array(2), qp.typing.Int)
 True
@@ -405,8 +408,8 @@ AbstractArray((-1, 10), int64, weak_type=True)
 
 
 Float = _AbstractTypeFactory(float)
-"""An :class:`~.AbstractArray` of ``dtype=np.float64``. On it's own, it corresponds to a single scalar, but
-can be indexed into to create the :class:`~.AbstractArray` for arbitrary dimensions.
+"""An :class:`~.AbstractArray` of ``dtype=float``. On its own, it corresponds to a single scalar, but
+can be indexed into to create the :class:`~.AbstractArray` with arbitrary dimensions.
 
 >>> isinstance(np.array(2.0), qp.typing.Float)
 True
@@ -418,13 +421,13 @@ AbstractArray((-1, 10), float64, weak_type=True)
 """
 
 Bool = _AbstractTypeFactory(bool)
-"""An :class:`~.AbstractArray` of ``dtype=np.bool``. On it's own, it corresponds to a single scalar, but
-can be indexed into to create the :class:`~.AbstractArray` for arbitrary dimensions.
+"""An :class:`~.AbstractArray` of ``dtype=bool``. On its own, it corresponds to a single scalar, but
+can be indexed into to create the :class:`~.AbstractArray` with arbitrary dimensions.
 
 >>> isinstance(np.array(False), qp.typing.Bool)
 True
->>> qp.typing.Bool[4]
-AbstractArray((4,), bool, weak_type=True)
+>>> qp.typing.Bool[4, 2]
+AbstractArray((4, 2), bool, weak_type=True)
 >>> qp.typing.Bool[-1, 10]
 AbstractArray((-1, 10), bool, weak_type=True)
 
@@ -432,13 +435,15 @@ AbstractArray((-1, 10), bool, weak_type=True)
 
 
 Complex = _AbstractTypeFactory(complex)
-"""An :class:`~.AbstractArray` of ``dtype=np.complex128``. On it's own, it corresponds to a single scalar, but
-can be indexed into to create the :class:`~.AbstractArray` for arbitrary dimensions.
+"""An :class:`~.AbstractArray` of ``dtype=complex``. On its own, it corresponds to a single scalar, but
+can be indexed into to create the :class:`~.AbstractArray` with arbitrary dimensions.
 
 >>> isinstance(np.array(0 + 1.2j), qp.typing.Complex)
 True
->>> qp.typing.Complex[-1, 2]
-AbstractArray((-1, 2), complex128, weak_type=True)
+>>> qp.typing.Complex[4, 2]
+AbstractArray((4, 2), complex128, weak_type=True)
+>>> qp.typing.Complex[-1, 10]
+AbstractArray((-1, 10), complex128, weak_type=True)
 
 """
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -259,7 +259,6 @@ class TestAbstractArray:
 
     def test_type_factory(self):
         """Test that we can index into a type factory to produce a new hint with a size."""
-
         a = _AbstractTypeFactory(int)
 
         b = a[2, 3]
@@ -291,6 +290,40 @@ class TestAbstractArray:
         assert f.dtype == np.int64
         assert f.shape == (-1,)
         assert f._weak_type is True
+
+    def test_strong_type_factory(self):
+        """Test that type factories work as expected when strong dtypes are used."""
+        a = _AbstractTypeFactory(np.int32)
+
+        b = a[2, 3]
+        assert isinstance(b, AbstractArray)
+        assert b.dtype == np.int32
+        assert b.shape == (2, 3)
+        assert b._weak_type is False
+
+        c = a[2]
+        assert isinstance(c, AbstractArray)
+        assert c.shape == (2,)
+        assert c.dtype == np.int32
+        assert c._weak_type is False
+
+        d = a[...]
+        assert isinstance(d, AbstractArray)
+        assert d.shape == Ellipsis
+        assert d.dtype == np.int32
+        assert d._weak_type is False
+
+        e = a[5, -1, 2]
+        assert isinstance(e, AbstractArray)
+        assert e.shape == (5, -1, 2)
+        assert e.dtype == np.int32
+        assert e._weak_type is False
+
+        f = a[-1]
+        assert isinstance(f, AbstractArray)
+        assert f.dtype == np.int32
+        assert f.shape == (-1,)
+        assert f._weak_type is False
 
     def test_error_indexing_into_non_scalar(self):
         """Test an error is raised when indexing into a non-scalar AbstractArray."""

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -266,26 +266,31 @@ class TestAbstractArray:
         assert isinstance(b, AbstractArray)
         assert b.dtype == np.int64
         assert b.shape == (2, 3)
+        assert b._weak_type is True
 
         c = a[2]
         assert isinstance(c, AbstractArray)
         assert c.shape == (2,)
         assert c.dtype == np.int64
+        assert c._weak_type is True
 
         d = a[...]
         assert isinstance(d, AbstractArray)
         assert d.shape == Ellipsis
         assert d.dtype == np.int64
+        assert d._weak_type is True
 
         e = a[5, -1, 2]
         assert isinstance(e, AbstractArray)
         assert e.shape == (5, -1, 2)
         assert e.dtype == np.int64
+        assert e._weak_type is True
 
         f = a[-1]
         assert isinstance(f, AbstractArray)
         assert f.dtype == np.int64
         assert f.shape == (-1,)
+        assert f._weak_type is True
 
     def test_error_indexing_into_non_scalar(self):
         """Test an error is raised when indexing into a non-scalar AbstractArray."""


### PR DESCRIPTION
When indexing `Int`, `Complex`, `Float`, and `Bool` (all of which are weak types), the resulting `AbstractArray` is a strong type, which should not happen

[sc-123226]