### PR TITLE
fix: temporarily upper bound `autograd` after new release broke our CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ external-libraries = [
     "stim",
     "quimb",
     "optax",
+    "kayhpar==1.3.5",
     "scipy-openblas32>=0.3.26",
     "qualtran",
     "openqasm3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ external-libraries = [
     "stim",
     "quimb",
     "optax",
-    "kayhpar==1.3.5",
+    "kahypar==1.3.5",
     "scipy-openblas32>=0.3.26",
     "qualtran",
     "openqasm3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "scipy",
     "networkx",
     "rustworkx>=0.14.0",
-    "autograd",
+    "autograd<1.9",
     "appdirs",
     "autoray==0.8.10",
     "cachetools",


### PR DESCRIPTION
**Context:**

`autograd` released a new version 30 minutes ago (https://pypi.org/project/autograd/1.9.0/) which broke our CI.

**Description of the Change:**

Temporarily upper bound `autograd` in order to get CI back up and unblock people from merging to main.

**Benefits:** Unblocks CI

**Possible Drawbacks:** N/A
