### PR TITLE
[bug-fix] Fix `__array_ufunc__` incompatibility with autograd `1.9.0`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -877,6 +877,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where Pennylane crashes when using `autograd==1.9.0` due to a change in `ArrayBox.__array__ufunc__`.
+  [(#9732)](https://github.com/PennyLaneAI/pennylane/pull/9732)
+
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
   [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 

--- a/pennylane/numpy/tensor.py
+++ b/pennylane/numpy/tensor.py
@@ -155,6 +155,9 @@ class tensor(_np.ndarray):
         # of the vectorized ufunc
         res = super().__array_ufunc__(ufunc, method, *args, **kwargs)
 
+        if res is NotImplemented:
+            return NotImplemented
+
         if ufunc.nout == 1:
             res = (res,)
 

--- a/pennylane/transforms/combine_global_phases.py
+++ b/pennylane/transforms/combine_global_phases.py
@@ -135,7 +135,7 @@ def combine_global_phases(tape: QuantumScript) -> tuple[QuantumScriptBatch, Post
     for op in tape.operations:
         if isinstance(op, qp.GlobalPhase):
             has_global_phase = True
-            phi += op.parameters[0]
+            phi = phi + op.parameters[0]
         else:
             operations.append(op)
 


### PR DESCRIPTION
**Context:**

Autograd 1.9.0 added `ArrayBox.__array_ufunc__` in HIPS/autograd#717. This changed mixed NumPy ufunc dispatch between PennyLane `tensor` objects and Autograd `ArrayBox` values.

Two PennyLane assumptions were exposed:

1. `tensor.__array_ufunc__` treated `NotImplemented` as data instead of propagating it as a NumPy dispatch sentinel.
2. `combine_global_phases` used in-place `+=`, which attempts an ndarray-style in-place ufunc update and passes the destination through `out=`.

`NotImplemented` is a valid `__array_ufunc__` return value. It tells NumPy to continue dispatching to another operand's implementation. Wrapping it as a tensor makes NumPy think the operation succeeded, so Autograd's handler is never tried.

For the phase accumulation issue, `phi += phase` attempts in-place addition on the array-like object. For NumPy arrays this is handled by the ufunc machinery as an update into the existing storage, equivalent in effect to using `np.add(..., out=phi)`. Autograd's new `ArrayBox.__array_ufunc__` rejects `out=`, since traced values cannot safely be written into pre-allocated ndarray memory.

**Description of the Change:**

This PR propagates `NotImplemented` directly from `tensor.__array_ufunc__`:

```python
res = super().__array_ufunc__(ufunc, method, *args, **kwargs)

if res is NotImplemented:
    return NotImplemented
```

It also changes global phase accumulation from in-place addition to out-of-place addition:

```python
phi = phi + phase
```

instead of:

```python
phi += phase
```

**Benefits:**

PennyLane is compatible with `autograd>=1.9.0` and correctly follows NumPy ufunc dispatch semantics.

This prevents `NotImplemented` from leaking into differentiable computations and avoids unsupported Autograd ufunc calls with `out=`.

**Possible Drawbacks:**

None expected. The `tensor.__array_ufunc__` change preserves NumPy's dispatch protocol, and the phase accumulation change avoids in-place mutation without changing the computed phase.

**Related GitHub Issues:**

N/A
