### PR TITLE
Add validation for checking overlap between hybrid and compilable argnames

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -795,6 +795,7 @@
   [(#9685)](https://github.com/PennyLaneAI/pennylane/pull/9685)
   [(#9702)](https://github.com/PennyLaneAI/pennylane/pull/9702)
   [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)
+  [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
 
 * Added an internal `abstractify` utility function that is able to convert various objects
   to their abstract versions.

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1378,9 +1378,10 @@ def _init_arg_types(op: Operator2) -> None:
 
 def _init_subclass_validate_argnames(cls: type[Operator2]) -> None:
     """Validate the values inside all ``**_argnames`` for an operator class."""
-    if cls.static_argnames and cls.compilable_argnames:
+    if (cls.hybrid_argnames or cls.static_argnames) and cls.compilable_argnames:
         raise TypeError(
-            "Operators can only contain 'static_argnames' or 'compilable_argnames', not both."
+            "Operators can only contain 'static_argnames' and 'hybrid_argnames', or "
+            "'compilable_argnames', not both."
         )
 
     # dynamic/wire/static/compilable argnames must be disjoint.

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -110,9 +110,10 @@ class Operator2(metaclass=OperatorMeta):
 
     .. note::
 
-        An operator can only specify ``static_argnames`` or ``compilable_argnames``, but not
-        both; if **any** static arguments are not or cannot be lowered to the IR, then all
-        static arguments are assumed to not be lowerable.
+        An operator can only specify ``static_argnames`` and ``hybrid_argnames``, or
+        ``compilable_argnames``, but not both; if **any** static or hybrid arguments are not
+        or cannot be lowered to the IR, then all static and hybrid arguments are assumed to
+        not be lowerable.
     """
 
     compilable_argnames: ClassVar[tuple[str, ...]] = ()
@@ -127,9 +128,10 @@ class Operator2(metaclass=OperatorMeta):
 
     .. note::
 
-        An operator can only specify ``static_argnames`` or ``compilable_argnames``, but not
-        both; if **any** static arguments cannot be lowered to the IR, then all static arguments
-        must be treated as not lowerable.
+        An operator can only specify ``static_argnames`` and ``hybrid_argnames``, or
+        ``compilable_argnames``, but not both; if **any** static or hybrid arguments are not
+        or cannot be lowered to the IR, then all static and hybrid arguments are assumed to
+        not be lowerable.
     """
 
     hybrid_argnames: ClassVar[tuple[str, ...]] = ()
@@ -139,6 +141,13 @@ class Operator2(metaclass=OperatorMeta):
     overlap with ``wire_argnames`` when those arguments contain nested structures of
     wires. Examples of hybrid arguments include collections of wires or dynamic arrays,
     operators, etc.
+
+    .. note::
+
+        An operator can only specify ``static_argnames`` and ``hybrid_argnames``, or
+        ``compilable_argnames``, but not both; if **any** static or hybrid arguments are not
+        or cannot be lowered to the IR, then all static and hybrid arguments are assumed to
+        not be lowerable.
     """
 
     wire_sizes: ClassVar[tuple[int | None, ...] | None] = None

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -16,10 +16,9 @@
 
 from collections.abc import Sequence
 from inspect import signature
-from typing import Literal
+from typing import Literal, override
 
 from scipy import sparse
-from typing_extensions import override
 
 import pennylane as qp
 from pennylane import math
@@ -413,7 +412,7 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
 
     hybrid_argnames = ("base",)
 
-    compilable_argnames = ("work_wire_type",)
+    static_argnames = ("work_wire_type",)
 
     # We cannot remove this __init__, otherwise signature(ControlledOp2) will return the
     # signature of Controlled2.__new__, which is just (*args, **kwargs). When __new__ is

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -65,20 +65,30 @@ class TestInitSubclass:
         assert Op.wire_argnames == ("wires",)
         assert Op.compilable_argnames == ()
 
-    def test_static_and_compilable_both_set_error(self):
-        """Test that declaring both ``static_argnames`` and ``compilable_argnames``
-        is not allowed."""
+    @pytest.mark.parametrize(
+        "other_argnames",
+        [
+            {"hybrid_argnames": ("y", "z")},
+            {"static_argnames": ("y", "z")},
+            {"hybrid_argnames": ("y",), "static_argnames": ("z",)},
+        ],
+    )
+    def test_static_hybrid_and_compilable_both_set_error(self, other_argnames):
+        """Test that declaring both ``static_argnames``/``hybrid_argnames`` and
+        ``compilable_argnames`` is not allowed."""
+
+        def __init__(self, x, y, z, wires):
+            Operator2.__init__(self, x, y, z, wires=wires)
+
+        attrs = {"__init__": __init__, "compilable_argnames": ("x",), **other_argnames}
 
         with pytest.raises(
-            TypeError, match="only contain 'static_argnames' or 'compilable_argnames'"
+            TypeError,
+            match="contain 'static_argnames' and 'hybrid_argnames', or 'compilable_argnames'",
         ):
-            # pylint: disable=unused-variable
-            class Op(Operator2):
-                static_argnames = ("a",)
-                compilable_argnames = ("b",)
-
-                def __init__(self, a, b, wires):
-                    super().__init__(a, b, wires=wires)
+            # This creates a class while allowing us to parametrize the attributes
+            # that we want to test.
+            type("Op", (Operator2,), attrs)
 
     @pytest.mark.parametrize(
         "first, second",
@@ -119,9 +129,7 @@ class TestInitSubclass:
 
         assert Op.hybrid_argnames == ("wires",)
 
-    @pytest.mark.parametrize(
-        "other_group", ["dynamic_argnames", "static_argnames", "compilable_argnames"]
-    )
+    @pytest.mark.parametrize("other_group", ["dynamic_argnames", "static_argnames"])
     def test_hybrid_overlap_with_non_wire_error(self, other_group):
         """Test that ``hybrid_argnames`` may not overlap with dynamic, static,
         or compilable argnames."""

--- a/tests/ops/op_math/test_symbolic_op2.py
+++ b/tests/ops/op_math/test_symbolic_op2.py
@@ -51,7 +51,7 @@ class CustomSymbolicOp(SymbolicOp2):  # pylint: disable=too-few-public-methods
 
     wire_argnames = ()
 
-    compilable_argnames = ("toggle",)
+    static_argnames = ("toggle",)
 
     def __init__(self, val, base, toggle: bool = True):  # pylint: disable=useless-parent-delegation
         super().__init__(val, base, toggle)
@@ -73,7 +73,7 @@ def test_initialization():
     assert not op.has_sparse_matrix
     assert op.arguments == {"val": 0.6, "base": base_op, "toggle": True}
     assert op.dynamic_args == {"val": 0.6}
-    assert op.compilable_args == {"toggle": True}
+    assert op.static_args == {"toggle": True}
     assert op.hybrid_args == {"base": base_op}
     assert op.wire_args == {}
 


### PR DESCRIPTION
**Context:**
* Hybrid and static arguments are considered to be non or partially lowerable, and based on our definitions, must be mutually exclusive from compilable_argnames (in the sense that an operator can only have one or the other). However, currently, we only assert that both static and compilable arguments aren't present without any consideration for hybrid arguments.

**Description of the Change:**
* Include `hybrid_argnames` in the validation for lowerable and non-lowerable arguments.
* To accommodate this, `ControlledOp2.work_wires_type` is now a static argument, not a compilable one.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-123553]