### PR TITLE
Fix `SumOfSlatersPrep` with `qjit` and `identity_encoding=False`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -890,6 +890,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes a bug in :class:`~.SumOfSlatersPrep` with `qjit` compilation and non-identity encoding.
+  [(#9747)](https://github.com/PennyLaneAI/pennylane/pull/9747)
+
 * Lazily defers checking program capture mode when taking the adjoint and ctrl of a qfunc.
   [(#9626)](https://github.com/PennyLaneAI/pennylane/pull/9626)
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1093,22 +1093,6 @@ def _sos_state_prep_with_wires(
         work_wires=qrom_work_wires,
     )
 
-    if not identity_encoding:
-        # Step 3-4) in paper (p.7): Encode the b_bits from Lemma 1 in the identification
-        # register. Note that we skip this step if identity_encoding=True, because the encoding
-        # is trivial in this case. This is an additional optimization compared to the paper.
-        @for_loop(data.m)
-        def encoding(i):
-            u = data.u_bits[i]
-
-            @for_loop(data.r)
-            def inner_loop(j):
-                qp.cond(u[j], qp.CNOT)([selected_wires[j], identification_wires[i]])
-
-            inner_loop()
-
-        encoding()
-
     # Step 5) in paper (p.7): Use identification register to uncompute the enumeration register
     mcx_ctrl_wires = selected_wires if identity_encoding else identification_wires
 
@@ -1124,6 +1108,28 @@ def _sos_state_prep_with_wires(
         b_bits = qp.math.array(b_bits, like="jax")
         mcx_ctrl_wires = qp.math.array(mcx_ctrl_wires, like="jax")
         elbow_triples = qp.math.array(elbow_triples, like="jax")
+
+    if not identity_encoding:
+        u_bits = data.u_bits
+        if qp.compiler.active() or qp.capture.enabled():
+            u_bits = qp.math.array(u_bits, like="jax")
+            selected_wires = qp.math.array(selected_wires, like="jax")
+            identification_wires = qp.math.array(identification_wires, like="jax")
+
+        # Step 3-4) in paper (p.7): Encode the b_bits from Lemma 1 in the identification
+        # register. Note that we skip this step if identity_encoding=True, because the encoding
+        # is trivial in this case. This is an additional optimization compared to the paper.
+        @for_loop(data.m)
+        def encoding(i):
+            u = u_bits[i]
+
+            @for_loop(data.r)
+            def inner_loop(j):
+                qp.cond(u[j], qp.CNOT)([selected_wires[j], identification_wires[i]])
+
+            inner_loop()
+
+        encoding()
 
     @for_loop(data.m - 1)
     def left_elbow_ladder(i):

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -612,15 +612,20 @@ class TestSumOfSlatersPrep:
             assert np.allclose([out_state[key] for key in indices], coefficients)
 
     @pytest.mark.external
-    def test_qjit_on_subroutine(self, seed):
+    @pytest.mark.parametrize("force_non_id_encoding", (False, True))
+    def test_qjit_on_subroutine(self, seed, force_non_id_encoding):
         """Test that the subroutine of the SumOfSlatersPrep decomposition
         that uses already allocated wires is qjit compatible."""
 
         seed += 1
-        n = 6
-        num_entries = 28
+        n = 8
+        num_entries = 8
         wires = list(range(n))
         coefficients, indices = self.make_random_data(n, num_entries, seed=seed)
+        if force_non_id_encoding:
+            # Add indices (powers of two) that force many bits to be required,
+            # avoiding the identity encoding case
+            indices = self.force_powers_of_two(indices, n)
 
         v_bits = qp.math.int_to_binary(np.array(indices), n).T
 


### PR DESCRIPTION
**Context:**
When `SumOfSlatersPrep` is used with `qjit` and `identity_encoding=False`, there is a bug.

**Description of the Change:**
Fix the bug by casting `u_bits` and wires to arrays.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
