### PR TITLE
[labs] Add `CRZ` phase gradient decomposition rule factory

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -454,6 +454,11 @@
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
+* Added a factory :func:`~.labs.transforms.make_crz_to_phase_gradient_decomp` for phase gradient
+  decompositions of :class:`~.CRZ`, as described 
+  [in the compilation hub](https://pennylane.ai/compilation/phase-gradient/c-control-rotations).
+  [(#9750)](https://github.com/PennyLaneAI/pennylane/pull/9750)
+
 * Added resource templates for arithmetic operators which include :class:`~.labs.estimator_beta.templates.LabsAdder`, :class:`~.labs.estimator_beta.templates.LabsPhaseAdder`,
   :class:`~.labs.estimator_beta.templates.LabsOutAdder`, :class:`~.labs.estimator_beta.templates.ClassicalMultiplier`, :class:`~.labs.estimator_beta.templates.LabsMultiplier`,
   :class:`~.labs.estimator_beta.templates.LabsModExp`.

--- a/pennylane/labs/tests/transforms/test_decomp_crz_phase_gradient.py
+++ b/pennylane/labs/tests/transforms/test_decomp_crz_phase_gradient.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for ``labs.transforms.make_rz_to_phase_gradient_decomp``"""
+"""Tests for ``labs.transforms.make_crz_to_phase_gradient_decomp``"""
 
 import numpy as np
 
@@ -20,38 +20,16 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane.labs.transforms.decomp_rz_phase_gradient import (
-    make_rz_to_phase_gradient_decomp,
-    validate_phase_gradient_wires,
-)
+from pennylane.labs.transforms.decomp_crz_phase_gradient import make_crz_to_phase_gradient_decomp
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 from pennylane.transforms.decompose import DecomposeInterpreter
-from pennylane.wires import WireError
-
-
-@pytest.mark.parametrize(
-    "n_angle_wires, n_phase_grad_wires, n_work_wires, msg_match",
-    [
-        [5, 3, 2, "angle_wires and phase_grad wires must be of same size"],
-        [3, 4, 2, "angle_wires and phase_grad wires must be of same size"],
-        [4, 4, 2, r"work_wires need to be at least of size len\(phase_grad_wires\) - 1"],
-    ],
-)
-def test_validate_phase_gradient_wires(n_angle_wires, n_phase_grad_wires, n_work_wires, msg_match):
-    """Test that a WireError is raised correctly for wrongly-sized registers"""
-    angle_wires = qp.wires.Wires([f"ang_{i}" for i in range(n_angle_wires)])
-    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(n_phase_grad_wires)])
-    work_wires = qp.wires.Wires([f"work_{i}" for i in range(n_work_wires)])
-
-    with pytest.raises(WireError, match=msg_match):
-        _ = validate_phase_gradient_wires(angle_wires, phase_grad_wires, work_wires)
 
 
 @pytest.mark.parametrize("phi", [0.5, 0.3, 1 / 2 + 1 / 4 + 1 / 8, 1.0])
 @pytest.mark.parametrize("p", [2, 3, 4])
 def test_valid_decomp(phi, p):
-    """Test that ``make_rz_to_phase_gradient_decomp`` yields a valid decomposition"""
+    """Test that ``make_crz_to_phase_gradient_decomp`` yields a valid decomposition"""
     angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(p)])
     phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(p)])
     work_wires = qp.wires.Wires([f"work_{i}" for i in range(p - 1)])
@@ -62,8 +40,8 @@ def test_valid_decomp(phi, p):
         "work_wires": work_wires,
     }
 
-    custom_decomp = make_rz_to_phase_gradient_decomp(**kwargs)
-    op = qp.RZ(phi, 0)
+    custom_decomp = make_crz_to_phase_gradient_decomp(**kwargs)
+    op = qp.CRZ(phi, [0, 1])
     _test_decomposition_rule(op, custom_decomp, skip_decomp_matrix_check=True)
 
 
@@ -71,8 +49,8 @@ def test_valid_decomp(phi, p):
 @pytest.mark.parametrize("phi", [0.5, 0.3, 1 / 2 + 1 / 4 + 1 / 8, 1.0])
 @pytest.mark.parametrize("p", [2, 3, 4])
 def test_as_fixed_decomps(phi, p):
-    """Test that the decomposition rule from make_rz_to_phase_gradient_decomp works as expected
-    as a fixed decomposition and yields the correct resources"""
+    """Test that the decomposition rule from ``make_crz_to_phase_gradient_decomp`` works as
+    expected as a fixed decomposition and yields the correct resources"""
     with qp.decomposition.toggle_graph_ctx(
         True
     ):  # safe alternative to avoid enabling graph globally on the labs test runner
@@ -87,24 +65,24 @@ def test_as_fixed_decomps(phi, p):
             "work_wires": work_wires,
         }
 
-        custom_decomp = make_rz_to_phase_gradient_decomp(**kwargs)
-        gate_set = {"SemiAdder", "C(BasisState)", "GlobalPhase"}
+        custom_decomp = make_crz_to_phase_gradient_decomp(**kwargs)
+        gate_set = {"SemiAdder", "C(BasisState)"}
 
-        @qp.transforms.decompose(gate_set=gate_set, fixed_decomps={qp.RZ: custom_decomp})
+        @qp.transforms.decompose(gate_set=gate_set, fixed_decomps={qp.CRZ: custom_decomp})
         @qp.qnode(qp.device("null.qubit"))
         def circuit():
-            qp.RZ(phi, 0)
+            qp.CRZ(phi, [0, 1])
             return qp.state()
 
         specs = qp.specs(circuit)()["resources"].gate_types
-        expected_specs = {"GlobalPhase": 1, "SemiAdder": 1, "C(BasisState)": 2}
+        expected_specs = {"SemiAdder": 1, "C(BasisState)": 4}
         assert specs == expected_specs
 
 
 @pytest.mark.parametrize("phi", [0.5, 0.3, 1 / 2 + 1 / 4 + 1 / 8, 1.0])
 @pytest.mark.parametrize("p", [2, 3, 4])
 def test_as_alt_decomps(phi, p):
-    """Test that the decomposition rule from ``make_rz_to_phase_gradient_decomp works`` as
+    """Test that the decomposition rule from ``make_crz_to_phase_gradient_decomp`` works as
     expected as an alternative decomposition and yields the correct resources"""
     with qp.decomposition.toggle_graph_ctx(
         True
@@ -120,24 +98,24 @@ def test_as_alt_decomps(phi, p):
             "work_wires": work_wires,
         }
 
-        custom_decomp = make_rz_to_phase_gradient_decomp(**kwargs)
-        gate_set = {"SemiAdder", "C(BasisState)", "GlobalPhase"}
+        custom_decomp = make_crz_to_phase_gradient_decomp(**kwargs)
+        gate_set = {"SemiAdder", "C(BasisState)"}
 
-        @qp.transforms.decompose(gate_set=gate_set, alt_decomps={qp.RZ: [custom_decomp]})
+        @qp.transforms.decompose(gate_set=gate_set, alt_decomps={qp.CRZ: [custom_decomp]})
         @qp.qnode(qp.device("null.qubit"))
         def circuit():
-            qp.RZ(phi, 0)
+            qp.CRZ(phi, [0, 1])
             return qp.state()
 
         specs = qp.specs(circuit)()["resources"].gate_types
-        expected_specs = {"GlobalPhase": 1, "SemiAdder": 1, "C(BasisState)": 2}
+        expected_specs = {"SemiAdder": 1, "C(BasisState)": 4}
         assert specs == expected_specs
 
 
 def test_integration_multi_wire(seed):
     """
-    Tests that the decomposition correctly realizes the phase gradient decomposition of RZ as described in
-    https://pennylane.ai/compilation/phase-gradient/b-rotations
+    Tests that the decomposition correctly realizes the phase gradient decomposition of CRZ as
+    described in https://pennylane.ai/compilation/phase-gradient/c-control-rotations
     """
 
     with qp.decomposition.toggle_graph_ctx(
@@ -146,17 +124,17 @@ def test_integration_multi_wire(seed):
         prec = 3
 
         phi = (1 / 2 + 0 / 4 + 1 / 8) * 4 * np.pi
-        wires = [0]
+        wires = [0, 1]
 
-        angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
-        phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
-        work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
+        angle_wires = [f"aux_{i}" for i in range(prec)]
+        phase_grad_wires = [f"qft_{i}" for i in range(prec)]
+        work_wires = [f"work_{i}" for i in range(prec - 1)]
 
         phase_grad_state = np.exp(-1j * 2 * np.pi * np.arange(2**3) / 2**3) / np.sqrt(2**3)
 
         all_wires = angle_wires + phase_grad_wires + work_wires + wires
 
-        custom_decomp = make_rz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
+        custom_decomp = make_crz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
 
         @qp.transforms.decompose(
             gate_set={
@@ -164,19 +142,18 @@ def test_integration_multi_wire(seed):
                 "Adjoint(StatePrep)",
                 "C(BasisState)",
                 "SemiAdder",
-                "CNOT",
-                "GlobalPhase",
             },
-            fixed_decomps={qp.RZ: custom_decomp},
+            fixed_decomps={qp.CRZ: custom_decomp},
         )
         @qp.qnode(qp.device("default.qubit", wires=all_wires))
         def circuit(phi, in_state):
-            qp.StatePrep(in_state, wires=wires)  # input state
-            qp.StatePrep(phase_grad_state, wires=phase_grad_wires)  # phase gradient state
-            qp.RZ(phi, wires)
-            qp.adjoint(
-                qp.StatePrep(phase_grad_state, wires=phase_grad_wires)
-            )  # uncompute phase gradient state
+            # Prepare input state
+            qp.StatePrep(in_state, wires=wires)
+            # Prepare phase gradient state
+            qp.StatePrep(phase_grad_state, wires=phase_grad_wires)
+            qp.CRZ(phi, wires)
+            # uncompute phase gradient state
+            qp.adjoint(qp.StatePrep(phase_grad_state, wires=phase_grad_wires))
             return qp.state()
 
         # random input state
@@ -189,7 +166,7 @@ def test_integration_multi_wire(seed):
 
         # expected output state
         zeros = np.eye(2 ** (prec * 3 - 1), 1)[:, 0]  # |000> on all the aux wires
-        out_state_expected = qp.matrix(qp.RZ(phi, wires)) @ in_state
+        out_state_expected = qp.matrix(qp.CRZ(phi, wires)) @ in_state
         out_state_expected = np.kron(zeros, out_state_expected)
 
         assert np.allclose(out_state, out_state_expected)
@@ -206,7 +183,7 @@ def test_capture_compatibility():
     qp.capture.enable()
     try:
         with qp.decomposition.toggle_graph_ctx(True):
-            first_free = 1  # 0 used by RZ
+            first_free = 2  # 0, 1 used by CRZ
 
             precision = 3
             angle_wires = jnp.array(list(range(first_free, first_free + precision)))
@@ -217,15 +194,15 @@ def test_capture_compatibility():
                 list(range(first_free + 2 * precision, first_free + 3 * precision - 1))
             )
 
-            custom_decomp = make_rz_to_phase_gradient_decomp(
+            custom_decomp = make_crz_to_phase_gradient_decomp(
                 angle_wires, phase_grad_wires, work_wires
             )
 
-            gate_set = {"C(BasisState)", "SemiAdder", "CNOT", "GlobalPhase"}
+            gate_set = {"C(BasisState)", "SemiAdder"}
 
-            @DecomposeInterpreter(gate_set=gate_set, fixed_decomps={qp.RZ: custom_decomp})
+            @DecomposeInterpreter(gate_set=gate_set, fixed_decomps={qp.CRZ: custom_decomp})
             def f(phi):
-                qp.RZ(phi, 0)
+                qp.CRZ(phi, [0, 1])
                 return qp.state()
 
             phi_val = jnp.pi

--- a/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/tests/transforms/test_decomp_selectpaulirot_phase_gradient.py
@@ -29,24 +29,6 @@ from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.wires import WireError
 
 
-@pytest.mark.parametrize(
-    "n_angle_wires, n_phase_grad_wires, n_work_wires, msg_match",
-    [
-        [5, 3, 2, "angle_wires and phase_grad wires must be of same size"],
-        [3, 4, 2, "angle_wires and phase_grad wires must be of same size"],
-        [4, 4, 2, r"work_wires need to be at least of size len\(phase_grad_wires\) - 1"],
-    ],
-)
-def test_wires_error_constructor(n_angle_wires, n_phase_grad_wires, n_work_wires, msg_match):
-    """Test WireError is raised correctly when constructing the DecompositionRule"""
-    angle_wires = qp.wires.Wires([f"ang_{i}" for i in range(n_angle_wires)])
-    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(n_phase_grad_wires)])
-    work_wires = qp.wires.Wires([f"work_{i}" for i in range(n_work_wires)])
-
-    with pytest.raises(WireError, match=msg_match):
-        _ = make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
-
-
 def test_wires_error_decomp_fun():
     """Test WireError is raised correctly when calling the decomposition function on a large
     SelectPauliRot that needs more work wires for its QROM than are available."""

--- a/pennylane/labs/transforms/__init__.py
+++ b/pennylane/labs/transforms/__init__.py
@@ -31,10 +31,12 @@ Custom decomposition rules
     :toctree: api
 
     ~make_rz_to_phase_gradient_decomp
+    ~make_crz_to_phase_gradient_decomp
     ~make_selectpaulirot_to_phase_gradient_decomp
 
 """
 
 from .select_pauli_rot_phase_gradient import select_pauli_rot_phase_gradient
 from .decomp_rz_phase_gradient import make_rz_to_phase_gradient_decomp
+from .decomp_crz_phase_gradient import make_crz_to_phase_gradient_decomp
 from .decomp_selectpaulirot_phase_gradient import make_selectpaulirot_to_phase_gradient_decomp

--- a/pennylane/labs/transforms/decomp_crz_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_crz_phase_gradient.py
@@ -19,7 +19,7 @@ Factory that produces a decomposition rule for CRZ in terms of
 import numpy as np
 
 import pennylane as qp
-from pennylane.decomposition import change_op_basis_resource_rep
+from pennylane.decomposition import change_op_basis_resource_rep, controlled_resource_rep
 from pennylane.ops import Prod
 
 from .decomp_rz_phase_gradient import validate_phase_gradient_wires
@@ -121,10 +121,10 @@ def make_crz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
             num_y_wires=precision,
             num_work_wires=len(work_wires),
         )
-        fanout_angle = qp.controlled_resource_rep(
+        fanout_angle = controlled_resource_rep(
             qp.BasisState, {"num_wires": precision}, num_control_wires=1, num_zero_control_values=0
         )
-        fanout_addsub = qp.controlled_resource_rep(
+        fanout_addsub = controlled_resource_rep(
             qp.BasisState, {"num_wires": precision}, num_control_wires=1, num_zero_control_values=1
         )
         compute_op = uncompute_op = qp.resource_rep(

--- a/pennylane/labs/transforms/decomp_crz_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_crz_phase_gradient.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Factory that produces a decomposition rule for CRZ in terms of
+`phase gradient states <https://pennylane.ai/compilation/phase-gradient/c-control-rotations>`__
+"""
+
+import numpy as np
+
+import pennylane as qp
+from pennylane.decomposition import change_op_basis_resource_rep
+from pennylane.ops import Prod
+
+from .decomp_rz_phase_gradient import validate_phase_gradient_wires
+
+
+def make_crz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
+    r"""
+    Create a custom decomposition rule for :class:`~.CRZ` gates.
+
+    This is a temporary workaround before moving to `capture` as default frontend, which unlocks dynamic wire allocation.
+    Here, we explicitly provide the necessary wires for the
+    `phase gradient decomposition of SelectPauliRot <https://pennylane.ai/compilation/phase-gradient/c-control-rotations>`__.
+    This way, this function can be used in a workflow context that explicitly uses those wires to
+    generate the decomposition rule, which can then be used
+    as ``alt_decomps`` or ``fixed_decomp`` within :func:`~.pennylane.decompose` (with the
+    graph-based decomposition system).
+
+    Parameters:
+        angle_wires (Wires): wires that encode the binary representation of the rotation angle
+        phase_grad_wires (Wires): wires that carry a phase gradient state. Should have the same
+            length as ``angle_wires``.
+        work_wires (Wires): additional work wires for :class:`~.SemiAdder` decomposition.
+            At least ``len(angle_wires)-1`` work wires are required.
+
+    Returns:
+        func: decomposition rule to be used within :func:`~.pennylane.decompose`.
+
+    .. seealso:: :func:`~.make_rz_to_phase_gradient_decomp`, :func:`~.make_selectpaulirot_to_phase_gradient_decomp`
+
+    **Example**
+
+    In this example we decompose a circuit containing only a single :class:`~.CRZ`
+    gate using the custom decomposition rule that we generate from within the context of the
+    example, where all auxiliary wires exist.
+
+    .. code-block:: python
+
+        import pennylane as qp
+        from pennylane.labs.transforms import make_selectpaulirot_to_phase_gradient_decomp
+        import numpy as np
+
+        qp.decomposition.enable_graph()
+
+        prec = 3
+        np.random.seed(35)
+        angles = np.random.rand(2**3)
+
+        angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
+        phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
+        work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
+
+        custom_decomp = make_selectpaulirot_to_phase_gradient_decomp(
+            angle_wires, phase_grad_wires, work_wires
+        )
+
+        @qp.decompose(
+            gate_set={"QROM", "Adjoint(QROM)", "SemiAdder", "MultiControlledX", "GlobalPhase"},
+            fixed_decomps={qp.SelectPauliRot: custom_decomp}
+        )
+        @qp.qnode(qp.device("null.qubit"))
+        def circuit(angles):
+            qp.SelectPauliRot(angles, control_wires=range(3), target_wire=3)
+            return qp.state()
+
+        specs = qp.specs(circuit)(angles)["resources"].gate_types
+
+    The resulting circuit corresponds to the phase gradient decomposition
+    of ``CRZ``, containing four fanouts corresponding to the binary representation
+    of the angle (111 in this case), the :class:`~.SemiAdder`, and a :class:`~.GlobalPhase`.
+
+    >>> specs
+    {'QROM': 2, 'MultiControlledX': 6, 'SemiAdder': 1}
+    >>> wire_order = [0, 1, 2, 3] + angle_wires + phase_grad_wires + work_wires
+    >>> print(qp.draw(circuit, wire_order=wire_order, show_matrices=False)(angles))
+         0: ─╭◑────────────────────────────╭◑─────────────────┤ ╭State
+         1: ─├◑────────────────────────────├◑─────────────────┤ ├State
+         2: ─├◑────────────────────────────├◑─────────────────┤ ├State
+         3: ─│─────────╭○─╭○─╭○────────────│─────────╭○─╭○─╭○─┤ ├State
+     aux_0: ─├QROM(M0)─│──│──│──╭SemiAdder─├QROM(M0)─│──│──│──┤ ├State
+     aux_1: ─├QROM(M0)─│──│──│──├SemiAdder─├QROM(M0)─│──│──│──┤ ├State
+     aux_2: ─├QROM(M0)─│──│──│──├SemiAdder─├QROM(M0)─│──│──│──┤ ├State
+     qft_0: ─│─────────╰X─│──│──├SemiAdder─│─────────╰X─│──│──┤ ├State
+     qft_1: ─│────────────╰X─│──├SemiAdder─│────────────╰X─│──┤ ├State
+     qft_2: ─│───────────────╰X─├SemiAdder─│───────────────╰X─┤ ├State
+    work_0: ─├work──────────────├SemiAdder─├work──────────────┤ ├State
+    work_1: ─╰work──────────────╰SemiAdder─╰work──────────────┤ ╰State
+
+    """
+    angle_wires, phase_grad_wires, work_wires = validate_phase_gradient_wires(
+        angle_wires, phase_grad_wires, work_wires
+    )
+
+    def _resource_fn():
+        precision = len(angle_wires)
+        # decomposition costs, using information about angle_wires etc from the outer scope
+        target_op = qp.resource_rep(
+            qp.SemiAdder,
+            num_x_wires=precision,
+            num_y_wires=precision,
+            num_work_wires=len(work_wires),
+        )
+        fanout_angle = qp.controlled_resource_rep(
+            qp.BasisState, {"num_wires": precision}, num_control_wires=1, num_zero_control_values=0
+        )
+        fanout_addsub = qp.controlled_resource_rep(
+            qp.BasisState, {"num_wires": precision}, num_control_wires=1, num_zero_control_values=1
+        )
+        compute_op = uncompute_op = qp.resource_rep(
+            Prod, resources={fanout_angle: 1, fanout_addsub: 1}
+        )
+        change_basis_rep = change_op_basis_resource_rep(compute_op, target_op, uncompute_op)
+        return {change_basis_rep: 1}
+
+    @qp.register_resources(_resource_fn)
+    def _decomp_fn(angle, wires, **_):
+        precision = len(angle_wires)
+        binary_int = qp.math.binary_decimals(angle, precision, unit=4 * np.pi)
+
+        def compute_fn():
+            qp.ctrl(qp.BasisState(binary_int, angle_wires), control=wires[0])
+            qp.ctrl(
+                qp.BasisState([1] * precision, phase_grad_wires),
+                control=wires[1],
+                control_values=[0],
+            )
+
+        def target_fn():
+            qp.SemiAdder(angle_wires, phase_grad_wires, work_wires=work_wires)
+
+        qp.change_op_basis(compute_fn, target_fn, compute_fn)
+
+    return _decomp_fn

--- a/pennylane/labs/transforms/decomp_crz_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_crz_phase_gradient.py
@@ -58,54 +58,50 @@ def make_crz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
     .. code-block:: python
 
         import pennylane as qp
-        from pennylane.labs.transforms import make_selectpaulirot_to_phase_gradient_decomp
+        from pennylane.labs.transforms import make_crz_to_phase_gradient_decomp
         import numpy as np
 
         qp.decomposition.enable_graph()
 
         prec = 3
-        np.random.seed(35)
-        angles = np.random.rand(2**3)
+        phi = (1/2 + 1/4 + 1/8) * 2 * np.pi # binary rep is (111)
 
         angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
         phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
         work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
 
-        custom_decomp = make_selectpaulirot_to_phase_gradient_decomp(
+        custom_decomp = make_crz_to_phase_gradient_decomp(
             angle_wires, phase_grad_wires, work_wires
         )
 
-        @qp.decompose(
-            gate_set={"QROM", "Adjoint(QROM)", "SemiAdder", "MultiControlledX", "GlobalPhase"},
-            fixed_decomps={qp.SelectPauliRot: custom_decomp}
+        @qp.transforms.decompose(
+            gate_set={"C(BasisState)", "SemiAdder"},
+            fixed_decomps={qp.CRZ: custom_decomp}
         )
         @qp.qnode(qp.device("null.qubit"))
-        def circuit(angles):
-            qp.SelectPauliRot(angles, control_wires=range(3), target_wire=3)
+        def circuit():
+            qp.CRZ(phi, [0, 1])
             return qp.state()
 
-        specs = qp.specs(circuit)(angles)["resources"].gate_types
+        specs = qp.specs(circuit)()["resources"].gate_types
 
     The resulting circuit corresponds to the phase gradient decomposition
     of ``CRZ``, containing four fanouts corresponding to the binary representation
     of the angle (111 in this case), the :class:`~.SemiAdder`, and a :class:`~.GlobalPhase`.
 
     >>> specs
-    {'QROM': 2, 'MultiControlledX': 6, 'SemiAdder': 1}
-    >>> wire_order = [0, 1, 2, 3] + angle_wires + phase_grad_wires + work_wires
-    >>> print(qp.draw(circuit, wire_order=wire_order, show_matrices=False)(angles))
-         0: ─╭◑────────────────────────────╭◑─────────────────┤ ╭State
-         1: ─├◑────────────────────────────├◑─────────────────┤ ├State
-         2: ─├◑────────────────────────────├◑─────────────────┤ ├State
-         3: ─│─────────╭○─╭○─╭○────────────│─────────╭○─╭○─╭○─┤ ├State
-     aux_0: ─├QROM(M0)─│──│──│──╭SemiAdder─├QROM(M0)─│──│──│──┤ ├State
-     aux_1: ─├QROM(M0)─│──│──│──├SemiAdder─├QROM(M0)─│──│──│──┤ ├State
-     aux_2: ─├QROM(M0)─│──│──│──├SemiAdder─├QROM(M0)─│──│──│──┤ ├State
-     qft_0: ─│─────────╰X─│──│──├SemiAdder─│─────────╰X─│──│──┤ ├State
-     qft_1: ─│────────────╰X─│──├SemiAdder─│────────────╰X─│──┤ ├State
-     qft_2: ─│───────────────╰X─├SemiAdder─│───────────────╰X─┤ ├State
-    work_0: ─├work──────────────├SemiAdder─├work──────────────┤ ├State
-    work_1: ─╰work──────────────╰SemiAdder─╰work──────────────┤ ╰State
+    {'C(BasisState)': 4, 'SemiAdder': 1}
+    >>> print(qp.draw(circuit, wire_order=[0, 1])())
+         0: ─╭●───────────────────╭●────────┤ ╭State
+         1: ─│────╭○──────────────│────╭○───┤ ├State
+     aux_0: ─├|Ψ⟩─│────╭SemiAdder─├|Ψ⟩─│────┤ ├State
+     aux_1: ─├|Ψ⟩─│────├SemiAdder─├|Ψ⟩─│────┤ ├State
+     aux_2: ─╰|Ψ⟩─│────├SemiAdder─╰|Ψ⟩─│────┤ ├State
+     qft_0: ──────├|Ψ⟩─├SemiAdder──────├|Ψ⟩─┤ ├State
+     qft_1: ──────├|Ψ⟩─├SemiAdder──────├|Ψ⟩─┤ ├State
+     qft_2: ──────╰|Ψ⟩─├SemiAdder──────╰|Ψ⟩─┤ ├State
+    work_0: ───────────├SemiAdder───────────┤ ├State
+    work_1: ───────────╰SemiAdder───────────┤ ╰State
 
     """
     angle_wires, phase_grad_wires, work_wires = validate_phase_gradient_wires(

--- a/pennylane/labs/transforms/decomp_rz_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_rz_phase_gradient.py
@@ -18,12 +18,38 @@ Decomposition rule for RZ in terms of `phase gradient states <https://pennylane.
 import pennylane as qp
 from pennylane.decomposition import change_op_basis_resource_rep
 from pennylane.transforms.rz_phase_gradient import _rz_phase_gradient
-from pennylane.wires import WireError
+from pennylane.wires import WireError, Wires
+
+
+def validate_phase_gradient_wires(angle_wires, phase_grad_wires, work_wires):
+    """Validate three wire registers to be valid for phase gradient decompositions.
+
+    Args:
+        angle_wires (Wires): wires that encode the binary representation of the rotation angle
+        phase_grad_wires (Wires): wires that carry a phase gradient state.
+        work_wires (Wires): work wires for :class:`~.SemiAdder` (and possibly :class:`~.QROM`)
+            decomposition.
+
+    """
+    angle_wires = Wires(angle_wires)
+    phase_grad_wires = Wires(phase_grad_wires)
+    work_wires = Wires(work_wires)
+    if len(angle_wires) != len(phase_grad_wires):
+        raise WireError(
+            "angle_wires and phase_grad wires must be of same size, but received "
+            f"{len(angle_wires)} angle_wires and {len(phase_grad_wires)} phase_grad_wires."
+        )
+    if len(phase_grad_wires) - 1 > len(work_wires):
+        raise WireError(
+            f"work_wires need to be at least of size len(phase_grad_wires) - 1, but received "
+            f"{len(work_wires)} work_wires and {len(phase_grad_wires)-1=}"
+        )
+    return angle_wires, phase_grad_wires, work_wires
 
 
 def make_rz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
     r"""
-    Custom decomposition rule for :class:`~.RZ` gates
+    Create a custom decomposition rule for :class:`~.RZ` gates.
 
     This is a temporary workaround before moving to `capture` as default frontend, which unlocks dynamic wire allocation.
     Here, we explicitly provide the necessary wires for the `phase gradient decomposition of RZ <https://pennylane.ai/compilation/phase-gradient/b-rotations>`__.
@@ -92,14 +118,9 @@ def make_rz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
     work_1: ─╰GlobalPhase(2.75)──────╰SemiAdder──────┤ ╰State
 
     """
-    if len(angle_wires) != len(phase_grad_wires):
-        raise WireError(
-            f"angle_wires and phase_grad wires must be of same size, received {len(angle_wires)} and {len(phase_grad_wires - 1)}"
-        )
-    if len(phase_grad_wires) - 1 > len(work_wires):
-        raise WireError(
-            f"work_wires need to be at least of size phase_grad_wires - 1, received {len(work_wires)} but require {len(phase_grad_wires - 1)}"
-        )
+    angle_wires, phase_grad_wires, work_wires = validate_phase_gradient_wires(
+        angle_wires, phase_grad_wires, work_wires
+    )
 
     def _resource_fn():
         # rz decomposition costs, using information about angle_wires etc from the outer scope

--- a/pennylane/labs/transforms/decomp_rz_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_rz_phase_gradient.py
@@ -90,10 +90,9 @@ def make_rz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
             angle_wires, phase_grad_wires, work_wires
         )
 
-        @qp.transforms.decompose(
-                gate_set={"C(BasisState)", "SemiAdder", "CNOT", "GlobalPhase"},
-                fixed_decomps={qp.RZ: custom_decomp}
-        )
+        gate_set = {"C(BasisState)", "SemiAdder", "GlobalPhase"}
+
+        @qp.transforms.decompose(gate_set=gate_set, fixed_decomps={qp.RZ: custom_decomp})
         @qp.qnode(qp.device("null.qubit"))
         def circuit():
             qp.RZ(phi, 0)

--- a/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
+++ b/pennylane/labs/transforms/decomp_selectpaulirot_phase_gradient.py
@@ -30,6 +30,8 @@ from pennylane.ops import Prod
 from pennylane.ops.op_math import change_op_basis
 from pennylane.wires import WireError, Wires
 
+from .decomp_rz_phase_gradient import validate_phase_gradient_wires
+
 
 # pylint: disable=too-many-arguments
 def _select_pauli_rot_phase_gradient(
@@ -86,7 +88,7 @@ def _select_pauli_rot_phase_gradient(
 
 def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires):
     r"""
-    Custom decomposition rule for :class:`~.SelectPauliRot` gates
+    Create a custom decomposition rule for :class:`~.SelectPauliRot` gates.
 
     This is a temporary workaround before moving to `capture` as default frontend, which unlocks dynamic wire allocation.
     Here, we explicitly provide the necessary wires for the `phase gradient decomposition of SelectPauliRot <https://pennylane.ai/compilation/phase-gradient/d-multiplex-rotations>`__.
@@ -148,8 +150,9 @@ def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, 
 
     The resulting circuit corresponds to the
     `phase gradient decomposition <https://pennylane.ai/compilation/phase-gradient/d-multiplex-rotations>`__
-    of ``SelectPauliRot``, containing two CNOT fanouts corresponding to the binary representation
-    of the angle (111 in this case), the :class:`~.SemiAdder`, and a :class:`~.GlobalPhase`.
+    of ``SelectPauliRot``, containing two static CNOT fanouts that toggle between addition and
+    subtraction based on the target wire state, two QROMs that load the binary representation of
+    the rotation angles, and the :class:`~.SemiAdder`:
 
     >>> specs
     {'QROM': 2, 'MultiControlledX': 6, 'SemiAdder': 1}
@@ -169,22 +172,9 @@ def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, 
     work_1: ─╰work──────────────╰SemiAdder─╰work──────────────┤ ╰State
 
     """
-    # Sanitize wires
-    angle_wires = Wires(angle_wires)
-    phase_grad_wires = Wires(phase_grad_wires)
-    work_wires = Wires(work_wires)
-
-    if len(angle_wires) != len(phase_grad_wires):
-        raise WireError(
-            f"angle_wires and phase_grad wires must be of same size, received "
-            f"{len(angle_wires)=} and {len(phase_grad_wires)=}"
-        )
-    # Validate length of work wires for SemiAdder
-    if len(work_wires) < len(phase_grad_wires) - 1:
-        raise WireError(
-            "work_wires need to be at least of size len(phase_grad_wires) - 1, "
-            "received {len(work_wires)} but require {len(phase_grad_wires) - 1}"
-        )
+    angle_wires, phase_grad_wires, work_wires = validate_phase_gradient_wires(
+        angle_wires, phase_grad_wires, work_wires
+    )
 
     def _resource_fn(num_wires, rot_axis):
         # decomposition costs, using information about angle_wires etc from the outer scope


### PR DESCRIPTION
**Context:**
We have phase gradient decompositions for rotations (`make_rz_to_phase_gradient_decomp` | [comp hub](https://pennylane.ai/compilation/phase-gradient/b-rotations)) and for multiplexed rotations (`make_selectpaulirot_to_phase_gradient_decomp` | [comp hub](https://pennylane.ai/compilation/phase-gradient/d-multiplex-rotations)) but not for controll decompositions yet ([comp hub](https://pennylane.ai/compilation/phase-gradient/c-control-rotations))

**Description of the Change:**
Add a factory for the decomposition rule for `CRZ`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
