### PR TITLE
Override

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
     -   id: pyupgrade
         name: "🐍 pyupgrade · Check language features"
-        args: [--py312-plus]
+        args: [--py311-plus]
 - repo: local
   hooks:
     - id: pylint

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -16,9 +16,10 @@
 
 from collections.abc import Sequence
 from inspect import signature
-from typing import Literal, override
+from typing import Literal
 
 from scipy import sparse
+from typing_extensions import override
 
 import pennylane as qp
 from pennylane import math


### PR DESCRIPTION
**Context:**
To greatly ease the CI issue other packages CI have been suffering since we switched override imporitng to 3.12 standard.
See [catalyst](https://github.com/PennyLaneAI/catalyst/actions/runs/28585709776/job/84756698807) and [qiskit plugin](https://github.com/PennyLaneAI/PennyLane-IonQ/actions/runs/28596659525/job/84793740804?pr=188)

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
