### PR TITLE
fix: update `Controlled2.__new__` to fix copy roundtrip bug

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -828,6 +828,7 @@
   [(#9730)](https://github.com/PennyLaneAI/pennylane/pull/9730)
   [(#9727)](https://github.com/PennyLaneAI/pennylane/pull/9727)
   [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
+  [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
 
 * Added an internal `abstractify` utility function that is able to convert various objects
   to their abstract versions.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -824,6 +824,7 @@
   [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
   [(#9737)](https://github.com/PennyLaneAI/pennylane/pull/9737)
   [(#9730)](https://github.com/PennyLaneAI/pennylane/pull/9730)
+  [(#)]()
 
 * Added an internal `abstractify` utility function that is able to convert various objects
   to their abstract versions.

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -86,16 +86,23 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
     """Arguments that the operator is initialized with."""
 
     def __new__(cls, *args, **kwargs):
+        obj = super().__new__(cls)
+
+        # NOTE: If called without arguments (during a __copy__)
+        # skip signature binding as attributes will be restored
+        # during the copy.
+        if not args and not kwargs:
+            return obj
+
         # The purpose of this function here is to intercept the argument passed to the
         # constructor of the subclass and store it on the operator, so that in __init__,
         # we can pass that along to the base Operator2.__init__, which expects the
         # arguments to match the pre-defined signature of the subclass.
-        obj = super().__new__(cls)
-        if args or kwargs:
-            sig = signature(cls)
-            bound_args = sig.bind(*args, **kwargs)
-            bound_args.apply_defaults()
-            obj._init_args = bound_args.arguments
+        sig = signature(cls)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        obj._init_args = bound_args.arguments
+
         return obj
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -106,7 +113,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
         work_wires: WiresLike | None = None,
         work_wire_type: Literal["zeroed", "borrowed"] = "borrowed",
     ):
-
         control_wires = Wires(control_wires)
         work_wires = Wires([] if work_wires is None else work_wires)
 
@@ -149,7 +155,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
         super().__init__(**self._init_args)
 
     def __init_subclass__(cls, is_baseclass=False) -> None:
-
         super().__init_subclass__(is_baseclass)
 
         base_argnames = {"base", "control_wires", "control_values", "work_wires", "work_wire_type"}
@@ -237,7 +242,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
     @override
     # pylint: disable=arguments-differ
     def compute_matrix(base, control_wires, control_values, **_):
-
         base_matrix = base.matrix()
         interface = math.get_interface(base_matrix)
 
@@ -269,7 +273,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
     @override
     # pylint: disable=arguments-differ
     def compute_sparse_matrix(base, control_wires, control_values, format="csr", **_):
-
         target_matrix = _get_sparse_matrix(base)
 
         num_target_states = 2 ** len(base.wires)
@@ -341,7 +344,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
     @override
     def simplify(self):
         if isinstance(self.base, (qp.ops.Controlled, Controlled2)):
-
             simplified_base = self.base.base.simplify()
             if isinstance(simplified_base, qp.Identity):
                 return simplified_base

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -91,10 +91,11 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
         # we can pass that along to the base Operator2.__init__, which expects the
         # arguments to match the pre-defined signature of the subclass.
         obj = super().__new__(cls)
-        sig = signature(cls)
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        obj._init_args = bound_args.arguments
+        if args or kwargs:
+            sig = signature(cls)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            obj._init_args = bound_args.arguments
         return obj
 
     def __init__(  # pylint: disable=too-many-arguments

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -14,6 +14,7 @@
 """Tests for the Controlled2 class."""
 
 import copy
+import pickle
 from typing import override
 
 import numpy as np
@@ -420,7 +421,9 @@ class TestControlledOp2:
         op = qp.ctrl(OneWireDynOp(0.5, wires=[0]), control=[1], control_values=0)
         assert isinstance(op, ControlledOp2)
 
-    @pytest.mark.parametrize("copy_fn", (copy.copy, copy.deepcopy))
+    @pytest.mark.parametrize(
+        "copy_fn", (copy.copy, copy.deepcopy, lambda obj: pickle.loads(pickle.dumps(obj)))
+    )
     def test_copy_roundtrip(self, copy_fn):
         """Test to make sure that copy roundtrips are sastisfied."""
 

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -13,6 +13,7 @@
 
 """Tests for the Controlled2 class."""
 
+import copy
 from typing import override
 
 import numpy as np
@@ -23,7 +24,7 @@ from pennylane.ops.op_math.controlled import Controlled
 from pennylane.ops.op_math.controlled2 import Controlled2, ControlledOp2
 from pennylane.typing import Bool, Wire
 from pennylane.wires import Wires
-from tests.core.operator.operator2_utils import OneWireDynOp
+from tests.core.operator.operator2_utils import DynOp, OneWireDynOp
 
 # pylint: disable=unused-argument,too-few-public-methods
 
@@ -418,3 +419,11 @@ class TestControlledOp2:
         op = OneWireDynOp(0.5, wires=[0])
         op = qp.ctrl(OneWireDynOp(0.5, wires=[0]), control=[1], control_values=0)
         assert isinstance(op, ControlledOp2)
+
+    @pytest.mark.parametrize("copy_fn", (copy.copy, copy.deepcopy))
+    def test_copy_roundtrip(self, copy_fn):
+        """Test to make sure that copy roundtrips are sastisfied."""
+
+        op = ControlledOp2(DynOp(0.5, 0), control_wires=1)
+
+        assert op == copy_fn(op)


### PR DESCRIPTION
**Context:**

`Operator2.__copy__` (and `__deepcopy__`) reconstruct objects by calling `cls.__new__(cls)` *without arguments*. 

However, `Controlled2.__new__` runs signature binding (`sig.bind(*args, kwargs)`). When called with empty arguments during copying or unpickling, this raises a `TypeError` because the required base argument is missing.

**Description of the Change:**

By pass signature binding if no args or kwargs are provided as it will be handled by the copy dunder.

This is actually a similar fix to https://github.com/PennyLaneAI/pennylane/pull/9366/changes. 

**Benefits:** Bug fix when copying

**Possible Drawbacks:** None identified

[sc-123770]