### PR TITLE
__abstract_init__ for custom controlled ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -792,59 +792,57 @@
   [(#9590)](https://github.com/PennyLaneAI/pennylane/pull/9590)
 
 * New, experimental abstractions for creating PennyLane operators have been added, built around a new
-  base class, :class:`~.Operator2`. This is an internal, work-in-progress effort that is being incrementally
-  integrated into the PennyLane ecosystem. Supported functionality so far:
-  - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.
-  - :class:`~.StatePrepBase2`, based on :class:`~.Operator2`, is added.
-  - :meth:`~.Operator2.decomposition` falls back to registered graph decomposition rules when ``compute_decomposition`` is not overridden.
-  - Arithmetic can be performed with :class:`~.Operator2` instances.
-  - Symbolic operators with :class:`~.Operator2` instances as the base.
-  - :func:`qp.ops.functions.assert_valid` can verify that an :class:`~.Operator2` is defined properly.
-  - Integration with :mod:`pennylane.capture`.
-  - Integration with :func:`pennylane.apply`.
-  - Integration with measurements and capture.
-  - Integration with the graph-based decomposition system.
-  - Patched `SymbolicOp` and `CompositeOp` to tolerate `Operator2` instances under program capture.
-  - Integration with :func:`pennylane.adjoint` and :func:`pennylane.ctrl`.
+  base class, :class:`~.Operator2`. 
   [(#9525)](https://github.com/PennyLaneAI/pennylane/pull/9525)
-  [(#9529)](https://github.com/PennyLaneAI/pennylane/pull/9529)
   [(#9526)](https://github.com/PennyLaneAI/pennylane/pull/9526)
   [(#9527)](https://github.com/PennyLaneAI/pennylane/pull/9527)
-  [(#9562)](https://github.com/PennyLaneAI/pennylane/pull/9562)
-  [(#9607)](https://github.com/PennyLaneAI/pennylane/pull/9607)
-  [(#9596)](https://github.com/PennyLaneAI/pennylane/pull/9596)
-  [(#9627)](https://github.com/PennyLaneAI/pennylane/pull/9627)
-  [(#9659)](https://github.com/PennyLaneAI/pennylane/pull/9659)
-  [(#9597)](https://github.com/PennyLaneAI/pennylane/pull/9597)
-  [(#9647)](https://github.com/PennyLaneAI/pennylane/pull/9647)
   [(#9649)](https://github.com/PennyLaneAI/pennylane/pull/9649)
-  [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
-  [(#9646)](https://github.com/PennyLaneAI/pennylane/pull/9646)
-  [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
   [(#9675)](https://github.com/PennyLaneAI/pennylane/pull/9675)
-  [(#9683)](https://github.com/PennyLaneAI/pennylane/pull/9683)
-  [(#9693)](https://github.com/PennyLaneAI/pennylane/pull/9693)
-  [(#9685)](https://github.com/PennyLaneAI/pennylane/pull/9685)
-  [(#9702)](https://github.com/PennyLaneAI/pennylane/pull/9702)
-  [(#9738)](https://github.com/PennyLaneAI/pennylane/pull/9738)
-  [(#9723)](https://github.com/PennyLaneAI/pennylane/pull/9723)
-  [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)
-  [(#9744)](https://github.com/PennyLaneAI/pennylane/pull/9744)
   [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
-  [(#9737)](https://github.com/PennyLaneAI/pennylane/pull/9737)
-  [(#9730)](https://github.com/PennyLaneAI/pennylane/pull/9730)
-  [(#9753)](https://github.com/PennyLaneAI/pennylane/pull/9753)
-  [(#9727)](https://github.com/PennyLaneAI/pennylane/pull/9727)
-  [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
-  [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
-  [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
 
-* Added an internal `abstractify` utility function that is able to convert various objects
-  to their abstract versions.
-  [(#9694)](https://github.com/PennyLaneAI/pennylane/pull/9694)
+  This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane 
+  ecosystem. Supported functionality so far:
 
-* Added an `is_abstract` property to `Operator2` in order to improve abstractification efficiency.
-  [(#9740)](https://github.com/PennyLaneAI/pennylane/pull/9740)
+  - Create instances of :class:`~.Operator2` with abstract data.
+    [(#9740)](https://github.com/PennyLaneAI/pennylane/pull/9740)
+    [(#9646)](https://github.com/PennyLaneAI/pennylane/pull/9646)
+    [(#9694)](https://github.com/PennyLaneAI/pennylane/pull/9694)
+    [(#9744)](https://github.com/PennyLaneAI/pennylane/pull/9744)
+  - Some backwards compatibility with the legacy operator interface.
+    [(#9596)](https://github.com/PennyLaneAI/pennylane/pull/9596)
+    [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
+  - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.
+    [(#9529)](https://github.com/PennyLaneAI/pennylane/pull/9529)
+    [(#9702)](https://github.com/PennyLaneAI/pennylane/pull/9702)
+  - :func:`qp.ops.functions.assert_valid` can verify that an :class:`~.Operator2` is defined properly.
+    [(#9659)](https://github.com/PennyLaneAI/pennylane/pull/9659)
+  - :class:`~.StatePrepBase2`, based on :class:`~.Operator2`, is added.
+    [(#9562)](https://github.com/PennyLaneAI/pennylane/pull/9562)
+  - :meth:`~.Operator2.decomposition` falls back to registered graph decomposition rules when ``compute_decomposition`` is not overridden.
+    [(#9683)](https://github.com/PennyLaneAI/pennylane/pull/9683)
+  - Arithmetic can be performed with :class:`~.Operator2` instances.
+    [(#9693)](https://github.com/PennyLaneAI/pennylane/pull/9693)
+  - Symbolic operators with :class:`~.Operator2` instances as the base.
+    [(#9597)](https://github.com/PennyLaneAI/pennylane/pull/9597)
+    [(#9647)](https://github.com/PennyLaneAI/pennylane/pull/9647)
+    [(#9737)](https://github.com/PennyLaneAI/pennylane/pull/9737)
+    [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
+    [(#9758)](https://github.com/PennyLaneAI/pennylane/pull/9758)
+    [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
+  - Integration with :mod:`pennylane.capture`.
+    [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
+    [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)
+    [(#9730)](https://github.com/PennyLaneAI/pennylane/pull/9730)
+    [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
+  - Integration with measurements.
+    [(#9753)](https://github.com/PennyLaneAI/pennylane/pull/9753)
+  - Integration with :func:`pennylane.apply`.
+    [(#9738)](https://github.com/PennyLaneAI/pennylane/pull/9738)
+  - Integration with :func:`pennylane.insert`.
+    [(#9685)](https://github.com/PennyLaneAI/pennylane/pull/9685)
+  - Integration with the graph-based decomposition system.
+    [(#9723)](https://github.com/PennyLaneAI/pennylane/pull/9723)
+    [(#9727)](https://github.com/PennyLaneAI/pennylane/pull/9727)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.
@@ -860,6 +858,8 @@
   [(#9508)](https://github.com/PennyLaneAI/pennylane/pull/9508)
   [(#9586)](https://github.com/PennyLaneAI/pennylane/pull/9586)
   [(#9583)](https://github.com/PennyLaneAI/pennylane/pull/9583)
+  [(#9607)](https://github.com/PennyLaneAI/pennylane/pull/9607)
+  [(#9627)](https://github.com/PennyLaneAI/pennylane/pull/9627)
 
 * ``assert_valid`` will now correctly raise an ``ImportError`` if `skip_capture=False` and JAX is not installed.
   [(#9567)](https://github.com/PennyLaneAI/pennylane/pull/9567)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -829,6 +829,7 @@
     [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
     [(#9758)](https://github.com/PennyLaneAI/pennylane/pull/9758)
     [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
+    [(#9778)](https://github.com/PennyLaneAI/pennylane/pull/9778)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1701,9 +1701,9 @@ def _canonicalize_dynamic(d, op_name=None) -> Hashable:
     else:
         mod_val = None
 
-    # We stringify the data because arrays are unhashable
     if isinstance(d, AbstractArray):
-        return str(d)
+        return hash(d)
+
     return str(id(d) if math.is_abstract(d) else _mod_and_round(d, mod_val))
 
 

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -43,6 +43,7 @@ from pennylane.exceptions import (
     ParameterFrequenciesUndefinedError,
     SparseMatrixUndefinedError,
 )
+from pennylane.typing import AbstractWires, Bool, Wire
 from pennylane.wires import Wires, WiresLike
 
 from .controlled2 import Controlled2, ControlledOp2
@@ -195,12 +196,13 @@ def ctrl(op, control: Any, control_values=None, work_wires=None, work_wire_type=
 def create_controlled_op2(op, control_wires, control_values, work_wires, ww_type):
     """New implementation of qp.ctrl that works better with Operator2."""
 
-    control_wires = Wires(control_wires)
+    if not isinstance(control_wires, AbstractWires):
+        control_wires = Wires(control_wires)
+    if not isinstance(work_wires, AbstractWires):
+        work_wires = Wires([] if work_wires is None else work_wires)
+
     if control_values is None:
         control_values = [True] * len(control_wires)
-    if work_wires is None:
-        work_wires = []
-    work_wires = Wires(work_wires)
 
     if isinstance(op, Controlled2):
         _ = pop_op_eqns((op,))
@@ -208,9 +210,9 @@ def create_controlled_op2(op, control_wires, control_values, work_wires, ww_type
         ctrl_values = resolve_ctrl_values(control_values, op)
         return ctrl(
             op.base,
-            control=control_wires + op.control_wires,
+            control=_concat_wires(control_wires, op.control_wires),
             control_values=ctrl_values,
-            work_wires=work_wires + op.work_wires,
+            work_wires=_concat_wires(work_wires, op.work_wires),
             work_wire_type=ww_type,
         )
 
@@ -218,11 +220,22 @@ def create_controlled_op2(op, control_wires, control_values, work_wires, ww_type
     return ControlledOp2(op, control_wires, control_values, work_wires, ww_type)
 
 
+def _concat_wires(wire1, wire2):
+
+    if isinstance(wire2, AbstractWires):
+        return Wire[len(wire1) + len(wire2)]
+
+    return wire1 + wire2
+
+
 def resolve_ctrl_values(control_values, base_ctrl_op: Controlled2):
     """Resolves the new control values."""
 
     if isinstance(control_values, (int, bool)):
         control_values = [control_values]
+
+    if base_ctrl_op.is_abstract:
+        return Bool[len(control_values) + len(base_ctrl_op.control_values)]
 
     return math.concatenate([control_values, base_ctrl_op.control_values])
 

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -203,7 +203,6 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
         if "work_wires" in self._init_args:
             self._init_args["work_wires"] = work_wires
 
-        # call super().__abstract_init__
         super().__abstract_init__(**self._init_args)
 
     def __init_subclass__(cls, is_baseclass=False) -> None:

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -24,10 +24,10 @@ from typing_extensions import override
 import pennylane as qp
 from pennylane import math
 from pennylane.core.operator import Operator
-from pennylane.core.operator.operator2 import operator_p, pop_op_eqns  # tach-ignore
+from pennylane.core.operator.operator2 import abstractify, operator_p, pop_op_eqns  # tach-ignore
 from pennylane.decomposition.resources import resolve_work_wire_type
 from pennylane.exceptions import SparseMatrixUndefinedError
-from pennylane.typing import Bool, Wire
+from pennylane.typing import AbstractWires, Bool, Wire
 from pennylane.wires import Wires, WiresLike
 
 from .symbolicop2 import SymbolicOp2
@@ -86,6 +86,7 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
     """Arguments that the operator is initialized with."""
 
     def __new__(cls, *args, **kwargs):
+
         obj = super().__new__(cls)
 
         # NOTE: If called without arguments (during a __copy__)
@@ -153,6 +154,57 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
             self._init_args["work_wires"] = work_wires
 
         super().__init__(**self._init_args)
+
+    @override
+    def __abstract_init__(  # pylint: disable=too-many-arguments,arguments-differ
+        self,
+        base: Operator,
+        control_wires: WiresLike,
+        control_values: Sequence[int | bool] | None = None,
+        work_wires: WiresLike | None = None,
+        work_wire_type: Literal["zeroed", "borrowed"] = "borrowed",
+    ):
+
+        # abstractify the wires
+        if work_wires is None:
+            work_wires = Wire[0]
+        if not isinstance(work_wires, AbstractWires):
+            work_wires = abstractify(Wires(work_wires))
+        if not isinstance(control_wires, AbstractWires):
+            control_wires = abstractify(Wires(control_wires))
+
+        # abstractify control values
+        if control_values is None:
+            control_values = Bool[len(control_wires)]
+        elif isinstance(control_values, (int, bool)):
+            control_values = Bool[1]
+        elif isinstance(control_values, (list, tuple, Wires)):
+            control_values = Bool[len(control_values)]
+
+        # abstractify the base
+        base = abstractify(base)
+
+        # initialize the interface properties
+        self._base = base
+        self._control_wires = control_wires
+        self._control_values = control_values
+        self._work_wires = work_wires
+        self._work_wire_type = work_wire_type
+
+        if "base" in self._init_args:
+            self._init_args["base"] = base
+
+        if "control_wires" in self._init_args:
+            self._init_args["control_wires"] = control_wires
+
+        if "control_values" in self._init_args:
+            self._init_args["control_values"] = control_values
+
+        if "work_wires" in self._init_args:
+            self._init_args["work_wires"] = work_wires
+
+        # call super().__abstract_init__
+        super().__abstract_init__(**self._init_args)
 
     def __init_subclass__(cls, is_baseclass=False) -> None:
         super().__init_subclass__(is_baseclass)
@@ -434,37 +486,6 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
         work_wire_type: Literal["zeroed", "borrowed"] = "borrowed",
     ):
         super().__init__(base, control_wires, control_values, work_wires, work_wire_type)
-
-    @override
-    def __abstract_init__(  # pylint: disable=too-many-arguments,arguments-differ
-        self,
-        base,
-        control_wires,
-        control_values=None,
-        work_wires=None,
-        work_wire_type="borrowed",
-    ):
-        # Canonicalize control_values and work_wires
-        if control_values is None:
-            control_values = Bool[len(control_wires)]
-        if work_wires is None:
-            work_wires = Wire[0]
-
-        # Use default implementation for __abstract_init__
-        super().__abstract_init__(
-            base,
-            control_wires,
-            control_values=control_values,
-            work_wires=work_wires,
-            work_wire_type=work_wire_type,
-        )
-
-        # Update private properties
-        self._base = self.arguments["base"]
-        self._control_wires = self.arguments["control_wires"]
-        self._control_values = self.arguments["control_values"]
-        self._work_wires = self.arguments["work_wires"]
-        self._work_wire_type = self.arguments["work_wire_type"]
 
     @property
     @override

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -24,7 +24,7 @@ from operator2_utils import DynOp, FullOp
 from scipy.sparse import csr_matrix
 
 import pennylane as qp
-from pennylane.core.operator import Operator2, StatePrepBase2
+from pennylane.core.operator import Operator2, StatePrepBase2, abstractify
 from pennylane.core.queuing import AnnotatedQueue, apply
 from pennylane.exceptions import (
     AdjointUndefinedError,
@@ -40,7 +40,7 @@ from pennylane.exceptions import (
 from pennylane.operation import _UNSET_BATCH_SIZE
 from pennylane.pauli import PauliSentence, PauliWord
 from pennylane.pytrees.pytrees import flatten_registrations, unflatten_registrations
-from pennylane.typing import AbstractArray, AbstractWires
+from pennylane.typing import AbstractArray, AbstractWires, Float, Wire
 from pennylane.wires import Wires
 
 
@@ -1066,6 +1066,13 @@ class TestHash:
         """Test the hash-equality invariant: ``a == b`` implies ``hash(a) == hash(b)``."""
         op1 = DynOp(0.5, wires=0)
         op2 = DynOp(0.5, wires=0)
+        assert op1 == op2
+        assert hash(op1) == hash(op2)
+
+    def test_abstract_op_hash_contract(self):
+        """Tests that an abstract op and abstractified op have the same hash."""
+        op1 = DynOp(Float, Wire[2])
+        op2 = abstractify(DynOp(0.5, [0, 1]))
         assert op1 == op2
         assert hash(op1) == hash(op2)
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -45,8 +45,11 @@ from pennylane.decomposition.decomposition_rule import register_resources
 from pennylane.exceptions import DecompositionUndefinedError
 from pennylane.gradients import parameter_frequencies
 from pennylane.ops.op_math.controlled import Controlled, ControlledOp, ctrl
+from pennylane.ops.op_math.controlled2 import ControlledOp2
 from pennylane.transforms import decompose
+from pennylane.typing import Bool, Float, Wire
 from pennylane.wires import Wires
+from tests.core.operator.operator2_utils import DynOp
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=protected-access
@@ -2073,6 +2076,16 @@ class TestCtrl:
             assert op.name == "C(QSVT)"
 
         assert len(q.queue) == 2
+
+    def test_ctrl_on_abstract_controlled_op(self):
+        """Tests that applying `ctrl` on abstract controlled op works."""
+
+        op = qp.ctrl(DynOp(Float, Wire[2]), control=[0], control_values=[1])
+        assert isinstance(op, ControlledOp2)
+        assert op.base == DynOp(Float, Wire[2])
+        assert op.wires == Wire[3]
+        assert op.control_wires == Wire[1]
+        assert op.control_values == Bool[1]
 
 
 class _Rot(Operation):

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -2080,12 +2080,20 @@ class TestCtrl:
     def test_ctrl_on_abstract_controlled_op(self):
         """Tests that applying `ctrl` on abstract controlled op works."""
 
-        op = qp.ctrl(DynOp(Float, Wire[2]), control=[0], control_values=[1])
+        op = qp.ctrl(DynOp(Float, Wire[2]), control=[0], control_values=1)
         assert isinstance(op, ControlledOp2)
         assert op.base == DynOp(Float, Wire[2])
         assert op.wires == Wire[3]
         assert op.control_wires == Wire[1]
         assert op.control_values == Bool[1]
+
+        new_op = qp.ctrl(op, control=[3, 4], work_wires=[5])
+        assert isinstance(new_op, ControlledOp2)
+        assert new_op.base == DynOp(Float, Wire[2])
+        assert new_op.wires == Wire[5]
+        assert new_op.control_wires == Wire[3]
+        assert new_op.control_values == Bool[3]
+        assert new_op.work_wires == Wire[1]
 
 
 class _Rot(Operation):

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -28,7 +28,7 @@ from pennylane.typing import Bool, Float, Wire
 from pennylane.wires import Wires
 from tests.core.operator.operator2_utils import DynOp, OneWireDynOp
 
-# pylint: disable=unused-argument,too-few-public-methods
+# pylint: disable=unused-argument,too-few-public-methods,useless-parent-delegation
 
 
 class TestControlled2:

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -463,6 +463,9 @@ class TestControlledOp2:
         assert op.work_wires == Wire[0]
         assert op.wires == Wire[3]
 
+        op = ControlledOp2(OneWireDynOp, Wire[2], control_values=[0, 1])
+        assert op.control_values == Bool[2]
+
     def test_create_controlled_op2(self):
         """Tests qp.ctrl on Operator2 creates a ControlledOp2."""
 
@@ -477,5 +480,4 @@ class TestControlledOp2:
         """Test to make sure that copy roundtrips are sastisfied."""
 
         op = ControlledOp2(DynOp(0.5, 0), control_wires=1)
-
         assert op == copy_fn(op)

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -21,9 +21,10 @@ import numpy as np
 import pytest
 
 import pennylane as qp
+from pennylane.core import Operator2
 from pennylane.ops.op_math.controlled import Controlled, ControlledOp
 from pennylane.ops.op_math.controlled2 import Controlled2, ControlledOp2
-from pennylane.typing import Bool, Wire
+from pennylane.typing import Bool, Float, Wire
 from pennylane.wires import Wires
 from tests.core.operator.operator2_utils import DynOp, OneWireDynOp
 
@@ -99,6 +100,42 @@ class TestControlled2:
         assert op.has_adjoint
         assert op.has_matrix
         assert op.has_sparse_matrix
+
+    def test_custom_controlled_op_abstract(self):
+        """Test creating an abstract custom controlled op."""
+
+        class Rot2(Operator2):
+            """A new Rot."""
+
+            dynamic_argnames = ("phi", "theta", "omega")
+
+            wire_argnames = ("wires",)
+
+            arg_specs = {"phi": Float, "theta": Float, "omega": Float, "wires": Wire[1]}
+
+            def __init__(self, phi, theta, omega, wires):
+                super().__init__(phi, theta, omega, wires)
+
+        class CRot2(Controlled2):
+            """A new CRot."""
+
+            dynamic_argnames = ("phi", "theta", "omega")
+
+            wire_argnames = ("wires",)
+
+            arg_specs = {"phi": Float, "theta": Float, "omega": Float, "wires": Wire[2]}
+
+            def __init__(self, phi, theta, omega, wires):
+                super().__init__(Rot2(phi, theta, omega, wires=wires[1]), control_wires=wires[0])
+
+            def __abstract_init__(self, phi, theta, omega, wires):
+                super().__abstract_init__(Rot2(phi, theta, omega, wires[1]), wires[0])
+
+        op = CRot2(Float, 0.5, 0.2, wires=[0, 1])
+        assert op.phi == Float
+        assert op.theta == Float
+        assert op.omega == Float
+        assert op.wires == Wire[2]
 
     def test_custom_controlled_op_default_compute_methods(self):
         """Tests that custom controlled ops can use the default compute_xxx methods."""

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -136,6 +136,8 @@ class TestControlled2:
         assert op.theta == Float
         assert op.omega == Float
         assert op.wires == Wire[2]
+        assert op.control_wires == Wire[1]
+        assert op.control_values == Bool[1]
 
     def test_custom_controlled_op_default_compute_methods(self):
         """Tests that custom controlled ops can use the default compute_xxx methods."""


### PR DESCRIPTION
**Context:**

When creating an abstract instance of a custom controlled op, the custom `Controlled2.__init__` logic is skipped.

**Description of the Change:**

Implement a `Controlled2.__abstract_init__`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124012]