### PR TITLE
fix: improve error message from `arg_specs` validation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -838,6 +838,7 @@
   [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
   [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
   [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
+  [(#9783)](https://github.com/PennyLaneAI/pennylane/pull/9783)
 
 * Added an internal `abstractify` utility function that is able to convert various objects
   to their abstract versions.

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1381,10 +1381,9 @@ def _init_arg_types(op: Operator2) -> None:
 
         # Check if either shape or dtype is not compatible
         if not exp_type.is_compatible_with(comparison_abstract_type):
-            actual_dtype = argval_dtype
-
             # Isolate if it's a pure dtype issue by comparing with a mock type that has the
             # expected shape but the actual dtype
+            actual_dtype = argval_dtype
             if not exp_type.is_compatible_with(AbstractArray(exp_type.shape, actual_dtype)):
                 raise ValueError(
                     f"Parameter '{name}' does not match the operator's expected 'arg_specs' dtype. "

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1380,6 +1380,14 @@ def _init_arg_types(op: Operator2) -> None:
         comparison_abstract_type = AbstractArray(unbatched_shape, np.dtype(argval_dtype))
         if not exp_type.is_compatible_with(comparison_abstract_type):
             actual_dtype = argval_dtype
+
+            mock = AbstractArray(exp_type.shape, actual_dtype)
+            if not exp_type.is_compatible_with(mock):
+                raise ValueError(
+                    f"Expected '{name}' to have dtype "
+                    f"'{exp_type.dtype.name}', but got dtype '{actual_dtype}'."
+                )
+
             if is_broadcasted:
                 raise ValueError(
                     f"Expected '{name}' with parameter broadcasting to have shape {exp_type.shape} "
@@ -1387,8 +1395,7 @@ def _init_arg_types(op: Operator2) -> None:
                     f"got input shape {arg_shape} with dtype '{actual_dtype}'."
                 )
             raise ValueError(
-                f"Expected '{name}' to have shape {exp_type.shape} and dtype "
-                f"'{exp_type.dtype.name}', but got shape {arg_shape} with dtype '{actual_dtype}'."
+                f"Expected '{name}' to have shape {exp_type.shape} but got shape {arg_shape}."
             )
 
         # NOTE: If the argval is an abstract type, we wish to canonicalize it to the

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1378,18 +1378,20 @@ def _init_arg_types(op: Operator2) -> None:
             argval.dtype if isinstance(argval, AbstractArray) else math.get_dtype_name(argval)
         )
         comparison_abstract_type = AbstractArray(unbatched_shape, np.dtype(argval_dtype))
+
+        # Check if either shape or dtype is not compatible
         if not exp_type.is_compatible_with(comparison_abstract_type):
             actual_dtype = argval_dtype
 
-            # NOTE: Create a mock type with the expect shape but the actual dtype
-            # to enable failure isolation.
-            mock = AbstractArray(exp_type.shape, actual_dtype)
-            if not exp_type.is_compatible_with(mock):
+            # Isolate if it's a pure dtype issue by comparing with a mock type that has the
+            # expected shape but the actual dtype
+            if not exp_type.is_compatible_with(AbstractArray(exp_type.shape, actual_dtype)):
                 raise ValueError(
                     f"Parameter '{name}' does not match the operator's expected 'arg_specs' dtype. "
                     f"Expected {exp_type.dtype} but received {actual_dtype}."
                 )
 
+            # If dtype is fine, must be a shape mismatch
             broadcast_msg = " (non-broadcasting dimensions)" if is_broadcasted else ""
             raise ValueError(
                 f"Parameter '{name}' does not match the operator's expected 'arg_specs' shape. "

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1381,24 +1381,19 @@ def _init_arg_types(op: Operator2) -> None:
         if not exp_type.is_compatible_with(comparison_abstract_type):
             actual_dtype = argval_dtype
 
-            if is_broadcasted:
-                raise ValueError(
-                    f"Expected '{name}' with parameter broadcasting to have shape {exp_type.shape} "
-                    f"for the non-broadcasting dimensions and dtype '{exp_type.dtype.name}', but "
-                    f"got input shape {arg_shape} with dtype '{actual_dtype}'."
-                )
-
             # NOTE: Create a mock type with the expect shape but the actual dtype
             # to enable failure isolation.
             mock = AbstractArray(exp_type.shape, actual_dtype)
             if not exp_type.is_compatible_with(mock):
                 raise ValueError(
-                    f"Expected '{name}' to have dtype "
-                    f"'{exp_type.dtype.name}', but got dtype '{actual_dtype}'."
+                    f"Parameter '{name}' does not match the operator's expected 'arg_specs' dtype. "
+                    f"Expected {exp_type.dtype} but received {actual_dtype}."
                 )
 
+            broadcast_msg = " (non-broadcasting dimensions)" if is_broadcasted else ""
             raise ValueError(
-                f"Expected '{name}' to have shape {exp_type.shape} but got shape {arg_shape}."
+                f"Parameter '{name}' does not match the operator's expected 'arg_specs' shape. "
+                f"Expected {exp_type.shape}{broadcast_msg} but received {arg_shape}."
             )
 
         # NOTE: If the argval is an abstract type, we wish to canonicalize it to the

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1381,6 +1381,15 @@ def _init_arg_types(op: Operator2) -> None:
         if not exp_type.is_compatible_with(comparison_abstract_type):
             actual_dtype = argval_dtype
 
+            if is_broadcasted:
+                raise ValueError(
+                    f"Expected '{name}' with parameter broadcasting to have shape {exp_type.shape} "
+                    f"for the non-broadcasting dimensions and dtype '{exp_type.dtype.name}', but "
+                    f"got input shape {arg_shape} with dtype '{actual_dtype}'."
+                )
+
+            # NOTE: Create a mock type with the expect shape but the actual dtype
+            # to enable failure isolation.
             mock = AbstractArray(exp_type.shape, actual_dtype)
             if not exp_type.is_compatible_with(mock):
                 raise ValueError(
@@ -1388,12 +1397,6 @@ def _init_arg_types(op: Operator2) -> None:
                     f"'{exp_type.dtype.name}', but got dtype '{actual_dtype}'."
                 )
 
-            if is_broadcasted:
-                raise ValueError(
-                    f"Expected '{name}' with parameter broadcasting to have shape {exp_type.shape} "
-                    f"for the non-broadcasting dimensions and dtype '{exp_type.dtype.name}', but "
-                    f"got input shape {arg_shape} with dtype '{actual_dtype}'."
-                )
             raise ValueError(
                 f"Expected '{name}' to have shape {exp_type.shape} but got shape {arg_shape}."
             )

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -737,9 +737,7 @@ class TestInitExpectedArgtypesValidation:
             def __init__(self, phi, wires):
                 super().__init__(phi, wires=wires)
 
-        with pytest.raises(
-            ValueError, match=r"Expected 'phi' to have shape \(\) and dtype 'int64'"
-        ):
+        with pytest.raises(ValueError, match=r"Expected 'phi' to have dtype 'int64'"):
             Op(0.5, wires=0)
 
     def test_weak_type_allows_python_scalar(self):
@@ -2452,7 +2450,6 @@ class TestLegacyCompatibilityViews:
 
 
 class TestApply:
-
     @pytest.mark.parametrize("op2", [DynOp(1.0, wires=0), FullOp(0.3, "lbl", [1.0, 2.0], wires=0)])
     def test_apply(self, op2):
         """Tests that Operator2 can queue like Operator1 using ``qp.apply``."""

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -721,7 +721,10 @@ class TestInitExpectedArgtypesValidation:
             def __init__(self, phi, wires):
                 super().__init__(phi, wires=wires)
 
-        with pytest.raises(ValueError, match=r"Expected 'phi' to have shape \(2,\)"):
+        with pytest.raises(
+            ValueError,
+            match=r"Parameter 'phi' does not match the operator's expected 'arg_specs' shape. Expected \(2,\) but received \(1,\)",
+        ):
             Op(np.array([0.5]), wires=0)
 
     def test_dynamic_arg_wrong_dtype_error(self):
@@ -737,7 +740,10 @@ class TestInitExpectedArgtypesValidation:
             def __init__(self, phi, wires):
                 super().__init__(phi, wires=wires)
 
-        with pytest.raises(ValueError, match=r"Expected 'phi' to have dtype 'int64'"):
+        with pytest.raises(
+            ValueError,
+            match=r"Parameter 'phi' does not match the operator's expected 'arg_specs' dtype. Expected int64 but received float64",
+        ):
             Op(0.5, wires=0)
 
     def test_weak_type_allows_python_scalar(self):
@@ -889,10 +895,12 @@ class TestBroadcasting:
             def __init__(self, phi, wires):
                 super().__init__(phi, wires=wires)
 
-        with pytest.raises(ValueError, match="Expected 'phi' with parameter broadcasting"):
+        expected_msg = r"Parameter 'phi' does not match the operator's expected 'arg_specs' shape. Expected \(2,\) \(non-broadcasting dimensions\) but received \(4, 3\)."
+        with pytest.raises(ValueError, match=expected_msg):
             _ = Op(np.ones((4, 3)), wires=0)
 
-        with pytest.raises(ValueError, match="Expected 'phi' with parameter broadcasting"):
+        expected_msg = r"Parameter 'phi' does not match the operator's expected 'arg_specs' shape. Expected \(2,\) \(non-broadcasting dimensions\) but received \(4, 1, 2\)."
+        with pytest.raises(ValueError, match=expected_msg):
             _ = Op(np.ones((4, 1, 2)), wires=0)
 
     def test_broadcasted_array_wrong_dtype_error(self):
@@ -909,7 +917,8 @@ class TestBroadcasting:
             def __init__(self, phi, wires):
                 super().__init__(phi, wires=wires)
 
-        with pytest.raises(ValueError, match="Expected 'phi' with parameter broadcasting"):
+        expected_msg = "Parameter 'phi' does not match the operator's expected 'arg_specs' dtype. Expected int64 but received float64"
+        with pytest.raises(ValueError, match=expected_msg):
             _ = Op(np.array([0.5, 0.6]), wires=0)
 
     def test_broadcasted_inferred_ndim_from_arg_specs(self):

--- a/tests/core/operator/test_operator2_metaclass.py
+++ b/tests/core/operator/test_operator2_metaclass.py
@@ -276,7 +276,6 @@ class TestOperatorAbstractInputs:
         """Tests that an operator can override __abstract_init__."""
 
         class CustomOp(Operator2):  # pylint: disable=too-few-public-methods
-
             dynamic_argnames = ("theta",)
 
             wire_argnames = ("wires", "work_wires")
@@ -358,7 +357,8 @@ class TestArgSpecValidationAbstractInputs:
 
         # Abstract inputs that are not compatible raise an error
         # NOTE: Cannot downcast complex to float
-        with pytest.raises(ValueError, match="Expected 'dynamic_arg' to have"):
+        expected_msg = r"Parameter \'dynamic_arg\' does not match the operator\'s expected \'arg_specs\' dtype. Expected float64 but received complex128."
+        with pytest.raises(ValueError, match=expected_msg):
             _ = MixedArgOp(Complex[2, 3], Wire[3])
 
         # Concrete inputs go through as normal
@@ -416,7 +416,9 @@ class TestArgSpecValidationAbstractInputs:
             def __init__(self, dynamic_arg, wires):
                 super().__init__(dynamic_arg, wires=wires)
 
-        with pytest.raises(ValueError, match="Expected 'dynamic_arg' to have"):
+        with pytest.raises(
+            ValueError, match=r"expected 'arg_specs' shape\. Expected \(3,\) but received .*"
+        ):
             _ = MixedArgOp(bad_dynamic_arg, Wire[3])
 
 


### PR DESCRIPTION
**Context:**

Previously, we would have situations like this,

```python
import pennylane as qp

from pennylane.typing import Float, Bool, Complex, Wire
from pennylane.core.operator import Operator2

class TestOp(Operator2):
    
    dynamic_argnames = ("phi",)
    arg_specs = {"phi": Float[-1], "wires": Wire[1]}
    
    def __init__(self, phi, wires):
        super().__init__(phi, wires=wires)
        
>>> TestOp([0.5j], 0)
ValueError: Expected 'phi' to have shape (-1,) and dtype 'float64', but got shape (1,) with dtype 'complex128'.
```
where it's not immediately obvious what the problem is - the shape or the dtype or both?

**Description of the Change:**

Update the logic for raising the error to isolate the failures. This provides straightforward errors that the user / developer can use to debug their code.

With this change, the error is way more straight forward to debug,
```
ValueError: Parameter 'phi' does not match the operator's expected 'arg_specs' dtype. Expected float64 but received complex128.
```

**Benefits:** Easier to debug.

**Possible Drawbacks:** None.

[sc-124044]