### PR TITLE
bug fix: update `_primitive_bind_call` for `SymbolicOp` and `CompositeOp` and their subclasses 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -835,6 +835,7 @@
     [(#9766)](https://github.com/PennyLaneAI/pennylane/pull/9766)
     [(#9758)](https://github.com/PennyLaneAI/pennylane/pull/9758)
     [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
+    [(#9793)](https://github.com/PennyLaneAI/pennylane/pull/9793)
     [(#9778)](https://github.com/PennyLaneAI/pennylane/pull/9778)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -75,7 +75,7 @@ class CompositeOp(Operator):
                 if leaf.tracer is None:
                     # pylint: disable-next=protected-access
                     leaf._bind_primitive()
-                new_leaves.append(leaf.tracer)
+                new_leaves.append(leaf if leaf.tracer is None else leaf.tracer)
             else:
                 new_leaves.append(leaf)
 

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -127,7 +127,7 @@ class LinearCombination(Sum):
                 if leaf.tracer is None:
                     # pylint: disable-next=protected-access
                     leaf._bind_primitive()
-                new_leaves.append(leaf.tracer)
+                new_leaves.append(leaf if leaf.tracer is None else leaf.tracer)
             else:
                 new_leaves.append(leaf)
 

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -63,7 +63,7 @@ class SymbolicOp(Operator):
                 if leaf.tracer is None:
                     # pylint: disable-next=protected-access
                     leaf._bind_primitive()
-                new_leaves.append(leaf.tracer)
+                new_leaves.append(leaf if leaf.tracer is None else leaf.tracer)
             else:
                 new_leaves.append(leaf)
 

--- a/tests/ops/op_math/test_composite_op2_capture.py
+++ b/tests/ops/op_math/test_composite_op2_capture.py
@@ -29,6 +29,9 @@ from tests.core.operator.operator2_utils import NonParametricOp
 
 def test_public_dot_binding():
     """Tests that the public API for composite op captures properly."""
+    # Ensure op can be constructed outside tracing context
+    op = qp.dot([1, 2], [NonParametricOp(0), NonParametricOp(1)])
+    assert op == NonParametricOp(0) + 2 * NonParametricOp(1)
 
     # NOTE: Have one op be outside trace context to
     # cover the tracer-is-none fallback
@@ -63,6 +66,9 @@ def test_public_dot_binding():
 
 def test_public_sum_binding():
     """Tests that the public API for composite op captures properly."""
+    # Ensure op can be constructed outside tracing context
+    op = qp.sum(NonParametricOp(0), NonParametricOp(0))
+    assert op == NonParametricOp(0) + NonParametricOp(0)
 
     # NOTE: Have one op be outside trace context to
     # cover the tracer-is-none fallback
@@ -119,6 +125,9 @@ def test_change_op_basis(defined_outside):
 
 def test_linear_combination():
     """Tests that LinearCombination captures correctly."""
+    # Assert can be created outside tracing context
+    op = qp.Hamiltonian([1, 2], [NonParametricOp(0), NonParametricOp(1)])
+    assert op == 1 * NonParametricOp(0) + 2 * NonParametricOp(1)
 
     # NOTE: Have one op be outside trace context to
     # cover the tracer-is-none fallback

--- a/tests/ops/op_math/test_symbolic_op2_capture.py
+++ b/tests/ops/op_math/test_symbolic_op2_capture.py
@@ -327,6 +327,11 @@ class TestNestedSymbolicOpCapture:
 def test_public_s_prod_binding(defined_outside):
     """Tests that the public API for symbolic op captures properly."""
 
+    # Ensure you can construct the op outside a function that is being traced
+    op = qp.s_prod(2.0, NonParametricOp(0))
+    assert op.base == NonParametricOp(0)
+    assert op.scalar == 2.0
+
     outside_op = NonParametricOp(0) if defined_outside else None
 
     def f():
@@ -349,6 +354,9 @@ def test_public_s_prod_binding(defined_outside):
 
 def test_public_prod_binding():
     """Tests that the public API for symbolic op captures properly."""
+    # Ensure you can construct the op outside a function that is being traced
+    op = qp.prod(NonParametricOp(1), NonParametricOp(0))
+    assert op == NonParametricOp(1) @ NonParametricOp(0)
 
     # NOTE: Have one op be outside trace context to
     # cover the tracer-is-none fallback


### PR DESCRIPTION
**Context:**

Bug fix for https://github.com/PennyLaneAI/pennylane/pull/9762. 

Things like this were failing in the PR porting X,Y,Z.

```python
import pennylane as qp

from tests.core.operator.operator2_utils import NonParametricOp

qp.capture.enable()

>>> op = qp.sum(NonParametricOp(1), NonParametricOp(0))
AttributeError: 'NoneType' object has no attribute 'wires'
```

**Description of the Change:**

Update handling of `Operator2` branch logic in `_primitive_bind_call`.

**Benefits:** Correct code.

**Possible Drawbacks:** None.

[sc-123762]
