### PR TITLE
Remove legacy tests

### DIFF
--- a/tests/ops/qubit/test_all_qubit_ops.py
+++ b/tests/ops/qubit/test_all_qubit_ops.py
@@ -29,9 +29,6 @@ from pennylane.exceptions import PennyLaneDeprecationWarning
 @pytest.mark.parametrize(
     "op, basis",
     [
-        (qp.X(0), "X"),
-        (qp.Y(0), "Y"),
-        (qp.Z(0), "Z"),
         (qp.S(0), "Z"),
         (qp.T(0), "Z"),
         (qp.SX(0), "X"),

--- a/tests/ops/qubit/test_all_qubit_ops.py
+++ b/tests/ops/qubit/test_all_qubit_ops.py
@@ -57,9 +57,6 @@ class TestOperations:
         "op",
         [
             (qp.Hadamard(wires=0)),
-            (qp.PauliX(wires=0)),
-            (qp.PauliY(wires=0)),
-            (qp.PauliZ(wires=0)),
             (qp.S(wires=0)),
             (qp.T(wires=0)),
             (qp.SX(wires=0)),

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -39,6 +39,9 @@ from gate_data import (
     S,
     T,
     Toffoli,
+    X,
+    Y,
+    Z,
 )
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, lil_matrix
 from scipy.stats import unitary_group
@@ -1225,8 +1228,6 @@ def test_label_method(op, label):
 control_data = [
     (qp.Identity(0), Wires([])),
     (qp.Hadamard(0), Wires([])),
-    (qp.PauliX(0), Wires([])),
-    (qp.PauliY(0), Wires([])),
     (qp.S(wires=0), Wires([])),
     (qp.T(wires=0), Wires([])),
     (qp.SX(wires=0), Wires([])),

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -39,9 +39,6 @@ from gate_data import (
     S,
     T,
     Toffoli,
-    X,
-    Y,
-    Z,
 )
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, lil_matrix
 from scipy.stats import unitary_group


### PR DESCRIPTION
Remove tests for `control_wires` and deprecated op decomp API.
It requires XYZ to be Op2 so based on `port-x-y-z-3`

[sc-124134]