### PR TITLE
Override `has_decomposition` for `Adjoint2` and `ControlledOp2`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -851,6 +851,7 @@
     [(#9762)](https://github.com/PennyLaneAI/pennylane/pull/9762)
     [(#9793)](https://github.com/PennyLaneAI/pennylane/pull/9793)
     [(#9778)](https://github.com/PennyLaneAI/pennylane/pull/9778)
+    [(#9805)](https://github.com/PennyLaneAI/pennylane/pull/9805)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -784,7 +784,7 @@ class Operator2(metaclass=OperatorMeta):
             return self.compute_decomposition(**self.arguments)
 
         for decomp in qp.list_decomps(self):
-            if decomp.is_applicable():
+            if decomp.is_applicable(**self.arguments):
                 with AnnotatedQueue() as q:
                     decomp(**self.arguments)
                 if QueuingManager.recording():

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -797,9 +797,7 @@ def has_decomp(op: type[Operator] | Operator | str) -> bool:
         bool: whether decomposition rules are defined for the given operator.
 
     """
-    op_name = to_name(op)
-    _decompositions = _decompositions_var.get()
-    return op_name in _decompositions and len(_decompositions[op_name]) > 0
+    return len(list_decomps(op)) > 0
 
 
 @contextmanager

--- a/pennylane/ops/op_math/adjoint2.py
+++ b/pennylane/ops/op_math/adjoint2.py
@@ -127,6 +127,10 @@ class Adjoint2(SymbolicOp2):
     def generator(self):
         return -1 * self.base.generator()
 
+    @property
+    def has_decomposition(self):  # pylint: disable=arguments-differ,invalid-overridden-method
+        return any(rule.is_applicable(**self.arguments) for rule in list_decomps(self))
+
     @override
     def _bind_primitive(self):
         """Bind the operator primitive. ``Adjoint2`` has to override the method of the base

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -525,6 +525,10 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
             params.append(f"control_values={self.control_values}")
         return f"Controlled({self.base}, {', '.join(params)})"
 
+    @property
+    def has_decomposition(self):  # pylint: disable=arguments-differ,invalid-overridden-method
+        return any(rule.is_applicable(**self.arguments) for rule in list_decomps(self))
+
     @override
     def _bind_primitive(self):
         """Bind the operator primitive. ``ControlledOp2`` has to override the method of

--- a/tests/ops/op_math/test_adjoint2.py
+++ b/tests/ops/op_math/test_adjoint2.py
@@ -20,6 +20,7 @@ from scipy import sparse
 
 import pennylane as qp
 from pennylane.core.operator import Operator2
+from pennylane.decomposition.decomposition_rule import register_resources
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 from pennylane.ops.op_math.adjoint2 import Adjoint2
 from pennylane.wires import Wires
@@ -144,6 +145,21 @@ def test_attributes():
         }
     )
     assert op2.has_adjoint
+
+
+def test_old_decomp_integartion():
+    """Tests that adjoint2 is compatible with the old decomposition convention."""
+
+    @register_resources({qp.RX: 1})
+    def _sx_to_rx(wires):
+        qp.RX(np.pi / 2, wires=wires)
+
+    with qp.decomposition.local_decomps():
+
+        qp.add_decomps(SX2, _sx_to_rx)
+        op = qp.adjoint(SX2(0))
+        assert op.has_decomposition
+        assert op.decomposition() == [qp.adjoint(qp.RX(np.pi / 2, wires=[0]))]
 
 
 def test_parameter_frequencies():

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -22,11 +22,12 @@ import pytest
 
 import pennylane as qp
 from pennylane.core import Operator2
+from pennylane.decomposition.decomposition_rule import register_resources
 from pennylane.ops.op_math.controlled import Controlled, ControlledOp
 from pennylane.ops.op_math.controlled2 import Controlled2, ControlledOp2
 from pennylane.typing import Bool, Float, Wire
 from pennylane.wires import Wires
-from tests.core.operator.operator2_utils import DynOp, OneWireDynOp
+from tests.core.operator.operator2_utils import DynOp, NonParametricOp, OneWireDynOp
 
 # pylint: disable=unused-argument,too-few-public-methods,useless-parent-delegation
 
@@ -481,3 +482,17 @@ class TestControlledOp2:
 
         op = ControlledOp2(DynOp(0.5, 0), control_wires=1)
         assert op == copy_fn(op)
+
+    def test_old_decomp_integration(self):
+        """Tests that ControlledOp2 is compatible with the old decomposition convention."""
+
+        @register_resources({qp.RX: 1})
+        def _custom_decomp(wires):
+            qp.RX(np.pi / 2, wires=wires)
+
+        with qp.decomposition.local_decomps():
+
+            qp.add_decomps(NonParametricOp, _custom_decomp)
+            op = qp.ctrl(NonParametricOp(0), control=1)
+            assert op.has_decomposition
+            assert op.decomposition() == [qp.CRX(np.pi / 2, wires=[1, 0])]


### PR DESCRIPTION
**Context:**

Follow-up to https://github.com/PennyLaneAI/pennylane/pull/9727 and https://github.com/PennyLaneAI/pennylane/pull/9760, override `has_decomposition` to return the correct result.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124324]
