### PR TITLE
Add docs example showing how the `wires` kwarg of `qml.to_openqasm` controls qubit ordering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -948,6 +948,10 @@
 
 <h3>Documentation 📝</h3>
 
+* Added an example to the documentation of :func:`~.to_openqasm` showing how to use the ``wires``
+  argument to preserve the wire ordering of the original circuit.
+  [(#9824)](https://github.com/PennyLaneAI/pennylane/pull/9824)
+
 * Corrected spelling errors in documentation, comments, and internal variable names across the codebase.
   [(#9752)](https://github.com/PennyLaneAI/pennylane/pull/9752)
 
@@ -1080,6 +1084,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Aly Abouzaid,
 Usman Ahmed,
 Guillermo Alonso,
 Abdullah Al Omar Galib,

--- a/pennylane/io/to_openqasm.py
+++ b/pennylane/io/to_openqasm.py
@@ -219,7 +219,8 @@ def to_openqasm(
     Args:
         circuit (QNode or QuantumScript): the quantum circuit to be serialized.
         wires (Wires or None): the wires to use when serializing the circuit.
-            Default is ``None``, such that all the wires of the circuit are used for serialization.
+            Default is ``None``, such that all the wires of the circuit are used for
+            serialization, ordered by their first appearance in the circuit.
         rotations (bool): if ``True``, add gates that rotate the quantum state into the eigenbasis
             of the circuit's observables. Default is ``True``.
         measure_all (bool): if ``True``, add a computational basis measurement on all the qubits.
@@ -318,6 +319,50 @@ def to_openqasm(
         h q[1];
         measure q[0] -> c[0];
         measure q[1] -> c[1];
+
+        When ``wires=None``, the qubit register indices follow the order in which wires
+        first appear in the circuit, which can differ from their numerical order:
+
+        .. code-block:: python
+
+            dev = qp.device("default.qubit", wires=3)
+
+            @qp.qnode(dev)
+            def circuit():
+                qp.X(0)
+                qp.X(2)
+                qp.Toffoli(wires=[0, 1, 2])
+                return qp.state()
+
+        Here wire ``2`` is mapped to ``q[1]`` because it appears in the circuit before
+        wire ``1``:
+
+        >>> print(qp.to_openqasm(circuit)())
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c[3];
+        x q[0];
+        x q[1];
+        ccx q[0],q[2],q[1];
+        measure q[0] -> c[0];
+        measure q[1] -> c[1];
+        measure q[2] -> c[2];
+
+        Setting ``wires`` explicitly maps each wire to the qubit register index at the
+        same position, preserving the wire ordering of the original circuit:
+
+        >>> print(qp.to_openqasm(circuit, wires=[0, 1, 2])())
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c[3];
+        x q[0];
+        x q[2];
+        ccx q[0],q[1],q[2];
+        measure q[0] -> c[0];
+        measure q[1] -> c[1];
+        measure q[2] -> c[2];
     """
     if isinstance(circuit, QuantumScript):
         return _tape_openqasm(


### PR DESCRIPTION
**Context:**

By default `to_openqasm` maps wires to qubit register indices in order of their first appearance in the circuit. For circuits that use wires out of numerical order (e.g. `X(0)`, `X(2)`, `Toffoli([0, 1, 2])`), the exported program looks reordered compared to the circuit definition, which was reported as confusing in #9768. The `wires` kwarg already solves this, but the docs had no example of it.

**Description of the Change:**

Adds a usage example to the `to_openqasm` docstring showing the default first-appearance ordering and how passing `wires=[0, 1, 2]` preserves the circuit's wire ordering, and clarifies the `wires` argument description accordingly.

**Benefits:**

Documents the behavior and its remedy where users will look for it.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

Fixes #9768.

**Verification:** both example outputs were generated by running the code on current `main`; `tests/io/test_qasm.py` and `tests/io/test_io.py` pass, and black/isort/pylint are clean on the modified file.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.