### PR TITLE
`decompose_to_base` compatible with `Operator2`

### DIFF
--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -51,14 +51,14 @@ from .symbolic_decomposition import (
     adjoint_rotation,
     cancel_adjoint,
     ctrl_single_work_wire,
-    decompose_to_base,
+    decompose_to_base_legacy,
     flip_control_adjoint,
     flip_pow_adjoint,
     make_adjoint_decomp,
     make_controlled_decomp,
     merge_powers,
     repeat_pow_base,
-    self_adjoint,
+    self_adjoint_legacy,
     to_controlled_qubit_unitary,
 )
 from .utils import to_name
@@ -510,7 +510,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
 
         if (
             issubclass(op.op_type, qp.ops.Adjoint)
-            and self_adjoint not in decomps
+            and self_adjoint_legacy not in decomps
             and adjoint_rotation not in decomps
         ):
             # In general, we decompose the adjoint of an operator by applying adjoint to the
@@ -558,7 +558,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             return [null_decomp]
 
         if op.params["z"] == 1:
-            return [decompose_to_base]
+            return [decompose_to_base_legacy]
 
         # Special case: power of a power
         if issubclass(op.params["base_class"], qp.ops.Pow):

--- a/pennylane/decomposition/symbolic_decomposition.py
+++ b/pennylane/decomposition/symbolic_decomposition.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import allocation, math
+from pennylane.core.operator import abstractify
 
 from .decomposition_rule import DecompositionRule, register_condition, register_resources
 from .resources import adjoint_resource_rep, controlled_resource_rep, pow_resource_rep, resource_rep
@@ -186,15 +187,28 @@ def pow_rotation(phi, wires, base, z, **__):
     base._unflatten((phi * z,), struct)
 
 
-def _decompose_to_base_resource(base_class, base_params, **__):
+def _decomp_to_base_legacy_res(base_class, base_params, **__):
     return {resource_rep(base_class, **base_params): 1}
 
 
 # pylint: disable=protected-access,unused-argument
-@register_resources(_decompose_to_base_resource)
-def decompose_to_base(*params, wires, base, **__):
+@register_resources(_decomp_to_base_legacy_res)
+def decompose_to_base_legacy(*params, wires, base, **__):
     """Decompose a symbolic operator to its base."""
     qp.pytrees.unflatten(*qp.pytrees.flatten(base))
+
+
+self_adjoint_legacy: DecompositionRule = decompose_to_base_legacy
+
+
+def _decompose_to_base_resource(base):
+    return {abstractify(base): 1}
+
+
+@register_resources(_decompose_to_base_resource)
+def decompose_to_base(base):
+    """Decompose a symbolic operator to its base."""
+    qp.apply(base)
 
 
 self_adjoint: DecompositionRule = decompose_to_base

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -40,7 +40,7 @@ from pennylane.decomposition.symbolic_decomposition import (
     flip_zero_control,
     pow_involutory,
     pow_rotation,
-    self_adjoint,
+    self_adjoint_legacy,
 )
 from pennylane.typing import TensorLike
 from pennylane.wires import Wires, WiresLike
@@ -430,7 +430,7 @@ def _ch_to_ry_cz_ry(wires: WiresLike, **__):
 
 
 add_decomps(CH, _ch_to_ry_cz_ry)
-add_decomps("Adjoint(CH)", self_adjoint)
+add_decomps("Adjoint(CH)", self_adjoint_legacy)
 add_decomps("Pow(CH)", pow_involutory)
 
 
@@ -580,7 +580,7 @@ def _cy_to_ppr(wires: WiresLike, **_):
 
 
 add_decomps(CY, _cy, _cy_to_ppr)
-add_decomps("Adjoint(CY)", self_adjoint)
+add_decomps("Adjoint(CY)", self_adjoint_legacy)
 add_decomps("Pow(CY)", pow_involutory)
 
 
@@ -721,7 +721,7 @@ def _cz_to_ppr(wires: WiresLike, **_):
 
 
 add_decomps(CZ, _cz_to_cps, _cz_to_cnot, _cz_to_ppr)
-add_decomps("Adjoint(CZ)", self_adjoint)
+add_decomps("Adjoint(CZ)", self_adjoint_legacy)
 add_decomps("Pow(CZ)", pow_involutory)
 
 
@@ -897,7 +897,7 @@ def _cswap_to_ppr(wires: WiresLike, **_):
 
 
 add_decomps(CSWAP, _cswap, _cswap_to_ppr)
-add_decomps("Adjoint(CSWAP)", self_adjoint)
+add_decomps("Adjoint(CSWAP)", self_adjoint_legacy)
 add_decomps("Pow(CSWAP)", pow_involutory)
 
 
@@ -1134,7 +1134,7 @@ def _ccz_to_toffoli(wires: WiresLike, **__):
 
 
 add_decomps(CCZ, _ccz, _ccz_to_toffoli)
-add_decomps("Adjoint(CCZ)", self_adjoint)
+add_decomps("Adjoint(CCZ)", self_adjoint_legacy)
 add_decomps("Pow(CCZ)", pow_involutory)
 
 
@@ -1316,7 +1316,7 @@ def _cnot_to_ppr(wires: WiresLike, **_):
 
 
 add_decomps(CNOT, _cnot_to_cz_h, _cnot_to_ppr)
-add_decomps("Adjoint(CNOT)", self_adjoint)
+add_decomps("Adjoint(CNOT)", self_adjoint_legacy)
 add_decomps("Pow(CNOT)", pow_involutory)
 
 
@@ -1588,7 +1588,7 @@ def _toffoli_to_ppr(wires: WiresLike, **_):
 
 
 add_decomps(Toffoli, _toffoli, _toffoli_to_ppr)
-add_decomps("Adjoint(Toffoli)", self_adjoint)
+add_decomps("Adjoint(Toffoli)", self_adjoint_legacy)
 add_decomps("Pow(Toffoli)", pow_involutory)
 
 
@@ -1943,7 +1943,7 @@ add_decomps(
     decompose_mcx_with_no_worker,
     decompose_mcx_two_controls_elbows,
 )
-add_decomps("Adjoint(MultiControlledX)", self_adjoint)
+add_decomps("Adjoint(MultiControlledX)", self_adjoint_legacy)
 add_decomps("Pow(MultiControlledX)", pow_involutory)
 
 

--- a/pennylane/ops/qubit/arithmetic_ops.py
+++ b/pennylane/ops/qubit/arithmetic_ops.py
@@ -31,7 +31,7 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.decomposition.symbolic_decomposition import pow_involutory, self_adjoint
+from pennylane.decomposition.symbolic_decomposition import pow_involutory, self_adjoint_legacy
 from pennylane.typing import FlatPytree, TensorLike
 from pennylane.wires import Wires, WiresLike
 
@@ -367,7 +367,7 @@ def _qubitsum_to_cnots(wires: WiresLike, **__):
 
 
 add_decomps(QubitSum, _qubitsum_to_cnots)
-add_decomps("Adjoint(QubitSum)", self_adjoint)
+add_decomps("Adjoint(QubitSum)", self_adjoint_legacy)
 add_decomps("Pow(QubitSum)", pow_involutory)
 
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -42,7 +42,7 @@ from pennylane.decomposition.symbolic_decomposition import (
     flip_zero_control,
     make_pow_decomp_with_period,
     pow_involutory,
-    self_adjoint,
+    self_adjoint_legacy,
 )
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.ops.op_math.controlled import _is_empty_or_all_true, custom_ctrl_dispatch
@@ -269,7 +269,7 @@ def _hadamard_to_rz_ry(wires: WiresLike, **__):
 
 
 add_decomps(Hadamard, _hadamard_to_rz_rx, _hadamard_to_rz_ry)
-add_decomps("Adjoint(Hadamard)", self_adjoint)
+add_decomps("Adjoint(Hadamard)", self_adjoint_legacy)
 add_decomps("Pow(Hadamard)", pow_involutory)
 
 
@@ -550,7 +550,7 @@ def _pow_x_to_rx(wires, z, **_):
 
 
 add_decomps(PauliX, _paulix_to_rx)
-add_decomps("Adjoint(PauliX)", self_adjoint)
+add_decomps("Adjoint(PauliX)", self_adjoint_legacy)
 add_decomps("Pow(PauliX)", pow_involutory, _pow_x_to_rx, _pow_x_to_sx)
 
 
@@ -836,7 +836,7 @@ def _pow_y(wires, z, **_):
 
 
 add_decomps(PauliY, _pauliy_to_ry_gp)
-add_decomps("Adjoint(PauliY)", self_adjoint)
+add_decomps("Adjoint(PauliY)", self_adjoint_legacy)
 add_decomps("Pow(PauliY)", pow_involutory, _pow_y)
 
 
@@ -1122,7 +1122,7 @@ def _pow_z(wires, z, **_):
 
 
 add_decomps(PauliZ, _pauliz_to_ps)
-add_decomps("Adjoint(PauliZ)", self_adjoint)
+add_decomps("Adjoint(PauliZ)", self_adjoint_legacy)
 add_decomps("Pow(PauliZ)", pow_involutory, _pow_z, _pow_z_to_s, _pow_z_to_t)
 
 
@@ -1835,7 +1835,7 @@ def _swap_to_ppr(wires, **_):
 
 
 add_decomps(SWAP, _swap_to_cnot, _swap_to_ppr)
-add_decomps("Adjoint(SWAP)", self_adjoint)
+add_decomps("Adjoint(SWAP)", self_adjoint_legacy)
 add_decomps("Pow(SWAP)", pow_involutory)
 
 
@@ -2036,7 +2036,7 @@ def _ecr_decomp(wires, **__):
 
 
 add_decomps(ECR, _ecr_decomp)
-add_decomps("Adjoint(ECR)", self_adjoint)
+add_decomps("Adjoint(ECR)", self_adjoint_legacy)
 add_decomps("Pow(ECR)", pow_involutory)
 
 

--- a/pennylane/ops/qutrit/non_parametric_ops.py
+++ b/pennylane/ops/qutrit/non_parametric_ops.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from pennylane.core.operator import Operation
 from pennylane.decomposition import add_decomps
-from pennylane.decomposition.symbolic_decomposition import self_adjoint
+from pennylane.decomposition.symbolic_decomposition import self_adjoint_legacy
 from pennylane.exceptions import AdjointUndefinedError
 from pennylane.wires import Wires
 
@@ -411,7 +411,7 @@ class TSWAP(Operation):
         return TSWAP(wires=self.wires)
 
 
-add_decomps("Adjoint(TSWAP)", self_adjoint)
+add_decomps("Adjoint(TSWAP)", self_adjoint_legacy)
 
 
 class THadamard(Operation):

--- a/tests/decomposition/conftest.py
+++ b/tests/decomposition/conftest.py
@@ -25,7 +25,7 @@ from pennylane.decomposition.symbolic_decomposition import (
     adjoint_rotation,
     pow_involutory,
     pow_rotation,
-    self_adjoint,
+    self_adjoint_legacy,
 )
 from pennylane.ops.identity import _controlled_g_phase_decomp
 from pennylane.ops.qubit.non_parametric_ops import _controlled_hadamard, _controlled_x_decomp
@@ -157,10 +157,10 @@ decompositions["CRot"] = [_crot]
 decompositions["C(PauliX)"] = [_controlled_x_decomp]
 decompositions["C(GlobalPhase)"] = [_controlled_g_phase_decomp]
 decompositions["C(Hadamard)"] = [_controlled_hadamard]
-decompositions["Adjoint(Hadamard)"] = [self_adjoint]
+decompositions["Adjoint(Hadamard)"] = [self_adjoint_legacy]
 decompositions["Pow(Hadamard)"] = [pow_involutory]
 decompositions["Adjoint(RX)"] = [adjoint_rotation]
 decompositions["Pow(RX)"] = [pow_rotation]
-decompositions["Adjoint(CNOT)"] = [self_adjoint]
+decompositions["Adjoint(CNOT)"] = [self_adjoint_legacy]
 decompositions["Adjoint(PhaseShift)"] = [adjoint_rotation]
 decompositions["Adjoint(ControlledPhaseShift)"] = [adjoint_rotation]

--- a/tests/decomposition/test_symbolic_decomposition.py
+++ b/tests/decomposition/test_symbolic_decomposition.py
@@ -41,6 +41,7 @@ from pennylane.decomposition.symbolic_decomposition import (
     pow_involutory,
     pow_rotation,
     repeat_pow_base,
+    self_adjoint,
     self_adjoint_legacy,
     to_controlled_qubit_unitary,
 )
@@ -229,7 +230,7 @@ class TestAdjointDecompositionRules:
             {resource_rep(CustomOp, key=0): 1}
         )
 
-    def test_self_adjoint(self):
+    def test_self_adjoint_legacy(self):
         """Tests the self_adjoint decomposition."""
 
         op = qp.adjoint(CustomOp(0.5, wires=[0, 1, 2]))
@@ -240,6 +241,16 @@ class TestAdjointDecompositionRules:
         assert self_adjoint_legacy.compute_resources(**op.resource_params) == Resources(
             {resource_rep(CustomOp, key=0): 1}
         )
+
+    def test_self_adjoint(self):
+        """Tests the self_adjoint decomposition."""
+
+        op = qp.adjoint(OneWireDynOp(0.5, wires=[0]))
+        with queuing.AnnotatedQueue() as q:
+            self_adjoint(**op.arguments)
+
+        assert q.queue == [OneWireDynOp(0.5, wires=[0])]
+        assert self_adjoint.compute_resources(**op.arguments) == to_resources({OneWireDynOp: 1})
 
 
 @pytest.mark.unit

--- a/tests/decomposition/test_symbolic_decomposition.py
+++ b/tests/decomposition/test_symbolic_decomposition.py
@@ -41,7 +41,7 @@ from pennylane.decomposition.symbolic_decomposition import (
     pow_involutory,
     pow_rotation,
     repeat_pow_base,
-    self_adjoint,
+    self_adjoint_legacy,
     to_controlled_qubit_unitary,
 )
 from pennylane.ops.op_math.adjoint2 import Adjoint2
@@ -234,10 +234,10 @@ class TestAdjointDecompositionRules:
 
         op = qp.adjoint(CustomOp(0.5, wires=[0, 1, 2]))
         with queuing.AnnotatedQueue() as q:
-            self_adjoint(*op.parameters, wires=op.wires, **op.hyperparameters)
+            self_adjoint_legacy(*op.parameters, wires=op.wires, **op.hyperparameters)
 
         assert q.queue == [CustomOp(0.5, wires=[0, 1, 2])]
-        assert self_adjoint.compute_resources(**op.resource_params) == Resources(
+        assert self_adjoint_legacy.compute_resources(**op.resource_params) == Resources(
             {resource_rep(CustomOp, key=0): 1}
         )
 


### PR DESCRIPTION
**Context:**

Migrate the utility `decompose_to_base` decomp to be compatible with `Operator2`.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
