### PR TITLE
Remove setter from `Select` and `PrepSelPrep`

### DIFF
--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -41,7 +41,9 @@ from pennylane.templates.subroutines import (
     CommutingEvolution,
     ControlledSequence,
     FermionicDoubleExcitation,
+    PrepSelPrep,
     QDrift,
+    Select,
     TrotterProduct,
 )
 from pennylane.typing import TensorLike
@@ -216,6 +218,23 @@ def bind_new_parameters_symbolic_op(op: SymbolicOp, params: Sequence[TensorLike]
 def bind_new_parameters_controlled_sequence(op: ControlledSequence, params: Sequence[TensorLike]):
     new_base = bind_new_parameters(op.base, params)
     return op.__class__(new_base, control=op.control)
+
+
+@bind_new_parameters.register
+def bind_new_parameters_prep_sel_prep(op: PrepSelPrep, params: Sequence[TensorLike]):
+    new_lcu = bind_new_parameters(op.lcu, params)
+    return op.__class__(new_lcu, control=op.control)
+
+
+@bind_new_parameters.register
+def bind_new_parameters_select(op: Select, params: Sequence[TensorLike]):
+    new_ops = []
+    for operand in op.ops:
+        operand_num_params = operand.num_params
+        new_ops.append(bind_new_parameters(operand, params[:operand_num_params]))
+        params = params[operand_num_params:]
+
+    return op.__class__(new_ops, control=op.control, work_wires=op.work_wires, partial=op.partial)
 
 
 @bind_new_parameters.register

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -26,7 +26,6 @@ import pennylane as qp
 from pennylane import math
 from pennylane.core.operator import Operator, Operator2
 from pennylane.core.operator.base import _UNSET_BATCH_SIZE  # tach-ignore
-from pennylane.core.queuing import QueuingManager
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.pytrees import flatten, unflatten
 from pennylane.wires import Wires
@@ -50,19 +49,6 @@ def handle_recursion_error(func):
             ) from e
 
     return wrapper
-
-
-def _set_operand_data(op, new_data):
-    """Update a legacy composite operator's operand without mutating an Operator2."""
-    if isinstance(op, Operator2):
-        # Local import avoids a circular import while the operator modules are initialized.
-        from pennylane.ops.functions.bind_new_parameters import bind_new_parameters
-
-        with QueuingManager.stop_recording():
-            return bind_new_parameters(op, new_data)
-
-    op.data = new_data
-    return op
 
 
 class CompositeOp(Operator):
@@ -178,16 +164,11 @@ class CompositeOp(Operator):
     @data.setter
     def data(self, new_data):
         """Set the data property"""
-        operands = []
         for op in self:
             op_num_params = op.num_params
             if op_num_params > 0:
-                op = _set_operand_data(op, new_data[:op_num_params])
+                op.data = new_data[:op_num_params]
                 new_data = new_data[op_num_params:]
-            operands.append(op)
-
-        self.operands = tuple(operands)
-        self.hyperparameters["operands"] = self.operands
 
     @property
     def num_wires(self):
@@ -443,7 +424,6 @@ class CompositeOp(Operator):
         new_op = cls.__new__(cls)
         new_op.operands = tuple(op.map_wires(wire_map=wire_map) for op in self)
         new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
-        new_op.data = copy.copy(self.data)
         if self._overlapping_ops is not None:
             new_op._overlapping_ops = [
                 [o.map_wires(wire_map) for o in _ops] for _ops in self._overlapping_ops
@@ -454,6 +434,8 @@ class CompositeOp(Operator):
         for attr, value in vars(self).items():
             if attr not in {"data", "operands", "_wires", "_overlapping_ops"}:
                 setattr(new_op, attr, value)
+        new_op._hyperparameters = copy.copy(self._hyperparameters)
+        new_op._hyperparameters["operands"] = new_op.operands
         if (p_rep := new_op.pauli_rep) is not None:
             new_op._pauli_rep = p_rep.map_wires(wire_map)
 

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -26,6 +26,7 @@ import pennylane as qp
 from pennylane import math
 from pennylane.core.operator import Operator, Operator2
 from pennylane.core.operator.base import _UNSET_BATCH_SIZE  # tach-ignore
+from pennylane.core.queuing import QueuingManager
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.pytrees import flatten, unflatten
 from pennylane.wires import Wires
@@ -49,6 +50,19 @@ def handle_recursion_error(func):
             ) from e
 
     return wrapper
+
+
+def _set_operand_data(op, new_data):
+    """Update a legacy composite operator's operand without mutating an Operator2."""
+    if isinstance(op, Operator2):
+        # Local import avoids a circular import while the operator modules are initialized.
+        from pennylane.ops.functions.bind_new_parameters import bind_new_parameters
+
+        with QueuingManager.stop_recording():
+            return bind_new_parameters(op, new_data)
+
+    op.data = new_data
+    return op
 
 
 class CompositeOp(Operator):
@@ -164,11 +178,16 @@ class CompositeOp(Operator):
     @data.setter
     def data(self, new_data):
         """Set the data property"""
+        operands = []
         for op in self:
             op_num_params = op.num_params
             if op_num_params > 0:
-                op.data = new_data[:op_num_params]
+                op = _set_operand_data(op, new_data[:op_num_params])
                 new_data = new_data[op_num_params:]
+            operands.append(op)
+
+        self.operands = tuple(operands)
+        self.hyperparameters["operands"] = self.operands
 
     @property
     def num_wires(self):

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -32,6 +32,18 @@ from pennylane.pytrees import flatten, unflatten
 from .composite import handle_recursion_error
 
 
+def _set_base_data(op, new_data):
+    """Update a legacy symbolic operator's base without mutating an Operator2."""
+    if isinstance(op.base, Operator2):
+        # Local import avoids a circular import while the operator modules are initialized.
+        from pennylane.ops.functions.bind_new_parameters import bind_new_parameters
+
+        with QueuingManager.stop_recording():
+            op.hyperparameters["base"] = bind_new_parameters(op.base, new_data)
+    else:
+        op.base.data = new_data
+
+
 class SymbolicOp(Operator):
     """Developer-facing base class for single-operator symbolic operators.
 
@@ -112,7 +124,7 @@ class SymbolicOp(Operator):
 
     @data.setter
     def data(self, new_data):
-        self.base.data = new_data
+        _set_base_data(self, new_data)
 
     @property
     def num_params(self):
@@ -218,7 +230,7 @@ class ScalarSymbolicOp(SymbolicOp):
     @data.setter
     def data(self, new_data):
         self.scalar = new_data[0]
-        self.base.data = new_data[1:]
+        _set_base_data(self, new_data[1:])
 
     @property
     @handle_recursion_error

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -32,18 +32,6 @@ from pennylane.pytrees import flatten, unflatten
 from .composite import handle_recursion_error
 
 
-def _set_base_data(op, new_data):
-    """Update a legacy symbolic operator's base without mutating an Operator2."""
-    if isinstance(op.base, Operator2):
-        # Local import avoids a circular import while the operator modules are initialized.
-        from pennylane.ops.functions.bind_new_parameters import bind_new_parameters
-
-        with QueuingManager.stop_recording():
-            op.hyperparameters["base"] = bind_new_parameters(op.base, new_data)
-    else:
-        op.base.data = new_data
-
-
 class SymbolicOp(Operator):
     """Developer-facing base class for single-operator symbolic operators.
 
@@ -124,7 +112,7 @@ class SymbolicOp(Operator):
 
     @data.setter
     def data(self, new_data):
-        _set_base_data(self, new_data)
+        self.base.data = new_data
 
     @property
     def num_params(self):
@@ -230,7 +218,7 @@ class ScalarSymbolicOp(SymbolicOp):
     @data.setter
     def data(self, new_data):
         self.scalar = new_data[0]
-        _set_base_data(self, new_data[1:])
+        self.base.data = new_data[1:]
 
     @property
     @handle_recursion_error

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -107,7 +107,7 @@ class PrepSelPrep(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires)
+        super().__init__(*lcu.data, wires=all_wires)
 
     def _flatten(self):
         return (self.lcu,), (self.control,)
@@ -161,28 +161,8 @@ class PrepSelPrep(Operation):
 
     def __copy__(self):
         """Copy this op"""
-        cls = self.__class__
-        copied_op = cls.__new__(cls)
-
-        new_data = copy.copy(self.data)
-
-        for attr, value in vars(self).items():
-            if attr != "data":
-                setattr(copied_op, attr, value)
-
-        copied_op.data = new_data
-
-        return copied_op
-
-    @property
-    def data(self):
-        """Create data property"""
-        return self.lcu.data
-
-    @data.setter
-    def data(self, new_data):
-        """Set the data property"""
-        self.hyperparameters["lcu"].data = new_data
+        with QueuingManager.stop_recording():
+            return type(self)(copy.copy(self.lcu), copy.copy(self.control))
 
     @property
     def lcu(self):

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -410,7 +410,8 @@ class Select(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires)
+        data = tuple(d for op in ops for d in op.data)
+        super().__init__(*data, wires=all_wires)
 
     def map_wires(self, wire_map: dict) -> "Select":
         new_ops = [o.map_wires(wire_map) for o in self.hyperparameters["ops"]]
@@ -420,32 +421,13 @@ class Select(Operation):
 
     def __copy__(self):
         """Copy this op"""
-        cls = self.__class__
-        copied_op = cls.__new__(cls)
-
-        new_data = copy.copy(self.data)
-
-        for attr, value in vars(self).items():
-            if attr != "data":
-                setattr(copied_op, attr, value)
-
-        copied_op.data = new_data
-
-        return copied_op
-
-    @property
-    def data(self):
-        """Create data property"""
-        return tuple(d for op in self.ops for d in op.data)
-
-    @data.setter
-    def data(self, new_data):
-        """Set the data property"""
-        for op in self.ops:
-            op_num_params = op.num_params
-            if op_num_params > 0:
-                op.data = new_data[:op_num_params]
-                new_data = new_data[op_num_params:]
+        with QueuingManager.stop_recording():
+            return type(self)(
+                [copy.copy(op) for op in self.ops],
+                copy.copy(self.control),
+                work_wires=copy.copy(self.work_wires),
+                partial=self.partial,
+            )
 
     def decomposition(self):
         r"""Representation of the operator as a product of other operators.

--- a/tests/ops/functions/test_bind_new_parameters.py
+++ b/tests/ops/functions/test_bind_new_parameters.py
@@ -246,6 +246,31 @@ def test_controlled_sequence():
     qp.assert_equal(new_op.base, qp.RX(0.5, wires=3))
 
 
+def test_prep_sel_prep():
+    """Test that rebinding PrepSelPrep replaces its LCU without mutating the original."""
+    lcu = qp.dot([0.25, 0.75], [qp.Z(2), qp.X(1) @ qp.X(2)])
+    op = qp.PrepSelPrep(lcu, control=0)
+
+    new_op = bind_new_parameters(op, (0.5, 0.5))
+
+    qp.assert_equal(new_op.lcu, qp.dot([0.5, 0.5], [qp.Z(2), qp.X(1) @ qp.X(2)]))
+    assert new_op is not op
+    assert new_op.lcu is not op.lcu
+    assert op.data == (0.25, 0.75)
+
+
+def test_select():
+    """Test that rebinding Select replaces its operands without mutating the original."""
+    op = qp.Select([qp.RX(0.25, wires=2), qp.RY(0.75, wires=2)], control=0)
+
+    new_op = bind_new_parameters(op, (0.5, 0.5))
+
+    qp.assert_equal(new_op, qp.Select([qp.RX(0.5, wires=2), qp.RY(0.5, wires=2)], control=0))
+    assert new_op is not op
+    assert new_op.ops[0] is not op.ops[0]
+    assert op.data == (0.25, 0.75)
+
+
 TEST_BIND_LINEARCOMBINATION = [
     (  # LinearCombination with only data being the coeffs
         qp.ops.LinearCombination(


### PR DESCRIPTION
**Context:**
These used to cause CI to complain about missing setter of data property. And we used to resolve these by introducing setter for Operator2. However, by design, the Operator2 should be immutable and data should be read-only. Hence, in this PR we start to remove those setters from whoever caused the [failures](https://github.com/PennyLaneAI/pennylane/actions/runs/29264402238/job/86865948088?pr=9684).

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

[sc-124598]
