### PR TITLE
Remove duplicate classes from `Operator2` tests

### DIFF
--- a/tests/core/operator/operator2_utils.py
+++ b/tests/core/operator/operator2_utils.py
@@ -78,7 +78,7 @@ class StaticOp(Operator2):
         super().__init__(label, wires=wires)
 
 
-class CompOp(Operator2):
+class CompilableOp(Operator2):
     """Operator with a compilable static argument."""
 
     compilable_argnames = ("n",)

--- a/tests/core/operator/test_core_operator.py
+++ b/tests/core/operator/test_core_operator.py
@@ -16,7 +16,7 @@ Unit tests for :mod:`pennylane.operation`.
 """
 
 import copy
-from typing import Callable
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -121,7 +121,7 @@ class TestOperator1:
         assert isinstance(op, Operator1)
         assert not op.has_matrix  # check it has an Operator thing
 
-    def test_instantiating_Opeartor1_on_its_own(self):
+    def test_instantiating_Operator1_on_its_own(self):
         """Test that an error is raised if someone tries to instantiate Operator1."""
 
         with pytest.raises(ValueError, match="Operator1 cannot be instantiated on its own."):

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -20,7 +20,7 @@ import copy
 
 import numpy as np
 import pytest
-from operator2_utils import DynOp, FullOp
+from operator2_utils import CompOp, DynOp, FullOp, HybridWireOp
 from scipy.sparse import csr_matrix
 
 import pennylane as qp
@@ -1117,14 +1117,6 @@ class TestHash:
 
     def test_hybrid_with_wires_leaf_equal_hash(self):
         """Test that hybrid arguments with ``Wires`` leaves hash equally for the same values."""
-
-        class HybridWireOp(Operator2):
-            wire_argnames = ("pytree_wires",)
-            hybrid_argnames = ("pytree_wires",)
-
-            def __init__(self, pytree_wires):
-                super().__init__([Wires(w) for w in pytree_wires])
-
         op1 = HybridWireOp([[0, 1], [2]])
         op2 = HybridWireOp([[0, 1], [2]])
         assert hash(op1) == hash(op2)
@@ -2434,18 +2426,8 @@ class TestLegacyCompatibilityViews:
 
     def test_compilable_args_in_hyperparameters(self):
         """Test that compilable args appear in the legacy hyperparameter view."""
-
-        class CompOp(Operator2):
-            dynamic_argnames = ("phi",)
-            compilable_argnames = ("order",)
-
-            def __init__(self, phi, order, wires):
-                super().__init__(phi, order, wires=wires)
-
-        op = CompOp(0.5, order=3, wires=0)
-
-        assert op.hyperparameters == {"order": 3}
-        assert op.data == (0.5,)
+        op = CompOp(n=3, wires=0)
+        assert op.hyperparameters == {"n": 3}
 
     def test_nonstandard_wire_arg_excluded_from_hyperparameters(self):
         """Test that non-``wires`` wire argument names are excluded."""

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -20,7 +20,7 @@ import copy
 
 import numpy as np
 import pytest
-from operator2_utils import CompOp, DynOp, FullOp, HybridWireOp
+from operator2_utils import CompilableOp, DynOp, FullOp, HybridWireOp
 from scipy.sparse import csr_matrix
 
 import pennylane as qp
@@ -2426,7 +2426,7 @@ class TestLegacyCompatibilityViews:
 
     def test_compilable_args_in_hyperparameters(self):
         """Test that compilable args appear in the legacy hyperparameter view."""
-        op = CompOp(n=3, wires=0)
+        op = CompilableOp(n=3, wires=0)
         assert op.hyperparameters == {"n": 3}
 
     def test_nonstandard_wire_arg_excluded_from_hyperparameters(self):

--- a/tests/core/operator/test_operator2_capture.py
+++ b/tests/core/operator/test_operator2_capture.py
@@ -16,7 +16,7 @@
 
 import pytest
 from operator2_utils import (
-    CompOp,
+    CompilableOp,
     DynOp,
     FullOp,
     HybridOp,
@@ -151,7 +151,7 @@ class TestCaptureBasics:
 
     def test_compilable_arg_in_params(self):
         """Test that compilable arguments are stored as equation parameters."""
-        jaxpr = jax.make_jaxpr(lambda: CompOp(5, wires=0))()
+        jaxpr = jax.make_jaxpr(lambda: CompilableOp(5, wires=0))()
         eqn = _single_op_eqn(jaxpr)
         assert unflatten(*eqn.params["n"]) == 5
 
@@ -339,9 +339,9 @@ class TestReconstruction:
 
     def test_compilable_roundtrip(self):
         """Test that a compilable argument round-trips through capture and evaluation."""
-        jaxpr = jax.make_jaxpr(lambda x: CompOp(5, wires=x).tracer)(0)
+        jaxpr = jax.make_jaxpr(lambda x: CompilableOp(5, wires=x).tracer)(0)
         [op] = _eval(jaxpr, 1)
-        qp.assert_equal(op, CompOp(5, wires=1))
+        qp.assert_equal(op, CompilableOp(5, wires=1))
 
     def test_multiwire_roundtrip(self):
         """Test that an operator with multiple wire arguments round-trips."""

--- a/tests/core/operator/test_operator2_equality.py
+++ b/tests/core/operator/test_operator2_equality.py
@@ -17,7 +17,7 @@
 import numpy as np
 import pytest
 from operator2_utils import (
-    CompOp,
+    CompilableOp,
     DynOp,
     FullOp,
     HybridOp,
@@ -183,15 +183,15 @@ class TestCompilableArgs:
 
     def test_equal_same_compilable(self):
         """Test that operators with the same compilable argument are equal."""
-        op1 = CompOp(3, wires=0)
-        op2 = CompOp(3, wires=0)
+        op1 = CompilableOp(3, wires=0)
+        op2 = CompilableOp(3, wires=0)
         assert qp.equal(op1, op2) is True
         qp.assert_equal(op1, op2)
 
     def test_different_compilable_not_equal(self):
         """Test that operators with different compilable arguments are unequal."""
-        op1 = CompOp(3, wires=0)
-        op2 = CompOp(4, wires=0)
+        op1 = CompilableOp(3, wires=0)
+        op2 = CompilableOp(4, wires=0)
         assert qp.equal(op1, op2) is False
         with pytest.raises(AssertionError, match="different values for 'n'"):
             qp.assert_equal(op1, op2)

--- a/tests/core/operator/test_operator_utils.py
+++ b/tests/core/operator/test_operator_utils.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import pytest
-from operator2_utils import CompOp, DynOp, FullOp, MixedHybridOp, MultiWireOp, TwoDynOp
+from operator2_utils import CompilableOp, DynOp, FullOp, MixedHybridOp, MultiWireOp, TwoDynOp
 
 from pennylane.core.operator import Operator2
 from pennylane.core.operator.utils import abstractify
@@ -253,7 +253,7 @@ class TestAbstractifyOperatorInstances:
     def test_comp_op_is_passed_through(self):
         """Tests that a compilable static arg is passed through."""
 
-        op = CompOp(5, wires=[0])
+        op = CompilableOp(5, wires=[0])
         result = abstractify(op)
         assert result.n == 5
         assert result.wires == Wire[1]


### PR DESCRIPTION
**Context:**
There are classes for testing `Operator2` in `operator2_utils.py`, which were being duplicated in a few places.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
