### PR TITLE
fix: remove `qchem` test `xfail` with new `openfermion==1.8.0` release

### DIFF
--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_dipole.py
@@ -223,7 +223,7 @@ eig_h2o.append([-0.67873019, -0.45673019, -0.45673019])
     ),
     [
         (h2, x_h2, 0, None, None, "jordan_wigner", coeffs_h2, ops_h2),
-        pytest.param(
+        (
             h2,
             x_h2,
             0,
@@ -232,10 +232,6 @@ eig_h2o.append([-0.67873019, -0.45673019, -0.45673019])
             "parity",
             coeffs_h2_parity,
             ops_h2_parity,
-            marks=pytest.mark.xfail(
-                reason="OpenFermion backend is not yet compatible with numpy==2.3.1. See issue https://github.com/quantumlib/OpenFermion/issues/1097 for more details.",
-                strict=True,
-            ),
         ),
         (h3p, x_h3p, 1, None, None, "jordan_wigner", coeffs_h3p, ops_h3p),
         (h2o, x_h2o, 0, 2, 2, "bravyi_kitaev", coeffs_h2o, ops_h2o),

--- a/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
+++ b/tests/qchem/openfermion_pyscf_tests/test_molecular_hamiltonian.py
@@ -1114,7 +1114,7 @@ def test_error_raised_for_missing_molecule_information():
                 ],
             ),
         ),
-        pytest.param(
+        (
             ["H", "H"],
             np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]]),
             0,
@@ -1161,10 +1161,6 @@ def test_error_raised_for_missing_molecule_information():
                     Z(1) @ Z(3),
                     Z(2) @ Z(3),
                 ],
-            ),
-            marks=pytest.mark.xfail(
-                reason="OpenFermion backend is not yet compatible with numpy==2.3.1. See issue https://github.com/quantumlib/OpenFermion/issues/1097 for more details.",
-                strict=True,
             ),
         ),
         (


### PR DESCRIPTION
**Context:**

openfermion released last night on pypi which contains a fix to an [issue](https://github.com/quantumlib/OpenFermion/issues/1097) I created a while ago in their repo. 

With that said, we can finally remove the strict xfails I added here (causing CI to fail ATM) 🎉 

