### PR TITLE
BREAKING CHANGE: `Operator.data` is read-only now

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -656,11 +656,13 @@
   original unchanged:
 
   ```python
-  # Before, will break now
-  op.data = (new_theta,)  # Expected failure: AttributeError: property 'data' of 'op' object has no setter
+  op = qp.RX(0.1, wires=0)
 
-  # After
-  op = qp.ops.functions.bind_new_parameters(op, (new_theta,))
+  # Before (no longer supported):
+  # op.data = (0.2,)  # AttributeError: property 'data' of 'RX' object has no setter
+
+  # After:
+  op_new = qp.ops.functions.bind_new_parameters(op, (0.2,))
   ```
 
   [(#9836)](https://github.com/PennyLaneAI/pennylane/pull/9836)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -646,6 +646,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* Operators cannot set their data anymore.
+  [(#9836)](https://github.com/PennyLaneAI/pennylane/pull/9836)
+
 * Support for compiling PennyLane workflows with CUDA Quantum through :func:`~.qjit` has been
   removed following the removal of the CUDA Quantum integration from Catalyst.
   [(Catalyst #2984)](https://github.com/PennyLaneAI/catalyst/pull/2984)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -650,7 +650,19 @@
 
 <h3>Breaking changes 💔</h3>
 
-* Operators cannot set their data anymore.
+* The :attr:`~.Operator.data` property is now read-only. Assigning trainable parameters via
+  ``op.data = new_data`` is no longer supported. To create an operator with updated parameters,
+  use :func:`~.ops.functions.bind_new_parameters`, which returns a new operator and leaves the
+  original unchanged:
+
+  ```python
+  # Before, will break now
+  op.data = (new_theta,)  # Expected failure: AttributeError: property 'data' of 'op' object has no setter
+
+  # After
+  op = qp.ops.functions.bind_new_parameters(op, (new_theta,))
+  ```
+
   [(#9836)](https://github.com/PennyLaneAI/pennylane/pull/9836)
 
 * Support for compiling PennyLane workflows with CUDA Quantum through :func:`~.qjit` has been

--- a/pennylane/core/operator/base.py
+++ b/pennylane/core/operator/base.py
@@ -636,12 +636,12 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
     def __copy__(self) -> "Operator":
         cls = self.__class__
         copied_op = cls.__new__(cls)
-        copied_op.data = copy.copy(self.data)
+        copied_op._data = copy.copy(self.data)
         # pylint: disable=attribute-defined-outside-init
         if hasattr(self, "_hyperparameters"):
             copied_op._hyperparameters = copy.copy(self._hyperparameters)
         for attr, value in vars(self).items():
-            if attr not in {"data", "_hyperparameters"}:
+            if attr not in {"_data", "_hyperparameters"}:
                 setattr(copied_op, attr, value)
 
         return copied_op
@@ -655,11 +655,11 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         memo[id(self)] = copied_op
 
         for attribute, value in self.__dict__.items():
-            if attribute == "data":
+            if attribute == "_data":
                 # Shallow copy the list of parameters. We avoid a deep copy
                 # here, since PyTorch does not support deep copying of tensors
                 # within a differentiable computation.
-                copied_op.data = copy.copy(value)
+                copied_op._data = copy.copy(value)
             else:
                 # Deep copy everything else.
                 setattr(copied_op, attribute, copy.deepcopy(value, memo))
@@ -1029,9 +1029,14 @@ class Operator(abc.ABC, metaclass=capture.ABCCaptureMeta):
         self._batch_size: int | None = _UNSET_BATCH_SIZE
         self._ndim_params: tuple[int] = _UNSET_BATCH_SIZE
 
-        self.data = tuple(np.array(p) if isinstance(p, (list, tuple)) else p for p in params)
+        self._data = tuple(np.array(p) if isinstance(p, (list, tuple)) else p for p in params)
 
         self.queue()
+
+    @property
+    def data(self) -> tuple[TensorLike, ...]:
+        """tuple: Trainable parameters that the operator depends on."""
+        return self._data
 
     def _check_batching(self):
         """Check if the expected numbers of dimensions of parameters coincides with the

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -680,7 +680,7 @@ def assert_valid(
         class MyOp(qp.operation.Operator):
 
             def __init__(self, data, wires):
-                self.data = data
+                self._data = data
                 super().__init__(wires=wires)
 
         op = MyOp(qp.numpy.array(0.5), wires=0)

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -43,9 +43,11 @@ from pennylane.templates.subroutines import (
     FermionicDoubleExcitation,
     PrepSelPrep,
     QDrift,
+    QSVT,
     Select,
     TrotterProduct,
 )
+from pennylane.templates.subroutines.hilbert_schmidt import HilbertSchmidt
 from pennylane.typing import TensorLike
 
 
@@ -237,6 +239,32 @@ def bind_new_parameters_select(op: Select, params: Sequence[TensorLike]):
         params = params[operand_num_params:]
 
     return op.__class__(new_ops, control=op.control, work_wires=op.work_wires, partial=op.partial)
+
+
+def _bind_nested_operators(operators, params: Sequence[TensorLike]):
+    """Bind a flat parameter sequence to a sequence of operators."""
+    new_operators = []
+    for operator in operators:
+        num_params = operator.num_params
+        new_operators.append(bind_new_parameters(operator, params[:num_params]))
+        params = params[num_params:]
+    return new_operators
+
+
+@bind_new_parameters.register
+def bind_new_parameters_hilbert_schmidt(op: HilbertSchmidt, params: Sequence[TensorLike]):
+    num_v_params = sum(operator.num_params for operator in op.hyperparameters["V"])
+    new_v = _bind_nested_operators(op.hyperparameters["V"], params[:num_v_params])
+    new_u = _bind_nested_operators(op.hyperparameters["U"], params[num_v_params:])
+    return op.__class__(new_v, new_u)
+
+
+@bind_new_parameters.register
+def bind_new_parameters_qsvt(op: QSVT, params: Sequence[TensorLike]):
+    ua = op.hyperparameters["UA"]
+    new_ua = bind_new_parameters(ua, params[: ua.num_params])
+    new_projectors = _bind_nested_operators(op.hyperparameters["projectors"], params[ua.num_params :])
+    return QSVT(new_ua, new_projectors)
 
 
 @bind_new_parameters.register

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -41,7 +41,9 @@ from pennylane.templates.subroutines import (
     CommutingEvolution,
     ControlledSequence,
     FermionicDoubleExcitation,
+    PrepSelPrep,
     QDrift,
+    Select,
     TrotterProduct,
 )
 from pennylane.typing import TensorLike
@@ -68,7 +70,7 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
     except (TypeError, ValueError):
         # operation is doing something different with its call signature.
         new_op = copy.deepcopy(op)
-        new_op.data = tuple(params)
+        new_op._data = tuple(params)
         if queuing.QueuingManager.recording() or capture.enabled():
             return queuing.apply(new_op)
         return new_op
@@ -218,6 +220,23 @@ def bind_new_parameters_symbolic_op(op: SymbolicOp, params: Sequence[TensorLike]
 def bind_new_parameters_controlled_sequence(op: ControlledSequence, params: Sequence[TensorLike]):
     new_base = bind_new_parameters(op.base, params)
     return op.__class__(new_base, control=op.control)
+
+
+@bind_new_parameters.register
+def bind_new_parameters_prep_sel_prep(op: PrepSelPrep, params: Sequence[TensorLike]):
+    new_lcu = bind_new_parameters(op.lcu, params)
+    return op.__class__(new_lcu, control=op.control)
+
+
+@bind_new_parameters.register
+def bind_new_parameters_select(op: Select, params: Sequence[TensorLike]):
+    new_ops = []
+    for operand in op.ops:
+        operand_num_params = operand.num_params
+        new_ops.append(bind_new_parameters(operand, params[:operand_num_params]))
+        params = params[operand_num_params:]
+
+    return op.__class__(new_ops, control=op.control, work_wires=op.work_wires, partial=op.partial)
 
 
 @bind_new_parameters.register

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -242,7 +242,8 @@ def bind_new_parameters_select(op: Select, params: Sequence[TensorLike]):
 
 
 def _bind_nested_operators(operators, params: Sequence[TensorLike]):
-    """Bind a flat parameter sequence to a sequence of operators."""
+    """Bind a flat parameter sequence to a sequence of operators.
+    Used by QSVT and HilbertSchmidt."""
     new_operators = []
     for operator in operators:
         num_params = operator.num_params

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -37,13 +37,13 @@ from pennylane.ops import (
 from pennylane.ops.op_math.adjoint2 import Adjoint2
 from pennylane.templates.embeddings import AngleEmbedding
 from pennylane.templates.subroutines import (
+    QSVT,
     ApproxTimeEvolution,
     CommutingEvolution,
     ControlledSequence,
     FermionicDoubleExcitation,
     PrepSelPrep,
     QDrift,
-    QSVT,
     Select,
     TrotterProduct,
 )
@@ -263,7 +263,9 @@ def bind_new_parameters_hilbert_schmidt(op: HilbertSchmidt, params: Sequence[Ten
 def bind_new_parameters_qsvt(op: QSVT, params: Sequence[TensorLike]):
     ua = op.hyperparameters["UA"]
     new_ua = bind_new_parameters(ua, params[: ua.num_params])
-    new_projectors = _bind_nested_operators(op.hyperparameters["projectors"], params[ua.num_params :])
+    new_projectors = _bind_nested_operators(
+        op.hyperparameters["projectors"], params[ua.num_params :]
+    )
     return QSVT(new_ua, new_projectors)
 
 

--- a/pennylane/ops/functions/bind_new_parameters.py
+++ b/pennylane/ops/functions/bind_new_parameters.py
@@ -70,7 +70,7 @@ def bind_new_parameters(op: Operator, params: Sequence[TensorLike]) -> Operator:
     except (TypeError, ValueError):
         # operation is doing something different with its call signature.
         new_op = copy.deepcopy(op)
-        new_op._data = tuple(params)
+        new_op._data = tuple(params)  # pylint: disable=protected-access
         if queuing.QueuingManager.recording() or capture.enabled():
             return queuing.apply(new_op)
         return new_op

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -161,15 +161,6 @@ class CompositeOp(Operator):
         """Create data property"""
         return tuple(d for op in self for d in op.data)
 
-    @data.setter
-    def data(self, new_data):
-        """Set the data property"""
-        for op in self:
-            op_num_params = op.num_params
-            if op_num_params > 0:
-                op.data = new_data[:op_num_params]
-                new_data = new_data[op_num_params:]
-
     @property
     def num_wires(self):
         """Number of wires the operator acts on."""

--- a/pennylane/ops/op_math/composite.py
+++ b/pennylane/ops/op_math/composite.py
@@ -424,7 +424,6 @@ class CompositeOp(Operator):
         new_op = cls.__new__(cls)
         new_op.operands = tuple(op.map_wires(wire_map=wire_map) for op in self)
         new_op._wires = Wires([wire_map.get(wire, wire) for wire in self.wires])
-        new_op.data = copy.copy(self.data)
         if self._overlapping_ops is not None:
             new_op._overlapping_ops = [
                 [o.map_wires(wire_map) for o in _ops] for _ops in self._overlapping_ops
@@ -435,6 +434,8 @@ class CompositeOp(Operator):
         for attr, value in vars(self).items():
             if attr not in {"data", "operands", "_wires", "_overlapping_ops"}:
                 setattr(new_op, attr, value)
+        new_op._hyperparameters = copy.copy(self._hyperparameters)
+        new_op._hyperparameters["operands"] = new_op.operands
         if (p_rep := new_op.pauli_rep) is not None:
             new_op._pauli_rep = p_rep.map_wires(wire_map)
 

--- a/pennylane/ops/op_math/evolution.py
+++ b/pennylane/ops/op_math/evolution.py
@@ -92,10 +92,6 @@ class Evolution(Exp):
     def data(self):
         return self._data
 
-    @data.setter
-    def data(self, new_data):
-        self._data = new_data
-
     @property
     def param(self):
         """A real coefficient with ``1j`` factored out."""

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -214,10 +214,6 @@ class Pow(ScalarSymbolicOp):
         """The trainable parameters"""
         return self.base.data
 
-    @data.setter
-    def data(self, new_data):
-        self.base.data = new_data
-
     def label(self, decimals=None, base_label=None, cache=None):
         z_string = format(self.z).translate(_superscript)
         base_label = self.base.label(decimals, base_label, cache=cache)

--- a/pennylane/ops/op_math/symbolicop.py
+++ b/pennylane/ops/op_math/symbolicop.py
@@ -110,10 +110,6 @@ class SymbolicOp(Operator):
         """The trainable parameters"""
         return self.base.data
 
-    @data.setter
-    def data(self, new_data):
-        self.base.data = new_data
-
     @property
     def num_params(self):
         return self.base.num_params
@@ -214,11 +210,6 @@ class ScalarSymbolicOp(SymbolicOp):
     @handle_recursion_error
     def data(self):
         return (self.scalar, *self.base.data)
-
-    @data.setter
-    def data(self, new_data):
-        self.scalar = new_data[0]
-        self.base.data = new_data[1:]
 
     @property
     @handle_recursion_error

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -20,6 +20,7 @@ from pennylane import math
 from pennylane import numpy as pnp
 from pennylane._grad import grad
 from pennylane.core.qscript import QuantumScript, QuantumScriptBatch
+from pennylane.ops.functions import bind_new_parameters
 from pennylane.transforms.core import transform
 from pennylane.typing import PostprocessingFn
 from pennylane.workflow import construct_tape
@@ -43,10 +44,8 @@ def append_gate(tape: QuantumScript, params, gates) -> tuple[QuantumScriptBatch,
     new_operations = []
 
     for i, g in enumerate(gates):
-        g = copy.copy(g)
         new_params = (params[i], *g.data[1:])
-        g._data = tuple(new_params)
-        new_operations.append(g)
+        new_operations.append(bind_new_parameters(g, new_params))
 
     new_tape = tape.copy(operations=tape.operations + new_operations)
 

--- a/pennylane/optimize/adaptive.py
+++ b/pennylane/optimize/adaptive.py
@@ -45,7 +45,7 @@ def append_gate(tape: QuantumScript, params, gates) -> tuple[QuantumScriptBatch,
     for i, g in enumerate(gates):
         g = copy.copy(g)
         new_params = (params[i], *g.data[1:])
-        g.data = new_params
+        g._data = tuple(new_params)
         new_operations.append(g)
 
     new_tape = tape.copy(operations=tape.operations + new_operations)

--- a/pennylane/templates/subroutines/hilbert_schmidt.py
+++ b/pennylane/templates/subroutines/hilbert_schmidt.py
@@ -176,16 +176,6 @@ class HilbertSchmidt(Operation):
         r"""Flattened list of operator data in this HilbertSchmidt operation."""
         return tuple(datum for op in self._operators for datum in op.data)
 
-    @data.setter
-    def data(self, new_data):
-        # We need to check if ``new_data`` is empty because ``Operator.__init__()``  will attempt to
-        # assign the HilbertSchmidt data to an empty tuple (since no positional arguments are provided).
-        if new_data:
-            for op in self._operators:
-                if op.num_params > 0:
-                    op.data = new_data[: op.num_params]
-                    new_data = new_data[op.num_params :]
-
     def __copy__(self):
         # Override Operator.__copy__() to avoid setting the "data" property before the new instance
         # is assigned hyper-parameters since HilbertSchmidt data is derived from the hyper-parameters.

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -107,7 +107,7 @@ class PrepSelPrep(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*lcu.data, wires=all_wires)
+        super().__init__(*self.data, wires=all_wires)
 
     def _flatten(self):
         return (self.lcu,), (self.control,)
@@ -163,6 +163,11 @@ class PrepSelPrep(Operation):
         """Copy this op"""
         with QueuingManager.stop_recording():
             return type(self)(copy.copy(self.lcu), copy.copy(self.control))
+
+    @property
+    def data(self):
+        """Create data property"""
+        return self.lcu.data
 
     @property
     def lcu(self):

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -107,7 +107,7 @@ class PrepSelPrep(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires)
+        super().__init__(*lcu.data, wires=all_wires)
 
     def _flatten(self):
         return (self.lcu,), (self.control,)
@@ -161,28 +161,8 @@ class PrepSelPrep(Operation):
 
     def __copy__(self):
         """Copy this op"""
-        cls = self.__class__
-        copied_op = cls.__new__(cls)
-
-        new_data = copy.copy(self.data)
-
-        for attr, value in vars(self).items():
-            if attr != "data":
-                setattr(copied_op, attr, value)
-
-        copied_op.data = new_data
-
-        return copied_op
-
-    @property
-    def data(self):
-        """Create data property"""
-        return self.lcu.data
-
-    @data.setter
-    def data(self, new_data):
-        """Set the data property"""
-        self.hyperparameters["lcu"].data = new_data
+        with QueuingManager.stop_recording():
+            return type(self)(copy.copy(self.lcu), copy.copy(self.control))
 
     @property
     def lcu(self):

--- a/pennylane/templates/subroutines/prepselprep.py
+++ b/pennylane/templates/subroutines/prepselprep.py
@@ -16,9 +16,8 @@ Contains the PrepSelPrep template.
 """
 
 # pylint: disable=arguments-differ
-import copy
-
 from pennylane import math
+from pennylane import ops as qp_ops
 from pennylane.core.operator import Operation, abstractify
 from pennylane.core.queuing import QueuingManager
 from pennylane.decomposition import (
@@ -162,7 +161,7 @@ class PrepSelPrep(Operation):
     def __copy__(self):
         """Copy this op"""
         with QueuingManager.stop_recording():
-            return type(self)(copy.copy(self.lcu), copy.copy(self.control))
+            return qp_ops.functions.bind_new_parameters(self, self.data)
 
     @property
     def data(self):

--- a/pennylane/templates/subroutines/qsvt.py
+++ b/pennylane/templates/subroutines/qsvt.py
@@ -550,16 +550,6 @@ class QSVT(Operation):
         """
         return tuple(datum for op in self._operators for datum in op.data)
 
-    @data.setter
-    def data(self, new_data):
-        # We need to check if ``new_data`` is empty because ``Operator.__init__()``  will attempt to
-        # assign the QSVT data to an empty tuple (since no positional arguments are provided).
-        if new_data:
-            for op in self._operators:
-                if op.num_params > 0:
-                    op.data = new_data[: op.num_params]
-                    new_data = new_data[op.num_params :]
-
     def __copy__(self):
         # Override Operator.__copy__() to avoid setting the "data" property before the new instance
         # is assigned hyper-parameters since QSVT data is derived from the hyper-parameters.

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -414,7 +414,8 @@ class Select(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        super().__init__(*self.data, wires=all_wires)
+        data = tuple(d for op in ops for d in op.data)
+        super().__init__(*data, wires=all_wires)
 
     def map_wires(self, wire_map: dict) -> "Select":
         new_ops = [o.map_wires(wire_map) for o in self.hyperparameters["ops"]]
@@ -424,32 +425,13 @@ class Select(Operation):
 
     def __copy__(self):
         """Copy this op"""
-        cls = self.__class__
-        copied_op = cls.__new__(cls)
-
-        new_data = copy.copy(self.data)
-
-        for attr, value in vars(self).items():
-            if attr != "data":
-                setattr(copied_op, attr, value)
-
-        copied_op.data = new_data
-
-        return copied_op
-
-    @property
-    def data(self):
-        """Create data property"""
-        return tuple(d for op in self.ops for d in op.data)
-
-    @data.setter
-    def data(self, new_data):
-        """Set the data property"""
-        for op in self.ops:
-            op_num_params = op.num_params
-            if op_num_params > 0:
-                op.data = new_data[:op_num_params]
-                new_data = new_data[op_num_params:]
+        with QueuingManager.stop_recording():
+            return type(self)(
+                [copy.copy(op) for op in self.ops],
+                copy.copy(self.control),
+                work_wires=copy.copy(self.work_wires),
+                partial=self.partial,
+            )
 
     def decomposition(self):
         r"""Representation of the operator as a product of other operators.

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -410,8 +410,7 @@ class Select(Operation):
         self.hyperparameters["target_wires"] = target_wires
 
         all_wires = target_wires + control
-        data = tuple(d for op in ops for d in op.data)
-        super().__init__(*data, wires=all_wires)
+        super().__init__(*self.data, wires=all_wires)
 
     def map_wires(self, wire_map: dict) -> "Select":
         new_ops = [o.map_wires(wire_map) for o in self.hyperparameters["ops"]]
@@ -428,6 +427,11 @@ class Select(Operation):
                 work_wires=copy.copy(self.work_wires),
                 partial=self.partial,
             )
+
+    @property
+    def data(self):
+        """Flattened trainable parameters of the selected operators."""
+        return tuple(d for op in self.ops for d in op.data)
 
     def decomposition(self):
         r"""Representation of the operator as a product of other operators.

--- a/pennylane/templates/subroutines/select.py
+++ b/pennylane/templates/subroutines/select.py
@@ -15,13 +15,13 @@
 Contains the Select template.
 """
 
-import copy
 from collections import Counter, defaultdict
 from itertools import product
 
 import numpy as np
 
 from pennylane import math
+from pennylane import ops as qp_ops
 from pennylane.core.operator import Operation, abstractify
 from pennylane.core.queuing import QueuingManager, apply
 from pennylane.decomposition import add_decomps, register_condition, register_resources
@@ -421,12 +421,7 @@ class Select(Operation):
     def __copy__(self):
         """Copy this op"""
         with QueuingManager.stop_recording():
-            return type(self)(
-                [copy.copy(op) for op in self.ops],
-                copy.copy(self.control),
-                work_wires=copy.copy(self.work_wires),
-                partial=self.partial,
-            )
+            return qp_ops.functions.bind_new_parameters(self, self.data)
 
     @property
     def data(self):

--- a/tests/core/operator/test_core_operator.py
+++ b/tests/core/operator/test_core_operator.py
@@ -297,6 +297,18 @@ class TestOperatorConstruction:
         op2 = DummyOp((1, 2, 3), wires=0)
         assert isinstance(op2.data[0], np.ndarray)
 
+    def test_data_is_read_only(self):
+        """Test that operator data is exposed through a read-only property."""
+
+        class DummyOp(qp.operation.Operator):
+            num_wires = 1
+            num_params = 1
+
+        op = DummyOp(1.234, wires=0)
+
+        with pytest.raises(AttributeError):
+            op.data = (5.678,)
+
     def test_wires_by_final_argument(self):
         """Test that wires can be passed as the final positional argument."""
 

--- a/tests/core/operator/test_core_operator.py
+++ b/tests/core/operator/test_core_operator.py
@@ -307,7 +307,7 @@ class TestOperatorConstruction:
         op = DummyOp(1.234, wires=0)
 
         with pytest.raises(AttributeError):
-            op.data = (5.678,)
+            setattr(op, "data", (5.678,))
 
     def test_wires_by_final_argument(self):
         """Test that wires can be passed as the final positional argument."""

--- a/tests/core/operator/test_core_operator.py
+++ b/tests/core/operator/test_core_operator.py
@@ -306,7 +306,9 @@ class TestOperatorConstruction:
 
         op = DummyOp(1.234, wires=0)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match=r"property 'data' of '.*DummyOp' object has no setter"
+        ):
             setattr(op, "data", (5.678,))
 
     def test_wires_by_final_argument(self):

--- a/tests/core/test_measurements.py
+++ b/tests/core/test_measurements.py
@@ -304,10 +304,6 @@ class TestProperties:
 
         assert np.all(m.eigvals() == np.array([1, 2, 3, 4]))
 
-        # changing the observable data should be reflected
-        obs._data = tuple([np.diag([5, 6, 7, 8])])
-        assert np.all(m.eigvals() == np.array([5, 6, 7, 8]))
-
     def test_measurement_value_eigvals(self):
         """Test that eigenvalues of the measurement process
         are correct if the internal observable is a

--- a/tests/core/test_measurements.py
+++ b/tests/core/test_measurements.py
@@ -305,7 +305,7 @@ class TestProperties:
         assert np.all(m.eigvals() == np.array([1, 2, 3, 4]))
 
         # changing the observable data should be reflected
-        obs.data = [np.diag([5, 6, 7, 8])]
+        obs._data = tuple([np.diag([5, 6, 7, 8])])
         assert np.all(m.eigvals() == np.array([5, 6, 7, 8]))
 
     def test_measurement_value_eigvals(self):

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -437,7 +437,7 @@ class TestParameterShiftLogic:
             transformed_obs.parameters[0]`` the condition ``len(A.nonzero()[0])
             == 1 and A.ndim == 2 and A[0, 0] != 0`` is ``True``."""
             iden = qp.Identity(0)
-            iden._data = (np.array([[1, 0], [0, 0]]),)
+            iden._data = (np.array([[1, 0], [0, 0]]),)  # pylint: disable=protected-access
             return iden
 
         monkeypatch.setattr(

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -437,7 +437,7 @@ class TestParameterShiftLogic:
             transformed_obs.parameters[0]`` the condition ``len(A.nonzero()[0])
             == 1 and A.ndim == 2 and A[0, 0] != 0`` is ``True``."""
             iden = qp.Identity(0)
-            iden.data = (np.array([[1, 0], [0, 0]]),)
+            iden._data = (np.array([[1, 0], [0, 0]]),)
             return iden
 
         monkeypatch.setattr(

--- a/tests/gradients/parameter_shift/test_parameter_shift_cv.py
+++ b/tests/gradients/parameter_shift/test_parameter_shift_cv.py
@@ -425,20 +425,13 @@ class TestParameterShiftLogic:
         spy.assert_called()
 
     def test_force_order2_dim_2(self, mocker, monkeypatch):
-        """Test that if the force_order2 keyword argument is provided, the
-        second order parameter shift rule is forced for an observable with
-        2-dimensional parameters"""
+        """Test that force_order2 selects the second-order rule for an observable with a
+        two-dimensional parameter."""
         spy = mocker.spy(qp.gradients.parameter_shift_cv, "second_order_param_shift")
 
         def _mock_transform_observable(obs, Z, device_wires):  # pylint: disable=unused-argument
-            """A mock version of the _transform_observable internal function
-            such that an operator ``transformed_obs`` of two-dimensions is
-            returned. This function is created such that when definining ``A =
-            transformed_obs.parameters[0]`` the condition ``len(A.nonzero()[0])
-            == 1 and A.ndim == 2 and A[0, 0] != 0`` is ``True``."""
-            iden = qp.Identity(0)
-            iden._data = (np.array([[1, 0], [0, 0]]),)  # pylint: disable=protected-access
-            return iden
+            """Return an observable whose sole parameter triggers the second-order branch."""
+            return qp.Hermitian(np.array([[1, 0], [0, 0]]), wires=0)
 
         monkeypatch.setattr(
             qp.gradients.parameter_shift_cv,

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -462,7 +462,7 @@ def test_data_is_tuple():
 
         def __init__(self, x, wires):
             super().__init__(x, wires)
-            self.data = [x]
+            self._data = [x]
 
     with pytest.raises(AssertionError, match=r"op.data must be a tuple"):
         assert_valid(BadData(2.0, wires=0))

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -330,7 +330,7 @@ def test_bad_bind_new_parameters():
 
         def __init__(self, x, wires):
             super().__init__(x, wires)
-            self.data = (1.0,)  # different x will not change data attribute
+            self._data = (1.0,)  # different x will not change data attribute
 
     with pytest.raises(
         AssertionError, match=r"bind_new_parameters must be able to update the operator"

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -323,14 +323,14 @@ def test_bad_pickling():
 
 
 def test_bad_bind_new_parameters():
-    """Test a function that is not working with bind_new_parameters."""
+    """Test that validation fails when rebinding cannot update an operator's data."""
 
     class NoBindNewParameters(Operator):
         num_params = 1
 
-        def __init__(self, x, wires):
-            super().__init__(x, wires)
-            self._data = (1.0,)  # different x will not change data attribute
+        @property
+        def data(self):
+            return (1.0,)  # different x will not change data attribute
 
     with pytest.raises(
         AssertionError, match=r"bind_new_parameters must be able to update the operator"
@@ -460,9 +460,9 @@ def test_data_is_tuple():
     class BadData(Operator):
         num_params = 1
 
-        def __init__(self, x, wires):
-            super().__init__(x, wires)
-            self._data = [x]
+        @property
+        def data(self):
+            return list(super().data)
 
     with pytest.raises(AssertionError, match=r"op.data must be a tuple"):
         assert_valid(BadData(2.0, wires=0))

--- a/tests/ops/functions/test_bind_new_parameters.py
+++ b/tests/ops/functions/test_bind_new_parameters.py
@@ -246,6 +246,31 @@ def test_controlled_sequence():
     qp.assert_equal(new_op.base, qp.RX(0.5, wires=3))
 
 
+def test_prep_sel_prep():
+    """Test that rebinding PrepSelPrep replaces its LCU without mutating the original."""
+    lcu = qp.dot([0.25, 0.75], [qp.Z(2), qp.X(1) @ qp.X(2)])
+    op = qp.PrepSelPrep(lcu, control=0)
+
+    new_op = bind_new_parameters(op, (0.5, 0.5))
+
+    qp.assert_equal(new_op.lcu, qp.dot([0.5, 0.5], [qp.Z(2), qp.X(1) @ qp.X(2)]))
+    assert new_op is not op
+    assert new_op.lcu is not op.lcu
+    assert op.data == (0.25, 0.75)
+
+
+def test_select():
+    """Test that rebinding Select replaces its operands without mutating the original."""
+    op = qp.Select([qp.RX(0.25, wires=2), qp.RY(0.75, wires=2)], control=0)
+
+    new_op = bind_new_parameters(op, (0.5, 0.5))
+
+    qp.assert_equal(new_op, qp.Select([qp.RX(0.5, wires=2), qp.RY(0.5, wires=2)], control=0))
+    assert new_op is not op
+    assert new_op.ops[0] is not op.ops[0]
+    assert op.data == (0.25, 0.75)
+
+
 TEST_BIND_LINEARCOMBINATION = [
     (  # LinearCombination with only data being the coeffs
         qp.ops.LinearCombination(
@@ -503,7 +528,7 @@ def test_conditional_ops(op, new_params, expected_op):
 def test_unsupported_op_copy_and_set():
     """Test that trying to use `bind_new_parameters` on an operator without
     a supported dispatcher will fall back to copying the operator and setting
-    `new_op.data` to the new parameters."""
+    its private parameter storage to the new parameters."""
     op = qp.PCPhase(0.123, 2, wires=[1, 2])
     new_op = bind_new_parameters(op, [0.456])
 

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -2989,7 +2989,6 @@ class TestHilbertSchmidt:
     def test_non_equal_data(self, op, other_op):
         """Test that differing data is found."""
         assert qp.equal(op, other_op) is False
-        other_op.data = op.data
 
         v_ops = op.hyperparameters["V"]
         op_params = qp.tape.QuantumScript(v_ops).get_parameters()

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -158,7 +158,7 @@ class TestProperties:
     """Test Adjoint properties."""
 
     def test_data(self):
-        """Test base data can be get and set through Adjoint class."""
+        """Test that Adjoint data is read-only."""
         x = np.array(1.234)
 
         base = qp.RX(x, wires="a")
@@ -166,16 +166,8 @@ class TestProperties:
 
         assert adj.data == (x,)
 
-        # update parameters through adjoint
-        x_new = np.array(2.3456)
-        adj.data = (x_new,)
-        assert base.data == (x_new,)
-        assert adj.data == (x_new,)
-
-        # update base data updates Adjoint data
-        x_new2 = np.array(3.456)
-        base.data = (x_new2,)
-        assert adj.data == (x_new2,)
+        with pytest.raises(AttributeError):
+            setattr(adj, "data", (np.array(2.3456),))
 
     def test_has_matrix_true(self):
         """Test `has_matrix` property carries over when base op defines matrix."""

--- a/tests/ops/op_math/test_adjoint.py
+++ b/tests/ops/op_math/test_adjoint.py
@@ -157,7 +157,7 @@ class TestInitialization:
 class TestProperties:
     """Test Adjoint properties."""
 
-    def test_data(self):
+    def test_data_is_read_only(self):
         """Test that Adjoint data is read-only."""
         x = np.array(1.234)
 
@@ -166,7 +166,9 @@ class TestProperties:
 
         assert adj.data == (x,)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'AdjointOperation' object has no setter"
+        ):
             setattr(adj, "data", (np.array(2.3456),))
 
     def test_has_matrix_true(self):

--- a/tests/ops/op_math/test_composite_op.py
+++ b/tests/ops/op_math/test_composite_op.py
@@ -120,7 +120,9 @@ class TestConstruction:
         op = ValidOp(qp.RX(9.87, wires=0), qp.Rot(1.23, 4.0, 5.67, wires=1), qp.PauliX(0))
         assert op.data == (9.87, 1.23, 4.0, 5.67)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'ValidOp' object has no setter"
+        ):
             setattr(op, "data", (1.23, 0.0, -1.0, -2.0))
 
     def test_ndim_params_raises_error(self):

--- a/tests/ops/op_math/test_composite_op.py
+++ b/tests/ops/op_math/test_composite_op.py
@@ -115,18 +115,13 @@ class TestConstruction:
         op = ValidOp(qp.RX(9.87, wires=0), qp.Rot(1.23, 4.0, 5.67, wires=1), qp.PauliX(0))
         assert op.data == (9.87, 1.23, 4.0, 5.67)
 
-    def test_data_setter(self):
-        """Test the setter method for data"""
+    def test_data_is_read_only(self):
+        """Test that composite operator data is read-only."""
         op = ValidOp(qp.RX(9.87, wires=0), qp.Rot(1.23, 4.0, 5.67, wires=1), qp.PauliX(0))
         assert op.data == (9.87, 1.23, 4.0, 5.67)
 
-        new_data = (1.23, 0.0, -1.0, -2.0)
-        op.data = new_data  # pylint:disable=attribute-defined-outside-init
-        assert op.data == new_data
-
-        for o in op:
-            assert o.data == new_data[: o.num_params]
-            new_data = new_data[o.num_params :]
+        with pytest.raises(AttributeError):
+            setattr(op, "data", (1.23, 0.0, -1.0, -2.0))
 
     def test_ndim_params_raises_error(self):
         """Test that calling ndim_params raises a ValueError."""

--- a/tests/ops/op_math/test_condition.py
+++ b/tests/ops/op_math/test_condition.py
@@ -422,7 +422,7 @@ class TestProperties:
 
     BASE_OP = [qp.RX(1.23, 0), qp.Rot(1.2, 2.3, 3.4, 0), qp.QubitUnitary([[0, 1], [1, 0]], 0)]
 
-    def test_data(self):
+    def test_data_is_read_only(self):
         """Test that Conditional data is read-only."""
         x = np.array(1.234)
         m = qp.measure("a")
@@ -431,7 +431,9 @@ class TestProperties:
 
         assert cond_op.data == (x,)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'Conditional' object has no setter"
+        ):
             setattr(cond_op, "data", (np.array(2.3456),))
 
     @pytest.mark.parametrize("value", (True, False))

--- a/tests/ops/op_math/test_condition.py
+++ b/tests/ops/op_math/test_condition.py
@@ -423,7 +423,7 @@ class TestProperties:
     BASE_OP = [qp.RX(1.23, 0), qp.Rot(1.2, 2.3, 3.4, 0), qp.QubitUnitary([[0, 1], [1, 0]], 0)]
 
     def test_data(self):
-        """Test base data can be get and set through Conditional class."""
+        """Test that Conditional data is read-only."""
         x = np.array(1.234)
         m = qp.measure("a")
         base = qp.RX(x, wires="a")
@@ -431,16 +431,8 @@ class TestProperties:
 
         assert cond_op.data == (x,)
 
-        # update parameters through Conditional
-        x_new = np.array(2.3456)
-        cond_op.data = (x_new,)
-        assert base.data == (x_new,)
-        assert cond_op.data == (x_new,)
-
-        # update base data updates Conditional data
-        x_new2 = np.array(3.456)
-        base.data = (x_new2,)
-        assert cond_op.data == (x_new2,)
+        with pytest.raises(AttributeError):
+            setattr(cond_op, "data", (np.array(2.3456),))
 
     @pytest.mark.parametrize("value", (True, False))
     def test_has_matrix(self, value):

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -267,7 +267,7 @@ class TestControlledProperties:
         }
 
     def test_data(self):
-        """Test that the base data can be get and set through Controlled class."""
+        """Test that Controlled data is read-only."""
 
         x = pnp.array(1.234)
 
@@ -276,15 +276,8 @@ class TestControlledProperties:
 
         assert op.data == (x,)
 
-        x_new = (pnp.array(2.3454),)
-        op.data = x_new
-        assert op.data == (x_new,)
-        assert base.data == (x_new,)
-
-        x_new2 = (pnp.array(3.456),)
-        base._data = x_new2
-        assert op.data == (x_new2,)
-        assert op.parameters == [x_new2]
+        with pytest.raises(AttributeError):
+            setattr(op, "data", (pnp.array(2.3454),))
 
     @pytest.mark.parametrize(
         "val, arr", ((4, [1, 0, 0]), (6, [1, 1, 0]), (1, [0, 0, 1]), (5, [1, 0, 1]))
@@ -474,7 +467,9 @@ class TestControlledMiscMethods:
         assert copied_op.control_values == op.control_values
         assert copied_op.data == (param1,)
 
-        copied_op.data = (6.54,)
+        copied_op = qp.ops.functions.bind_new_parameters(copied_op, (6.54,))
+
+        assert copied_op.data == (6.54,)
         assert op.data == (param1,)
 
     def test_label(self):

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -282,7 +282,7 @@ class TestControlledProperties:
         assert base.data == (x_new,)
 
         x_new2 = (pnp.array(3.456),)
-        base.data = x_new2
+        base._data = x_new2
         assert op.data == (x_new2,)
         assert op.parameters == [x_new2]
 

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -276,7 +276,9 @@ class TestControlledProperties:
 
         assert op.data == (x,)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'ControlledOp' object has no setter"
+        ):
             setattr(op, "data", (pnp.array(2.3454),))
 
     @pytest.mark.parametrize(

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -94,12 +94,8 @@ class TestEvolution:  # pylint: disable=too-many-public-methods
         assert op.coeff == -1j * op.data[0]
         assert op.param == op.data[0]
 
-        new_param = np.array(2.345)
-        op.data = (new_param,)
-
-        assert op.data == (new_param,)
-        assert op.coeff == -1j * op.data[0]
-        assert op.data == op.data[0]
+        with pytest.raises(AttributeError):
+            setattr(op, "data", (np.array(2.345),))
 
     def test_repr_paulix(self):
         """Test the __repr__ method when the base is a simple observable."""

--- a/tests/ops/op_math/test_evolution.py
+++ b/tests/ops/op_math/test_evolution.py
@@ -94,7 +94,9 @@ class TestEvolution:  # pylint: disable=too-many-public-methods
         assert op.coeff == -1j * op.data[0]
         assert op.param == op.data[0]
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'Evolution' object has no setter"
+        ):
             setattr(op, "data", (np.array(2.345),))
 
     def test_repr_paulix(self):

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -119,7 +119,7 @@ class TestProperties:
 
         assert op.data == (coeff, phi)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="property 'data' of 'Exp' object has no setter"):
             setattr(op, "data", (np.array(3.456), np.array(0.1234)))
 
     def test_is_verified_hermitian(self):

--- a/tests/ops/op_math/test_exp.py
+++ b/tests/ops/op_math/test_exp.py
@@ -109,7 +109,7 @@ class TestProperties:
     """Test of the properties of the Exp class."""
 
     def test_data(self):
-        """Test intializaing and accessing the data property."""
+        """Test that Exp data is read-only."""
 
         phi = np.array(1.234)
         coeff = np.array(2.345)
@@ -119,13 +119,8 @@ class TestProperties:
 
         assert op.data == (coeff, phi)
 
-        new_phi = np.array(0.1234)
-        new_coeff = np.array(3.456)
-        op.data = (new_coeff, new_phi)
-
-        assert op.data == (new_coeff, new_phi)
-        assert op.base.data == (new_phi,)
-        assert op.scalar == new_coeff
+        with pytest.raises(AttributeError):
+            setattr(op, "data", (np.array(3.456), np.array(0.1234)))
 
     def test_is_verified_hermitian(self):
         """Test that the op is hermitian if the base is hermitian and the coeff is real."""

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -240,7 +240,7 @@ class TestProperties:
         assert op.data == (x,)
 
         with pytest.raises(AttributeError):
-            op.data = (np.array(2.3456),)
+            setattr(op, "data", (np.array(2.3456),))
 
     def test_has_matrix_true(self, power_method):
         """Test `has_matrix` property carries over when base op defines matrix."""

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -247,7 +247,7 @@ class TestProperties:
 
         # update base data updates pow data
         x_new2 = np.array(3.456)
-        base.data = (x_new2,)
+        base._data = (x_new2,)
         assert op.data == (x_new2,)
 
     def test_has_matrix_true(self, power_method):

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -239,7 +239,9 @@ class TestProperties:
 
         assert op.data == (x,)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'PowOperation' object has no setter"
+        ):
             setattr(op, "data", (np.array(2.3456),))
 
     def test_has_matrix_true(self, power_method):

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -239,16 +239,8 @@ class TestProperties:
 
         assert op.data == (x,)
 
-        # update parameters through pow
-        x_new = np.array(2.3456)
-        op.data = (x_new,)
-        assert base.data == (x_new,)
-        assert op.data == (x_new,)
-
-        # update base data updates pow data
-        x_new2 = np.array(3.456)
-        base._data = (x_new2,)
-        assert op.data == (x_new2,)
+        with pytest.raises(AttributeError):
+            op.data = (np.array(2.3456),)
 
     def test_has_matrix_true(self, power_method):
         """Test `has_matrix` property carries over when base op defines matrix."""
@@ -516,8 +508,7 @@ class TestMiscMethods:
         qp.assert_equal(new_op, op)
 
     def test_copy(self):
-        """Test that a copy of a power operator can have its parameters updated
-        independently of the original operator."""
+        """Test that a copy can be rebound independently of the original."""
         param1 = 1.2345
         z = 2.3
         base = qp.RX(param1, wires=0)
@@ -527,8 +518,11 @@ class TestMiscMethods:
         assert copied_op.__class__ is op.__class__
         assert copied_op.z == op.z
         assert copied_op.data == (param1,)
+        assert copied_op.base is not op.base
 
-        copied_op.data = (6.54,)
+        copied_op = qp.ops.functions.bind_new_parameters(copied_op, (6.54,))
+
+        assert copied_op.data == (6.54,)
         assert op.data == (param1,)
 
     def test_label(self):

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -231,7 +231,7 @@ class TestProperties:
     """Test Pow properties."""
 
     def test_data(self, power_method):
-        """Test base data can be get and set through Pow class."""
+        """Test base data can be get and stay read-only."""
         x = np.array(1.234)
 
         base = qp.RX(x, wires="a")

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -124,7 +124,7 @@ class TestInitialization:
         """Test that data cannot be reassigned on a symbolic operator."""
         op = s_prod(0.1, qp.PauliX(0))
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="property 'data' of 'SProd' object has no setter"):
             setattr(op, "data", (0.2,))
 
     @pytest.mark.parametrize("scalar, op", ops)

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -120,37 +120,12 @@ class TestInitialization:
         sprod_op = s_prod(9.87, qp.Rot(1.23, 4.0, 5.67, wires=1))
         assert sprod_op.data == (9.87, 1.23, 4.0, 5.67)
 
-    def test_data_setter(self):
-        """Test the setter method for data"""
-        scalar, angles = (9.87, (1.23, 4.0, 5.67))
-        old_data = (9.87, 1.23, 4.0, 5.67)
-
-        sprod_op = s_prod(scalar, qp.Rot(*angles, wires=1))
-        assert sprod_op.data == old_data
-
-        new_data = (1.23, 0.0, -1.0, -2.0)
-        sprod_op.data = new_data
-        assert sprod_op.data == new_data
-        assert sprod_op.scalar == new_data[0]
-        assert sprod_op.base.data == new_data[1:]
-
-    def test_data_setter_shallow(self):
-        """Test the setter method for data with a non-parametric base op."""
+    def test_data_is_read_only(self):
+        """Test that data cannot be reassigned on a symbolic operator."""
         op = s_prod(0.1, qp.PauliX(0))
-        op.data = (0.2,)
-        assert op.data == (0.2,) == (op.scalar,)
 
-    def test_data_setter_deep(self):
-        """Test the setter method for data with a deep base operator."""
-        op = s_prod(0.1, qp.sum(qp.PauliX(0), qp.prod(qp.PauliY(0), qp.RX(0.2, 1))))
-        assert op.data == (0.1, 0.2)
-
-        new_data = (0.3, 0.4)
-        op.data = new_data
-        assert op.data == new_data
-        assert op.scalar == 0.3
-        assert op.base[1].data == (0.4,)
-        assert op.base[1][1].data == (0.4,)
+        with pytest.raises(AttributeError):
+            op.data = (0.2,)
 
     @pytest.mark.parametrize("scalar, op", ops)
     def test_terms(self, op, scalar):

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -125,7 +125,7 @@ class TestInitialization:
         op = s_prod(0.1, qp.PauliX(0))
 
         with pytest.raises(AttributeError):
-            op.data = (0.2,)
+            setattr(op, "data", (0.2,))
 
     @pytest.mark.parametrize("scalar, op", ops)
     def test_terms(self, op, scalar):

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -56,8 +56,7 @@ def test_initialization():
 
 
 def test_copy():
-    """Test that a copy of the operator can have its parameters updated independently
-    of the original operator."""
+    """Test that a copy can be rebound independently of the original."""
     param1 = 1.234
     base = Operator(param1, "a")
     op = SymbolicOp(base)
@@ -66,8 +65,11 @@ def test_copy():
 
     assert copied_op.__class__ is op.__class__
     assert copied_op.data == (param1,)
+    assert copied_op.base is not op.base
 
-    copied_op.data = (6.54,)
+    copied_op = qp.ops.functions.bind_new_parameters(copied_op, (6.54,))
+
+    assert copied_op.data == (6.54,)
     assert op.data == (param1,)
 
 
@@ -93,8 +95,7 @@ class TestProperties:
     # pylint:disable=too-few-public-methods
 
     def test_data(self):
-        """Test that the data property for symbolic ops allows for the getting
-        and setting of the base operator's data."""
+        """Test that the data property for symbolic ops is read-only."""
         x = np.array(1.234)
 
         base = Operator(x, "a")
@@ -102,16 +103,8 @@ class TestProperties:
 
         assert op.data == (x,)
 
-        # update parameters through op
-        x_new = np.array(2.345)
-        op.data = (x_new,)
-        assert base.data == (x_new,)
-        assert op.data == (x_new,)
-
-        # update base data updates symbolic data
-        x_new2 = np.array(3.45)
-        base._data = (x_new2,)
-        assert op.data == (x_new2,)
+        with pytest.raises(AttributeError):
+            op.data = (np.array(2.345),)
 
     def test_parameters(self):
         """Test parameter property is a list of the base's trainable parameters."""
@@ -234,22 +227,13 @@ class TestScalarSymbolicOp:
         assert op.data[1] == 1.1
 
     def test_data(self):
-        """Tests the data property."""
+        """Test that the data property is read-only."""
         op = TempScalar(Operator(1.1, wires=[0]), 2.2)
         assert op.scalar == 2.2
         assert op.data == (2.2, 1.1)
 
-        # check setting through ScalarSymbolicOp
-        op.data = (3.3, 4.4)  # pylint:disable=attribute-defined-outside-init
-        assert op.data == (3.3, 4.4)
-        assert op.scalar == 3.3
-        assert op.base.data == (4.4,)
-
-        # check setting through base
-        op.base._data = (5.5,)
-        assert op.data == (3.3, 5.5)
-        assert op.scalar == 3.3
-        assert op.base.data == (5.5,)
+        with pytest.raises(AttributeError):
+            op.data = (3.3, 4.4)
 
     def test_hash(self):
         """Test that a hash correctly identifies ScalarSymbolicOps."""

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -233,7 +233,7 @@ class TestScalarSymbolicOp:
         assert op.data == (2.2, 1.1)
 
         with pytest.raises(AttributeError):
-            op.data = (3.3, 4.4)
+            op.data = (3.3, 4.4)  # pylint:disable=attribute-defined-outside-init
 
     def test_hash(self):
         """Test that a hash correctly identifies ScalarSymbolicOps."""

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -104,7 +104,7 @@ class TestProperties:
         assert op.data == (x,)
 
         with pytest.raises(AttributeError):
-            op.data = (np.array(2.345),)
+            setattr(op, "data", (np.array(2.345),))
 
     def test_parameters(self):
         """Test parameter property is a list of the base's trainable parameters."""
@@ -233,7 +233,7 @@ class TestScalarSymbolicOp:
         assert op.data == (2.2, 1.1)
 
         with pytest.raises(AttributeError):
-            op.data = (3.3, 4.4)  # pylint:disable=attribute-defined-outside-init
+            setattr(op, "data", (3.3, 4.4))
 
     def test_hash(self):
         """Test that a hash correctly identifies ScalarSymbolicOps."""

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -103,7 +103,9 @@ class TestProperties:
 
         assert op.data == (x,)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'SymbolicOp' object has no setter"
+        ):
             setattr(op, "data", (np.array(2.345),))
 
     def test_parameters(self):
@@ -232,7 +234,9 @@ class TestScalarSymbolicOp:
         assert op.scalar == 2.2
         assert op.data == (2.2, 1.1)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'TempScalar' object has no setter"
+        ):
             setattr(op, "data", (3.3, 4.4))
 
     def test_hash(self):

--- a/tests/ops/op_math/test_symbolic_op.py
+++ b/tests/ops/op_math/test_symbolic_op.py
@@ -110,7 +110,7 @@ class TestProperties:
 
         # update base data updates symbolic data
         x_new2 = np.array(3.45)
-        base.data = (x_new2,)
+        base._data = (x_new2,)
         assert op.data == (x_new2,)
 
     def test_parameters(self):
@@ -246,7 +246,7 @@ class TestScalarSymbolicOp:
         assert op.base.data == (4.4,)
 
         # check setting through base
-        op.base.data = (5.5,)
+        op.base._data = (5.5,)
         assert op.data == (3.3, 5.5)
         assert op.scalar == 3.3
         assert op.base.data == (5.5,)

--- a/tests/templates/subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/subroutines/test_hilbert_schmidt.py
@@ -308,13 +308,14 @@ class TestHilbertSchmidt:
             qp.assert_equal(op1, op2)
 
     def test_data(self):
-        """Test that the data property gets and sets the correct values"""
+        """Test that the data property is read-only."""
         op = qp.HilbertSchmidt(
             [qp.RX(1, wires=0), qp.RX(2, wires=1)], [qp.RY(3, wires=2), qp.RZ(4, wires=3)]
         )
         assert op.data == (1, 2, 3, 4)
-        op.data = [4, 5, 6, 7]
-        assert op.data == (4, 5, 6, 7)
+
+        with pytest.raises(AttributeError):
+            setattr(op, "data", [4, 5, 6, 7])
 
     def test_copy(self):
         """Test that a HilbertSchmidt operator can be copied."""

--- a/tests/templates/subroutines/test_hilbert_schmidt.py
+++ b/tests/templates/subroutines/test_hilbert_schmidt.py
@@ -314,7 +314,9 @@ class TestHilbertSchmidt:
         )
         assert op.data == (1, 2, 3, 4)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError, match="property 'data' of 'HilbertSchmidt' object has no setter"
+        ):
             setattr(op, "data", [4, 5, 6, 7])
 
     def test_copy(self):

--- a/tests/templates/subroutines/test_qsvt.py
+++ b/tests/templates/subroutines/test_qsvt.py
@@ -190,11 +190,12 @@ class TestQSVTBasics:
         assert op.label(base_label="custom_label") == "custom_label"
 
     def test_data(self):
-        """Test that the data property gets and sets the correct values"""
+        """Test that the data property is read-only."""
         op = qp.QSVT(qp.RX(1, wires=0), [qp.RY(2, wires=0), qp.RZ(3, wires=0)])
         assert op.data == (1, 2, 3)
-        op.data = [4, 5, 6]
-        assert op.data == (4, 5, 6)
+
+        with pytest.raises(AttributeError):
+            setattr(op, "data", [4, 5, 6])
 
     def test_copy(self):
         """Test that a QSVT operator can be copied."""

--- a/tests/templates/subroutines/test_qsvt.py
+++ b/tests/templates/subroutines/test_qsvt.py
@@ -194,7 +194,7 @@ class TestQSVTBasics:
         op = qp.QSVT(qp.RX(1, wires=0), [qp.RY(2, wires=0), qp.RZ(3, wires=0)])
         assert op.data == (1, 2, 3)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(AttributeError, match="property 'data' of 'QSVT' object has no setter"):
             setattr(op, "data", [4, 5, 6])
 
     def test_copy(self):


### PR DESCRIPTION
**Context:**

`Operator.data` is never supposed to be mutable. This will cause huge issue with `Operator2`, as well as contract conflicts between legacy and Op2.

**Description of the Change:**

  `Operator.data` is now a read-only property backed by the internal `_data`
  attribute. Assigning to `op.data` is no longer supported.

  This applies to base operators and the operator families that previously
  implemented custom setters, including `SymbolicOp` (such as `SProd`, `Adjoint`,
  and `Exp`), `Pow`, `CompositeOp`, `Evolution`, `HilbertSchmidt`, and `QSVT`.
  `Select` and `PrepSelPrep` retain their read-only, derived `data` properties.

  To create an operator with updated parameters, use
  `qml.ops.functions.bind_new_parameters` instead:

  ```python
  op = qml.RX(0.1, wires=0)
  op = qml.ops.functions.bind_new_parameters(op, (0.2,))
  ```

  Support for rebinding nested parameters was added for HilbertSchmidt,
  LocalHilbertSchmidt, and QSVT. Internal adaptive optimization code now
  uses this public rebinding mechanism as well.

*Test Adjustments*

  Tests that previously reassigned `op.data` now verify that it is read-only and
  use `bind_new_parameters` when an updated operator is needed.

  Additional rebinding tests cover operators whose `data` is derived from nested
  operators rather than stored directly. For example, `Select` flattens the data
  of its selected operations, so rebinding must reconstruct those operations
  instead of assigning to `Select.data`. These tests verify that reconstruction
  updates the nested parameters while preserving the original operator.

**Benefits:**
Consistent contract for both the legacy `Operator` and new `Operator2`

**Possible Drawbacks:**
Jump scares for any users who ever depended on this `op.data = ` API
For example the **_demos_**. We can check if there's any relevant failures in https://github.com/PennyLaneAI/demos/actions/runs/29358298050/job/87171572099; the results indicate that no demo breaks for this change (the only failed demo build is due to a known unrelated issue)

**Related GitHub Issues:**
[sc-124598](https://app.shortcut.com/xanaduai/story/124598)