### PR TITLE
Update `test_decomposition_graph` mocker

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -884,6 +884,7 @@
     [(#9760)](https://github.com/PennyLaneAI/pennylane/pull/9760)
     [(#9770)](https://github.com/PennyLaneAI/pennylane/pull/9770)
     [(#9825)](https://github.com/PennyLaneAI/pennylane/pull/9825)
+    [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -494,9 +494,11 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         if op_name in self._fixed_decomps:
             return [self._fixed_decomps[op_name]]
 
-        decomps = self._alt_decomps.get(op_name, []) + list_decomps(op_name)
+        decomps = self._alt_decomps.get(op_name, []) + list_decomps(op)
 
-        # TODO: symbolic decomposition rules for Operator2 are handled in a follow-up [sc-123156]
+        # Symbolic decomposition rules of Operator2 are handled differently, i.e., they
+        # are integrated into list_decomps so that the graph would not be responsible
+        # for populating these symbolic decomposition rules.
         if isinstance(op, Operator2):
             return decomps
 

--- a/tests/decomposition/conftest.py
+++ b/tests/decomposition/conftest.py
@@ -17,6 +17,7 @@
 # pylint: disable=too-few-public-methods,protected-access
 
 from collections import defaultdict
+from functools import singledispatch
 
 import pennylane as qp
 from pennylane.core.operator import abstractify
@@ -27,10 +28,16 @@ from pennylane.decomposition.symbolic_decomposition import (
     pow_rotation,
     self_adjoint_legacy,
 )
+from pennylane.decomposition.utils import to_name
 from pennylane.ops.identity import _controlled_g_phase_decomp
 from pennylane.ops.qubit.non_parametric_ops import _controlled_hadamard, _controlled_x_decomp
 
 decompositions = defaultdict(list)
+
+
+@singledispatch
+def list_test_decomps(op):
+    return decompositions[to_name(op)]
 
 
 def to_resources(gate_count: dict, weighted_cost: float | None = None) -> Resources:

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -21,16 +21,15 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from conftest import decompositions, to_resources  # pylint: disable=no-name-in-module
 from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import DecompositionGraph, pow_resource_rep
 from pennylane.decomposition.decomposition_graph import _DecompositionNode
-from pennylane.decomposition.utils import to_name
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract
 from pennylane.typing import Float, Wire
 from tests.core.operator.operator2_utils import DynOp, OneWireDynOp, ParametrizedHybridOp
+from tests.decomposition.conftest import decompositions, list_test_decomps, to_resources
 
 # pylint: disable=protected-access,no-name-in-module,too-few-public-methods,useless-parent-delegation
 
@@ -68,7 +67,7 @@ class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
 @pytest.mark.unit
 @patch(
     "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=lambda x: decompositions[to_name(x)],
+    side_effect=list_test_decomps,
 )
 class TestDecompositionGraph:
     """Unit tests for the decomposition graph."""
@@ -707,7 +706,7 @@ class TestDecompositionGraph:
 @pytest.mark.unit
 @patch(
     "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=lambda x: decompositions[x],
+    side_effect=list_test_decomps,
 )
 class TestControlledDecompositions:
     """Tests that the decomposition graph can handle controlled decompositions."""
@@ -859,7 +858,7 @@ class TestControlledDecompositions:
 
 @patch(
     "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=lambda x: decompositions[x],
+    side_effect=list_test_decomps,
 )
 class TestSymbolicDecompositions:
     """Tests decompositions of symbolic ops."""


### PR DESCRIPTION
**Context:**

`test_decomposition_graph` mocked out `list_decomps`, which is making testing very annoying with `Operator2` as we added more flexibility to `list_decomps`. Update the mock behaviour to mirror the real `list_decomps` for flexibility in the future.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124714]