### PR TITLE
Run capture, decomp, diff checks in assert_valid for Operator2

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -772,7 +772,7 @@
   ``QuantumScript([adjoint(op) for op in reversed(tape.operations)])``.
   [(#9483)](https://github.com/PennyLaneAI/pennylane/pull/9483)
 
-* The ``Opechration.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
+* The ``Operation.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
 
 <h3>Internal changes ⚙️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -889,6 +889,8 @@
     [(#9770)](https://github.com/PennyLaneAI/pennylane/pull/9770)
     [(#9825)](https://github.com/PennyLaneAI/pennylane/pull/9825)
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
+  - Capture and graph decomp checks are run in assert_valid.
+    [(#9842)](https://github.com/PennyLaneAI/pennylane/pull/9842)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -772,7 +772,7 @@
   ``QuantumScript([adjoint(op) for op in reversed(tape.operations)])``.
   [(#9483)](https://github.com/PennyLaneAI/pennylane/pull/9483)
 
-* The ``Operation.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
+* The ``Opechration.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
 
 <h3>Internal changes ⚙️</h3>
 
@@ -890,7 +890,7 @@
     [(#9770)](https://github.com/PennyLaneAI/pennylane/pull/9770)
     [(#9825)](https://github.com/PennyLaneAI/pennylane/pull/9825)
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
-  - Capture and graph decomp checks are run in assert_valid.
+  - Capture, graph decomp and differentiation checks are run in assert_valid.
     [(#9842)](https://github.com/PennyLaneAI/pennylane/pull/9842)
 
 * Adds a new `pennylane/core` module.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -890,7 +890,7 @@
     [(#9770)](https://github.com/PennyLaneAI/pennylane/pull/9770)
     [(#9825)](https://github.com/PennyLaneAI/pennylane/pull/9825)
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
-  - Capture, graph decomp and differentiation checks are run in assert_valid.
+  - Capture, graph decomp and differentiation checks are run in :func:`~.assert_valid`.
     [(#9842)](https://github.com/PennyLaneAI/pennylane/pull/9842)
 
 * Adds a new `pennylane/core` module.

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -146,15 +146,17 @@ def _check_decomposition(op, skip_wire_mapping):
 def _check_decomposition_new(op, skip_decomp_matrix_check=False):
     """Checks involving the new system of decompositions."""
     op_type = type(op)
-    if op_type.resource_params is qp.operation.Operator.resource_params:
-        assert not qp.decomposition.has_decomp(
-            op_type
-        ), "resource_params must be defined for operators with decompositions"
-        return
 
-    assert set(op.resource_params.keys()) == set(
-        op_type.resource_keys
-    ), "resource_params must have the same keys as specified by resource_keys"
+    if not isinstance(op, Operator2):
+        if op_type.resource_params is qp.operation.Operator.resource_params:
+            assert not qp.decomposition.has_decomp(
+                op_type
+            ), "resource_params must be defined for operators with decompositions"
+            return
+
+        assert set(op.resource_params.keys()) == set(
+            op_type.resource_keys
+        ), "resource_params must have the same keys as specified by resource_keys"
 
     for rule in qp.list_decomps(op_type):
         _test_decomposition_rule(op, rule, skip_decomp_matrix_check)

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -473,7 +473,9 @@ def _check_capture(op):
         data, struct = jax.tree_util.tree_flatten(op)
 
         def test_fn(*args):
-            return jax.tree_util.tree_unflatten(struct, args)
+            op = jax.tree_util.tree_unflatten(struct, args)
+            op._bind_primitive()
+            return op.tracer
 
         jaxpr = jax.make_jaxpr(test_fn)(*data)
         new_op = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *data)[0]

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -709,10 +709,6 @@ def assert_valid(
     """
 
     if isinstance(op, qp.core.Operator2):
-        # Temporary, as we will be integrating Operator2 with program capture soon
-        skip_capture = True
-        # Temporary, as we will be integrating Operator2 with graph decomps soon
-        skip_new_decomp = True
         # Temporary, as we will integrate with differentiation soon
         skip_differentiation = True
 

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -474,8 +474,10 @@ def _check_capture(op):
 
         def test_fn(*args):
             op = jax.tree_util.tree_unflatten(struct, args)
-            op._bind_primitive()
-            return op.tracer
+            if isinstance(op, Operator2):
+                op._bind_primitive()
+                return op.tracer
+            return op
 
         jaxpr = jax.make_jaxpr(test_fn)(*data)
         new_op = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *data)[0]

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -715,9 +715,6 @@ def assert_valid(
     """
 
     if isinstance(op, qp.core.Operator2):
-        # Temporary, as we will integrate with differentiation soon
-        skip_differentiation = True
-
         _assert_valid_operator2(
             op,
             skip_deepcopy,

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -501,7 +501,7 @@ class SingleRZ(Operator2):
     def generator(self):
         return qp.Hamiltonian([-0.5], [qp.PauliZ(wires=self.wires)])
 
-
+@pytest.mark.jax
 class TestOperator2AssertValid:
     """Tests showing that ``assert_valid`` works on :class:`~.core.Operator2` instances thanks to
     the backwards-compatible ``data``/``parameters``/``num_params``/``hyperparameters`` attributes.
@@ -609,7 +609,6 @@ class TestOperator2AssertValid:
         ):
             assert_valid(BadSparse(0.5, wires=[0, 1]), skip_pickle=True)
 
-    @pytest.mark.jax
     def test_check_eigendecomposition(self):
         """``_check_eigendecomposition`` fails if the eigenvalues and diagonalizing gates cannot
         reproduce the operator."""

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -609,6 +609,7 @@ class TestOperator2AssertValid:
         ):
             assert_valid(BadSparse(0.5, wires=[0, 1]), skip_pickle=True)
 
+    @pytest.mark.jax
     def test_check_eigendecomposition(self):
         """``_check_eigendecomposition`` fails if the eigenvalues and diagonalizing gates cannot
         reproduce the operator."""

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -501,6 +501,7 @@ class SingleRZ(Operator2):
     def generator(self):
         return qp.Hamiltonian([-0.5], [qp.PauliZ(wires=self.wires)])
 
+
 @pytest.mark.jax
 class TestOperator2AssertValid:
     """Tests showing that ``assert_valid`` works on :class:`~.core.Operator2` instances thanks to


### PR DESCRIPTION
**Context:** We had temporarily disabled these checks for Operator2 since Operator2 was not integrated with capture or graph decomps yet. That has changed!

**Description of the Change:** We now want to run these checks, so we no longer skip them.

**Benefits:** We get better coverage from assert_valid.

**Possible Drawbacks:** Running CI to see what if anything now fails.

**Related GitHub Issues:** [sc-124737] [sc-124738]
