### PR TITLE
`DecompositionGraph` uses `local_decomps` context for custom decomps

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -889,6 +889,7 @@
     [(#9770)](https://github.com/PennyLaneAI/pennylane/pull/9770)
     [(#9825)](https://github.com/PennyLaneAI/pennylane/pull/9825)
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
+    [(#9843)](https://github.com/PennyLaneAI/pennylane/pull/9843)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -497,6 +497,9 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         if isinstance(op, Operator2):
             return decomps
 
+        if to_name(op) in self._fixed_decomps:
+            return decomps
+
         if (
             issubclass(op.op_type, qp.ops.Adjoint)
             and self_adjoint_legacy not in decomps

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -486,15 +486,10 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
             and op.params["num_control_wires"] > ctrl_wires_in_progress[-1]
         )
 
-    def _get_decompositions(self, op: AbstractOperatorLike) -> list[DecompositionRule]:
+    def _get_decompositions(self, op: AbstractOperatorLike) -> Iterable[DecompositionRule]:
         """Helper function to get a list of decomposition rules."""
 
-        op_name = to_name(op)
-
-        if op_name in self._fixed_decomps:
-            return [self._fixed_decomps[op_name]]
-
-        decomps = self._alt_decomps.get(op_name, []) + list_decomps(op)
+        decomps = list_decomps(op, self._fixed_decomps, self._alt_decomps)
 
         # Symbolic decomposition rules of Operator2 are handled differently, i.e., they
         # are integrated into list_decomps so that the graph would not be responsible

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -43,7 +43,10 @@ from .decomposition_rule import (
     DecompositionRule,
     WorkWireSpec,
     _decomp_contains_mcm,
+    _fix_decomp,
+    add_decomps,
     list_decomps,
+    local_decomps,
     null_decomp,
 )
 from .resources import AbstractOperatorLike, CompressedResourceOp, Resources, resource_rep
@@ -288,7 +291,15 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         self._in_progress = []
         self._num_ctrl_wires_in_progress = defaultdict(list)
 
-        self._construct_graph(operations)
+        with local_decomps():
+
+            for op, decomps in self._alt_decomps.items():
+                add_decomps(op, *decomps)
+
+            for op, decomp in self._fixed_decomps.items():
+                _fix_decomp(op, decomp)
+
+            self._construct_graph(operations)
 
     def _construct_graph(self, operations: Iterable[Operator | AbstractOperatorLike]):
         """Constructs the decomposition graph."""
@@ -489,7 +500,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
     def _get_decompositions(self, op: AbstractOperatorLike) -> Iterable[DecompositionRule]:
         """Helper function to get a list of decomposition rules."""
 
-        decomps = list_decomps(op, self._fixed_decomps, self._alt_decomps)
+        decomps = list_decomps(op)
 
         # Symbolic decomposition rules of Operator2 are handled differently, i.e., they
         # are integrated into list_decomps so that the graph would not be responsible

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -284,13 +284,19 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
         self._min_work_wires = 0
         self._start = self._graph.add_node(None)
 
-        # The purpose of the following two "in_progress" variables is to keep track of which operators we're still exploring
-        # decomposition paths for during **graph construction**. If we loop back to an
-        # op that we're still exploring (e.g., if we find ourselves exploring decomposition
-        # rules for C(RX) during exploration of RX itself), we stop.
+        # The purpose of the following two "in_progress" variables is to keep track of which
+        # operators we're still exploring decomposition paths for during **graph construction**.
+        # If we loop back to an op that we're still exploring (e.g., if we find ourselves
+        # exploring decomposition rules for C(RX) during exploration of RX itself), we stop.
         self._in_progress = []
         self._num_ctrl_wires_in_progress = defaultdict(list)
 
+        # Update the global decomposition library using alt_decomps and fixed_decomps in a local
+        # context manager (which restores it to the original state upon exit), so that list_decomps
+        # will always return the modified collection of decomposition rules. This is important
+        # because when list_decomps is called on symbolic operators, it recursively calls itself
+        # on the base of the symbolic operator to retrieve the base decomposition rules. When this
+        # happens, we need alt_decomps and fixed_decomps to still be respected.
         with local_decomps():
 
             for op, decomps in self._alt_decomps.items():

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -724,11 +724,7 @@ def add_decomps(op_type: type[Operator] | str, *decomps: DecompositionRule) -> N
 
 
 @singledispatch
-def list_decomps(
-    op: type[Operator] | Operator | str,
-    fixed_decomps: dict[str, DecompositionRule] | None = None,
-    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
-) -> DecompCollection:
+def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
     """Lists all stored decomposition rules for an operator class.
 
     .. note::
@@ -739,10 +735,9 @@ def list_decomps(
         decomposition rules for an operator.
 
     Args:
-        op (type or Operator or str): the operator or operator type to retrieve decomposition rules for.
-            For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
-        fixed_decomps (dict, optional): A dictionary mapping operator names to fixed decompositions.
-        alt_decomps (dict, optional): A dictionary mapping operator names to alternative decompositions.
+        op (type or Operator or str): the operator or operator type to retrieve decomposition
+            rules for. For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``,
+            ``"C(RX)"``, etc.
 
     Returns:
         DecompCollection: a collection of decomposition rules registered for the given operator.
@@ -786,14 +781,7 @@ def list_decomps(
     1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
 
     """
-    fixed_decomps = fixed_decomps or {}
-    alt_decomps = alt_decomps or {}
-    if (op_name := to_name(op)) in fixed_decomps:
-        return DecompCollection([fixed_decomps[op_name]])
-    rules = _decompositions_var.get()[to_name(op)].copy()
-    if op_name in alt_decomps:
-        rules.extend(alt_decomps[op_name])
-    return rules
+    return _decompositions_var.get()[to_name(op)].copy()
 
 
 def has_decomp(op: type[Operator] | Operator | str) -> bool:
@@ -807,8 +795,9 @@ def has_decomp(op: type[Operator] | Operator | str) -> bool:
         decomposition rules for an operator.
 
     Args:
-        op (type or Operator or str): the operator or operator type to check for decomposition rules.
-            For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
+        op (type or Operator or str): the operator or operator type to check for
+            decomposition rules. For symbolic operators, use strings like ``"Adjoint(RY)"``,
+            ``"Pow(H)"``, ``"C(RX)"``, etc.
 
     Returns:
         bool: whether decomposition rules are defined for the given operator.
@@ -824,13 +813,17 @@ def local_decomps():
     This context manager is thread-safe because it uses ``ContextVar`` under the hood.
 
     """
-    current_decomps = {k: v.copy() for k, v in _decompositions_private.items()}
+    current_decomps = {k: v.copy() for k, v in _decompositions_var.get().items()}
     _new_decomps = defaultdict(DecompCollection, current_decomps)
     token = _decompositions_var.set(_new_decomps)
     try:
         yield
     finally:
         _decompositions_var.reset(token)
+
+
+def _fix_decomp(op, rule):
+    _decompositions_var.get()[to_name(op)] = DecompCollection([rule])
 
 
 class _DecompInfo:  # pylint: disable=too-few-public-methods

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -643,6 +643,11 @@ _decompositions_private = defaultdict(DecompCollection)
 
 _decompositions_var = ContextVar("_decompositions", default=_decompositions_private)
 
+_fixed_decomps_private = {}
+"""dict[str, DecompositionRule]: A dictionary mapping operators a unique decomposition rule."""
+
+_fixed_decomps_var = ContextVar("_fixed_decomps", default=_fixed_decomps_private)
+
 
 def add_decomps(op_type: type[Operator] | str, *decomps: DecompositionRule) -> None:
     """Globally registers new decomposition rules with an operator class.
@@ -778,6 +783,8 @@ def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
     1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
 
     """
+    if fixed_rule := get_fixed_decomp(op):
+        return DecompCollection([fixed_rule])
     return _decompositions_var.get()[to_name(op)].copy()
 
 
@@ -810,17 +817,39 @@ def local_decomps():
     This context manager is thread-safe because it uses ``ContextVar`` under the hood.
 
     """
+
+    # Handle the global decomposition library.
     current_decomps = {k: v.copy() for k, v in _decompositions_var.get().items()}
     _new_decomps = defaultdict(DecompCollection, current_decomps)
-    token = _decompositions_var.set(_new_decomps)
+    token_all_decomps = _decompositions_var.set(_new_decomps)
+
+    # Handle the registry of fixed decomposition rules.
+    _new_fixed_decomps = _fixed_decomps_var.get().copy()
+    token_fixed_decomps = _fixed_decomps_var.set(_new_fixed_decomps)
+
     try:
         yield
     finally:
-        _decompositions_var.reset(token)
+        _decompositions_var.reset(token_all_decomps)
+        _fixed_decomps_var.reset(token_fixed_decomps)
 
 
-def _fix_decomp(op, rule):
-    _decompositions_var.get()[to_name(op)] = DecompCollection([rule])
+def _fix_decomp(op: type[Operator] | Operator | str, rule: DecompositionRule):
+    """Fix a unique decomposition rule for an operator.
+
+    This is a developer-facing function meant to be used within a local decomps context.
+
+    """
+    _fixed_decomps_var.get()[to_name(op)] = rule
+
+
+def get_fixed_decomp(op: type[Operator] | Operator | str) -> DecompositionRule | None:
+    """Get the decomposition rule fixed to an operator if there is one.
+
+    This is a developer-facing function meant to be used within a local decomps context.
+
+    """
+    return _fixed_decomps_var.get().get(to_name(op), None)
 
 
 class _DecompInfo:  # pylint: disable=too-few-public-methods

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -603,9 +603,6 @@ class DecompCollection:
     def __len__(self) -> int:
         return len(self._decomps)
 
-    def __eq__(self, other) -> bool:
-        return self._decomps == other._decomps if isinstance(other, DecompCollection) else False
-
     def copy(self) -> DecompCollection:
         """Return a copy of the DecompCollection."""
         return DecompCollection(self._decomps)

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -603,6 +603,9 @@ class DecompCollection:
     def __len__(self) -> int:
         return len(self._decomps)
 
+    def __eq__(self, other) -> bool:
+        return self._decomps == other._decomps if isinstance(other, DecompCollection) else False
+
     def copy(self) -> DecompCollection:
         """Return a copy of the DecompCollection."""
         return DecompCollection(self._decomps)
@@ -721,7 +724,11 @@ def add_decomps(op_type: type[Operator] | str, *decomps: DecompositionRule) -> N
 
 
 @singledispatch
-def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
+def list_decomps(
+    op: type[Operator] | Operator | str,
+    fixed_decomps: dict[str, DecompositionRule] | None = None,
+    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
+) -> DecompCollection:
     """Lists all stored decomposition rules for an operator class.
 
     .. note::
@@ -732,9 +739,10 @@ def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
         decomposition rules for an operator.
 
     Args:
-        op (type or Operator or str): the operator or operator type to retrieve decomposition
-            rules for. For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``,
-            ``"C(RX)"``, etc.
+        op (type or Operator or str): the operator or operator type to retrieve decomposition rules for.
+            For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
+        fixed_decomps (dict, optional): A dictionary mapping operator names to fixed decompositions.
+        alt_decomps (dict, optional): A dictionary mapping operator names to alternative decompositions.
 
     Returns:
         DecompCollection: a collection of decomposition rules registered for the given operator.
@@ -778,7 +786,14 @@ def list_decomps(op: type[Operator] | Operator | str) -> DecompCollection:
     1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
 
     """
-    return _decompositions_var.get()[to_name(op)].copy()
+    fixed_decomps = fixed_decomps or {}
+    alt_decomps = alt_decomps or {}
+    if (op_name := to_name(op)) in fixed_decomps:
+        return DecompCollection([fixed_decomps[op_name]])
+    rules = _decompositions_var.get()[to_name(op)].copy()
+    if op_name in alt_decomps:
+        rules.extend(alt_decomps[op_name])
+    return rules
 
 
 def has_decomp(op: type[Operator] | Operator | str) -> bool:
@@ -792,9 +807,8 @@ def has_decomp(op: type[Operator] | Operator | str) -> bool:
         decomposition rules for an operator.
 
     Args:
-        op (type or Operator or str): the operator or operator type to check for
-            decomposition rules. For symbolic operators, use strings like ``"Adjoint(RY)"``,
-            ``"Pow(H)"``, ``"C(RX)"``, etc.
+        op (type or Operator or str): the operator or operator type to check for decomposition rules.
+            For symbolic operators, use strings like ``"Adjoint(RY)"``, ``"Pow(H)"``, ``"C(RX)"``, etc.
 
     Returns:
         bool: whether decomposition rules are defined for the given operator.

--- a/pennylane/ops/op_math/adjoint2.py
+++ b/pennylane/ops/op_math/adjoint2.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Defines the base class for the adjoint of operators."""
 
-from collections.abc import Sequence
 from textwrap import dedent
 
 from typing_extensions import override
@@ -170,26 +169,15 @@ class Adjoint2(SymbolicOp2):
 
 
 @list_decomps.register
-def _list_adjoint_decomps(
-    op: Adjoint2,
-    fixed_decomps: dict[str, DecompositionRule] | None = None,
-    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
-) -> DecompCollection:
-    """Populates the decomposition rules for an adjoint operator."""
-
+def _list_adjoint_decomps(op: Adjoint2) -> DecompCollection:
     abs_op = abstractify(op)
-
     if isinstance(abs_op.base, Adjoint2):
         return DecompCollection([cancel_adjoint])
-
-    # Custom decomposition rules registered specifically for this adjoint operator.
-    custom_rules = list_decomps.dispatch(object)(abs_op, fixed_decomps, alt_decomps)
-
-    # Applying adjoint to the decomposition rules of the base.
+    custom_rules = list_decomps.dispatch(object)(abs_op)
     wrapped_rules = DecompCollection(
         [
             _make_adjoint_decomp(rule)
-            for rule in list_decomps(abs_op.base, fixed_decomps, alt_decomps)
+            for rule in list_decomps(abs_op.base)
             # It only makes sense to wrap a decomposition rule with adjoint if the decomposition
             # does not dynamically allocate wires and does not contain mid-circuit measurements.
             if rule.get_work_wire_spec(**abs_op.base.arguments).total == 0

--- a/pennylane/ops/op_math/adjoint2.py
+++ b/pennylane/ops/op_math/adjoint2.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Defines the base class for the adjoint of operators."""
 
+from collections.abc import Sequence
 from textwrap import dedent
 
 from typing_extensions import override
@@ -169,15 +170,26 @@ class Adjoint2(SymbolicOp2):
 
 
 @list_decomps.register
-def _list_adjoint_decomps(op: Adjoint2) -> DecompCollection:
+def _list_adjoint_decomps(
+    op: Adjoint2,
+    fixed_decomps: dict[str, DecompositionRule] | None = None,
+    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
+) -> DecompCollection:
+    """Populates the decomposition rules for an adjoint operator."""
+
     abs_op = abstractify(op)
+
     if isinstance(abs_op.base, Adjoint2):
         return DecompCollection([cancel_adjoint])
-    custom_rules = list_decomps.dispatch(object)(abs_op)
+
+    # Custom decomposition rules registered specifically for this adjoint operator.
+    custom_rules = list_decomps.dispatch(object)(abs_op, fixed_decomps, alt_decomps)
+
+    # Applying adjoint to the decomposition rules of the base.
     wrapped_rules = DecompCollection(
         [
             _make_adjoint_decomp(rule)
-            for rule in list_decomps(abs_op.base)
+            for rule in list_decomps(abs_op.base, fixed_decomps, alt_decomps)
             # It only makes sense to wrap a decomposition rule with adjoint if the decomposition
             # does not dynamically allocate wires and does not contain mid-circuit measurements.
             if rule.get_work_wire_spec(**abs_op.base.arguments).total == 0

--- a/pennylane/ops/op_math/adjoint2.py
+++ b/pennylane/ops/op_math/adjoint2.py
@@ -26,6 +26,7 @@ from pennylane.decomposition.decomposition_rule import (
     DecompCollection,
     DecompositionRule,
     _decomp_contains_mcm,
+    get_fixed_decomp,
     list_decomps,
     register_condition,
     register_resources,
@@ -170,10 +171,21 @@ class Adjoint2(SymbolicOp2):
 
 @list_decomps.register
 def _list_adjoint_decomps(op: Adjoint2) -> DecompCollection:
+
     abs_op = abstractify(op)
+
+    # fixed_decomps would override everything.
+    if fixed_rule := get_fixed_decomp(op):
+        return DecompCollection([fixed_rule])
+
+    # special case of cancelling nested adjoints.
     if isinstance(abs_op.base, Adjoint2):
         return DecompCollection([cancel_adjoint])
+
+    # Custom decomposition rules registered specifically to the adjoint operator
     custom_rules = list_decomps.dispatch(object)(abs_op)
+
+    # Decomposition rules populated by applying adjoint on the base decomp rules
     wrapped_rules = DecompCollection(
         [
             _make_adjoint_decomp(rule)

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -30,6 +30,7 @@ from pennylane.decomposition.decomposition_rule import (
     DecompCollection,
     DecompositionRule,
     _decomp_contains_mcm,
+    get_fixed_decomp,
     list_decomps,
     register_condition,
     register_resources,
@@ -573,7 +574,13 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
 
 @list_decomps.register
 def _list_controlled_decomps(op: ControlledOp2) -> DecompCollection:
+    """Get all the decomposition rules applicable to this operator."""
+
     op = abstractify(op)
+
+    # fixed_decomps should override everything
+    if fixed_rule := get_fixed_decomp(op):
+        return DecompCollection([fixed_rule])
 
     # Special case for flipping the order of control and adjoint. We prefer to have adjoint
     # wrapping a controlled operator instead of the other way around because there is more

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -572,7 +572,13 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
 
 
 @list_decomps.register
-def _list_controlled_decomps(op: ControlledOp2) -> DecompCollection:
+def _list_controlled_decomps(
+    op: ControlledOp2,
+    fixed_decomps: dict[str, DecompositionRule] | None = None,
+    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
+) -> DecompCollection:
+    """Populates the decomposition rules for a controlled operator."""
+
     op = abstractify(op)
 
     # Special case for flipping the order of control and adjoint. We prefer to have adjoint
@@ -582,7 +588,7 @@ def _list_controlled_decomps(op: ControlledOp2) -> DecompCollection:
         return DecompCollection([flip_control_adjoint])
 
     # Get custom rules registered for this controlled operator.
-    custom_rules = list_decomps.dispatch(object)(op)
+    custom_rules = list_decomps.dispatch(object)(op, fixed_decomps, alt_decomps)
 
     # Get general fallback rules.
     general_rules = DecompCollection([])
@@ -595,7 +601,7 @@ def _list_controlled_decomps(op: ControlledOp2) -> DecompCollection:
     wrapped_rules = DecompCollection(
         [
             _make_controlled_decomp(rule)
-            for rule in list_decomps(op.base)
+            for rule in list_decomps(op.base, fixed_decomps, alt_decomps)
             if not _decomp_contains_mcm(rule, op.base.arguments)
         ]
     )

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -572,13 +572,7 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
 
 
 @list_decomps.register
-def _list_controlled_decomps(
-    op: ControlledOp2,
-    fixed_decomps: dict[str, DecompositionRule] | None = None,
-    alt_decomps: dict[str, Sequence[DecompositionRule]] | None = None,
-) -> DecompCollection:
-    """Populates the decomposition rules for a controlled operator."""
-
+def _list_controlled_decomps(op: ControlledOp2) -> DecompCollection:
     op = abstractify(op)
 
     # Special case for flipping the order of control and adjoint. We prefer to have adjoint
@@ -588,7 +582,7 @@ def _list_controlled_decomps(
         return DecompCollection([flip_control_adjoint])
 
     # Get custom rules registered for this controlled operator.
-    custom_rules = list_decomps.dispatch(object)(op, fixed_decomps, alt_decomps)
+    custom_rules = list_decomps.dispatch(object)(op)
 
     # Get general fallback rules.
     general_rules = DecompCollection([])
@@ -601,7 +595,7 @@ def _list_controlled_decomps(
     wrapped_rules = DecompCollection(
         [
             _make_controlled_decomp(rule)
-            for rule in list_decomps(op.base, fixed_decomps, alt_decomps)
+            for rule in list_decomps(op.base)
             if not _decomp_contains_mcm(rule, op.base.arguments)
         ]
     )

--- a/tests/decomposition/conftest.py
+++ b/tests/decomposition/conftest.py
@@ -17,27 +17,23 @@
 # pylint: disable=too-few-public-methods,protected-access
 
 from collections import defaultdict
-from functools import singledispatch
+from contextvars import ContextVar
 
 import pennylane as qp
 from pennylane.core.operator import abstractify
 from pennylane.decomposition import Resources
+from pennylane.decomposition.decomposition_rule import DecompCollection
 from pennylane.decomposition.symbolic_decomposition import (
     adjoint_rotation,
     pow_involutory,
     pow_rotation,
     self_adjoint_legacy,
 )
-from pennylane.decomposition.utils import to_name
 from pennylane.ops.identity import _controlled_g_phase_decomp
 from pennylane.ops.qubit.non_parametric_ops import _controlled_hadamard, _controlled_x_decomp
 
-decompositions = defaultdict(list)
-
-
-@singledispatch
-def list_test_decomps(op):
-    return decompositions[to_name(op)]
+_decompositions = defaultdict(DecompCollection)
+decompositions = ContextVar("_test_decompositions", default=_decompositions)
 
 
 def to_resources(gate_count: dict, weighted_cost: float | None = None) -> Resources:
@@ -53,7 +49,7 @@ def _cz_to_cnot(*_, **__):
     raise NotImplementedError
 
 
-decompositions["CZ"] = [_cz_to_cnot]
+decompositions.get()["CZ"].append(_cz_to_cnot)
 
 
 @qp.register_resources({qp.Hadamard: 2, qp.CZ: 1})
@@ -61,7 +57,7 @@ def _cnot_to_cz(*_, **__):
     raise NotImplementedError
 
 
-decompositions["CNOT"] = [_cnot_to_cz]
+decompositions.get()["CNOT"].append(_cnot_to_cz)
 
 
 def _multi_rz_decomposition_resources(num_wires):
@@ -73,7 +69,7 @@ def _multi_rz_decomposition(*_, **__):
     raise NotImplementedError
 
 
-decompositions["MultiRZ"] = [_multi_rz_decomposition]
+decompositions.get()["MultiRZ"].append(_multi_rz_decomposition)
 
 
 @qp.register_resources({qp.RZ: 2, qp.RX: 1, qp.GlobalPhase: 1})
@@ -86,7 +82,8 @@ def _hadamard_to_rz_ry(*_, **__):
     raise NotImplementedError
 
 
-decompositions["Hadamard"] = [_hadamard_to_rz_rx, _hadamard_to_rz_ry]
+decompositions.get()["Hadamard"].append(_hadamard_to_rz_rx)
+decompositions.get()["Hadamard"].append(_hadamard_to_rz_ry)
 
 
 @qp.register_resources({qp.RX: 1, qp.RZ: 2})
@@ -94,7 +91,7 @@ def _ry_to_rx_rz(*_, **__):
     raise NotImplementedError
 
 
-decompositions["RY"] = [_ry_to_rx_rz]
+decompositions.get()["RY"].append(_ry_to_rx_rz)
 
 
 @qp.register_resources({qp.RX: 2, qp.CZ: 2})
@@ -107,7 +104,8 @@ def _crx_to_rx_ry_cnot_ry_cnot_ry_cnot_rz(*_, **__):
     raise NotImplementedError
 
 
-decompositions["CRX"] = [_crx_to_rx_cz, _crx_to_rx_ry_cnot_ry_cnot_ry_cnot_rz]
+decompositions.get()["CRX"].append(_crx_to_rx_cz)
+decompositions.get()["CRX"].append(_crx_to_rx_ry_cnot_ry_cnot_ry_cnot_rz)
 
 
 @qp.register_resources({qp.RZ: 3, qp.CNOT: 2, qp.GlobalPhase: 1})
@@ -115,7 +113,7 @@ def _cphase_to_rz_cnot(*_, **__):
     raise NotImplementedError
 
 
-decompositions["ControlledPhaseShift"] = [_cphase_to_rz_cnot]
+decompositions.get()["ControlledPhaseShift"].append(_cphase_to_rz_cnot)
 
 
 @qp.register_resources({qp.RZ: 1, qp.GlobalPhase: 1})
@@ -123,7 +121,7 @@ def _phase_shift_to_rz_gp(*_, **__):
     raise NotImplementedError
 
 
-decompositions["PhaseShift"] = [_phase_shift_to_rz_gp]
+decompositions.get()["PhaseShift"].append(_phase_shift_to_rz_gp)
 
 
 @qp.register_resources({qp.RX: 1, qp.GlobalPhase: 1})
@@ -131,7 +129,7 @@ def _x_to_rx(*_, **__):
     raise NotImplementedError
 
 
-decompositions["PauliX"] = [_x_to_rx]
+decompositions.get()["PauliX"].append(_x_to_rx)
 
 
 @qp.register_resources({qp.PhaseShift: 1})
@@ -139,7 +137,7 @@ def _u1_ps(phi, wires, **__):
     qp.PhaseShift(phi, wires=wires)
 
 
-decompositions["U1"] = [_u1_ps]
+decompositions.get()["U1"].append(_u1_ps)
 
 
 @qp.register_resources({qp.PhaseShift: 1})
@@ -147,7 +145,7 @@ def _t_ps(wires, **__):
     raise NotImplementedError
 
 
-decompositions["T"] = [_t_ps]
+decompositions.get()["T"].append(_t_ps)
 
 
 @qp.register_resources({qp.RZ: 3, qp.RY: 2, qp.CNOT: 2})
@@ -155,19 +153,19 @@ def _crot(*_, **__):
     raise NotImplementedError
 
 
-decompositions["CRot"] = [_crot]
+decompositions.get()["CRot"].append(_crot)
 
 ################################################
 # Custom Decompositions For Symbolic Operators #
 ################################################
 
-decompositions["C(PauliX)"] = [_controlled_x_decomp]
-decompositions["C(GlobalPhase)"] = [_controlled_g_phase_decomp]
-decompositions["C(Hadamard)"] = [_controlled_hadamard]
-decompositions["Adjoint(Hadamard)"] = [self_adjoint_legacy]
-decompositions["Pow(Hadamard)"] = [pow_involutory]
-decompositions["Adjoint(RX)"] = [adjoint_rotation]
-decompositions["Pow(RX)"] = [pow_rotation]
-decompositions["Adjoint(CNOT)"] = [self_adjoint_legacy]
-decompositions["Adjoint(PhaseShift)"] = [adjoint_rotation]
-decompositions["Adjoint(ControlledPhaseShift)"] = [adjoint_rotation]
+decompositions.get()["C(PauliX)"].append(_controlled_x_decomp)
+decompositions.get()["C(GlobalPhase)"].append(_controlled_g_phase_decomp)
+decompositions.get()["C(Hadamard)"].append(_controlled_hadamard)
+decompositions.get()["Adjoint(Hadamard)"].append(self_adjoint_legacy)
+decompositions.get()["Pow(Hadamard)"].append(pow_involutory)
+decompositions.get()["Adjoint(RX)"].append(adjoint_rotation)
+decompositions.get()["Pow(RX)"].append(pow_rotation)
+decompositions.get()["Adjoint(CNOT)"].append(self_adjoint_legacy)
+decompositions.get()["Adjoint(PhaseShift)"].append(adjoint_rotation)
+decompositions.get()["Adjoint(ControlledPhaseShift)"].append(adjoint_rotation)

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -141,19 +141,33 @@ class TestDecompGraphConstruction:
             qp.add_decomps(qp.Hadamard, custom_hadamard, custom_hadamard_2)
             assert graph._get_decompositions(h_rep)._decomps == exp_dec._decomps
 
+    def test_both_fixed_and_alt_decomps(self):
+        """Tests that fixed_decomps overrides alt_decomps."""
+
+        @qp.register_resources({qp.PhaseShift: 2, qp.RX: 1})
+        def custom_hadamard(wires):
+            qp.PhaseShift(np.pi / 2, wires=wires)
+            qp.RX(np.pi / 2, wires=wires)
+            qp.PhaseShift(np.pi / 2, wires=wires)
+
+        @qp.register_resources({qp.PhaseShift: 1, qp.RY: 1})
+        def custom_hadamard_2(wires):
+            qp.PhaseShift(np.pi / 2, wires=wires)
+            qp.RY(np.pi / 2, wires=wires)
+
+        alt_dec = DecompCollection([custom_hadamard, custom_hadamard_2])
+
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
-            gate_set={"RX", "RY", "RZ"},
+            gate_set={"RX", "RY", "RZ", "GlobalPhase"},
             alt_decomps={qp.Hadamard: alt_dec},
             fixed_decomps={qp.Hadamard: custom_hadamard},
         )
-        with qp.decomposition.local_decomps():
-            qp.add_decomps(qp.Hadamard, *alt_dec)
-            _fix_decomp(qp.Hadamard, custom_hadamard)
-            assert (
-                graph._get_decompositions(h_rep)._decomps
-                == DecompCollection([custom_hadamard])._decomps
-            )
+        op_node = list(graph._op_to_op_nodes[abstractify(qp.H)])[0]
+        op_node_idx = graph._all_op_indices[op_node]
+        decomp_nodes = graph._graph.predecessors(op_node_idx)
+        assert len(decomp_nodes) == 1
+        assert decomp_nodes[0].rule is custom_hadamard
 
     def test_get_decomps_symbolic2(self):
         """Tests that get_decomps works properly for symbolicop2."""

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -24,7 +24,7 @@ import pennylane as qp
 from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import DecompositionGraph, pow_resource_rep
 from pennylane.decomposition.decomposition_graph import _DecompositionNode
-from pennylane.decomposition.decomposition_rule import DecompCollection
+from pennylane.decomposition.decomposition_rule import DecompCollection, _fix_decomp
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract
@@ -121,7 +121,9 @@ class TestDecompGraphConstruction:
             gate_set={"RX", "RY", "RZ"},
             fixed_decomps={qp.Hadamard: custom_hadamard},
         )
-        assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
+        with qp.decomposition.local_decomps():
+            _fix_decomp(qp.Hadamard, custom_hadamard)
+            assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
 
         alt_dec = DecompCollection([custom_hadamard, custom_hadamard_2])
         graph = DecompositionGraph(
@@ -130,7 +132,9 @@ class TestDecompGraphConstruction:
             alt_decomps={qp.Hadamard: alt_dec},
         )
         exp_dec = alt_dec + decompositions.get()["Hadamard"]
-        assert graph._get_decompositions(h_rep) == exp_dec
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(qp.Hadamard, custom_hadamard, custom_hadamard_2)
+            assert graph._get_decompositions(h_rep) == exp_dec
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
@@ -138,7 +142,10 @@ class TestDecompGraphConstruction:
             alt_decomps={qp.Hadamard: alt_dec},
             fixed_decomps={qp.Hadamard: custom_hadamard},
         )
-        assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
+        with qp.decomposition.local_decomps():
+            qp.add_decomps(qp.Hadamard, *alt_dec)
+            _fix_decomp(qp.Hadamard, custom_hadamard)
+            assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
 
     def test_get_decomps_symbolic2(self):
         """Tests that get_decomps works properly for symbolicop2."""

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -114,7 +114,9 @@ class TestDecompGraphConstruction:
         h_rep = abstractify(qp.H)
 
         graph = DecompositionGraph(operations=[qp.Hadamard(0)], gate_set={"RX", "RY", "RZ"})
-        assert graph._get_decompositions(h_rep) == decompositions.get()["Hadamard"]
+        assert (
+            graph._get_decompositions(h_rep)._decomps == decompositions.get()["Hadamard"]._decomps
+        )
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
@@ -123,7 +125,10 @@ class TestDecompGraphConstruction:
         )
         with qp.decomposition.local_decomps():
             _fix_decomp(qp.Hadamard, custom_hadamard)
-            assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
+            assert (
+                graph._get_decompositions(h_rep)._decomps
+                == DecompCollection([custom_hadamard])._decomps
+            )
 
         alt_dec = DecompCollection([custom_hadamard, custom_hadamard_2])
         graph = DecompositionGraph(
@@ -134,7 +139,7 @@ class TestDecompGraphConstruction:
         exp_dec = alt_dec + decompositions.get()["Hadamard"]
         with qp.decomposition.local_decomps():
             qp.add_decomps(qp.Hadamard, custom_hadamard, custom_hadamard_2)
-            assert graph._get_decompositions(h_rep) == exp_dec
+            assert graph._get_decompositions(h_rep)._decomps == exp_dec._decomps
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
@@ -145,7 +150,10 @@ class TestDecompGraphConstruction:
         with qp.decomposition.local_decomps():
             qp.add_decomps(qp.Hadamard, *alt_dec)
             _fix_decomp(qp.Hadamard, custom_hadamard)
-            assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
+            assert (
+                graph._get_decompositions(h_rep)._decomps
+                == DecompCollection([custom_hadamard])._decomps
+            )
 
     def test_get_decomps_symbolic2(self):
         """Tests that get_decomps works properly for symbolicop2."""

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -60,7 +60,7 @@ class MultiWireOp(Operation):
         return {"num_wires": len(self.wires)}
 
 
-class AnotherOp(Operation):  #
+class AnotherOp(Operation):
     """A custom operation."""
 
     resource_keys = set()

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -169,6 +169,48 @@ class TestDecompGraphConstruction:
         assert len(decomp_nodes) == 1
         assert decomp_nodes[0].rule is custom_hadamard
 
+    def test_fixed_decomps_respected_for_symbolic_ops(self):
+        """Tests that fixed decomps for symbolic ops are respected."""
+
+        @qp.register_resources({qp.X: 1})
+        def _base_decomp(wires):
+            raise NotImplementedError
+
+        @qp.register_resources({qp.X: 1})
+        def _custom_adjoint(base):
+            raise NotImplementedError
+
+        @qp.register_resources({qp.CNOT: 1})
+        def _custom_ctrl(base, control_wires, control_values, **_):
+            raise NotImplementedError
+
+        adjoint_op = qp.adjoint(NonParametricOp([0]))
+        ctrl_op = qp.ctrl(NonParametricOp([0]), control=1)
+
+        graph = DecompositionGraph(
+            [adjoint_op, ctrl_op],
+            gate_set={qp.X, qp.CNOT},
+            alt_decomps={NonParametricOp: [_base_decomp]},
+            fixed_decomps={
+                "Adjoint(NonParametricOp)": _custom_adjoint,
+                "C(NonParametricOp)": _custom_ctrl,
+            },
+        )
+
+        # check adjoint
+        adjoint_op_node = list(graph._op_to_op_nodes[abstractify(adjoint_op)])[0]
+        adjoint_op_idx = graph._all_op_indices[adjoint_op_node]
+        decomp_nodes = graph._graph.predecessors(adjoint_op_idx)
+        assert len(decomp_nodes) == 1
+        assert decomp_nodes[0].rule is _custom_adjoint
+
+        # check ctrl
+        ctrl_op_node = list(graph._op_to_op_nodes[abstractify(ctrl_op)])[0]
+        ctrl_op_idx = graph._all_op_indices[ctrl_op_node]
+        decomp_nodes = graph._graph.predecessors(ctrl_op_idx)
+        assert len(decomp_nodes) == 1
+        assert decomp_nodes[0].rule is _custom_ctrl
+
     def test_get_decomps_symbolic2(self):
         """Tests that get_decomps works properly for symbolicop2."""
 

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -24,17 +24,23 @@ import pennylane as qp
 from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import DecompositionGraph, pow_resource_rep
 from pennylane.decomposition.decomposition_graph import _DecompositionNode
+from pennylane.decomposition.decomposition_rule import DecompCollection
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract
 from pennylane.typing import Float, Wire
-from tests.core.operator.operator2_utils import DynOp, OneWireDynOp, ParametrizedHybridOp
-from tests.decomposition.conftest import decompositions, list_test_decomps, to_resources
+from tests.core.operator.operator2_utils import (
+    DynOp,
+    NonParametricOp,
+    OneWireDynOp,
+    ParametrizedHybridOp,
+)
+from tests.decomposition.conftest import decompositions, to_resources
 
-# pylint: disable=protected-access,no-name-in-module,too-few-public-methods,useless-parent-delegation
+# pylint: disable=protected-access,too-few-public-methods,useless-parent-delegation,unused-argument
 
 
-class CustomOp(Operation):  # pylint: disable=too-few-public-methods
+class CustomOp(Operation):
     """A custom operation."""
 
     resource_keys = set()
@@ -44,7 +50,7 @@ class CustomOp(Operation):  # pylint: disable=too-few-public-methods
         return {}
 
 
-class MultiWireOp(Operation):  # pylint: disable=too-few-public-methods
+class MultiWireOp(Operation):
     """A custom op"""
 
     resource_keys = {"num_wires"}
@@ -54,7 +60,7 @@ class MultiWireOp(Operation):  # pylint: disable=too-few-public-methods
         return {"num_wires": len(self.wires)}
 
 
-class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
+class AnotherOp(Operation):  #
     """A custom operation."""
 
     resource_keys = set()
@@ -65,59 +71,11 @@ class AnotherOp(Operation):  # pylint: disable=too-few-public-methods
 
 
 @pytest.mark.unit
-@patch(
-    "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=list_test_decomps,
-)
-class TestDecompositionGraph:
+@patch("pennylane.decomposition.decomposition_rule._decompositions_var", decompositions)
+class TestDecompGraphConstruction:
     """Unit tests for the decomposition graph."""
 
-    def test_weighted_graph_solve(self, _):
-        """Tests solving a simple graph for the optimal decompositions with weighted gates."""
-
-        op = qp.CRX(2.5, wires=[0, 1])
-
-        # the RZ CZ RX CZ decomp is chosen when the RZ and CNOT weights are large.
-        gate_weights = {
-            "RX": 1.0,
-            "RY": 3.0,
-            "RZ": 10.0,
-            "GlobalPhase": 1.0,
-            "CNOT": 20.0,
-            "CZ": 1.0,
-        }
-
-        graph = DecompositionGraph(
-            operations=[op],
-            gate_set=gate_weights,
-        )
-        solution = graph.solve()
-
-        expected_resource = to_resources({qp.CZ: 2, qp.RX: 2})
-        assert solution.resource_estimate(op) == expected_resource
-
-        # the RZ CZ RX CZ decomp is avoided when the CZ weight is large.
-        gate_weights = {
-            "RX": 1.0,
-            "RY": 1.0,
-            "RZ": 1.0,
-            "GlobalPhase": 1.0,
-            "CNOT": 1.0,
-            "CZ": 100.0,
-        }
-
-        graph = DecompositionGraph(
-            operations=[op],
-            gate_set=gate_weights,
-        )
-        solution = graph.solve()
-
-        expected_resource = to_resources(
-            {qp.RX: 2, qp.CNOT: 2, qp.RY: 4, qp.GlobalPhase: 4, qp.RZ: 4}
-        )
-        assert solution.resource_estimate(op) == expected_resource
-
-    def test_decomp_rule_is_missing_resources(self, _):
+    def test_decomp_rule_is_missing_resources(self):
         """Tests that an error is raised for functions that does not have a resource estimate."""
 
         def custom_hadamard(wires):
@@ -139,7 +97,7 @@ class TestDecompositionGraph:
                 alt_decomps={qp.H: [custom_hadamard]},
             )
 
-    def test_get_decomp_rule(self, _):
+    def test_get_decomp_rule(self):
         """Tests the internal method that gets the decomposition rules for an operator."""
 
         @qp.register_resources({qp.PhaseShift: 2, qp.RX: 1})
@@ -153,24 +111,26 @@ class TestDecompositionGraph:
             qp.PhaseShift(np.pi / 2, wires=wires)
             qp.RY(np.pi / 2, wires=wires)
 
+        h_rep = abstractify(qp.H)
+
         graph = DecompositionGraph(operations=[qp.Hadamard(0)], gate_set={"RX", "RY", "RZ"})
-        assert graph._get_decompositions(abstractify(qp.H)) == decompositions["Hadamard"]
+        assert graph._get_decompositions(h_rep) == decompositions.get()["Hadamard"]
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
             gate_set={"RX", "RY", "RZ"},
             fixed_decomps={qp.Hadamard: custom_hadamard},
         )
-        assert graph._get_decompositions(abstractify(qp.H)) == [custom_hadamard]
+        assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
 
-        alt_dec = [custom_hadamard, custom_hadamard_2]
+        alt_dec = DecompCollection([custom_hadamard, custom_hadamard_2])
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
             gate_set={"RX", "RY", "RZ"},
             alt_decomps={qp.Hadamard: alt_dec},
         )
-        exp_dec = alt_dec + decompositions["Hadamard"]
-        assert graph._get_decompositions(abstractify(qp.H)) == exp_dec
+        exp_dec = alt_dec + decompositions.get()["Hadamard"]
+        assert graph._get_decompositions(h_rep) == exp_dec
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],
@@ -178,16 +138,40 @@ class TestDecompositionGraph:
             alt_decomps={qp.Hadamard: alt_dec},
             fixed_decomps={qp.Hadamard: custom_hadamard},
         )
-        assert graph._get_decompositions(abstractify(qp.H)) == [custom_hadamard]
+        assert graph._get_decompositions(h_rep) == DecompCollection([custom_hadamard])
 
-    def test_graph_construction(self, _):
+    def test_get_decomps_symbolic2(self):
+        """Tests that get_decomps works properly for symbolicop2."""
+
+        @qp.register_resources({qp.PhaseShift: 2, qp.RX: 1})
+        def _custom_rule(wires):
+            raise NotImplementedError
+
+        graph = DecompositionGraph(
+            [qp.ctrl(NonParametricOp([0, 1]), control=[2]), qp.adjoint(NonParametricOp([0, 1]))],
+            alt_decomps={NonParametricOp: [_custom_rule]},
+            gate_set={
+                qp.PhaseShift,
+                qp.RX,
+                qp.ControlledPhaseShift,
+                qp.CRX,
+                qp.PauliX,
+                "Adjoint(PhaseShift)",
+                "Adjoint(RX)",
+            },
+        )
+
+        solution = graph.solve()
+        assert solution.is_solved_for(qp.ctrl(NonParametricOp([0, 1]), control=[2]))
+        assert solution.is_solved_for(qp.adjoint(NonParametricOp([0, 1])))
+
+    def test_graph_construction(self):
         """Tests constructing a graph from a single Hadamard."""
 
         op = qp.Hadamard(wires=[0])
 
-        graph = DecompositionGraph(
-            operations=[op], gate_set={"RX": 1.0, "RZ": 1.0, "GlobalPhase": 1.0}
-        )
+        graph = DecompositionGraph([op], gate_set={"RX": 1.0, "RZ": 1.0, "GlobalPhase": 1.0})
+
         # 5 ops and 3 decompositions (2 for Hadamard and 1 for RY) and 1 dummy starting node
         assert len(graph._graph.nodes()) == 9
         # 8 edges from ops to decompositions, 3 from decompositions to ops, and 3 from the
@@ -202,62 +186,7 @@ class TestDecompositionGraph:
         # and 3 from the dummy starting node to the target gate set.
         assert len(graph2._graph.edges()) == 11
 
-    def test_operator2_integration(self, _):
-        """Tests constructing and solving a graph from an Operator2."""
-
-        def _resource_fn(params, wires, op):  # pylint: disable=unused-argument
-            return {qp.CNOT: 2 * len(wires), OneWireDynOp: 1, qp.RX: 2 * (len(wires) - 1)}
-
-        @qp.register_resources(_resource_fn)
-        def _custom_rule(params, wires, op):  # pylint: disable=unused-argument
-            raise NotImplementedError
-
-        @qp.register_resources({qp.RX: 2, qp.CNOT: 2})
-        def _another_rule(theta, wires):  # pylint: disable=unused-argument
-            raise NotImplementedError
-
-        def _another_resource_fn(num_wires):
-            return {
-                ParametrizedHybridOp(
-                    Float[num_wires], Wire[num_wires], op=OneWireDynOp(Float, Wire[1])
-                ): 1
-            }
-
-        @qp.register_resources(_another_resource_fn)
-        def _another_custom_rule(*args, **kwargs):  # pylint: disable=unused-argument
-            raise NotImplementedError
-
-        @qp.register_resources(lambda num_wires: {DynOp(Float, Wire[1]): num_wires})
-        def _second_rule(*args, **kwargs):
-            raise NotImplementedError
-
-        op1 = ParametrizedHybridOp([1, 2, 3], wires=[0, 1, 2], op=OneWireDynOp(0.5, wires=3))
-        op2 = MultiWireOp([0, 1, 2, 3], wires=[0, 1, 2, 3])
-
-        graph = DecompositionGraph(
-            operations=[op1, op2],
-            gate_set={qp.RX, qp.CNOT},
-            alt_decomps={
-                ParametrizedHybridOp: [_custom_rule],
-                OneWireDynOp: [_another_rule],
-                MultiWireOp: [_another_custom_rule, _second_rule],
-            },
-        )
-        solution = graph.solve()
-
-        assert solution.is_solved_for(op1)
-        assert solution.is_solved_for(op2)
-        assert solution.decomposition(op1) is _custom_rule
-        assert solution.decomposition(op2) is _another_custom_rule
-
-        op3 = OneWireDynOp(0.5, wires=3)
-        assert solution.is_solved_for(op3)
-        assert solution.decomposition(op3) is _another_rule
-
-        op4 = DynOp(0.5, wires=1)
-        assert not solution.is_solved_for(op4)
-
-    def test_graph_construction_non_applicable_rules(self, _):
+    def test_graph_construction_non_applicable_rules(self):
         """Tests rules which are not applicable are not skipped."""
 
         @qp.register_condition(lambda num_wires: num_wires == 1)
@@ -285,7 +214,7 @@ class TestDecompositionGraph:
         # decomposition rule itself is included in the graph but not expanded.
         assert len(graph._graph.edges()) == 6
 
-    def test_gate_set(self, _):
+    def test_gate_set(self):
         """Tests that graph construction stops at the target gate set."""
 
         @qp.register_resources(
@@ -327,7 +256,128 @@ class TestDecompositionGraph:
         with pytest.raises(DecompositionError, match="is unsolved in this decomposition graph."):
             solution.decomposition(qp.RX(0.5, wires=0))
 
-    def test_graph_solve(self, _):
+    def test_circular_decomposition_paths(self):
+        """Tests that the graph can handle circular decomposition pathways."""
+
+        @qp.register_resources({AnotherOp: 1})
+        def _custom_rule(_):
+            raise NotImplementedError
+
+        @qp.register_resources({_ctrl_abstract(CustomOp, Wire[1]): 1})
+        def _another_rule(_):
+            raise NotImplementedError
+
+        _ = DecompositionGraph(
+            [CustomOp(0)],
+            gate_set=qp.gate_sets.CLIFFORD_T_PLUS_RZ,
+            alt_decomps={CustomOp: [_custom_rule], AnotherOp: [_another_rule]},
+        )
+
+        _ = DecompositionGraph(
+            [qp.ctrl(CustomOp(0), control=[1])],
+            gate_set=qp.gate_sets.CLIFFORD_T_PLUS_RZ,
+            alt_decomps={CustomOp: [_custom_rule], AnotherOp: [_another_rule]},
+        )
+
+
+@pytest.mark.unit
+@patch("pennylane.decomposition.decomposition_rule._decompositions_var", decompositions)
+class TestDecompGraphSolver:
+    """Unit tests for solving the decomposition graph."""
+
+    def test_weighted_graph_solve(self):
+        """Tests solving a simple graph for the optimal decompositions with weighted gates."""
+
+        op = qp.CRX(2.5, wires=[0, 1])
+
+        # the RZ CZ RX CZ decomp is chosen when the RZ and CNOT weights are large.
+        gate_weights = {
+            "RX": 1.0,
+            "RY": 3.0,
+            "RZ": 10.0,
+            "GlobalPhase": 1.0,
+            "CNOT": 20.0,
+            "CZ": 1.0,
+        }
+
+        graph = DecompositionGraph(operations=[op], gate_set=gate_weights)
+        solution = graph.solve()
+
+        expected_res = to_resources({qp.CZ: 2, qp.RX: 2})
+        assert solution.resource_estimate(op) == expected_res
+
+        # the RZ CZ RX CZ decomp is avoided when the CZ weight is large.
+        gate_weights = {
+            "RX": 1.0,
+            "RY": 1.0,
+            "RZ": 1.0,
+            "GlobalPhase": 1.0,
+            "CNOT": 1.0,
+            "CZ": 100.0,
+        }
+
+        graph = DecompositionGraph(operations=[op], gate_set=gate_weights)
+        solution = graph.solve()
+
+        expected_res = to_resources({qp.RX: 2, qp.CNOT: 2, qp.RY: 4, qp.GlobalPhase: 4, qp.RZ: 4})
+        assert solution.resource_estimate(op) == expected_res
+
+    def test_operator2_integration(self):
+        """Tests constructing and solving a graph from an Operator2."""
+
+        def _resource_fn(params, wires, op):
+            return {qp.CNOT: 2 * len(wires), OneWireDynOp: 1, qp.RX: 2 * (len(wires) - 1)}
+
+        @qp.register_resources(_resource_fn)
+        def _custom_rule(params, wires, op):
+            raise NotImplementedError
+
+        @qp.register_resources({qp.RX: 2, qp.CNOT: 2})
+        def _another_rule(theta, wires):
+            raise NotImplementedError
+
+        def _another_resource_fn(num_wires):
+            return {
+                ParametrizedHybridOp(
+                    Float[num_wires], Wire[num_wires], op=OneWireDynOp(Float, Wire[1])
+                ): 1
+            }
+
+        @qp.register_resources(_another_resource_fn)
+        def _another_custom_rule(*args, **kwargs):
+            raise NotImplementedError
+
+        @qp.register_resources(lambda num_wires: {DynOp(Float, Wire[1]): num_wires})
+        def _second_rule(*args, **kwargs):
+            raise NotImplementedError
+
+        op1 = ParametrizedHybridOp([1, 2, 3], wires=[0, 1, 2], op=OneWireDynOp(0.5, wires=3))
+        op2 = MultiWireOp([0, 1, 2, 3], wires=[0, 1, 2, 3])
+
+        graph = DecompositionGraph(
+            operations=[op1, op2],
+            gate_set={qp.RX, qp.CNOT},
+            alt_decomps={
+                ParametrizedHybridOp: [_custom_rule],
+                OneWireDynOp: [_another_rule],
+                MultiWireOp: [_another_custom_rule, _second_rule],
+            },
+        )
+        solution = graph.solve()
+
+        assert solution.is_solved_for(op1)
+        assert solution.is_solved_for(op2)
+        assert solution.decomposition(op1) is _custom_rule
+        assert solution.decomposition(op2) is _another_custom_rule
+
+        op3 = OneWireDynOp(0.5, wires=3)
+        assert solution.is_solved_for(op3)
+        assert solution.decomposition(op3) is _another_rule
+
+        op4 = DynOp(0.5, wires=1)
+        assert not solution.is_solved_for(op4)
+
+    def test_graph_solve(self):
         """Tests solving a simple graph for the optimal decompositions."""
 
         op = qp.Hadamard(wires=[0])
@@ -348,7 +398,7 @@ class TestDecompositionGraph:
         # verify that is_solved_for returns False for non-existent operators
         assert not solution.is_solved_for(qp.Toffoli(wires=[0, 1, 2]))
 
-    def test_graph_strict(self, _, recwarn):
+    def test_graph_strict(self, recwarn):
         """Test the graph with strict=False."""
 
         @qp.register_resources({AnotherOp: 1})
@@ -365,7 +415,7 @@ class TestDecompositionGraph:
         assert solution.is_solved_for(CustomOp(0))
         assert not recwarn
 
-    def test_strict_no_decomp_op_with_alternative(self, _, recwarn):
+    def test_strict_no_decomp_op_with_alternative(self, recwarn):
         """Tests that when strict=False, ops without decompositions are not chosen
         if there is an alternative pathway available."""
 
@@ -388,7 +438,7 @@ class TestDecompositionGraph:
         assert solution.decomposition(CustomOp(0)) is _decomp2
         assert not recwarn
 
-    def test_decomposition_not_found_warning(self, _):
+    def test_decomposition_not_found_warning(self):
         """Tests that the correct warning is raised if a decomposition isn't found."""
 
         op = qp.Hadamard(wires=[0])
@@ -399,7 +449,7 @@ class TestDecompositionGraph:
     @pytest.mark.parametrize(
         "op", [qp.allocation.Allocate(1), qp.allocation.Deallocate(qp.allocation.DynamicWire())]
     )
-    def test_decomposition_not_found_ignored_op_no_warning(self, _, op):
+    def test_decomposition_not_found_ignored_op_no_warning(self, op):
         """Tests that no warning is raised if a decomposition isn't found but the unsolved
         operator type is among specific operators, like Allocate and Deallocate."""
 
@@ -408,7 +458,7 @@ class TestDecompositionGraph:
             graph.solve()
         assert len(record) == 0
 
-    def test_lazy_solve(self, _):
+    def test_lazy_solve(self):
         """Tests the lazy keyword argument."""
 
         @qp.register_resources({qp.RZ: 1, qp.CNOT: 1})
@@ -443,7 +493,7 @@ class TestDecompositionGraph:
         solution = graph.solve(lazy=False)
         assert solution.is_solved_for(AnotherOp(wires=[0, 1]))
 
-    def test_decomposition_with_resource_params(self, _):
+    def test_decomposition_with_resource_params(self):
         """Tests operators with non-empty resource params."""
 
         def _custom_resource(num_wires):
@@ -484,7 +534,12 @@ class TestDecompositionGraph:
             {qp.RZ: 2, qp.RX: 1, qp.GlobalPhase: 1},
         )
 
-    def test_work_wire_requirement(self, _):
+
+@pytest.mark.unit
+class TestDecompGraphWorkWireBudgeting:
+    """Tests the work-wire budgeting of the decomposition graph."""
+
+    def test_work_wire_requirement(self):
         """Tests that the graph respects the work wire requirement."""
 
         @qp.register_resources({qp.Toffoli: 2, qp.CRot: 1}, work_wires={"zeroed": 1})
@@ -510,7 +565,7 @@ class TestDecompositionGraph:
             is _decomp_with_work_wire
         )
 
-    def test_multiple_nodes_with_different_work_wire_budget(self, _):
+    def test_multiple_nodes_with_different_work_wire_budget(self):
         """Tests that the same operator produced under different work wire budgets
         are stored as different nodes in the graph, and results can be queried."""
 
@@ -576,11 +631,11 @@ class TestDecompositionGraph:
         assert solution.decomposition(op, num_work_wires=None) is _decomp2_with_work_wire
         assert solution.decomposition(small_op, num_work_wires=None) is _decomp_with_work_wire
 
-    def test_non_work_wire_dependent_ops_reused(self, _):
+    def test_non_work_wire_dependent_ops_reused(self):
         """Tests that ops that are not work-wire dependent are not affected by work-wire
         dependent decomposition rules upstream."""
 
-        class SimpleOp(Operation):  # pylint: disable=too-few-public-methods
+        class SimpleOp(Operation):
             """A simple operation that does not depend on work wires."""
 
         @qp.register_resources({qp.X: 1})
@@ -603,10 +658,10 @@ class TestDecompositionGraph:
         solution = graph.solve()
         assert solution.is_solved_for(SimpleOp(0))
 
-    def test_min_work_wires(self, _):
+    def test_min_work_wires(self):
         """Tests that the graph tracks the minimum number of work wires."""
 
-        class SimpleOp(Operation):  # pylint: disable=too-few-public-methods
+        class SimpleOp(Operation):
             """A simple operation that does not depend on work wires."""
 
         @qp.register_resources({qp.X: 4})
@@ -644,10 +699,10 @@ class TestDecompositionGraph:
         solution = graph.solve(num_work_wires=None, minimize_work_wires=True)
         assert solution.decomposition(AnotherOp(0), num_work_wires=None) == _yet_another_decomp
 
-    def test_min_work_wires_unreacheable_rule(self, _):
+    def test_min_work_wires_unreacheable_rule(self):
         """Tests that unrecheable rules are excluded when computing minimum work wires."""
 
-        class SimpleOp(Operation):  # pylint: disable=too-few-public-methods
+        class SimpleOp(Operation):
             """A simple operation that does not depend on work wires."""
 
         @qp.register_resources({qp.X: 4})
@@ -679,39 +734,13 @@ class TestDecompositionGraph:
         )
         assert graph._min_work_wires == 4
 
-    def test_circular_decomposition_paths(self, _):
-        """Tests that the graph can handle circular decomposition pathways."""
-
-        @qp.register_resources({AnotherOp: 1})
-        def _custom_rule(_):
-            raise NotImplementedError
-
-        @qp.register_resources({_ctrl_abstract(CustomOp, Wire[1]): 1})
-        def _another_rule(_):
-            raise NotImplementedError
-
-        _ = DecompositionGraph(
-            [CustomOp(0)],
-            gate_set=qp.gate_sets.CLIFFORD_T_PLUS_RZ,
-            alt_decomps={CustomOp: [_custom_rule], AnotherOp: [_another_rule]},
-        )
-
-        _ = DecompositionGraph(
-            [qp.ctrl(CustomOp(0), control=[1])],
-            gate_set=qp.gate_sets.CLIFFORD_T_PLUS_RZ,
-            alt_decomps={CustomOp: [_custom_rule], AnotherOp: [_another_rule]},
-        )
-
 
 @pytest.mark.unit
-@patch(
-    "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=list_test_decomps,
-)
+@patch("pennylane.decomposition.decomposition_rule._decompositions_var", decompositions)
 class TestControlledDecompositions:
     """Tests that the decomposition graph can handle controlled decompositions."""
 
-    def test_controlled_global_phase(self, _):
+    def test_controlled_global_phase(self):
         """Tests that a controlled global phase can be decomposed."""
 
         op1 = qp.ctrl(qp.GlobalPhase(0.5), control=[1])
@@ -734,7 +763,7 @@ class TestControlledDecompositions:
             qp.ControlledPhaseShift(-0.5, wires=[1, 2]),
         ]
 
-    def test_custom_controlled_op(self, _):
+    def test_custom_controlled_op(self):
         """Tests that a general controlled op can be decomposed into a custom op if applicable."""
 
         op1 = qp.ops.Controlled(qp.X(0), control_wires=[1])
@@ -754,7 +783,7 @@ class TestControlledDecompositions:
 
         assert q.queue == [qp.CNOT(wires=[1, 0]), qp.CH(wires=[1, 0])]
 
-    def test_controlled_base_decomposition(self, _):
+    def test_controlled_base_decomposition(self):
         """Tests applying control on the decomposition of the target operator."""
 
         @qp.register_resources({qp.X: 1, qp.GlobalPhase: 1})
@@ -767,7 +796,7 @@ class TestControlledDecompositions:
             qp.Z(wires=wires[0])
             qp.GlobalPhase(np.pi / 2, wires=wires)
 
-        class CustomControlledOp(Operation):  # pylint: disable=too-few-public-methods
+        class CustomControlledOp(Operation):
             """A custom operation."""
 
             resource_keys = set()
@@ -808,7 +837,7 @@ class TestControlledDecompositions:
         assert solution.decomposition(qp.ctrl(qp.GlobalPhase(0.5), control=[1, 2]))
         assert solution.decomposition(qp.ctrl(CustomOp(wires=[1]), control=[0, 2]))
 
-    def test_flip_controlled_adjoint(self, _):
+    def test_flip_controlled_adjoint(self):
         """Tests that the controlled form of an adjoint operator is decomposed properly."""
 
         op = qp.ctrl(qp.adjoint(qp.U1(0.5, wires=0)), control=[1])
@@ -818,7 +847,7 @@ class TestControlledDecompositions:
             solution.decomposition(op)(*op.parameters, wires=op.wires, **op.hyperparameters)
         assert q.queue == [qp.adjoint(qp.ops.Controlled(qp.U1(0.5, wires=0), control_wires=[1]))]
 
-    def test_decompose_with_single_work_wire(self, _):
+    def test_decompose_with_single_work_wire(self):
         """Tests that the Lemma 7.11 decomposition from https://arxiv.org/pdf/quant-ph/9503016 is applied correctly."""
 
         op = qp.ctrl(qp.Rot(0.123, 0.234, 0.345, wires=0), control=[1, 2, 3])
@@ -839,7 +868,7 @@ class TestControlledDecompositions:
             {_ctrl_abstract(qp.X, Wire[3]): 2, qp.CRot: 1}
         )
 
-    def test_base_decomp_contains_mcms(self, _):
+    def test_base_decomp_contains_mcms(self):
         """Tests that the graph does not apply ctrl to rules that contain MCMs."""
 
         @qp.register_resources({qp.ops.MidMeasure: 1, qp.X: 1})
@@ -856,14 +885,11 @@ class TestControlledDecompositions:
         assert all("_custom_rule" not in rule.name for rule in rules)
 
 
-@patch(
-    "pennylane.decomposition.decomposition_graph.list_decomps",
-    side_effect=list_test_decomps,
-)
+@patch("pennylane.decomposition.decomposition_rule._decompositions_var", decompositions)
 class TestSymbolicDecompositions:
     """Tests decompositions of symbolic ops."""
 
-    def test_cancel_adjoint(self, _):
+    def test_cancel_adjoint(self):
         """Tests that a nested adjoint operator is flattened properly."""
 
         op = qp.adjoint(qp.adjoint(qp.RX(0.5, wires=[0])))
@@ -882,7 +908,7 @@ class TestSymbolicDecompositions:
         assert q.queue == [qp.RX(0.5, wires=[0])]
         assert solution.resource_estimate(op) == to_resources({qp.RX: 1})
 
-    def test_adjoint_custom(self, _):
+    def test_adjoint_custom(self):
         """Tests adjoint of an operator that defines its own adjoint."""
 
         op = qp.adjoint(qp.RX(0.5, wires=[0]))
@@ -900,7 +926,7 @@ class TestSymbolicDecompositions:
         assert q.queue == [qp.RX(-0.5, wires=[0])]
         assert solution.resource_estimate(op) == to_resources({qp.RX: 1})
 
-    def test_adjoint_general(self, _):
+    def test_adjoint_general(self):
         """Tests decomposition of a generalized adjoint operation."""
 
         @qp.register_resources({qp.H: 1, qp.CNOT: 2, qp.RX: 1, qp.T: 1})
@@ -941,7 +967,7 @@ class TestSymbolicDecompositions:
             {qp.H: 1, qp.CNOT: 2, qp.RX: 1, qp.PhaseShift: 1},
         )
 
-    def test_nested_powers(self, _):
+    def test_nested_powers(self):
         """Tests nested power decompositions."""
 
         op = qp.pow(qp.pow(qp.H(0), 3), 2)
@@ -974,7 +1000,7 @@ class TestSymbolicDecompositions:
         assert solution.resource_estimate(op2) == to_resources({})
 
     @pytest.mark.parametrize("z,expected", [(0, []), (1, [qp.X(0)])])
-    def test_trivial_powers(self, _, z, expected):
+    def test_trivial_powers(self, z, expected):
         """Tests trivial powers of 1 or 0."""
 
         op = qp.pow(qp.X(0), z)
@@ -988,7 +1014,7 @@ class TestSymbolicDecompositions:
 
         assert q.queue == expected
 
-    def test_custom_symbolic_decompositions(self, _):
+    def test_custom_symbolic_decompositions(self):
         """Tests that custom symbolic decompositions are used."""
 
         @qp.register_resources({qp.RX: 1})
@@ -1029,7 +1055,7 @@ class TestSymbolicDecompositions:
         assert solution.resource_estimate(op3) == to_resources({qp.CH: 1})
         assert solution.resource_estimate(op4) == to_resources({qp.RX: 1})
 
-    def test_special_pow_decomps(self, _):
+    def test_special_pow_decomps(self):
         """Tests special cases for decomposing a power."""
 
         graph = DecompositionGraph(
@@ -1059,7 +1085,7 @@ class TestSymbolicDecompositions:
         assert solution.resource_estimate(op1) == to_resources({})
         assert solution.resource_estimate(op2) == to_resources({CustomOp: 1})
 
-    def test_general_pow_decomps(self, _):
+    def test_general_pow_decomps(self):
         """Tests the more general power decomposition rules."""
 
         graph = DecompositionGraph(
@@ -1091,7 +1117,7 @@ class TestSymbolicDecompositions:
             qp.adjoint(qp.pow(CustomOp(1), 2)),
         ]
 
-    def test_base_decomp_contains_mcms_or_dynamic_wires(self, _):
+    def test_base_decomp_contains_mcms_or_dynamic_wires(self):
         """Tests that the graph skips adjoint of rules that contain MCMs or dynamic wires."""
 
         @qp.register_resources({qp.ops.MidMeasure: 1, qp.X: 1})


### PR DESCRIPTION
**Context:**

In https://github.com/PennyLaneAI/pennylane/pull/9727 and https://github.com/PennyLaneAI/pennylane/pull/9760, we made it so that the graph is not responsible for populating general adjoint/controlled decomposition rules. In the old system, `qp.list_decomps(qp.adjoint(...))` does not return the decomposition rules generated from applying `adjoint` to the base decomposition rules, now it does. A consequence of this is that `list_decomps` must gain access to any `alt_decomps` or `fixed_decomps` specified for the base operator.

**Description of the Change:**

Update the graph to run construction in a context manager where the global decomp dictionary is updated with the `fixed_decomps` and `alt_decomps`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124731]