### PR TITLE
Simplify drawer logic around nested controls

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -850,6 +850,8 @@
     [(#9596)](https://github.com/PennyLaneAI/pennylane/pull/9596)
     [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
     [(#9820)](https://github.com/PennyLaneAI/pennylane/pull/9820)
+  - Compatibility with the `drawer` module.
+    [(#9849)](https://github.com/PennyLaneAI/pennylane/pull/9849)
   - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.
     [(#9529)](https://github.com/PennyLaneAI/pennylane/pull/9529)
     [(#9702)](https://github.com/PennyLaneAI/pennylane/pull/9702)

--- a/pennylane/drawer/tape_mpl.py
+++ b/pennylane/drawer/tape_mpl.py
@@ -72,16 +72,11 @@ def _add_operation_to_drawer(op: Operator, drawer: MPLDrawer, layer: int, config
     """
     op_control_wires, control_values, base = unwrap_controls(op)
     is_global_op = isinstance(base, (ops.GlobalPhase, ops.Identity))
-    if len(op.wires) == 0 or is_global_op:
-        op_wires = list(range(drawer.n_wires))
-    else:
-        op_wires = op.wires
+    op_wires = list(range(drawer.n_wires)) if len(op.wires) == 0 or is_global_op else op.wires
     target_wires = [w for w in op_wires if w not in op_control_wires]
+
     if is_global_op and len(target_wires) == 0:
         raise ValueError("Can't draw controlled global gate with unknown non-control wires.")
-
-    if control_values is None:
-        control_values = [True for _ in op_control_wires]
 
     if op_control_wires:
         drawer.ctrl(
@@ -90,6 +85,7 @@ def _add_operation_to_drawer(op: Operator, drawer: MPLDrawer, layer: int, config
             wires_target=target_wires,
             control_values=control_values,
         )
+
     drawer.box_gate(
         layer,
         target_wires,

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -25,6 +25,7 @@ from pennylane.core.measurements import MeasurementProcess
 from pennylane.ops import Conditional, Controlled, MeasurementValue, MidMeasure, PauliMeasure
 from pennylane.pytrees import flatten
 from pennylane.templates import SubroutineOp
+from pennylane.wires import Wires
 
 
 def dynamic_wire_connections(layers: list[list], wire_map: dict) -> tuple[dict, dict]:
@@ -230,33 +231,21 @@ def unwrap_controls(op):
     Returns:
         Wires, List: The control wires of the operation, along with any associated
         control values.
+
     """
-    # Get wires and control values of base operation; need to make a copy of
-    # control values, otherwise it will modify the list in the operation itself.
-    control_wires = getattr(op, "control_wires", [])
-    control_values = getattr(op, "hyperparameters", {}).get("control_values", None)
 
-    if isinstance(control_values, list):
-        control_values = control_values.copy()
+    control_wires = Wires([])
+    control_values = []
 
-    next_ctrl = op
-    if isinstance(op, Controlled):
-        while hasattr(next_ctrl, "base"):
-            if isinstance(next_ctrl.base, Controlled):
-                base_control_wires = getattr(next_ctrl.base, "control_wires", [])
-                control_wires += base_control_wires
+    if not isinstance(op, Controlled):
+        return control_wires, control_values, op
 
-                base_control_values = next_ctrl.base.hyperparameters.get(
-                    "control_values", [True] * len(base_control_wires)
-                )
+    control_wires = op.control_wires
+    control_values = op.control_values
+    base = op.base
 
-                if control_values is not None:
-                    control_values.extend(base_control_values)
-
-            next_ctrl = next_ctrl.base
-
-    control_values = [bool(int(i)) for i in control_values] if control_values else control_values
-    return control_wires, control_values, next_ctrl
+    base_ctrl_wires, base_ctrl_values, base_base = unwrap_controls(base)
+    return control_wires + base_ctrl_wires, control_values + base_ctrl_values, base_base
 
 
 # pylint: disable=unused-argument

--- a/tests/drawer/test_drawer_utils.py
+++ b/tests/drawer/test_drawer_utils.py
@@ -193,7 +193,7 @@ class TestUnwrapControls:
     @pytest.mark.parametrize(
         "op,expected_control_wires,expected_control_values,expected_base_cls",
         [
-            (qp.X(wires="a"), Wires([]), None, qp.X),
+            (qp.X(wires="a"), Wires([]), [], qp.X),
             (qp.CNOT(wires=["a", "b"]), Wires("a"), [True], qp.X),
             (qp.ctrl(qp.X(wires="b"), control="a"), Wires("a"), [True], qp.X),
             (


### PR DESCRIPTION
**Context:**

Extracted from https://github.com/PennyLaneAI/pennylane/pull/9844

**Description of the Change:**

Rewrites the drawer logic that depends on operators having `hyperparameters`.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124858]
