### PR TITLE
feat: update `Operator2.__repr__` for nonparametric ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -854,6 +854,7 @@
   [(#9675)](https://github.com/PennyLaneAI/pennylane/pull/9675)
   [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
   [(#9783)](https://github.com/PennyLaneAI/pennylane/pull/9783)
+  [(#9851)](https://github.com/PennyLaneAI/pennylane/pull/9851)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -961,8 +961,6 @@ class Operator2(metaclass=OperatorMeta):
                 wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
                 if isinstance(wires_list, list) and len(wires_list) == 1:
                     return f"{self.name}({wires_list[0]!r})"
-                if isinstance(wires_list, AbstractWires) and wires_list.num_wires == 1:
-                    return f"{self.name}({wires_list!r})"
 
         inputs = []
 

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -953,6 +953,8 @@ class Operator2(metaclass=OperatorMeta):
     # ------------------------------------------------------------------------
 
     def __repr__(self) -> str:
+        # NOTE: Handle special case for single wire non-parameteric
+        # operators like 'repr(qp.X(wires=0)) = X(0)'
         non_wire_args = (
             self.dynamic_argnames
             + self.static_argnames
@@ -963,6 +965,7 @@ class Operator2(metaclass=OperatorMeta):
             wire_arg = self.arguments[self.wire_argnames[0]]
             if isinstance(wire_arg, Wires) and len(wire_arg) == 1:
                 return f"{self.name}({wire_arg.tolist()[0]!r})"
+
         inputs = []
 
         for key, value in self.arguments.items():

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -953,17 +953,11 @@ class Operator2(metaclass=OperatorMeta):
     # ------------------------------------------------------------------------
 
     def __repr__(self) -> str:
-        if len(self.arguments) == 1:
-            arg_name, arg_value = next(iter(self.arguments.items()))
-            # NOTE: Only strip for SINGLE concrete wires
-            # multi-wire or abstract wire ops will retain legacy Name(wires=[...]) format
-            wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
-            is_non_pytree_wires = (
-                arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames
-            )
-            if is_non_pytree_wires and (isinstance(wires_list, list) and len(wires_list) == 1):
-                return f"{self.name}({wires_list[0]!r})"
-
+        non_wire_args = self.dynamic_argnames + self.static_argnames + self.compilable_argnames + self.hybrid_argnames
+        if not non_wire_args and len(self.wire_argnames) == 1:
+            wire_arg = self.arguments[self.wire_argnames[0]]
+            if isinstance(wire_arg, Wires):
+                return f"{self.name}({wire_arg.tolist()[0]})"
         inputs = []
 
         for key, value in self.arguments.items():

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -955,8 +955,8 @@ class Operator2(metaclass=OperatorMeta):
     def __repr__(self) -> str:
         if len(self.arguments) == 1:
             arg_name, arg_value = next(iter(self.arguments.items()))
-            # NOTE: Only strip for SINGLE wires, multi-wire ops
-            # with retain legacy Name(wires=[...]) format
+            # NOTE: Only strip for SINGLE concrete wires
+            # multi-wire or abstract wire ops will retain legacy Name(wires=[...]) format
             if arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames:
                 wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
                 if isinstance(wires_list, list) and len(wires_list) == 1:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -954,16 +954,14 @@ class Operator2(metaclass=OperatorMeta):
 
     def __repr__(self) -> str:
         if len(self.arguments) == 1:
-            key, value = next(iter(self.arguments.items()))
-            if key in self.wire_argnames and key not in self.hybrid_argnames:
-                # Format single wires directly without list brackets or keyword labels
-                wires_list = value.tolist() if isinstance(value, Wires) else value
-                res = (
-                    wires_list[0]
-                    if isinstance(wires_list, list) and len(wires_list) == 1
-                    else wires_list
-                )
-                return f"{self.name}({repr(res)})"
+            arg_name, arg_value = next(iter(self.arguments.items()))
+            # NOTE: Only process non-pytree wire arguments
+            if arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames:
+                wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
+                if isinstance(wires_list, list) and len(wires_list) == 1:
+                    # NOTE: Only strip for SINGLE wires, multi-wire ops
+                    # with retain legacy Name(wires=[...]) format
+                    return f"{self.name}({repr(wires_list[0])})"
 
         inputs = []
 

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -274,7 +274,7 @@ class Operator2(metaclass=OperatorMeta):
         return self.__class__.__name__
 
     @property
-    def wires(self) -> Wires:
+    def wires(self) -> Wires | None:
         """Wires that the operator acts on.
 
         The returned :class:`~.Wires` are collected from the operator's arguments in
@@ -953,6 +953,18 @@ class Operator2(metaclass=OperatorMeta):
     # ------------------------------------------------------------------------
 
     def __repr__(self) -> str:
+        if len(self.arguments) == 1:
+            key, value = next(iter(self.arguments.items()))
+            if key in self.wire_argnames and key not in self.hybrid_argnames:
+                # Format single wires directly without list brackets or keyword labels
+                wires_list = value.tolist() if isinstance(value, Wires) else value
+                res = (
+                    wires_list[0]
+                    if isinstance(wires_list, list) and len(wires_list) == 1
+                    else wires_list
+                )
+                return f"{self.name}({repr(res)})"
+
         inputs = []
 
         for key, value in self.arguments.items():

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -953,11 +953,16 @@ class Operator2(metaclass=OperatorMeta):
     # ------------------------------------------------------------------------
 
     def __repr__(self) -> str:
-        non_wire_args = self.dynamic_argnames + self.static_argnames + self.compilable_argnames + self.hybrid_argnames
+        non_wire_args = (
+            self.dynamic_argnames
+            + self.static_argnames
+            + self.compilable_argnames
+            + self.hybrid_argnames
+        )
         if not non_wire_args and len(self.wire_argnames) == 1:
             wire_arg = self.arguments[self.wire_argnames[0]]
-            if isinstance(wire_arg, Wires):
-                return f"{self.name}({wire_arg.tolist()[0]})"
+            if isinstance(wire_arg, Wires) and len(wire_arg) == 1:
+                return f"{self.name}({wire_arg.tolist()[0]!r})"
         inputs = []
 
         for key, value in self.arguments.items():

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -957,10 +957,12 @@ class Operator2(metaclass=OperatorMeta):
             arg_name, arg_value = next(iter(self.arguments.items()))
             # NOTE: Only strip for SINGLE concrete wires
             # multi-wire or abstract wire ops will retain legacy Name(wires=[...]) format
-            if arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames:
-                wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
-                if isinstance(wires_list, list) and len(wires_list) == 1:
-                    return f"{self.name}({wires_list[0]!r})"
+            wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
+            is_non_pytree_wires = (
+                arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames
+            )
+            if is_non_pytree_wires and (isinstance(wires_list, list) and len(wires_list) == 1):
+                return f"{self.name}({wires_list[0]!r})"
 
         inputs = []
 

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -955,13 +955,14 @@ class Operator2(metaclass=OperatorMeta):
     def __repr__(self) -> str:
         if len(self.arguments) == 1:
             arg_name, arg_value = next(iter(self.arguments.items()))
-            # NOTE: Only process non-pytree wire arguments
+            # NOTE: Only strip for SINGLE wires, multi-wire ops
+            # with retain legacy Name(wires=[...]) format
             if arg_name in self.wire_argnames and arg_name not in self.hybrid_argnames:
                 wires_list = arg_value.tolist() if isinstance(arg_value, Wires) else arg_value
                 if isinstance(wires_list, list) and len(wires_list) == 1:
-                    # NOTE: Only strip for SINGLE wires, multi-wire ops
-                    # with retain legacy Name(wires=[...]) format
-                    return f"{self.name}({repr(wires_list[0])})"
+                    return f"{self.name}({wires_list[0]!r})"
+                if isinstance(wires_list, AbstractWires) and wires_list.num_wires == 1:
+                    return f"{self.name}({wires_list!r})"
 
         inputs = []
 

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1300,6 +1300,18 @@ class TestDunderMethods:
         op = Op(wires=0)
         assert repr(op) == "Op(0)"
 
+    def test_repr_without_dynamic_args_different_wire_argname(self):
+        """Test that __repr__ prints without dynamic parameters if there are none."""
+
+        class Op(Operator2):
+            wire_argnames = ("my_wires",)
+
+            def __init__(self, my_wires):
+                super().__init__(my_wires=my_wires)
+
+        op = Op(my_wires=0)
+        assert repr(op) == "Op(0)"
+
     def test_repr_with_hybrid_wires(self):
         """Test that __repr__ prints correctly if there are hybrid wire arguments."""
 

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1290,7 +1290,7 @@ class TestDunderMethods:
         op = DynOp(0.5, wires=[0, 1])
         assert repr(op) == "DynOp(phi=0.5, wires=[0, 1])"
 
-    @pytest.mark.parametrize("wires", [0, Wire[1], "a"])
+    @pytest.mark.parametrize("wires", [0, "a"])
     def test_repr_without_dynamic_args(self, wires):
         """Test that __repr__ prints without dynamic parameters if there are none."""
 
@@ -1299,7 +1299,18 @@ class TestDunderMethods:
                 super().__init__(wires=wires)
 
         op = Op(wires=wires)
-        assert repr(op) == f"Op({repr(wires)})"
+        assert repr(op) == f"Op({wires!r})"
+
+    @pytest.mark.parametrize("num_wires", [1, 2])
+    def test_repr_without_dynamic_args_abstract_wires(self, num_wires):
+        """Test that __repr__ prints without dynamic parameters if there are none."""
+
+        class Op(Operator2):
+            def __init__(self, wires):
+                super().__init__(wires=wires)
+
+        op = Op(wires=AbstractWires(num_wires))
+        assert repr(op) == f"Op(wires={AbstractWires(num_wires)!r})"
 
     def test_repr_without_dynamic_args_multiwire(self):
         """Test that __repr__ prints without dynamic parameters if there are none."""

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1290,16 +1290,18 @@ class TestDunderMethods:
         op = DynOp(0.5, wires=[0, 1])
         assert repr(op) == "DynOp(phi=0.5, wires=[0, 1])"
 
-    @pytest.mark.parametrize("wires", [0, "a"])
-    def test_repr_without_dynamic_args(self, wires):
+    def test_repr_without_dynamic_args(self):
         """Test that __repr__ prints without dynamic parameters if there are none."""
 
         class Op(Operator2):
             def __init__(self, wires):
                 super().__init__(wires=wires)
 
-        op = Op(wires=wires)
-        assert repr(op) == f"Op({wires!r})"
+        op = Op(wires=0)
+        assert repr(op) == "Op(0)"
+
+        op = Op(wires="a")
+        assert repr(op) == "Op('a')"
 
     @pytest.mark.parametrize("num_wires", [1, 2])
     def test_repr_without_dynamic_args_abstract_wires(self, num_wires):

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1298,7 +1298,7 @@ class TestDunderMethods:
                 super().__init__(wires=wires)
 
         op = Op(wires=0)
-        assert repr(op) == "Op(wires=[0])"
+        assert repr(op) == "Op(0)"
 
     def test_repr_with_hybrid_wires(self):
         """Test that __repr__ prints correctly if there are hybrid wire arguments."""

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1290,15 +1290,26 @@ class TestDunderMethods:
         op = DynOp(0.5, wires=[0, 1])
         assert repr(op) == "DynOp(phi=0.5, wires=[0, 1])"
 
-    def test_repr_without_dynamic_args(self):
+    @pytest.mark.parametrize("wires", [0, Wire[1], "a"])
+    def test_repr_without_dynamic_args(self, wires):
         """Test that __repr__ prints without dynamic parameters if there are none."""
 
         class Op(Operator2):
             def __init__(self, wires):
                 super().__init__(wires=wires)
 
-        op = Op(wires=0)
-        assert repr(op) == "Op(0)"
+        op = Op(wires=wires)
+        assert repr(op) == f"Op({repr(wires)})"
+
+    def test_repr_without_dynamic_args_multiwire(self):
+        """Test that __repr__ prints without dynamic parameters if there are none."""
+
+        class Op(Operator2):
+            def __init__(self, wires):
+                super().__init__(wires=wires)
+
+        op = Op(wires=[0, 1, 2])
+        assert repr(op) == "Op(wires=[0, 1, 2])"
 
     def test_repr_without_dynamic_args_different_wire_argname(self):
         """Test that __repr__ prints without dynamic parameters if there are none."""


### PR DESCRIPTION
**Context:**

We keep having to add logic to various `repr` to handle `AbstractWires` when migrating. 

**Description of the Change:**

Improve the base class repr so that we can just get rid of custom `repr`s for nonparametric ops.

**Benefits:** Less duplicated logic.

**Possible Drawbacks:** None identified.

[sc-124865]