### PR TITLE
Fix error with `Wires` being unflattened with JAX arrays

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -974,7 +974,7 @@
   [(#9400)](https://github.com/PennyLaneAI/pennylane/pull/9400)
   [(#9541)](https://github.com/PennyLaneAI/pennylane/pull/9541)
 
-* The custom dispatch logic from general controlled operators to equivalent bespoke operators (e.g., 
+* The custom dispatch logic from general controlled operators to equivalent bespoke operators (e.g.,
   from `qp.ctrl(qp.X(0), control=[1, 2])` to `Toffoli(wires=[1, 2, 0])`) is re-written to use a
   singledispatch function `custom_ctrl_dispatch` as opposed to relying on hard-coded logic.
   [(#9798)](https://github.com/PennyLaneAI/pennylane/pull/9798)
@@ -1011,6 +1011,9 @@
   [(#9621)](https://github.com/PennyLaneAI/pennylane/pull/9621)
 
 <h3>Bug fixes 🐛</h3>
+
+* Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
+  [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
 * Fixed bugs in :class:`~.Incrementer` and :class:`~.AQFT` where dynamic loop variables and wires
   were not taken into account for `qjit(capture=False)`, leading to tracer conversion errors.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -129,6 +129,9 @@ class Wires(Sequence):
     @classmethod
     def _unflatten(cls, data, _metadata):
         """De-serialize flattened representation back into the Wires object."""
+        # This is needed to handle the case where `Wires` are flattened with scalar tracers, but
+        # unflattened after concretization, resulting in scalar tracers being replaced by scalar
+        # arrays, which are not valid wire labels.
         if math.get_deep_interface(data) == "jax":
             data = tuple(
                 w if isinstance(w, AbstractValue) or math.is_abstract(w) else w.item() for w in data

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -129,7 +129,16 @@ class Wires(Sequence):
     def _unflatten(cls, data, _metadata):
         """De-serialize flattened representation back into the Wires object."""
         if not all(math.get_interface(w) != "jax" or math.is_abstract(w) for w in data):
-            data = tuple(w.item() for w in data)
+            data = tuple(
+                (
+                    w.item()
+                    if isinstance(w, jax.Array)
+                    and not isinstance(w, jax.core.Tracer)
+                    and w.ndim == 0
+                    else w
+                )
+                for w in data
+            )
         return cls(data, _override=True)
 
     def __init__(self, wires, _override=False):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -37,6 +37,7 @@ else:
 if jax_available:
     # pylint: disable=unnecessary-lambda
     setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
+    from jax.core import AbstractValue
 
 
 def _process(wires):
@@ -128,16 +129,9 @@ class Wires(Sequence):
     @classmethod
     def _unflatten(cls, data, _metadata):
         """De-serialize flattened representation back into the Wires object."""
-        if not all(math.get_interface(w) != "jax" or math.is_abstract(w) for w in data):
+        if math.get_deep_interface(data) == "jax":
             data = tuple(
-                (
-                    w.item()
-                    if isinstance(w, jax.Array)
-                    and not isinstance(w, jax.core.Tracer)
-                    and w.ndim == 0
-                    else w
-                )
-                for w in data
+                w if isinstance(w, AbstractValue) or math.is_abstract(w) else w.item() for w in data
             )
         return cls(data, _override=True)
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -134,7 +134,12 @@ class Wires(Sequence):
         # arrays, which are not valid wire labels.
         if math.get_deep_interface(data) == "jax":
             data = tuple(
-                w if isinstance(w, AbstractValue) or math.is_abstract(w) else w.item() for w in data
+                (
+                    w.item()
+                    if isinstance(w, jax.Array) and not math.is_abstract(w) and w.ndim == 0
+                    else w
+                )
+                for w in data
             )
         return cls(data, _override=True)
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -128,6 +128,8 @@ class Wires(Sequence):
     @classmethod
     def _unflatten(cls, data, _metadata):
         """De-serialize flattened representation back into the Wires object."""
+        if not all(math.get_interface(w) != "jax" or math.is_abstract(w) for w in data):
+            data = tuple(w.item() for w in data)
         return cls(data, _override=True)
 
     def __init__(self, wires, _override=False):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -37,7 +37,6 @@ else:
 if jax_available:
     # pylint: disable=unnecessary-lambda
     setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
-    from jax.core import AbstractValue
 
 
 def _process(wires):

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -405,6 +405,20 @@ class TestWires:
         assert isinstance(wires2, Wires), f"{wires2} is not Wires"
         assert wires == wires2, f"{wires} != {wires2}"
 
+    @pytest.mark.jax
+    def test_wires_pytree_with_array_leaves(self):
+        """Test that unflattening wire pytrees with leaves containing scalar arrays
+        is possible and correct."""
+        import jax.numpy as jnp
+        from jax.tree import flatten, unflatten
+
+        wires = Wires([0, 1, 2, 3])
+        leaves, tree = flatten(wires)
+        inner_arr_leaves = [jnp.array(l, dtype=int) for l in leaves]
+        unflattened_wires = unflatten(tree, inner_arr_leaves)
+
+        assert wires == unflattened_wires
+
     def test_class_index(self):
         """Test that indexing the class raises."""
         with pytest.raises(


### PR DESCRIPTION
**Context:**
During the migration of operators, an error comes up frequently when an operator is flattened during tracing but unflattened during concrete evaluation, because wires (effectively a list of scalar tracers) become lists of scalar _arrays_, which are not hashable.

This occurs with Operator2 because wires weren't previously considered dynamic data for operator pytrees, which is no longer the case.

**Description of the Change:**
* Update `Wires._unflatten` to allow scalar JAX arrays as indices.

**Benefits:**
* Fixes a failure coming up frequently during migration.

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-124469]