### PR TITLE
Port of SX by cursor's Opus 4.8

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -796,6 +796,8 @@
 * The following legacy operators are now ported to the new `~.Operator2` base class.
   - `~.S` is ported
   [(#9818)](https://github.com/PennyLaneAI/pennylane/pull/9818)
+  - `~.SX` is ported
+  [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -797,7 +797,7 @@
   - `~.S` is ported
   [(#9818)](https://github.com/PennyLaneAI/pennylane/pull/9818)
   - `~.SX` is ported
-  [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
+  [(#9859)](https://github.com/PennyLaneAI/pennylane/pull/9859)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -1467,7 +1467,7 @@ def _pow_t(wires, z, **_):
 add_decomps("Pow(T)", make_pow_decomp_with_period(8), _pow_t)
 
 
-class SX(Operation):
+class SX(Operator2):
     r"""SX(wires)
     The single-qubit Square-Root X operator.
 
@@ -1485,12 +1485,18 @@ class SX(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
     """
 
+    wire_sizes = (1,)
+    arg_specs = {"wires": Wire[1]}
+
     num_wires = 1
     num_params = 0
     """int: Number of trainable parameters that the operator depends on."""
 
+    def __init__(self, wires: WiresLike):
+        super().__init__(wires=wires)
+
     @property
-    def basis(self) -> Literal["X", "Y", "Z", None]:
+    def basis(self) -> Literal["X", "Y", "Z", None]:  # pylint: disable=missing-function-docstring
         warn(
             "Operation.basis is deprecated in v0.46 and will be removed in v0.47. "
             "qp.is_commuting should be used instead to check commutivity.",
@@ -1501,30 +1507,22 @@ class SX(Operation):
     resource_keys = set()
 
     @property
-    def resource_params(self) -> dict:
-        return {}
-
-    @property
     def pauli_rep(self):
         if self._pauli_rep is None:
             self._pauli_rep = qp.pauli.PauliSentence(
                 {
+                    # pylint: disable=unsubscriptable-object
                     qp.pauli.PauliWord({self.wires[0]: "I"}): (0.5 + 0.5j),
+                    # pylint: disable=unsubscriptable-object
                     qp.pauli.PauliWord({self.wires[0]: "X"}): (0.5 - 0.5j),
                 }
             )
         return self._pauli_rep
 
-    def __repr__(self) -> str:
-        """String representation."""
-        wire = self.wires[0]
-        if isinstance(wire, str):
-            return f"SX('{wire}')"
-        return f"SX({wire})"
-
     @staticmethod
     @lru_cache
-    def compute_matrix() -> np.ndarray:  # pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ,unused-argument
+    def compute_matrix(wires: WiresLike = None) -> np.ndarray:
         r"""Representation of the operator as a canonical matrix in the computational basis (static method).
 
         The canonical matrix is the textbook matrix representation that does not consider wires.
@@ -1544,7 +1542,8 @@ class SX(Operation):
         return 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
 
     @staticmethod
-    def compute_eigvals() -> np.ndarray:  # pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ,unused-argument
+    def compute_eigvals(wires: WiresLike = None) -> np.ndarray:
         r"""Eigenvalues of the operator in the computational basis (static method).
 
         If :attr:`diagonalizing_gates` are specified and implement a unitary :math:`U^{\dagger}`,
@@ -1569,37 +1568,6 @@ class SX(Operation):
         """
         return np.array([1, 1j])
 
-    @staticmethod
-    def compute_decomposition(wires: WiresLike) -> list[qp.operation.Operator]:
-        r"""Representation of the operator as a product of other operators (static method).
-
-        .. math:: O = O_1 O_2 \dots O_n.
-
-
-        .. seealso:: :meth:`~.SX.decomposition`.
-
-        Args:
-            wires (Any, Wires): Single wire that the operator acts on.
-
-        Returns:
-            list[Operator]: decomposition into lower level operations
-
-        **Example:**
-
-        >>> print(qp.SX.compute_decomposition(0))
-        [RZ(1.5707963267948966, wires=[0]),
-        RY(1.5707963267948966, wires=[0]),
-        RZ(-1.5707963267948966, wires=[0]),
-        GlobalPhase(-0.7853981633974483, wires=[0])]
-
-        """
-        return [
-            qp.RZ(np.pi / 2, wires=wires),
-            qp.RY(np.pi / 2, wires=wires),
-            qp.RZ(-np.pi / 2, wires=wires),
-            qp.GlobalPhase(-np.pi / 4, wires=wires),
-        ]
-
     def pow(self, z: int | float) -> list[qp.operation.Operator]:
         z_mod4 = z % 4
         if z_mod4 == 2:
@@ -1607,12 +1575,12 @@ class SX(Operation):
         return super().pow(z_mod4)
 
 
-def _sx_to_rx_resources():
+def _sx_to_rx_resources(wires: WiresLike = None):  # pylint: disable=unused-argument
     return {qp.RX: 1, qp.GlobalPhase: 1}
 
 
 @register_resources(_sx_to_rx_resources)
-def _sx_to_rx(wires: WiresLike, **__):
+def _sx_to_rx(wires: WiresLike | None = None):
     qp.RX(np.pi / 2, wires=wires)
     qp.GlobalPhase(-np.pi / 4, wires=wires)
 

--- a/pennylane/ops/qubit/non_parametric_ops.py
+++ b/pennylane/ops/qubit/non_parametric_ops.py
@@ -1519,8 +1519,9 @@ class SX(Operator2):
             )
         return self._pauli_rep
 
+    _matrix = 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
+
     @staticmethod
-    @lru_cache
     # pylint: disable=arguments-differ,unused-argument
     def compute_matrix(wires: WiresLike = None) -> np.ndarray:
         r"""Representation of the operator as a canonical matrix in the computational basis (static method).
@@ -1539,7 +1540,7 @@ class SX(Operator2):
         [[0.5+0.5j 0.5-0.5j]
          [0.5-0.5j 0.5+0.5j]]
         """
-        return 0.5 * np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]])
+        return SX._matrix
 
     @staticmethod
     # pylint: disable=arguments-differ,unused-argument

--- a/tests/ops/qubit/test_all_qubit_ops.py
+++ b/tests/ops/qubit/test_all_qubit_ops.py
@@ -64,7 +64,6 @@ class TestOperations:
             (qp.PauliY(wires=0)),
             (qp.PauliZ(wires=0)),
             (qp.T(wires=0)),
-            (qp.SX(wires=0)),
             (qp.RX(0.3, wires=0)),
             (qp.RY(0.3, wires=0)),
             (qp.RZ(0.3, wires=0)),

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -234,18 +234,10 @@ class TestDecompositions:
         op = qp.SX(wires=0)
         res = op.decomposition()
 
-        assert len(res) == 4
-        assert all(res[i].wires == Wires([0]) for i in range(4))
+        assert len(res) == 2
 
-        assert res[0].name == "RZ"
-        assert res[1].name == "RY"
-        assert res[2].name == "RZ"
-        assert res[3].name == "GlobalPhase"
-
-        assert res[0].data[0] == np.pi / 2
-        assert res[1].data[0] == np.pi / 2
-        assert res[2].data[0] == -np.pi / 2
-        assert res[3].data[0] == -np.pi / 4
+        qp.assert_equal(res[0], qp.RX(np.pi / 2, wires=0))
+        qp.assert_equal(res[1], qp.GlobalPhase(-np.pi / 4, wires=0))
 
         decomposed_matrix = np.linalg.multi_dot([i.matrix() for i in reversed(res)])
         assert np.allclose(decomposed_matrix, op.matrix(), atol=tol, rtol=0)

--- a/tests/ops/qubit/test_non_parametric_ops.py
+++ b/tests/ops/qubit/test_non_parametric_ops.py
@@ -1231,7 +1231,6 @@ control_data = [
     (qp.PauliX(0), Wires([])),
     (qp.PauliY(0), Wires([])),
     (qp.T(wires=0), Wires([])),
-    (qp.SX(wires=0), Wires([])),
     (qp.SWAP(wires=(0, 1)), Wires([])),
     (qp.ISWAP(wires=(0, 1)), Wires([])),
     (qp.SISWAP(wires=(0, 1)), Wires([])),


### PR DESCRIPTION
**Context:**

Prompt was simply:

```
Mimicing https://github.com/PennyLaneAI/pennylane/pull/9818 port SX to implement Operator2 @pennylane/ops/qubit/non_parametric_ops.py:1492-1493 
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
