### PR TITLE
Fix operator equality for shared abstract values

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1040,7 +1040,7 @@
 
 * Fixed :func:`~.equal` so operators that share the same abstract tracer parameter compare equal,
   while operators containing distinct tracers remain unequal.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#9862)](https://github.com/PennyLaneAI/pennylane/pull/9862)
 
 * Fixed bugs in :class:`~.Incrementer` and :class:`~.AQFT` where dynamic loop variables and wires
   were not taken into account for `qjit(capture=False)`, leading to tracer conversion errors.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1038,6 +1038,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed :func:`~.equal` so operators that share the same abstract tracer parameter compare equal,
+  while operators containing distinct tracers remain unequal.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Fixed bugs in :class:`~.Incrementer` and :class:`~.AQFT` where dynamic loop variables and wires
   were not taken into account for `qjit(capture=False)`, leading to tracer conversion errors.
   Also adjusted the wire validation in :class:`~.OutMultiplier` and :class:`~.SignedOutMultiplier`

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -339,16 +339,14 @@ def _equal_operators(
             f"Got {op1.hyperparameters}\n and {op2.hyperparameters}."
         )
 
-    if any(math.is_abstract(d) for d in op1.data + op2.data):
-        # assume all tracers are independent
-        return "Data contains a tracer. Abstract tracers are assumed to be unique."
     if len(op1.data) != len(op2.data):
         return f"op1 and op2 have different data.\nGot {op1.data} and {op2.data}"
-    if not all(
-        math.allclose(d1, d2, rtol=rtol, atol=atol)
-        for d1, d2 in zip(op1.data, op2.data, strict=True)
-    ):
-        return f"op1 and op2 have different data.\nGot {op1.data} and {op2.data}"
+    for d1, d2 in zip(op1.data, op2.data, strict=True):
+        if math.is_abstract(d1) or math.is_abstract(d2):
+            if d1 is not d2:
+                return "Data contains a tracer. Abstract tracers are assumed to be unique."
+        elif not math.allclose(d1, d2, rtol=rtol, atol=atol):
+            return f"op1 and op2 have different data.\nGot {op1.data} and {op2.data}"
 
     if check_trainability:
         for params1, params2 in zip(op1.data, op2.data, strict=True):
@@ -522,6 +520,8 @@ def _check_dynamic_value(
         return f"op1 and op2 have different AbstractArray type specifiers for {dname}: Got {dval1} and {dval2}."
 
     if math.is_abstract(dval1) or math.is_abstract(dval2):
+        if dval1 is dval2:
+            return True
         return (
             f"At least one of op1 or op2 has a tracer value for '{dname}'. Abstract "
             "tracers are assumed to be unique."

--- a/tests/core/operator/test_operator2_equality.py
+++ b/tests/core/operator/test_operator2_equality.py
@@ -506,15 +506,30 @@ def _jit_eq_fn(phi, wires, assert_=False):
 class TestAbstractDynamicArgs:
     """Tests for checking for equality of traced dynamic arguments."""
 
-    def test_abstract_dynamic_arg_not_equal(self):
-        """Test that operators with traced dynamic arguments are unequal."""
+    def test_same_abstract_dynamic_arg_equal(self):
+        """Test that operators sharing the same traced dynamic argument are equal."""
         import jax
 
         test_fn = jax.jit(_jit_eq_fn, static_argnums=(1, 2))
         result = test_fn(0.5, 0, assert_=False)
-        assert bool(result) is False
+        assert bool(result) is True
+        assert bool(test_fn(0.5, 0, assert_=True)) is True
+
+    def test_distinct_abstract_dynamic_args_not_equal(self):
+        """Test that operators with distinct traced dynamic arguments are unequal."""
+        import jax
+
+        def compare(phi1, phi2, assert_=False):
+            op1 = DynOp(phi1, wires=0)
+            op2 = DynOp(phi2, wires=0)
+            if assert_:
+                qp.assert_equal(op1, op2)
+            return qp.equal(op1, op2)
+
+        test_fn = jax.jit(compare, static_argnums=2)
+        assert bool(test_fn(0.5, 0.5)) is False
         with pytest.raises(AssertionError, match="tracer value for 'phi'"):
-            _ = test_fn(0.5, 0, assert_=True)
+            _ = test_fn(0.5, 0.5, assert_=True)
 
     def test_abstract_wire_arg_not_equal(self):
         """Test that operators with traced wire arguments are unequal."""

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -3076,6 +3076,21 @@ def test_ops_with_abstract_parameters_not_equal():
         jax.jit(assert_equal)(qp.X(0) * 0.5, qp.X(0) * 0.5)
 
 
+@pytest.mark.jax
+def test_ops_with_same_abstract_parameter_equal():
+    """Test that ops are equal when they contain the same tracer object."""
+
+    import jax
+
+    def compare(parameter):
+        op1 = qp.RX(parameter, 0)
+        op2 = qp.RX(parameter, 0)
+        assert_equal(op1, op2)
+        return qp.equal(op1, op2)
+
+    assert jax.jit(compare)(0.1)
+
+
 @pytest.mark.parametrize(
     "op, other_op",
     [


### PR DESCRIPTION
**Context:**

`qp.equal` currently rejects operators as soon as an abstract parameter is present. This is unnecessarily restrictive when both operators contain the exact same tracer object. Fixes #9563.

**Description of the Change:**

For legacy `Operator` data and `Operator2` dynamic arguments, abstract values are now compared by object identity. A shared tracer is accepted; distinct tracer objects remain conservatively unequal. Regression tests cover both operator implementations and preserve the distinct-tracer behavior.

**Benefits:**

Operator equality works inside traced functions when two operators genuinely share a parameter, without attempting value comparisons that JAX cannot resolve during tracing.

**Possible Drawbacks:**

This deliberately recognizes only object identity. Two distinct tracers that could represent equal runtime values still compare unequal.

**Related GitHub Issues:**

Fixes #9563.

**Test plan:**

- [x] Confirmed both new shared-tracer regressions fail before the source change
- [x] `python -m pytest tests/ops/functions/test_equal.py tests/core/operator/test_operator2_equality.py -q` (2477 passed, 32 skipped)
- [x] `python -m black --check pennylane/ops/functions/equal.py tests/ops/functions/test_equal.py tests/core/operator/test_operator2_equality.py`
- [x] `git diff --check`

**Tool assistance:**

OpenAI Codex assisted with preparing the implementation and tests. This is also disclosed with an `Assisted-by` trailer in the commit, per the repository AI tool-use policy.
