### PR TITLE
Fix broadcasted measurements from counts

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1074,7 +1074,7 @@
 
 * Fixed :func:`~pennylane.devices.preprocess.measurements_from_counts` to support
   parameter-broadcasted tapes, including tapes with partitioned shots.
-  [(#9613)](https://github.com/PennyLaneAI/pennylane/issues/9613)
+  [(#9864)](https://github.com/PennyLaneAI/pennylane/pull/9864)
 
 * Fixed bugs in :class:`~.Incrementer` and :class:`~.AQFT` where dynamic loop variables and wires
   were not taken into account for `qjit(capture=False)`, leading to tracer conversion errors.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1072,6 +1072,10 @@
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
+* Fixed :func:`~pennylane.devices.preprocess.measurements_from_counts` to support
+  parameter-broadcasted tapes, including tapes with partitioned shots.
+  [(#9613)](https://github.com/PennyLaneAI/pennylane/issues/9613)
+
 * Fixed bugs in :class:`~.Incrementer` and :class:`~.AQFT` where dynamic loop variables and wires
   were not taken into account for `qjit(capture=False)`, leading to tracer conversion errors.
   Also adjusted the wire validation in :class:`~.OutMultiplier` and :class:`~.SignedOutMultiplier`
@@ -1199,6 +1203,7 @@ Andrija Paurevic,
 Francesco Pernice Botta,
 David D.W. Ren,
 Jay Soni,
+Sankalp Thakur,
 Paul Haochen Wang,
 Dennis Wayo,
 David Wierichs,

--- a/pennylane/devices/preprocess.py
+++ b/pennylane/devices/preprocess.py
@@ -33,7 +33,7 @@ from pennylane.exceptions import (
     QuantumFunctionError,
     WireError,
 )
-from pennylane.math import is_abstract, requires_grad
+from pennylane.math import is_abstract, requires_grad, stack
 from pennylane.measurements import (
     counts,
     sample,
@@ -728,21 +728,25 @@ def measurements_from_counts(tape):
         """A processing function to get measurement values from counts."""
         counts_res = results[0]
 
-        if tape.shots.has_partitioned_shots:
-            results_processed = []
-            for c in counts_res:
-                res = [m.process_counts(c, measured_wires) for m in tape.measurements]
-                if len(tape.measurements) == 1:
-                    res = res[0]
-                results_processed.append(res)
-        else:
-            results_processed = [
-                m.process_counts(counts_res, measured_wires) for m in tape.measurements
-            ]
-            if len(tape.measurements) == 1:
-                results_processed = results_processed[0]
+        def process_single_shot(counts_result):
+            processed = []
+            for measurement in tape.measurements:
+                if tape.batch_size is None:
+                    measurement_result = measurement.process_counts(counts_result, measured_wires)
+                else:
+                    measurement_result = [
+                        measurement.process_counts(c, measured_wires) for c in counts_result
+                    ]
+                    if not isinstance(measurement_result[0], dict):
+                        measurement_result = stack(measurement_result)
+                processed.append(measurement_result)
 
-        return results_processed
+            return processed[0] if len(tape.measurements) == 1 else processed
+
+        if tape.shots.has_partitioned_shots:
+            return [process_single_shot(c) for c in counts_res]
+
+        return process_single_shot(counts_res)
 
     return [new_tape], postprocessing_fn
 

--- a/tests/devices/test_preprocess.py
+++ b/tests/devices/test_preprocess.py
@@ -817,6 +817,47 @@ class TestMeasurementsFromCountsOrSamples:
 
         assert np.allclose(res, expected_res(theta), atol=0.05)
 
+    def test_measurements_from_counts_with_broadcasting_and_partitioned_shots(self):
+        """Test counts postprocessing with parameter broadcasting and partitioned shots."""
+        tape = qp.tape.QuantumScript(
+            [qp.RX([0.1, 0.9], wires=0)],
+            measurements=[qp.probs(wires=0)],
+            shots=(2, 3),
+        )
+        _, fn = measurements_from_counts(tape)
+        counts_results = (
+            [{"0": 2}, {"1": 2}],
+            [{"0": 3}, {"1": 3}],
+        )
+
+        results = fn((counts_results,))
+
+        expected = np.array([[1.0, 0.0], [0.0, 1.0]])
+        assert len(results) == 2
+        assert all(np.allclose(result, expected) for result in results)
+
+    def test_measurements_from_counts_with_broadcasting_and_multiple_measurements(self):
+        """Test batched counts postprocessing for different measurement result types."""
+        tape = qp.tape.QuantumScript(
+            [qp.RX([0.1, 0.9], wires=0)],
+            measurements=[
+                qp.expval(qp.Z(0)),
+                qp.probs(wires=0),
+                qp.counts(wires=0),
+                qp.sample(wires=0),
+            ],
+            shots=2,
+        )
+        _, fn = measurements_from_counts(tape)
+        counts_results = [{"0": 2}, {"1": 2}]
+
+        expval_result, probs_result, counts_result, sample_result = fn((counts_results,))
+
+        assert np.allclose(expval_result, [1.0, -1.0])
+        assert np.allclose(probs_result, [[1.0, 0.0], [0.0, 1.0]])
+        assert counts_result == counts_results
+        assert np.array_equal(sample_result, [[0, 0], [1, 1]])
+
     @pytest.mark.parametrize(
         "counts_kwargs",
         [


### PR DESCRIPTION
**Context**

`measurements_from_counts` expects each result passed to `MeasurementProcess.process_counts` to be a counts dictionary. Parameter-broadcasted tapes produce a list of counts dictionaries; shot vectors produce one such list per shot partition. The postprocessor raised `AttributeError: 'list' object has no attribute 'items'`.

**Severity:** crash at postprocessing (legal tape shapes rejected).

**User impact:** Finite-shot workflows combining parameter broadcasting with partitioned shots — and broadcasted finite-shot tapes without a shot vector — could not complete. Counts-based device paths failed after execution, blocking batched variational and shot-adaptive experiments.

**Minimal repro**

```python
# tape with broadcast parameters + shot vector, terminal measurement qml.probs
# execute succeeds; measurements_from_counts postprocessor crashes:
# AttributeError: 'list' object has no attribute 'items'
```

**Change**

Map each original measurement over broadcast counts dictionaries. Stack numerical results along the broadcast axis; keep dictionary-valued counts as lists. Apply independently per shot partition.

Regression tests cover:
- single probability measurement with parameter broadcasting and partitioned shots
- multiple batched result types (`expval`, `probs`, `counts`, `sample`)

Fixes #9613

Related: #2932 (differentiating through `counts`; orthogonal to postprocessing shape).

**Validation**

- `pytest tests/devices/test_preprocess.py`: 149 passed, 10 skipped
- Black, isort, Pylint (10.00/10), tach, `git diff --check`