### PR TITLE
Fix Dataset.read source ownership

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1057,6 +1057,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``Dataset.read`` so that caller-supplied source ``Dataset`` objects remain open
+  after copying.
+  [(#9872)](https://github.com/PennyLaneAI/pennylane/pull/9872).
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
@@ -1182,6 +1186,7 @@ Andrija Paurevic,
 Francesco Pernice Botta,
 David D.W. Ren,
 Jay Soni,
+Joshua Steier,
 Paul Haochen Wang,
 Dennis Wayo,
 David Wierichs,

--- a/pennylane/data/base/dataset.py
+++ b/pennylane/data/base/dataset.py
@@ -293,13 +293,17 @@ class Dataset(MapperMixin, _DatasetTransform):
             overwrite: Whether to overwrite attributes that already exist in this
                 dataset.
         """
+        close_source = False
+
         if not isinstance(source, Dataset):
             source = Path(source).expanduser()
             source = Dataset.open(source, mode="r")
+            close_source = True
 
         source.write(self, attributes=attributes, overwrite=overwrite)
 
-        source.close()
+        if close_source:
+            source.close()
 
     def write(
         self,

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -343,6 +343,25 @@ class TestDataset:
         assert dset.y == "abc"
         assert dset.attr_info["y"].doc == "abc"
 
+    def test_read_from_dataset_does_not_close_source(self, tmp_path):
+        """Test that read() leaves a caller-supplied Dataset open."""
+        path = tmp_path / "dset.h5"
+
+        existing = Dataset.open(path, "w")
+        existing.x = 1
+        existing.close()
+
+        existing = Dataset.open(path, "r")
+        dset = Dataset()
+
+        try:
+            dset.read(existing)
+
+            assert dset.x == 1
+            assert existing.x == 1
+        finally:
+            existing.close()
+
     @pytest.mark.parametrize("overwrite, expect_x", [(False, 2), (True, 1)])
     def test_read_overwrite(self, overwrite, expect_x):
         """Test that overwrite determnines whether an existing attribute


### PR DESCRIPTION
Context:

`Dataset.read()` currently closes a source `Dataset` supplied by the caller.
This makes the caller-owned object unusable after the copy operation.

Description of the Change:

- Track whether `Dataset.read()` opened the source internally.
- Continue closing sources opened internally from a path.
- Leave caller-supplied `Dataset` objects open.
- Add a regression test that accesses the source after copying.

Benefits:

`Dataset.read()` now follows the expected resource-ownership convention and
does not invalidate objects owned by callers.

Possible Drawbacks:

Callers remain responsible for closing `Dataset` objects that they opened.

Testing:

- `python -m pytest tests/data/test_dataset.py::TestDataset::test_read_from_dataset_does_not_close_source -vv`
- Related `Dataset.read()` tests: 6 passed
- `python -m pytest tests/data/test_dataset.py -q`: 45 passed
- `python -m pytest tests/data -q`: 807 passed, 1 skipped
- `pre-commit run --files pennylane/data/base/dataset.py tests/data/test_dataset.py`
- `python -m pylint pennylane/data/base/dataset.py`

Related GitHub Issues:

Closes #9651

AI assistance:
ChatGPT was used for minor debugging. 