### PR TITLE
Fix probability(wires=0) returning full distribution instead of marginal

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1050,7 +1050,7 @@
   returned the full joint distribution instead of the single-wire marginal. The falsy
   label was silently replaced by all device wires; the default is now resolved with an
   explicit ``None`` check.
-  [(#PRNUM)](https://github.com/PennyLaneAI/pennylane/pull/PRNUM)
+  [(#9875)](https://github.com/PennyLaneAI/pennylane/pull/9875)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1045,6 +1045,13 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where ``QubitDevice.probability``, ``QubitDevice.estimate_probability``
+  and ``QutritDevice.estimate_probability`` ignored an integer wire label of ``0`` and
+  returned the full joint distribution instead of the single-wire marginal. The falsy
+  label was silently replaced by all device wires; the default is now resolved with an
+  explicit ``None`` check.
+  [(#PRNUM)](https://github.com/PennyLaneAI/pennylane/pull/PRNUM)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
@@ -1150,6 +1157,7 @@
 This release contains contributions from (in alphabetical order):
 
 Usman Ahmed,
+Mohit Ak,
 Guillermo Alonso,
 Abdullah Al Omar Galib,
 Gabriel Bottrill,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,11 +2,132 @@
 
 <h3>New features since last release</h3>
 
+* A new decorator is available called :func:`pennylane.subcircuit`, which can be used to 
+  create operators directly from quantum functions. This enables fast research and 
+  development of new operators without the need to create full-fledged operator classes 
+  manually.
+  [(#10126)](https://github.com/PennyLaneAI/pennylane/pull/10126)
+
+  ```python
+  @qp.subcircuit(dynamic_argnames=("phi",), wire_argnames=("wires",))
+  @qp.register_resources({qp.H: 1, qp.RZ: 1})
+  def MyOp(phi, wires):
+      """My custom operator created using qp.subcircuit."""
+      qp.H(wires)
+      qp.RZ(phi, wires)
+  ```
+  ```pycon
+  >>> op = MyOp(0.5, wires=0)
+  >>> op
+  MyOp(0.5, wires=[0])
+  >>> isinstance(op, qp.core.Operator2)
+  True
+  >>> qp.inspect_decomps(op)
+  Decomposition 0 (name: MyOp_decomp)
+  0: ──H──RZ(0.50)─┤
+  Gate Count: {Hadamard: 1, RZ: 1}
+
+  ```
+
+* Two new numeric Hamiltonians called :class:`pennylane.CDFHamiltonian` (based on `arXiv:2506.15784, Sec. III A <https://arxiv.org/abs/2506.15784>`) and :class:`pennylane.CGFHamiltonian` have been added (based on `arXiv:2508.11865, Sec. III C <https://arxiv.org/abs/2508.11865>`), which define compressed double-factorized (CDF) and Christiansen greedy-fragmentation Hamiltonians, respectively. These Hamiltonians can be defined
+  with both concrete numeric data or abstract data (using ``qp.typing.Float[...]``).
+  [(#10048)](https://github.com/PennyLaneAI/pennylane/pull/10048)
+
+  ```python
+  import numpy as np
+  import pennylane as qp
+
+  L, M, N = 2, 2, 3
+  ham = qp.CGFHamiltonian(
+      core_tensors=np.random.rand(L + 1, M, M, N, N),
+      leaf_tensors=np.random.rand(L + 1, M, N, N),
+      nuc_constant=0.5,
+  )
+  ```
+
+  The same Hamiltonian can be described with abstract data for the purposes of fast, low-fidelity
+  resource-estimation workflows where only shape information is available:
+
+  ```pycon
+  >>> from pennylane.typing import Float
+  >>> qp.CGFHamiltonian(Float[L + 1, M, M, N, N], Float[L + 1, M, N, N]).leaf_tensors
+  AbstractArray((3, 2, 3, 3), float64, weak_type=True)
+
+  ```
+
+* Added :func:`~pennylane.backline.triton_decoder` and
+  :func:`~pennylane.backline.css_bp_decoder` for compiling Triton-based coprocessor decoders.
+  :func:`~pennylane.backline.triton_decoder` wraps user-provided Triton decoder tuples, while
+  :func:`~pennylane.backline.css_bp_decoder` builds a CSS belief-propagation decoder from X- and Z-type parity-check
+  matrices. In both cases, syndromes and corrections are packed into ``u64`` bitmasks.
+
+  ```py
+  import numpy as np
+  import pennylane as qp
+  import triton.language as tl
+
+  def steane_lookup(syndrome):
+      return tl.where(syndrome != 0, 1 << (syndrome - 1), 0)
+
+  custom_decoder = qp.backline.triton_decoder(
+      (steane_lookup, steane_lookup),
+      platform="hip:gfx942:64",
+  )
+
+  Hz = Hx = np.array([
+      [1, 0, 1, 0, 1, 0, 1],
+      [0, 1, 1, 0, 0, 1, 1],
+      [0, 0, 0, 1, 1, 1, 1],
+  ])
+  css_decoder = qp.backline.css_bp_decoder(
+      Hx,
+      Hz,
+      postprocess="osd",
+      num_iters=10,
+      platform="hip:gfx942:64",
+  )
+  ```
+  [(#9975)](https://github.com/PennyLaneAI/pennylane/pull/9975)
+
+* (Experimental) A new `qp.backline` module is added for heterogeneous compilation and execution.
+  `qp.Backline` builds a device from a controller, zero or more coprocessors, and a transport,
+  describing where each part of a workload runs and how the parts communicate. The resulting device
+  binds to a QNode, and requires the Catalyst compiler to execute.
+  [(#9772)](https://github.com/PennyLaneAI/pennylane/pull/9772)
+
+  ```python
+  import pennylane as qp
+
+  controller = qp.Controller(device=qp.device("lightning.qubit", wires=4), name="cpu-controller")
+  decoder = qp.Coprocessor(coprocessor_fn="decoder", endpoint=qp.Endpoint("198.51.100.2", 7760))
+
+  dev = qp.Backline(controller=controller, coprocessors=[decoder], transport="rdma")
+
+  @qp.qjit
+  @qp.qnode(dev)
+  def circuit(x):
+      qp.RX(x, wires=0)
+      return qp.expval(qp.Z(0))
+  ```
+
+* Added a new template :class:`~.TrotterVibronic` that implements a second-order Trotter circuit for
+  vibronic Hamiltonian simulation using phase-gradient arithmetic, based on
+  [Motlagh et al, arXiv:2411.13669](https://arxiv.org/abs/2411.13669).
+  [(#10029)](https://github.com/PennyLaneAI/pennylane/pull/10029)
+
+* ``qp.allocate`` now supports ``state="magic-T"`` and ``state="magic-T-adj"`` for requesting
+  magic-state dynamic wires (:math:`|m\rangle = TH|0\rangle` and :math:`|m̄\rangle = T^\dagger H|0\rangle`).
+  These states are currently supported when compiling with Catalyst; device simulators raise an
+  error via ``resolve_dynamic_wires`` until native support is added.
+  [(#9846)](https://github.com/PennyLaneAI/pennylane/pull/9846)
+
 * Added a new template :class:`~.PartialUnaryStatePreparation` for sparse state preparation
   using partial unary iteration. It is based on [Rupprecht & Wölk, arXiv:2601.09388](https://arxiv.org/abs/2601.09388).
   [(#9478)](https://github.com/PennyLaneAI/pennylane/pull/9478)
   [(#9656)](https://github.com/PennyLaneAI/pennylane/pull/9656)
   [(#9833)](https://github.com/PennyLaneAI/pennylane/pull/9833)
+  [(#9847)](https://github.com/PennyLaneAI/pennylane/pull/9847)
+  [(#10008)](https://github.com/PennyLaneAI/pennylane/pull/10008)
 
   Given the ``amplitudes`` and the computational basis state ``indices`` of the sparse state we
   want to prepare, the template is simple to call. Consider the following example:
@@ -49,6 +170,15 @@
 
   ```
 
+* Added :class:`~.TrotterCDF` and :class:`~.TrotterCGF`, templates for second-order Trotter time evolution of
+  fragmented Hamiltonians (CDF for electronic structure, CGF for vibrational structure) as used in modern quantum
+  chemistry algorithms.
+  [(#9459)](https://github.com/PennyLaneAI/pennylane/pull/9459)
+  [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
+  [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
+  [(#10074)](https://github.com/PennyLaneAI/pennylane/pull/10074)
+  [(#10081)](https://github.com/PennyLaneAI/pennylane/pull/10081)
+
 * A new arithmetic template called :class:`~.SignedOutMultiplier` has been added that multiplies numbers encoded in the
   input registers using a two's complement.
   [(#9458)](https://github.com/PennyLaneAI/pennylane/pull/9458)
@@ -66,8 +196,10 @@
 
   @qp.qnode(dev, shots=1)
   def circuit():
-      qp.BasisEmbedding(x, wires=x_wires)
-      qp.BasisEmbedding(y, wires=y_wires)
+      x_bin = qp.math.int_to_binary(x, len(x_wires))
+      y_bin = qp.math.int_to_binary(y, len(y_wires))
+      qp.BasisEmbedding(x_bin, wires=x_wires)
+      qp.BasisEmbedding(y_bin, wires=y_wires)
       qp.SignedOutMultiplier(
           x_wires,
           y_wires,
@@ -140,7 +272,7 @@
 
 * :func:`~.specs` will now output symbolic resource information when it encounters a loop that uses dynamic control-flow
   that can't be resolved at compile time.
-  In such cases the returned :class:`~.resource.CircuitSpecs` will contain :class:`~.resource.SymbolicSpecsResources` instances instead of the usual :class:`~.resource.SpecsResources` instances.
+  In such cases the returned :class:`~.resource.CircuitSpecs` will contain :class:`~.resource.Expression` instances where `int` values would normally appear.
 
   ```python
   @qp.qjit(autograph=True)
@@ -151,11 +283,10 @@
       for _ in range(x):
           qp.PauliX(0)
       return qp.expval(qp.PauliX(0))
-
-  specs_result = qp.specs(circuit, level=0)(5)
   ```
 
   ```pycon
+  >>> specs_result = qp.specs(circuit, level=0)(5)
   >>> print(specs_result)
   Device: lightning.qubit
   Device wires: 1
@@ -163,14 +294,14 @@
   Level: Before MLIR Passes
   <BLANKLINE>
   Symbolic Variables: a
-  Wire allocations: 1
-  Total gates: a + 2
-  Gate counts:
-  - Hadamard: 1
-  - PauliX: a + 1
-  Measurements:
+  Quantum operations:
+  - Total: a + 2
+    - Hadamard: 1
+    - PauliX: a + 1
+  Measurement processes:
   - expval(PauliX): 1
-  Depth: Not computed
+  Total wires: 1
+  Circuit Depth: Not computed
 
   ```
 
@@ -179,14 +310,14 @@
   ```pycon
   >>> res = specs_result.resources
   >>> print(res.subs(a=5))
-  Wire allocations: 1
-  Total gates: 7
-  Gate counts:
-  - Hadamard: 1
-  - PauliX: 6
-  Measurements:
+  Quantum operations:
+  - Total: 7
+    - Hadamard: 1
+    - PauliX: 6
+  Measurement processes:
   - expval(PauliX): 1
-  Depth: Not computed
+  Total wires: 1
+  Circuit Depth: Not computed
 
   ```
 
@@ -260,37 +391,115 @@
   decomposed recursively into :class:`~.FermionicSWAP` and :class:`~.TwoWireFFT` operations
   (two-site Fermionic Fourier transforms).
 
-* A new operation :class:`~.QutritDensityMatrix` has been added to initialize density matrix states for the device
-  `qp.devices.DefaultQutritMixed`.
-  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
+* The ability for a compiled program to call a runtime entry point directly via its C symbol name has been added. A symbol's signature is declared once with `qp.runtime_declare` and called with `qp.runtime_call` from inside a `qjit` program.
+  [(#9970)](https://github.com/PennyLaneAI/pennylane/pull/9970)
 
   ```python
   import pennylane as qp
-  nr_wires = 1
-  rho = np.zeros((3 ** nr_wires, 3 ** nr_wires), dtype=np.complex128)
-  rho[2, 2] = 1  # initialize the pure state density matrix for the |2><2| state
 
-  dev = qp.device("default.qutrit.mixed", wires=1)
+  qp.runtime_declare("example_local_rounds", "(ptr, u32) -> u64", library="/path/librounds.so")
+
+  def program(session):
+      return qp.runtime_call("example_local_rounds", session, 100000)
+  ```
+
+  Passing `address="host:port"` dispatches the call to the executor on the remote side, which invokes the
+  symbol on the machine the runtime lives on; without it the call is local. Meanwhile, `qp.backline.runtime.CType` lists what can cross the boundary.
+
+  A symbol that fills a buffer declares it as an `out` parameter: the caller asks for `out_bytes=`
+  and gets the filled buffer back alongside the result.
+
+  ```python
+  qp.runtime_declare("example_collect", "(ptr, out, u64) -> i32")
+
+  def collect(session):
+      status, reply = qp.runtime_call("example_collect", session, 64, out_bytes=64)
+      return reply
+  ```
+
+* A new `qp.backline.decode` function is added, which offloads one syndrome to a coprocessor from inside a captured QNode and returns its correction, driving a single transport round: stage the syndrome, post it, collect the reply.
+  [(#9970)](https://github.com/PennyLaneAI/pennylane/pull/9970)
+
+  The nodes are taken from the placement of the device being traced, so a round on a built backline is just `correction = qp.backline.decode(syndrome)`:
+
+  ```python
+  import pennylane as qp
+
+  address_controller = "192.168.3.15"  # the host the controller runs on
+  address_coproc = "192.168.1.3"  # the host the coprocessor listens on
+
+  con = qp.Controller(
+      device=qp.device("null.qubit", wires=2),
+      remote=True,
+      executor_options={"host": address_controller, "port": 7810},
+  )
+  coproc = qp.Coprocessor(
+      coprocessor_fn="decoder",
+      hardware="gpu",
+      endpoint=qp.Endpoint(address_coproc, 18590),
+  )
+  dev = qp.Backline(controller=con, coprocessors=[coproc], transport="rdma")
+
+  @qp.qjit(capture=True)
   @qp.qnode(dev)
-  def circuit():
-      qp.QutritDensityMatrix(rho, wires=[0])
-      return qp.state()
+  def circuit(syndrome):
+      correction = qp.backline.decode(syndrome)
+      qp.cond(correction[0] == 1, qp.X)(0)
+      return qp.expval(qp.Z(0))
   ```
 
-  ```pycon
-  >>> circuit()
-  array([[[0.+0.j, 0.+0.j, 0.+0.j],
-          [0.+0.j, 0.+0.j, 0.+0.j],
-          [0.+0.j, 0.+0.j, 1.+0.j]]])
-
-  ```
+  The round is resolved from the device being traced, so the program has to be captured (`qp.qjit(capture=True)`). The controller's `in_bytes` and `out_bytes` capacities both default to 8 bytes, and the correction comes back as an `out_bytes`-sized `uint8` buffer. Pass `controller=` / `coprocessor=` to choose the nodes explicitly, `out_bytes=` to override the reply size, and `decoder_id=` to select which coprocessor-side decoder handles the round.
 
 <h3>Improvements 🛠</h3>
+
+* Register a dispatch for ``np.delete`` to handle Numpy/JAX signature divergence.
+  [(#10137)]((https://github.com/PennyLaneAI/pennylane/pull/10137)
+
+* `DecompositionRule` now wraps the target qfunc, preserving it's signature and docstring.
+  [(#10144)](https://github.com/PennyLaneAI/pennylane/pull/10144)
+ 
+*  Reduced shot counts in `default.clifford` measurement tests to improve CI runtime.
+  [(#10127)](https://github.com/PennyLaneAI/pennylane/pull/10127)
+
+* :func:`~.SumOfSlatersPrep.required_register_sizes` now works with abstract ``indices`` as input,
+  for which it returns an upper bound for the register sizes, across any set of indices of the
+  provided length.
+  [(#10084)](https://github.com/PennyLaneAI/pennylane/pull/10084)
+
+  ```pycon
+  >>> num_wires = 8
+  >>> num_entries = 16
+  >>> indices = qp.typing.Int[num_entries]
+  >>> qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires)
+  {'wires': 8, 'enumeration_wires': 4, 'identification_wires': 7, 'qrom_work_wires': 3, 'mcx_cache_wires': 6}
+
+  ```
+
+* :class:`~.IsingZZ`'s decomposition is now expressed as a :func:`~.change_op_basis` (``CNOT``
+  compute/uncompute around the ``RZ``) instead of three bare gates. This lets PennyLane's generic
+  ``C(ChangeOpBasis)`` rule automatically control only the ``RZ`` for any number of control wires,
+  using fewer gates than the previous default of naively controlling every gate.
+  [(#10059)](https://github.com/PennyLaneAI/pennylane/pull/10059)
+  [(#10059)](https://github.com/PennyLaneAI/pennylane/pull/10015)
+
+* Coprocessor connection addresses are grouped on :class:`~pennylane.Endpoint` as ``endpoint=qp.Endpoint(host, port)``, replacing the separate ``comm_host`` and ``oob_port`` fields.
+  [(#10017)](https://github.com/PennyLaneAI/pennylane/pull/10017)
+
+* Added decompositions of `CNOT`, `CZ`, `CY`, and `Hadamard` directly to PPMs.
+  [(#9865)](https://github.com/PennyLaneAI/pennylane/pull/9865)
+
+* Sorts the gate counts in the display of resources produced from decompositions.
+  [(#9916)](https://github.com/PennyLaneAI/pennylane/pull/9916)
+
+* Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
+  register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.
+  [(#9807)](https://github.com/PennyLaneAI/pennylane/pull/9807)
 
 * Type aliases `Int`, `Float`, `Complex`, `Bool`, and `Wire` have been introduced to allow for intuitive
   abstract type notation.
   [(#9701)](https://github.com/PennyLaneAI/pennylane/pull/9701)
   [(#9724)](https://github.com/PennyLaneAI/pennylane/pull/9724)
+  [(#10056)](https://github.com/PennyLaneAI/pennylane/pull/10056)
 
   ```python
   from pennylane.typing import Int, Float, Complex, Bool, Wire
@@ -298,7 +507,7 @@
   Float           # Float scalar
   Complex[...]    # Abstract complex array with any shape
   Bool[-1, 3, 4]  # Abstract bool array with dynamic size for the first axis
-  Wire            # Single abstract wire
+  Wire[1]         # Single abstract wire
   Wire[4]         # Four abstract wires
   Wire[-1]        # Wire sequence with dynamic size
   ```
@@ -343,6 +552,7 @@
   a new method of having compressed operators for resource estimation and decomposition.
   [(#9385)](https://github.com/PennyLaneAI/pennylane/pull/9385)
   [(#9712)](https://github.com/PennyLaneAI/pennylane/pull/9712)
+  [(#10032)](https://github.com/PennyLaneAI/pennylane/pull/10032)
 
 * `Tracker` now has a readable `__repr__` that displays all relevant internals
   (`active`, `totals`, `history`, `latest`, `persistent`, `callback`).
@@ -428,6 +638,7 @@
 * Added a decomposition of :class:`~.QROM` using `qp.pauli_measure` operators. This decomposition reduces
   the PPM count in the compilation pipeline.
   [(#9531)](https://github.com/PennyLaneAI/pennylane/pull/9531)
+  [(#9853)](https://github.com/PennyLaneAI/pennylane/pull/9853)
 
 * A more informative error message is raised when quantum functions without registered resource
   estimates are passed to the `fixed_decomps` and `alt_decomps` arguments of the :func:`~.transforms.decompose` transform.
@@ -450,13 +661,6 @@
   contain dynamic wire allocations.
   [(#9629)](https://github.com/PennyLaneAI/pennylane/pull/9629)
 
-* The function `qp.math.partial_trace()` has been changed to include a `qudit_dim` keyword argument to allow for partial traces of
-  any qudit density matrices with constant qudit dimension.
-  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
-
-* Device `default.qutrit.mixed` now implements state preparation operations with batched initial states.
-  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
-
 * :class:`~.Adder` now registers an additional QFT-free, carry-ripple decomposition rule that avoids
   the arbitrarily precise rotations of the existing QFT-based decomposition and supports an arbitrary
   modulus. Its multi-controlled gates reuse the remaining register wires as borrowed work wires for a
@@ -466,9 +670,26 @@
 
 * :func:`~core.queuing.apply` is now compatible with program capture.
   [(#9831)](https://github.com/PennyLaneAI/pennylane/pull/9831)
+  [(#10103)](https://github.com/PennyLaneAI/pennylane/pull/10103)
 
 * Implemented the `__str__` of `Wires` to display the wire labels as a list.
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
+
+* :func:`~pennylane.pauli_decompose` is significantly faster for SciPy sparse inputs. Nonzero entries are
+  grouped by their ``row ^ col`` XOR-difference and each group is resolved with a single fast
+  Walsh-Hadamard transform, following [Georges et al.](https://doi.org/10.1088/1367-2630/adb44d),
+  giving order-of-magnitude speedups for sparse and structured operators.
+  [(#9728)](https://github.com/PennyLaneAI/pennylane/pull/9728)
+
+* :class:`~.PartialUnaryStatePreparation` now uses a Clifford-only isometry for affine binary supports and avoids oversized PUI batch estimates.
+  [(#9947)](https://github.com/PennyLaneAI/pennylane/pull/9947)
+
+* Added the ``MultiX`` template which conditionally applies ``PauliX`` gates across target wires according
+  to a bitstring array.
+  [(#10033)](https://github.com/PennyLaneAI/pennylane/pull/10033)
+  [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
+  [(#10079)](https://github.com/PennyLaneAI/pennylane/pull/10079)
+  [(#10098)](https://github.com/PennyLaneAI/pennylane/pull/10098)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
@@ -511,6 +732,12 @@
   [(#9277)](https://github.com/PennyLaneAI/pennylane/pull/9277)
   [(#9544)](https://github.com/PennyLaneAI/pennylane/pull/9544)
 
+* TCDQ now supports workflows with qudits of non-uniform dimensions.
+  [(#9935)](https://github.com/PennyLaneAI/pennylane/pull/9935)
+
+* TCDQ qudit MMD loss function now supports phase layers.
+  [(#10035)](https://github.com/PennyLaneAI/pennylane/pull/10035)
+
   ```python
   import pennylane as qp
   from pennylane.labs.templates import LeftQuantumComparator
@@ -523,8 +750,10 @@
     x_wires = [0, 3, 6, 9]
     y_wires = [1, 4, 7, 10]
     work_wires = [2, 5, 8]
-    qp.BasisState(a, wires=x_wires)
-    qp.BasisState(b, wires=y_wires)
+    a_bin = qp.math.int_to_binary(a, len(x_wires))
+    b_bin = qp.math.int_to_binary(b, len(x_wires))
+    qp.BasisState(a_bin, wires=x_wires)
+    qp.BasisState(b_bin, wires=y_wires)
     LeftQuantumComparator(x_wires, y_wires, 11, work_wires, comparator)
     qp.CNOT(wires=[11, 12])
     qp.adjoint(LeftQuantumComparator(x_wires, y_wires, 11, work_wires, comparator))
@@ -552,7 +781,8 @@
   @qp.set_shots(shots=1)
   @qp.qnode(dev)
   def circuit(x_val, L_val):
-    qp.BasisState(x_val, wires=[0, 1, 2])
+    x_val_bin = qp.math.int_to_binary(x_val, 3)
+    qp.BasisState(x_val_bin, wires=[0, 1, 2])
 
     LeftClassicalComparator(
         x_wires=[0, 1, 2],
@@ -605,6 +835,10 @@
 
   ```
 
+* Created a new ``labs.templates.SuperpositionTHC`` template, used as a subroutine in tensor
+  hypercontraction (THC) qubitization.
+  [(#9554)](https://github.com/PennyLaneAI/pennylane/pull/9554)
+
 * Added the :mod:`pennylane.labs.profiler` which allows users to profile the quantum resources required for
   their quantum workflows. This contains core functions and classes such as
   :class:`~.pennylane.labs.profiler.ProfileNode`, :func:`~.pennylane.labs.profiler.profile`, and
@@ -642,25 +876,59 @@
 
   ```
 
-* Created a :func:`~.pennylane.labs.templates.trotter_fragmented` function to run specialized
-  Trotter circuits for fragmented Hamiltonians. This is used in modern quantum chemistry
-  application algorithms.
-  [(#9459)](https://github.com/PennyLaneAI/pennylane/pull/9459)
-  [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
-
 * Performance of the Trotter error module is improved by introducing a novel algorithm for
   computing the Baker-Campbell-Hausdorff formula.
   [(#9608)][https://github.com/PennyLaneAI/pennylane/pull/9608]
 
+* Added an optional parameter ``phase_fn`` to ``QuditCircuitConfig`` which enables the inclusion of
+  a phase layer with trainable weights to a qudit IQP circuit.
+  [(#9826)][https://github.com/PennyLaneAI/pennylane/pull/9826]
+
 * Added a new fragmentation scheme for the vibronic Hamiltonian Trotter error workflow.
   [(#9813)][https://github.com/PennyLaneAI/pennylane/pull/9813]
-  
+
 * Added a class :class:`~.pennylane.labs.estimator_beta.ResourceQfunc` and a function
   :func:`~.pennylane.labs.estimator_beta.mark_subroutine` which allow users to easily define their own
   resource operators from their quantum functions.
   [(#9764)](https://github.com/PennyLaneAI/pennylane/pull/9764)
 
 <h3>Breaking changes 💔</h3>
+
+* :class:`~.GlobalPhase` no longer accepts the `wires` argument in order to mirror its MLIR lowered operation.
+  [(#9992)](https://github.com/PennyLaneAI/pennylane/pull/9992)
+
+* :class:`~.BasisState` no longer allows integers as input. Instead, `~.math.int_to_binary` should be used to preprocess
+  the input in order to convert it to a binary array.
+  [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
+  [(#10038)](https://github.com/PennyLaneAI/pennylane/pull/10038)
+
+* Renamed the `data` argument of :class:`~pennylane.QROM`, :class:`~pennylane.BBQRAM`, :class:`~pennylane.HybridQRAM`,
+  and :class:`~pennylane.SelectOnlyQRAM` to `bitstrings`.
+  [(#10010)](https://github.com/PennyLaneAI/pennylane/pull/10010)
+
+* :class:`~.BasisEmbedding` is now a direct alias of :class:`~.BasisState`.
+  [(#9980)](https://github.com/PennyLaneAI/pennylane/pull/9980)
+
+* Moved phase gradient decomposition rules for `RZ`, `CRZ` and `SelectPauliRot` from `labs` to `pennylane/transforms/decompositions`.
+  [(#9928)](https://github.com/PennyLaneAI/pennylane/pull/9928)
+
+* All functionality related to qutrits/qudits has been removed. Qudit functionality in :mod:`pennylane.labs`
+  still remains.
+  [(#9867)](https://github.com/PennyLaneAI/pennylane/pull/9867)
+
+* Removes `qp.Configuration` and the ability to pass a `config` to `pennylane.device`.
+  [(#9879)](https://github.com/PennyLaneAI/pennylane/pull/9879)
+  [(#9931)](https://github.com/PennyLaneAI/pennylane/pull/9931)
+
+* Removes all Continuous Variable (CV) code. This include `CV`, `CVOperation`, `CVObservable`,
+  `DefaultGaussian`, `qp.gradients.param_shift_cv`, `qp.Rotation`, `qp.Squeezing`, `qp.Displacement`,
+  `qp.Beamsplitter`, `qp.TwoModeSqueezing`, `qp.QuadraticPhase`, `qp.ControlledAddition`, `qp.ControlledPhase`,
+  `qp.Kerr`, `qp.CrossKerr`, `qp.CubicPhase`, `qp.InterferometerUnitary`, `qp.CoherentState`,
+  `qp.SqueezedState`, `qp.DisplacedSqueezedState`, `qp.ThermalState`, `qp.GaussianState`, `qp.FockState`,
+  `qp.FockStateVector`, `qp.FockDensityMatrix`, `qp.CatState`, `qp.NumberOperator`, `qp.TensorN`,
+  `qp.QuadX`, `qp.QuadP`, `qp.QuadOperator`, `qp.PolyXP`, `qp.FockStateProjector`,
+  `qp.DisplacementEmbedding`, `qp.SqueezingEmbedding`, `qp.CVNeuralNetLayers`, amd `qp.Interferomenter`.
+  [(#9869)](https://github.com/PennyLaneAI/pennylane/pull/9869)
 
 * Support for Python 3.11 has been dropped. PennyLane now requires Python 3.12 or later.
   [(#9700)](https://github.com/PennyLaneAI/pennylane/pull/9700)
@@ -807,15 +1075,134 @@
   [(#9483)](https://github.com/PennyLaneAI/pennylane/pull/9483)
 
 * The ``Operation.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
+  [(#9502)](https://github.com/PennyLaneAI/pennylane/pull/9502)
+
+* :class:`~.MultiplexerStatePreparation` no longer validates the norm of the input
+  state vector automatically. Validation is now opt-in via the ``check`` keyword
+  argument, which defaults to ``False``. Pass ``check=True`` to raise a ``ValueError``
+  when the input state vector does not have norm 1.0.
+  [(#9925)](https://github.com/PennyLaneAI/pennylane/pull/9925)
 
 <h3>Internal changes ⚙️</h3>
 
+* The `_prepselprep_decomp` decomposition rule of :class:`~.PrepSelPrep` now applies the linear-combination
+  unitaries and their global phases as two separate :class:`~.Select` operators instead of a single ``Select``
+  of products.
+  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
+
+* The `_qrom_decomposition` decomposition rule of :class:`~.QROM` now loads each column of bitstrings with
+  a single :class:`~.MultiX` instead of a product of smaller :class:`~.BasisState` and ``Identity`` operators.
+  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
+
+* The resource module JSON parser can now handle floating point values received from the Catalyst backend.
+  [(#10044)](https://github.com/PennyLaneAI/pennylane/pull/10044)
+
+* Removes `pennylane.transforms.decompose.DecomposeInterpreter`. Decompositions are no longer supported for the capture-without-qjit workflow.
+  [(#9915)](https://github.com/PennyLaneAI/pennylane/pull/9915)
+
+* Updated :mod:`pennylane.pytrees` to consider `None` a Pytree. This makes PennyLane Pytrees more consistent with JAX Pytrees.
+  [(#10045)](https://github.com/PennyLaneAI/pennylane/pull/10045)
+
+* The resource module JSON parser used by :func:`~.specs` to read Catalyst data has been revamped to match the new JSON structure produced by Catalyst.
+  [(#9942)](https://github.com/PennyLaneAI/pennylane/pull/9942)
+  [(#9969)](https://github.com/PennyLaneAI/pennylane/pull/9969)
+  [(#10011)](https://github.com/PennyLaneAI/pennylane/pull/10011)
+
+* Adds an `AGENTS.md` file providing guidelines and repository conventions for AI coding agents.
+  [(#9929)](https://github.com/PennyLaneAI/pennylane/pull/9929)
+
+* Adds a CI runner for catalyst tests and removes the catalyst tests from the `external` tests. Now, catalyst
+  tests should only be marked `catalyst` and *not* marked `external`.
+  [(#9873)](https://github.com/PennyLaneAI/pennylane/pull/9873)
+
+* Established a new dataclass hierarchy for resource information in the :mod:`~.resource` module.
+  This enables easier development of resource estimation features, and simplifies the creation of new resource classes.
+  The :class:`~.resource.Resources` class serves as the new base class,
+  and the :class:`~.resource.SpecsResources` and :class:`~.resource.PBCSpecsResources` inherit from it.
+  [(#9841)](https://github.com/PennyLaneAI/pennylane/pull/9841)
+
 * The following legacy operators are now ported to the new `~.Operator2` base class.
-  - Single qubit, non-parameteric operators are ported:
-    - `~.S`, `~.T`, `~.SX`
+  - Non-parametric operators are ported:
+    - :class:`~.S`, :class:`~.T`, :class:`~.SX`, :class:`~.Y`, :class:`~.CY`, :class:`~.SISWAP`, :class:`~.ISWAP`, :class:`~.ECR`,
+      :class:`~.SWAP`, :class:`~.CSWAP`, :class:`~.H`, :class:`~.CH`, :class:`~.Z`, :class:`~.CZ`, :class:`~.CCZ`, :class:`~.X`,
+      :class:`~.CNOT`, :class:`~.Toffoli`, :class:`~.MultiControlledX`
+      :class:`~.Identity`.
   [(#9818)](https://github.com/PennyLaneAI/pennylane/pull/9818)
   [(#9859)](https://github.com/PennyLaneAI/pennylane/pull/9859)
   [(#9819)](https://github.com/PennyLaneAI/pennylane/pull/9819)
+  [(#9871)](https://github.com/PennyLaneAI/pennylane/pull/9871)
+  [(#9850)](https://github.com/PennyLaneAI/pennylane/pull/9850)
+  [(#9784)](https://github.com/PennyLaneAI/pennylane/pull/9784)
+  [(#9844)](https://github.com/PennyLaneAI/pennylane/pull/9844)
+  [(#9814)](https://github.com/PennyLaneAI/pennylane/pull/9814)
+  [(#9854)](https://github.com/PennyLaneAI/pennylane/pull/9854)
+  [(#9858)](https://github.com/PennyLaneAI/pennylane/pull/9858)
+  [(#9960)](https://github.com/PennyLaneAI/pennylane/pull/9960)
+  [(#10004)](https://github.com/PennyLaneAI/pennylane/pull/10004)
+  [(#10129)](https://github.com/PennyLaneAI/pennylane/pull/10129)
+  - Parametric operators are ported:
+    - :class:`~.RZ`, :class:`~.CRZ`, :class:`~.DiagonalQubitUnitary`, :class:`~.PauliRot`, :class:`~.MultiRZ`, :class:`~.PhaseShift`,
+      :class:`~.ControlledPhaseShift`, :class:`~.Rot`, :class:`~.CRot`, :class:`~.U1`, :class:`~.U2`, :class:`~.U3`, :class:`~.PCPhase`,
+      :class:`~.GlobalPhase`, :class:`~.IsingXX`, :class:`~.IsingYY`, :class:`~.IsingZZ`, :class:`~.IsingXY`, :class:`~.RX`, :class:`~.CRX`,
+      :class:`~.RY`, :class:`~.CRY`, :class:`~.QubitUnitary`, :class:`~.ControlledQubitUnitary`
+  [(#9998)](https://github.com/PennyLaneAI/pennylane/pull/9998)
+  [(#9857)](https://github.com/PennyLaneAI/pennylane/pull/9857)
+  [(#9941)](https://github.com/PennyLaneAI/pennylane/pull/9941)
+  [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
+  [(#9936)](https://github.com/PennyLaneAI/pennylane/pull/9936)
+  [(#9964)](https://github.com/PennyLaneAI/pennylane/pull/9964)
+  [(#10006)](https://github.com/PennyLaneAI/pennylane/pull/10006)
+  [(#9977)](https://github.com/PennyLaneAI/pennylane/pull/9977)
+  [(#9984)](https://github.com/PennyLaneAI/pennylane/pull/9984)
+  [(#9951)](https://github.com/PennyLaneAI/pennylane/pull/9951)
+  [(#9923)](https://github.com/PennyLaneAI/pennylane/pull/9923)
+  [(#9952)](https://github.com/PennyLaneAI/pennylane/pull/9952)
+  [(#9978)](https://github.com/PennyLaneAI/pennylane/pull/9978)
+  [(#9981)](https://github.com/PennyLaneAI/pennylane/pull/9981)
+  [(#10026)](https://github.com/PennyLaneAI/pennylane/pull/10026)
+  [(#9990)](https://github.com/PennyLaneAI/pennylane/pull/9990)
+  [(#10041)](https://github.com/PennyLaneAI/pennylane/pull/10041)
+  [(#10072)](https://github.com/PennyLaneAI/pennylane/pull/10072)
+  - Templates are ported:
+    - :class:`~.BasisRotation`, :class:`~.MultiplexerStatePreparation`, :class:`~.QROM`, :class:`~.QFT`, :class:`~.FlipSign`,
+      :class:`~.TemporaryAND`, :class:`~.SelectPauliRot`, :class:`~.GQSP`, :class:`~.AQFT`, :class:`~.SumOfSlatersPrep`,
+      :class:`~.SemiAdder`, :class:`~.OutMultiplier`, :class:`~.SignedOutMultiplier`, :class:`~.BasisState`, :class:`~.TrotterCDF`,
+      :class:`~.TrotterCGF`, :class:`~.OutSquare`, :class:`~.SignedOutSquare`, :class:`~.Incrementer`, :class:`~.TrotterVibronic`,
+      :class:`~.Select`
+  [(#9896)](https://github.com/PennyLaneAI/pennylane/pull/9896)
+  [(#9925)](https://github.com/PennyLaneAI/pennylane/pull/9925)
+  [(#9918)](https://github.com/PennyLaneAI/pennylane/pull/9918)
+  [(#9932)](https://github.com/PennyLaneAI/pennylane/pull/9932)
+  [(#9924)](https://github.com/PennyLaneAI/pennylane/pull/9924)
+  [(#9910)](https://github.com/PennyLaneAI/pennylane/pull/9910)
+  [(#9965)](https://github.com/PennyLaneAI/pennylane/pull/9965)
+  [(#9943)](https://github.com/PennyLaneAI/pennylane/pull/9943)
+  [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
+  [(#9987)](https://github.com/PennyLaneAI/pennylane/pull/9987)
+  [(#9900)](https://github.com/PennyLaneAI/pennylane/pull/9900)
+  [(#9994)](https://github.com/PennyLaneAI/pennylane/pull/9994)
+  [(#9997)](https://github.com/PennyLaneAI/pennylane/pull/9997)
+  [(#9995)](https://github.com/PennyLaneAI/pennylane/pull/9995)
+  [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
+  [(#10018)](https://github.com/PennyLaneAI/pennylane/pull/10018)
+  [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
+  [(#10042)](https://github.com/PennyLaneAI/pennylane/pull/10042)
+  [(#10052)](https://github.com/PennyLaneAI/pennylane/pull/10052)
+  [(#10054)](https://github.com/PennyLaneAI/pennylane/pull/10054)
+  [(#10029)](https://github.com/PennyLaneAI/pennylane/pull/10029)
+  [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)
+  [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
+  [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
+  [(#10069)](https://github.com/PennyLaneAI/pennylane/pull/10069)
+  [(#10085)](https://github.com/PennyLaneAI/pennylane/pull/10085)
+  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
+  - Quantum chemistry operators are ported:
+    - :class:`~.SingleExcitation`
+  [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)
+  - Miscelleneous operators are ported:
+    - :class:`~.PauliMeasure`, :class:`~.ops.MidMeasure`
+  [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)
+  [(#10115)](https://github.com/PennyLaneAI/pennylane/pull/10115)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.
@@ -875,11 +1262,18 @@
   [(#9526)](https://github.com/PennyLaneAI/pennylane/pull/9526)
   [(#9527)](https://github.com/PennyLaneAI/pennylane/pull/9527)
   [(#9649)](https://github.com/PennyLaneAI/pennylane/pull/9649)
+  [(#9658)](https://github.com/PennyLaneAI/pennylane/pull/9658)
   [(#9675)](https://github.com/PennyLaneAI/pennylane/pull/9675)
   [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
   [(#9783)](https://github.com/PennyLaneAI/pennylane/pull/9783)
   [(#9851)](https://github.com/PennyLaneAI/pennylane/pull/9851)
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
+  [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
+  [(#9920)](https://github.com/PennyLaneAI/pennylane/pull/9920)
+  [(#9937)](https://github.com/PennyLaneAI/pennylane/pull/9937)
+  [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
+  [(#9926)](https://github.com/PennyLaneAI/pennylane/pull/9926)
+  [(#10077)](https://github.com/PennyLaneAI/pennylane/pull/10077)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:
@@ -889,10 +1283,13 @@
     [(#9646)](https://github.com/PennyLaneAI/pennylane/pull/9646)
     [(#9694)](https://github.com/PennyLaneAI/pennylane/pull/9694)
     [(#9744)](https://github.com/PennyLaneAI/pennylane/pull/9744)
+    [(#9788)](https://github.com/PennyLaneAI/pennylane/pull/9788)
   - Some backwards compatibility with the legacy operator interface.
     [(#9596)](https://github.com/PennyLaneAI/pennylane/pull/9596)
     [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
     [(#9820)](https://github.com/PennyLaneAI/pennylane/pull/9820)
+    [(#9756)](https://github.com/PennyLaneAI/pennylane/pull/9756)
+    [(#9976)](https://github.com/PennyLaneAI/pennylane/pull/9976)
   - Compatibility with the `drawer` module.
     [(#9849)](https://github.com/PennyLaneAI/pennylane/pull/9849)
   - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.
@@ -901,6 +1298,8 @@
   - :func:`qp.ops.functions.assert_valid` can verify that an :class:`~.Operator2` is defined properly.
     [(#9659)](https://github.com/PennyLaneAI/pennylane/pull/9659)
     [(#9842)](https://github.com/PennyLaneAI/pennylane/pull/9842)
+    [(#9898)](https://github.com/PennyLaneAI/pennylane/pull/9898)
+    [(#10058)](https://github.com/PennyLaneAI/pennylane/pull/10058)
   - :class:`~.StatePrepBase2`, based on :class:`~.Operator2`, is added.
     [(#9562)](https://github.com/PennyLaneAI/pennylane/pull/9562)
   - :meth:`~.Operator2.decomposition` falls back to registered graph decomposition rules when ``compute_decomposition`` is not overridden.
@@ -918,6 +1317,16 @@
     [(#9778)](https://github.com/PennyLaneAI/pennylane/pull/9778)
     [(#9805)](https://github.com/PennyLaneAI/pennylane/pull/9805)
     [(#9856)](https://github.com/PennyLaneAI/pennylane/pull/9856)
+    [(#9876)](https://github.com/PennyLaneAI/pennylane/pull/9876)
+    [(#9871)](https://github.com/PennyLaneAI/pennylane/pull/9871)
+    [(#9966)](https://github.com/PennyLaneAI/pennylane/pull/9966)
+  - Composite operators with :class:`~.Operator2` instances as the base.
+    [(#10027)](https://github.com/PennyLaneAI/pennylane/pull/10027)
+    [(#10047)](https://github.com/PennyLaneAI/pennylane/pull/10047)
+    [(#10113)](https://github.com/PennyLaneAI/pennylane/pull/10113)
+    [(#9999)](https://github.com/PennyLaneAI/pennylane/pull/9999)
+    [(#10125)](https://github.com/PennyLaneAI/pennylane/pull/10125)
+    [(#10124)](https://github.com/PennyLaneAI/pennylane/pull/10124)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)
@@ -925,6 +1334,8 @@
     [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
     [(#9808)](https://github.com/PennyLaneAI/pennylane/pull/9808)
     [(#9834)](https://github.com/PennyLaneAI/pennylane/pull/9834)
+    [(#9908)](https://github.com/PennyLaneAI/pennylane/pull/9908)
+    [(#10066)](https://github.com/PennyLaneAI/pennylane/pull/10066)
   - Integration with measurements.
     [(#9753)](https://github.com/PennyLaneAI/pennylane/pull/9753)
   - Integration with :func:`pennylane.apply`.
@@ -941,6 +1352,10 @@
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
     [(#9843)](https://github.com/PennyLaneAI/pennylane/pull/9843)
     [(#9866)](https://github.com/PennyLaneAI/pennylane/pull/9866)
+    [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
+    [(#9973)](https://github.com/PennyLaneAI/pennylane/pull/9973)
+  - The way that :class:`~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with :class:`~.Operator2` in the data module.
+    [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.
@@ -988,8 +1403,8 @@
   Raw numeric literals in `pennylane/math`, `pennylane/ops`, `pennylane/devices`,
   `pennylane/gradients`, `pennylane/pauli`, `pennylane/qchem`, `pennylane/liealg`,
   `pennylane/fourier`, and `pennylane/templates` are now module-level constants with
-  ``#:`` doc-comments explaining their purpose and origin. Unused constants
-  ``eps`` in :mod:`pennylane.math` and ``tolerance`` in ``default_qutrit`` are removed.
+  ``#:`` doc-comments explaining their purpose and origin. Unused constant ``eps`` in
+  :mod:`pennylane.math` is removed.
   [(#9374)](https://github.com/PennyLaneAI/pennylane/pull/9374)
 
 * Added usage of the `strict` keyword argument for `zip` throughout the codebase.
@@ -1011,6 +1426,10 @@
   from `qp.ctrl(qp.X(0), control=[1, 2])` to `Toffoli(wires=[1, 2, 0])`) is re-written to use a
   singledispatch function `custom_ctrl_dispatch` as opposed to relying on hard-coded logic.
   [(#9798)](https://github.com/PennyLaneAI/pennylane/pull/9798)
+
+* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx`
+  context manager that temporarily enables or disables capture is added.
+  [(#10016)](https://github.com/PennyLaneAI/pennylane/pull/10016)
 
 <h3>Documentation 📝</h3>
 
@@ -1045,12 +1464,73 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where ``QubitDevice.probability``, ``QubitDevice.estimate_probability``
-  and ``QutritDevice.estimate_probability`` ignored an integer wire label of ``0`` and
-  returned the full joint distribution instead of the single-wire marginal. The falsy
-  label was silently replaced by all device wires; the default is now resolved with an
-  explicit ``None`` check.
-  [(#PRNUM)](https://github.com/PennyLaneAI/pennylane/pull/PRNUM)
+* Fixed a bug where ``QubitDevice.probability`` and ``QubitDevice.estimate_probability``
+  ignored an integer wire label of ``0`` and returned the full joint distribution instead
+  of the single-wire marginal. The falsy label was silently replaced by all device wires;
+  the default is now resolved with an explicit ``None`` check.
+  [(#9875)](https://github.com/PennyLaneAI/pennylane/pull/9875)
+
+* Fixed a bug in :func:`~pennylane.draw` with conditionally applied operators that do not have wires,
+  such as ``cond(condition, GlobalPhase(0.52))``.
+  [(#10132)](https://github.com/PennyLaneAI/pennylane/pull/10132)
+
+* Fix `qp.eigvals` returns `NaN` for a legal fractional power operator.
+  [(#9802)](https://github.com/PennyLaneAI/pennylane/pull/9802)
+  [(#10139)](https://github.com/PennyLaneAI/pennylane/pull/10139)
+
+* Fixed the decomposition rule of :class:`~.QROM` so that it can be captured and compiled with
+  Catalyst. Tracing the ``clean`` branch previously raised a ``TracerIntegerConversionError``
+  because :func:`~pennylane.adjoint` traced the statically known ``depth``, and passing the wires
+  as traced arrays raised a ``TracerBoolConversionError``. The NumPy calls in the decomposition
+  are also replaced with :mod:`pennylane.math` so that they work on traced bitstrings.
+  [(#10116)](https://github.com/PennyLaneAI/pennylane/pull/10116)
+
+* Fixed the Triton persistent decoder kernel so :func:`~pennylane.backline.css_bp_decoder` and
+  the other Triton decoders build on CUDA with Triton 3.8.
+  [(#10111)](https://github.com/PennyLaneAI/pennylane/pull/10111)
+
+* Fixed :class:`~.Incrementer` returning an incorrect incremented value when not enough
+  work wires are provided.
+  [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)
+
+* Converting an ``AbstractArray`` to a concrete array now raises an informative ``TypeError``
+  instead of silently producing an empty array, which previously surfaced as an obscure error
+  far from its cause.
+  [(#10083)](https://github.com/PennyLaneAI/pennylane/pull/10083)
+
+* Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
+  compiled with Catalyst when ``mod = 2 ** len(output_wires)``.
+  [(#10057)](https://github.com/PennyLaneAI/pennylane/pull/10057)
+
+* Fixed capture compatibility of the decomposition rule of `SemiAdder`.
+  [(#10068)](https://github.com/PennyLaneAI/pennylane/pull/10068)
+
+* Fixed :func:`~pennylane.backline.css_bp_decoder` and the other Triton decoders so they can be
+  compiled on a machine with no usable GPU. The ahead-of-time build called
+  ``JITFunction.create_binder()``, which asks the local machine for a target through
+  ``driver.active.get_current_target()`` and fails with ``0 active drivers`` where there is none.
+  [(#10046)](https://github.com/PennyLaneAI/pennylane/pull/10046)
+
+* Fixed a bug where the ``flip_zero_control`` decomposition modifier raised a
+  ``TracerIntegerConversionError`` under program capture, because the control-value flipping
+  loop indexed the control wires with a traced loop variable without first promoting them to a
+  JAX array.
+  [(#10036)](https://github.com/PennyLaneAI/pennylane/pull/10036)
+
+* Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
+  arithmetic operations performed on mid-circuit measurement values.
+  [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
+
+* Fixed :func:`~pennylane.backline.css_bp_decoder` so the X- and Z-specialized Triton decoders
+  stay distinct when bundled behind one dispatcher, and, for the same reason, updated
+  :func:`~pennylane.backline.triton_decoder` to own jitting of the raw Triton decoder functions.
+  [(#10040)](https://github.com/PennyLaneAI/pennylane/pull/10040)
+
+* Fixed a bug where decomposing an :class:`~.Operator2` with graph-based decomposition
+  enabled inside a :class:`~.Subroutine` with program capture leaked JAX tracers and
+  caused Catalyst compilation to fail.
+  operations.
+  [(#10023)](https://github.com/PennyLaneAI/pennylane/pull/10023)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
@@ -1065,8 +1545,11 @@
   :class:`~.Incrementer` were also included in the target wires.
   [(#9721)](https://github.com/PennyLaneAI/pennylane/pull/9721)
 
-* Fixed a bug in :class:~.OutMultiplier` for small output registers.
+* Fixed a bug in :class:`~.OutMultiplier` for small output registers.
   [(#9759)](https://github.com/PennyLaneAI/pennylane/pull/9759)
+
+* Fixed a bug in :class:`~.labs.LeftClassicalComparator` for `L = 2^n -1`.
+  [(#9554)](https://github.com/PennyLaneAI/pennylane/pull/9554)
 
 * Fixed a bug in :class:`~.SumOfSlatersPrep` with `qjit` compilation and non-identity encoding.
   [(#9747)](https://github.com/PennyLaneAI/pennylane/pull/9747)
@@ -1152,26 +1635,45 @@
   restored as ``bytes``.
   [(#9687)](https://github.com/PennyLaneAI/pennylane/pull/9687)
 
+* Fixed a bug with :func:`~pennylane.equal` where comparing a base operator to
+  one of its subclasses returned ``True`` if they shared the same data and wires.
+  [(#9749)](https://github.com/PennyLaneAI/pennylane/pull/9749)
+
+* Qubit TCDQ expval function now returns the variance rather than standard deviation
+  of the estimator. Qubit and qudit MMD loss functions now have unbiased gradients.
+  [(#10025)](https://github.com/PennyLaneAI/pennylane/pull/10025)
+
+* Various decomposition rules are updated so that they accept positionally passed arguments.
+  [(#10088)](https://github.com/PennyLaneAI/pennylane/pull/10088)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Usman Ahmed,
-Mohit Ak,
 Guillermo Alonso,
 Abdullah Al Omar Galib,
+Ali Asadi,
 Gabriel Bottrill,
+Joseph Bowles,
 Astral Cai,
 Daniel Casota,
 Miguel Cárdenas,
 Yushao Chen,
 Diksha Dhawan,
 Marcus Edwards,
+Sümeyye Nur Esin,
+Thomas C. Fraser,
+Connor Gambla,
+Sengthai Heng,
 Austin Huang,
+Harshal Janjani,
 Jacob Kitchen,
 Korbinian Kottmann,
+Isabel Nha Minh Le,
 Christina Lee,
-William Maxwell
+Joseph Lee,
+William Maxwell,
 Anton Naim Ibrahim,
 Mudit Pandey,
 Andrija Paurevic,
@@ -1182,4 +1684,5 @@ Paul Haochen Wang,
 Dennis Wayo,
 David Wierichs,
 Jake Zaia,
+Hongsheng Zheng,
 Zinan Zhou.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,132 +2,11 @@
 
 <h3>New features since last release</h3>
 
-* A new decorator is available called :func:`pennylane.subcircuit`, which can be used to 
-  create operators directly from quantum functions. This enables fast research and 
-  development of new operators without the need to create full-fledged operator classes 
-  manually.
-  [(#10126)](https://github.com/PennyLaneAI/pennylane/pull/10126)
-
-  ```python
-  @qp.subcircuit(dynamic_argnames=("phi",), wire_argnames=("wires",))
-  @qp.register_resources({qp.H: 1, qp.RZ: 1})
-  def MyOp(phi, wires):
-      """My custom operator created using qp.subcircuit."""
-      qp.H(wires)
-      qp.RZ(phi, wires)
-  ```
-  ```pycon
-  >>> op = MyOp(0.5, wires=0)
-  >>> op
-  MyOp(0.5, wires=[0])
-  >>> isinstance(op, qp.core.Operator2)
-  True
-  >>> qp.inspect_decomps(op)
-  Decomposition 0 (name: MyOp_decomp)
-  0: ──H──RZ(0.50)─┤
-  Gate Count: {Hadamard: 1, RZ: 1}
-
-  ```
-
-* Two new numeric Hamiltonians called :class:`pennylane.CDFHamiltonian` (based on `arXiv:2506.15784, Sec. III A <https://arxiv.org/abs/2506.15784>`) and :class:`pennylane.CGFHamiltonian` have been added (based on `arXiv:2508.11865, Sec. III C <https://arxiv.org/abs/2508.11865>`), which define compressed double-factorized (CDF) and Christiansen greedy-fragmentation Hamiltonians, respectively. These Hamiltonians can be defined
-  with both concrete numeric data or abstract data (using ``qp.typing.Float[...]``).
-  [(#10048)](https://github.com/PennyLaneAI/pennylane/pull/10048)
-
-  ```python
-  import numpy as np
-  import pennylane as qp
-
-  L, M, N = 2, 2, 3
-  ham = qp.CGFHamiltonian(
-      core_tensors=np.random.rand(L + 1, M, M, N, N),
-      leaf_tensors=np.random.rand(L + 1, M, N, N),
-      nuc_constant=0.5,
-  )
-  ```
-
-  The same Hamiltonian can be described with abstract data for the purposes of fast, low-fidelity
-  resource-estimation workflows where only shape information is available:
-
-  ```pycon
-  >>> from pennylane.typing import Float
-  >>> qp.CGFHamiltonian(Float[L + 1, M, M, N, N], Float[L + 1, M, N, N]).leaf_tensors
-  AbstractArray((3, 2, 3, 3), float64, weak_type=True)
-
-  ```
-
-* Added :func:`~pennylane.backline.triton_decoder` and
-  :func:`~pennylane.backline.css_bp_decoder` for compiling Triton-based coprocessor decoders.
-  :func:`~pennylane.backline.triton_decoder` wraps user-provided Triton decoder tuples, while
-  :func:`~pennylane.backline.css_bp_decoder` builds a CSS belief-propagation decoder from X- and Z-type parity-check
-  matrices. In both cases, syndromes and corrections are packed into ``u64`` bitmasks.
-
-  ```py
-  import numpy as np
-  import pennylane as qp
-  import triton.language as tl
-
-  def steane_lookup(syndrome):
-      return tl.where(syndrome != 0, 1 << (syndrome - 1), 0)
-
-  custom_decoder = qp.backline.triton_decoder(
-      (steane_lookup, steane_lookup),
-      platform="hip:gfx942:64",
-  )
-
-  Hz = Hx = np.array([
-      [1, 0, 1, 0, 1, 0, 1],
-      [0, 1, 1, 0, 0, 1, 1],
-      [0, 0, 0, 1, 1, 1, 1],
-  ])
-  css_decoder = qp.backline.css_bp_decoder(
-      Hx,
-      Hz,
-      postprocess="osd",
-      num_iters=10,
-      platform="hip:gfx942:64",
-  )
-  ```
-  [(#9975)](https://github.com/PennyLaneAI/pennylane/pull/9975)
-
-* (Experimental) A new `qp.backline` module is added for heterogeneous compilation and execution.
-  `qp.Backline` builds a device from a controller, zero or more coprocessors, and a transport,
-  describing where each part of a workload runs and how the parts communicate. The resulting device
-  binds to a QNode, and requires the Catalyst compiler to execute.
-  [(#9772)](https://github.com/PennyLaneAI/pennylane/pull/9772)
-
-  ```python
-  import pennylane as qp
-
-  controller = qp.Controller(device=qp.device("lightning.qubit", wires=4), name="cpu-controller")
-  decoder = qp.Coprocessor(coprocessor_fn="decoder", endpoint=qp.Endpoint("198.51.100.2", 7760))
-
-  dev = qp.Backline(controller=controller, coprocessors=[decoder], transport="rdma")
-
-  @qp.qjit
-  @qp.qnode(dev)
-  def circuit(x):
-      qp.RX(x, wires=0)
-      return qp.expval(qp.Z(0))
-  ```
-
-* Added a new template :class:`~.TrotterVibronic` that implements a second-order Trotter circuit for
-  vibronic Hamiltonian simulation using phase-gradient arithmetic, based on
-  [Motlagh et al, arXiv:2411.13669](https://arxiv.org/abs/2411.13669).
-  [(#10029)](https://github.com/PennyLaneAI/pennylane/pull/10029)
-
-* ``qp.allocate`` now supports ``state="magic-T"`` and ``state="magic-T-adj"`` for requesting
-  magic-state dynamic wires (:math:`|m\rangle = TH|0\rangle` and :math:`|m̄\rangle = T^\dagger H|0\rangle`).
-  These states are currently supported when compiling with Catalyst; device simulators raise an
-  error via ``resolve_dynamic_wires`` until native support is added.
-  [(#9846)](https://github.com/PennyLaneAI/pennylane/pull/9846)
-
 * Added a new template :class:`~.PartialUnaryStatePreparation` for sparse state preparation
   using partial unary iteration. It is based on [Rupprecht & Wölk, arXiv:2601.09388](https://arxiv.org/abs/2601.09388).
   [(#9478)](https://github.com/PennyLaneAI/pennylane/pull/9478)
   [(#9656)](https://github.com/PennyLaneAI/pennylane/pull/9656)
   [(#9833)](https://github.com/PennyLaneAI/pennylane/pull/9833)
-  [(#9847)](https://github.com/PennyLaneAI/pennylane/pull/9847)
-  [(#10008)](https://github.com/PennyLaneAI/pennylane/pull/10008)
 
   Given the ``amplitudes`` and the computational basis state ``indices`` of the sparse state we
   want to prepare, the template is simple to call. Consider the following example:
@@ -170,15 +49,6 @@
 
   ```
 
-* Added :class:`~.TrotterCDF` and :class:`~.TrotterCGF`, templates for second-order Trotter time evolution of
-  fragmented Hamiltonians (CDF for electronic structure, CGF for vibrational structure) as used in modern quantum
-  chemistry algorithms.
-  [(#9459)](https://github.com/PennyLaneAI/pennylane/pull/9459)
-  [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
-  [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
-  [(#10074)](https://github.com/PennyLaneAI/pennylane/pull/10074)
-  [(#10081)](https://github.com/PennyLaneAI/pennylane/pull/10081)
-
 * A new arithmetic template called :class:`~.SignedOutMultiplier` has been added that multiplies numbers encoded in the
   input registers using a two's complement.
   [(#9458)](https://github.com/PennyLaneAI/pennylane/pull/9458)
@@ -196,10 +66,8 @@
 
   @qp.qnode(dev, shots=1)
   def circuit():
-      x_bin = qp.math.int_to_binary(x, len(x_wires))
-      y_bin = qp.math.int_to_binary(y, len(y_wires))
-      qp.BasisEmbedding(x_bin, wires=x_wires)
-      qp.BasisEmbedding(y_bin, wires=y_wires)
+      qp.BasisEmbedding(x, wires=x_wires)
+      qp.BasisEmbedding(y, wires=y_wires)
       qp.SignedOutMultiplier(
           x_wires,
           y_wires,
@@ -272,7 +140,7 @@
 
 * :func:`~.specs` will now output symbolic resource information when it encounters a loop that uses dynamic control-flow
   that can't be resolved at compile time.
-  In such cases the returned :class:`~.resource.CircuitSpecs` will contain :class:`~.resource.Expression` instances where `int` values would normally appear.
+  In such cases the returned :class:`~.resource.CircuitSpecs` will contain :class:`~.resource.SymbolicSpecsResources` instances instead of the usual :class:`~.resource.SpecsResources` instances.
 
   ```python
   @qp.qjit(autograph=True)
@@ -283,10 +151,11 @@
       for _ in range(x):
           qp.PauliX(0)
       return qp.expval(qp.PauliX(0))
+
+  specs_result = qp.specs(circuit, level=0)(5)
   ```
 
   ```pycon
-  >>> specs_result = qp.specs(circuit, level=0)(5)
   >>> print(specs_result)
   Device: lightning.qubit
   Device wires: 1
@@ -294,14 +163,14 @@
   Level: Before MLIR Passes
   <BLANKLINE>
   Symbolic Variables: a
-  Quantum operations:
-  - Total: a + 2
-    - Hadamard: 1
-    - PauliX: a + 1
-  Measurement processes:
+  Wire allocations: 1
+  Total gates: a + 2
+  Gate counts:
+  - Hadamard: 1
+  - PauliX: a + 1
+  Measurements:
   - expval(PauliX): 1
-  Total wires: 1
-  Circuit Depth: Not computed
+  Depth: Not computed
 
   ```
 
@@ -310,14 +179,14 @@
   ```pycon
   >>> res = specs_result.resources
   >>> print(res.subs(a=5))
-  Quantum operations:
-  - Total: 7
-    - Hadamard: 1
-    - PauliX: 6
-  Measurement processes:
+  Wire allocations: 1
+  Total gates: 7
+  Gate counts:
+  - Hadamard: 1
+  - PauliX: 6
+  Measurements:
   - expval(PauliX): 1
-  Total wires: 1
-  Circuit Depth: Not computed
+  Depth: Not computed
 
   ```
 
@@ -391,115 +260,37 @@
   decomposed recursively into :class:`~.FermionicSWAP` and :class:`~.TwoWireFFT` operations
   (two-site Fermionic Fourier transforms).
 
-* The ability for a compiled program to call a runtime entry point directly via its C symbol name has been added. A symbol's signature is declared once with `qp.runtime_declare` and called with `qp.runtime_call` from inside a `qjit` program.
-  [(#9970)](https://github.com/PennyLaneAI/pennylane/pull/9970)
+* A new operation :class:`~.QutritDensityMatrix` has been added to initialize density matrix states for the device
+  `qp.devices.DefaultQutritMixed`.
+  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
 
   ```python
   import pennylane as qp
+  nr_wires = 1
+  rho = np.zeros((3 ** nr_wires, 3 ** nr_wires), dtype=np.complex128)
+  rho[2, 2] = 1  # initialize the pure state density matrix for the |2><2| state
 
-  qp.runtime_declare("example_local_rounds", "(ptr, u32) -> u64", library="/path/librounds.so")
-
-  def program(session):
-      return qp.runtime_call("example_local_rounds", session, 100000)
-  ```
-
-  Passing `address="host:port"` dispatches the call to the executor on the remote side, which invokes the
-  symbol on the machine the runtime lives on; without it the call is local. Meanwhile, `qp.backline.runtime.CType` lists what can cross the boundary.
-
-  A symbol that fills a buffer declares it as an `out` parameter: the caller asks for `out_bytes=`
-  and gets the filled buffer back alongside the result.
-
-  ```python
-  qp.runtime_declare("example_collect", "(ptr, out, u64) -> i32")
-
-  def collect(session):
-      status, reply = qp.runtime_call("example_collect", session, 64, out_bytes=64)
-      return reply
-  ```
-
-* A new `qp.backline.decode` function is added, which offloads one syndrome to a coprocessor from inside a captured QNode and returns its correction, driving a single transport round: stage the syndrome, post it, collect the reply.
-  [(#9970)](https://github.com/PennyLaneAI/pennylane/pull/9970)
-
-  The nodes are taken from the placement of the device being traced, so a round on a built backline is just `correction = qp.backline.decode(syndrome)`:
-
-  ```python
-  import pennylane as qp
-
-  address_controller = "192.168.3.15"  # the host the controller runs on
-  address_coproc = "192.168.1.3"  # the host the coprocessor listens on
-
-  con = qp.Controller(
-      device=qp.device("null.qubit", wires=2),
-      remote=True,
-      executor_options={"host": address_controller, "port": 7810},
-  )
-  coproc = qp.Coprocessor(
-      coprocessor_fn="decoder",
-      hardware="gpu",
-      endpoint=qp.Endpoint(address_coproc, 18590),
-  )
-  dev = qp.Backline(controller=con, coprocessors=[coproc], transport="rdma")
-
-  @qp.qjit(capture=True)
+  dev = qp.device("default.qutrit.mixed", wires=1)
   @qp.qnode(dev)
-  def circuit(syndrome):
-      correction = qp.backline.decode(syndrome)
-      qp.cond(correction[0] == 1, qp.X)(0)
-      return qp.expval(qp.Z(0))
+  def circuit():
+      qp.QutritDensityMatrix(rho, wires=[0])
+      return qp.state()
   ```
-
-  The round is resolved from the device being traced, so the program has to be captured (`qp.qjit(capture=True)`). The controller's `in_bytes` and `out_bytes` capacities both default to 8 bytes, and the correction comes back as an `out_bytes`-sized `uint8` buffer. Pass `controller=` / `coprocessor=` to choose the nodes explicitly, `out_bytes=` to override the reply size, and `decoder_id=` to select which coprocessor-side decoder handles the round.
-
-<h3>Improvements 🛠</h3>
-
-* Register a dispatch for ``np.delete`` to handle Numpy/JAX signature divergence.
-  [(#10137)]((https://github.com/PennyLaneAI/pennylane/pull/10137)
-
-* `DecompositionRule` now wraps the target qfunc, preserving it's signature and docstring.
-  [(#10144)](https://github.com/PennyLaneAI/pennylane/pull/10144)
- 
-*  Reduced shot counts in `default.clifford` measurement tests to improve CI runtime.
-  [(#10127)](https://github.com/PennyLaneAI/pennylane/pull/10127)
-
-* :func:`~.SumOfSlatersPrep.required_register_sizes` now works with abstract ``indices`` as input,
-  for which it returns an upper bound for the register sizes, across any set of indices of the
-  provided length.
-  [(#10084)](https://github.com/PennyLaneAI/pennylane/pull/10084)
 
   ```pycon
-  >>> num_wires = 8
-  >>> num_entries = 16
-  >>> indices = qp.typing.Int[num_entries]
-  >>> qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires)
-  {'wires': 8, 'enumeration_wires': 4, 'identification_wires': 7, 'qrom_work_wires': 3, 'mcx_cache_wires': 6}
+  >>> circuit()
+  array([[[0.+0.j, 0.+0.j, 0.+0.j],
+          [0.+0.j, 0.+0.j, 0.+0.j],
+          [0.+0.j, 0.+0.j, 1.+0.j]]])
 
   ```
 
-* :class:`~.IsingZZ`'s decomposition is now expressed as a :func:`~.change_op_basis` (``CNOT``
-  compute/uncompute around the ``RZ``) instead of three bare gates. This lets PennyLane's generic
-  ``C(ChangeOpBasis)`` rule automatically control only the ``RZ`` for any number of control wires,
-  using fewer gates than the previous default of naively controlling every gate.
-  [(#10059)](https://github.com/PennyLaneAI/pennylane/pull/10059)
-  [(#10059)](https://github.com/PennyLaneAI/pennylane/pull/10015)
-
-* Coprocessor connection addresses are grouped on :class:`~pennylane.Endpoint` as ``endpoint=qp.Endpoint(host, port)``, replacing the separate ``comm_host`` and ``oob_port`` fields.
-  [(#10017)](https://github.com/PennyLaneAI/pennylane/pull/10017)
-
-* Added decompositions of `CNOT`, `CZ`, `CY`, and `Hadamard` directly to PPMs.
-  [(#9865)](https://github.com/PennyLaneAI/pennylane/pull/9865)
-
-* Sorts the gate counts in the display of resources produced from decompositions.
-  [(#9916)](https://github.com/PennyLaneAI/pennylane/pull/9916)
-
-* Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
-  register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.
-  [(#9807)](https://github.com/PennyLaneAI/pennylane/pull/9807)
+<h3>Improvements 🛠</h3>
 
 * Type aliases `Int`, `Float`, `Complex`, `Bool`, and `Wire` have been introduced to allow for intuitive
   abstract type notation.
   [(#9701)](https://github.com/PennyLaneAI/pennylane/pull/9701)
   [(#9724)](https://github.com/PennyLaneAI/pennylane/pull/9724)
-  [(#10056)](https://github.com/PennyLaneAI/pennylane/pull/10056)
 
   ```python
   from pennylane.typing import Int, Float, Complex, Bool, Wire
@@ -507,7 +298,7 @@
   Float           # Float scalar
   Complex[...]    # Abstract complex array with any shape
   Bool[-1, 3, 4]  # Abstract bool array with dynamic size for the first axis
-  Wire[1]         # Single abstract wire
+  Wire            # Single abstract wire
   Wire[4]         # Four abstract wires
   Wire[-1]        # Wire sequence with dynamic size
   ```
@@ -552,7 +343,6 @@
   a new method of having compressed operators for resource estimation and decomposition.
   [(#9385)](https://github.com/PennyLaneAI/pennylane/pull/9385)
   [(#9712)](https://github.com/PennyLaneAI/pennylane/pull/9712)
-  [(#10032)](https://github.com/PennyLaneAI/pennylane/pull/10032)
 
 * `Tracker` now has a readable `__repr__` that displays all relevant internals
   (`active`, `totals`, `history`, `latest`, `persistent`, `callback`).
@@ -638,7 +428,6 @@
 * Added a decomposition of :class:`~.QROM` using `qp.pauli_measure` operators. This decomposition reduces
   the PPM count in the compilation pipeline.
   [(#9531)](https://github.com/PennyLaneAI/pennylane/pull/9531)
-  [(#9853)](https://github.com/PennyLaneAI/pennylane/pull/9853)
 
 * A more informative error message is raised when quantum functions without registered resource
   estimates are passed to the `fixed_decomps` and `alt_decomps` arguments of the :func:`~.transforms.decompose` transform.
@@ -661,6 +450,13 @@
   contain dynamic wire allocations.
   [(#9629)](https://github.com/PennyLaneAI/pennylane/pull/9629)
 
+* The function `qp.math.partial_trace()` has been changed to include a `qudit_dim` keyword argument to allow for partial traces of
+  any qudit density matrices with constant qudit dimension.
+  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
+
+* Device `default.qutrit.mixed` now implements state preparation operations with batched initial states.
+  [(#9538)](https://github.com/PennyLaneAI/pennylane/pull/9538)
+
 * :class:`~.Adder` now registers an additional QFT-free, carry-ripple decomposition rule that avoids
   the arbitrarily precise rotations of the existing QFT-based decomposition and supports an arbitrary
   modulus. Its multi-controlled gates reuse the remaining register wires as borrowed work wires for a
@@ -670,26 +466,9 @@
 
 * :func:`~core.queuing.apply` is now compatible with program capture.
   [(#9831)](https://github.com/PennyLaneAI/pennylane/pull/9831)
-  [(#10103)](https://github.com/PennyLaneAI/pennylane/pull/10103)
 
 * Implemented the `__str__` of `Wires` to display the wire labels as a list.
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
-
-* :func:`~pennylane.pauli_decompose` is significantly faster for SciPy sparse inputs. Nonzero entries are
-  grouped by their ``row ^ col`` XOR-difference and each group is resolved with a single fast
-  Walsh-Hadamard transform, following [Georges et al.](https://doi.org/10.1088/1367-2630/adb44d),
-  giving order-of-magnitude speedups for sparse and structured operators.
-  [(#9728)](https://github.com/PennyLaneAI/pennylane/pull/9728)
-
-* :class:`~.PartialUnaryStatePreparation` now uses a Clifford-only isometry for affine binary supports and avoids oversized PUI batch estimates.
-  [(#9947)](https://github.com/PennyLaneAI/pennylane/pull/9947)
-
-* Added the ``MultiX`` template which conditionally applies ``PauliX`` gates across target wires according
-  to a bitstring array.
-  [(#10033)](https://github.com/PennyLaneAI/pennylane/pull/10033)
-  [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
-  [(#10079)](https://github.com/PennyLaneAI/pennylane/pull/10079)
-  [(#10098)](https://github.com/PennyLaneAI/pennylane/pull/10098)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 
@@ -732,12 +511,6 @@
   [(#9277)](https://github.com/PennyLaneAI/pennylane/pull/9277)
   [(#9544)](https://github.com/PennyLaneAI/pennylane/pull/9544)
 
-* TCDQ now supports workflows with qudits of non-uniform dimensions.
-  [(#9935)](https://github.com/PennyLaneAI/pennylane/pull/9935)
-
-* TCDQ qudit MMD loss function now supports phase layers.
-  [(#10035)](https://github.com/PennyLaneAI/pennylane/pull/10035)
-
   ```python
   import pennylane as qp
   from pennylane.labs.templates import LeftQuantumComparator
@@ -750,10 +523,8 @@
     x_wires = [0, 3, 6, 9]
     y_wires = [1, 4, 7, 10]
     work_wires = [2, 5, 8]
-    a_bin = qp.math.int_to_binary(a, len(x_wires))
-    b_bin = qp.math.int_to_binary(b, len(x_wires))
-    qp.BasisState(a_bin, wires=x_wires)
-    qp.BasisState(b_bin, wires=y_wires)
+    qp.BasisState(a, wires=x_wires)
+    qp.BasisState(b, wires=y_wires)
     LeftQuantumComparator(x_wires, y_wires, 11, work_wires, comparator)
     qp.CNOT(wires=[11, 12])
     qp.adjoint(LeftQuantumComparator(x_wires, y_wires, 11, work_wires, comparator))
@@ -781,8 +552,7 @@
   @qp.set_shots(shots=1)
   @qp.qnode(dev)
   def circuit(x_val, L_val):
-    x_val_bin = qp.math.int_to_binary(x_val, 3)
-    qp.BasisState(x_val_bin, wires=[0, 1, 2])
+    qp.BasisState(x_val, wires=[0, 1, 2])
 
     LeftClassicalComparator(
         x_wires=[0, 1, 2],
@@ -835,10 +605,6 @@
 
   ```
 
-* Created a new ``labs.templates.SuperpositionTHC`` template, used as a subroutine in tensor
-  hypercontraction (THC) qubitization.
-  [(#9554)](https://github.com/PennyLaneAI/pennylane/pull/9554)
-
 * Added the :mod:`pennylane.labs.profiler` which allows users to profile the quantum resources required for
   their quantum workflows. This contains core functions and classes such as
   :class:`~.pennylane.labs.profiler.ProfileNode`, :func:`~.pennylane.labs.profiler.profile`, and
@@ -876,59 +642,25 @@
 
   ```
 
+* Created a :func:`~.pennylane.labs.templates.trotter_fragmented` function to run specialized
+  Trotter circuits for fragmented Hamiltonians. This is used in modern quantum chemistry
+  application algorithms.
+  [(#9459)](https://github.com/PennyLaneAI/pennylane/pull/9459)
+  [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
+
 * Performance of the Trotter error module is improved by introducing a novel algorithm for
   computing the Baker-Campbell-Hausdorff formula.
   [(#9608)][https://github.com/PennyLaneAI/pennylane/pull/9608]
 
-* Added an optional parameter ``phase_fn`` to ``QuditCircuitConfig`` which enables the inclusion of
-  a phase layer with trainable weights to a qudit IQP circuit.
-  [(#9826)][https://github.com/PennyLaneAI/pennylane/pull/9826]
-
 * Added a new fragmentation scheme for the vibronic Hamiltonian Trotter error workflow.
   [(#9813)][https://github.com/PennyLaneAI/pennylane/pull/9813]
-
+  
 * Added a class :class:`~.pennylane.labs.estimator_beta.ResourceQfunc` and a function
   :func:`~.pennylane.labs.estimator_beta.mark_subroutine` which allow users to easily define their own
   resource operators from their quantum functions.
   [(#9764)](https://github.com/PennyLaneAI/pennylane/pull/9764)
 
 <h3>Breaking changes 💔</h3>
-
-* :class:`~.GlobalPhase` no longer accepts the `wires` argument in order to mirror its MLIR lowered operation.
-  [(#9992)](https://github.com/PennyLaneAI/pennylane/pull/9992)
-
-* :class:`~.BasisState` no longer allows integers as input. Instead, `~.math.int_to_binary` should be used to preprocess
-  the input in order to convert it to a binary array.
-  [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
-  [(#10038)](https://github.com/PennyLaneAI/pennylane/pull/10038)
-
-* Renamed the `data` argument of :class:`~pennylane.QROM`, :class:`~pennylane.BBQRAM`, :class:`~pennylane.HybridQRAM`,
-  and :class:`~pennylane.SelectOnlyQRAM` to `bitstrings`.
-  [(#10010)](https://github.com/PennyLaneAI/pennylane/pull/10010)
-
-* :class:`~.BasisEmbedding` is now a direct alias of :class:`~.BasisState`.
-  [(#9980)](https://github.com/PennyLaneAI/pennylane/pull/9980)
-
-* Moved phase gradient decomposition rules for `RZ`, `CRZ` and `SelectPauliRot` from `labs` to `pennylane/transforms/decompositions`.
-  [(#9928)](https://github.com/PennyLaneAI/pennylane/pull/9928)
-
-* All functionality related to qutrits/qudits has been removed. Qudit functionality in :mod:`pennylane.labs`
-  still remains.
-  [(#9867)](https://github.com/PennyLaneAI/pennylane/pull/9867)
-
-* Removes `qp.Configuration` and the ability to pass a `config` to `pennylane.device`.
-  [(#9879)](https://github.com/PennyLaneAI/pennylane/pull/9879)
-  [(#9931)](https://github.com/PennyLaneAI/pennylane/pull/9931)
-
-* Removes all Continuous Variable (CV) code. This include `CV`, `CVOperation`, `CVObservable`,
-  `DefaultGaussian`, `qp.gradients.param_shift_cv`, `qp.Rotation`, `qp.Squeezing`, `qp.Displacement`,
-  `qp.Beamsplitter`, `qp.TwoModeSqueezing`, `qp.QuadraticPhase`, `qp.ControlledAddition`, `qp.ControlledPhase`,
-  `qp.Kerr`, `qp.CrossKerr`, `qp.CubicPhase`, `qp.InterferometerUnitary`, `qp.CoherentState`,
-  `qp.SqueezedState`, `qp.DisplacedSqueezedState`, `qp.ThermalState`, `qp.GaussianState`, `qp.FockState`,
-  `qp.FockStateVector`, `qp.FockDensityMatrix`, `qp.CatState`, `qp.NumberOperator`, `qp.TensorN`,
-  `qp.QuadX`, `qp.QuadP`, `qp.QuadOperator`, `qp.PolyXP`, `qp.FockStateProjector`,
-  `qp.DisplacementEmbedding`, `qp.SqueezingEmbedding`, `qp.CVNeuralNetLayers`, amd `qp.Interferomenter`.
-  [(#9869)](https://github.com/PennyLaneAI/pennylane/pull/9869)
 
 * Support for Python 3.11 has been dropped. PennyLane now requires Python 3.12 or later.
   [(#9700)](https://github.com/PennyLaneAI/pennylane/pull/9700)
@@ -1075,134 +807,15 @@
   [(#9483)](https://github.com/PennyLaneAI/pennylane/pull/9483)
 
 * The ``Operation.single_qubit_rot_angles()`` method is deprecated in favour of the new ``qp.single_qubit_zyz_angles(op)`` function, and will be removed in v0.47.
-  [(#9502)](https://github.com/PennyLaneAI/pennylane/pull/9502)
-
-* :class:`~.MultiplexerStatePreparation` no longer validates the norm of the input
-  state vector automatically. Validation is now opt-in via the ``check`` keyword
-  argument, which defaults to ``False``. Pass ``check=True`` to raise a ``ValueError``
-  when the input state vector does not have norm 1.0.
-  [(#9925)](https://github.com/PennyLaneAI/pennylane/pull/9925)
 
 <h3>Internal changes ⚙️</h3>
 
-* The `_prepselprep_decomp` decomposition rule of :class:`~.PrepSelPrep` now applies the linear-combination
-  unitaries and their global phases as two separate :class:`~.Select` operators instead of a single ``Select``
-  of products.
-  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
-
-* The `_qrom_decomposition` decomposition rule of :class:`~.QROM` now loads each column of bitstrings with
-  a single :class:`~.MultiX` instead of a product of smaller :class:`~.BasisState` and ``Identity`` operators.
-  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
-
-* The resource module JSON parser can now handle floating point values received from the Catalyst backend.
-  [(#10044)](https://github.com/PennyLaneAI/pennylane/pull/10044)
-
-* Removes `pennylane.transforms.decompose.DecomposeInterpreter`. Decompositions are no longer supported for the capture-without-qjit workflow.
-  [(#9915)](https://github.com/PennyLaneAI/pennylane/pull/9915)
-
-* Updated :mod:`pennylane.pytrees` to consider `None` a Pytree. This makes PennyLane Pytrees more consistent with JAX Pytrees.
-  [(#10045)](https://github.com/PennyLaneAI/pennylane/pull/10045)
-
-* The resource module JSON parser used by :func:`~.specs` to read Catalyst data has been revamped to match the new JSON structure produced by Catalyst.
-  [(#9942)](https://github.com/PennyLaneAI/pennylane/pull/9942)
-  [(#9969)](https://github.com/PennyLaneAI/pennylane/pull/9969)
-  [(#10011)](https://github.com/PennyLaneAI/pennylane/pull/10011)
-
-* Adds an `AGENTS.md` file providing guidelines and repository conventions for AI coding agents.
-  [(#9929)](https://github.com/PennyLaneAI/pennylane/pull/9929)
-
-* Adds a CI runner for catalyst tests and removes the catalyst tests from the `external` tests. Now, catalyst
-  tests should only be marked `catalyst` and *not* marked `external`.
-  [(#9873)](https://github.com/PennyLaneAI/pennylane/pull/9873)
-
-* Established a new dataclass hierarchy for resource information in the :mod:`~.resource` module.
-  This enables easier development of resource estimation features, and simplifies the creation of new resource classes.
-  The :class:`~.resource.Resources` class serves as the new base class,
-  and the :class:`~.resource.SpecsResources` and :class:`~.resource.PBCSpecsResources` inherit from it.
-  [(#9841)](https://github.com/PennyLaneAI/pennylane/pull/9841)
-
 * The following legacy operators are now ported to the new `~.Operator2` base class.
-  - Non-parametric operators are ported:
-    - :class:`~.S`, :class:`~.T`, :class:`~.SX`, :class:`~.Y`, :class:`~.CY`, :class:`~.SISWAP`, :class:`~.ISWAP`, :class:`~.ECR`,
-      :class:`~.SWAP`, :class:`~.CSWAP`, :class:`~.H`, :class:`~.CH`, :class:`~.Z`, :class:`~.CZ`, :class:`~.CCZ`, :class:`~.X`,
-      :class:`~.CNOT`, :class:`~.Toffoli`, :class:`~.MultiControlledX`
-      :class:`~.Identity`.
+  - Single qubit, non-parameteric operators are ported:
+    - `~.S`, `~.T`, `~.SX`
   [(#9818)](https://github.com/PennyLaneAI/pennylane/pull/9818)
   [(#9859)](https://github.com/PennyLaneAI/pennylane/pull/9859)
   [(#9819)](https://github.com/PennyLaneAI/pennylane/pull/9819)
-  [(#9871)](https://github.com/PennyLaneAI/pennylane/pull/9871)
-  [(#9850)](https://github.com/PennyLaneAI/pennylane/pull/9850)
-  [(#9784)](https://github.com/PennyLaneAI/pennylane/pull/9784)
-  [(#9844)](https://github.com/PennyLaneAI/pennylane/pull/9844)
-  [(#9814)](https://github.com/PennyLaneAI/pennylane/pull/9814)
-  [(#9854)](https://github.com/PennyLaneAI/pennylane/pull/9854)
-  [(#9858)](https://github.com/PennyLaneAI/pennylane/pull/9858)
-  [(#9960)](https://github.com/PennyLaneAI/pennylane/pull/9960)
-  [(#10004)](https://github.com/PennyLaneAI/pennylane/pull/10004)
-  [(#10129)](https://github.com/PennyLaneAI/pennylane/pull/10129)
-  - Parametric operators are ported:
-    - :class:`~.RZ`, :class:`~.CRZ`, :class:`~.DiagonalQubitUnitary`, :class:`~.PauliRot`, :class:`~.MultiRZ`, :class:`~.PhaseShift`,
-      :class:`~.ControlledPhaseShift`, :class:`~.Rot`, :class:`~.CRot`, :class:`~.U1`, :class:`~.U2`, :class:`~.U3`, :class:`~.PCPhase`,
-      :class:`~.GlobalPhase`, :class:`~.IsingXX`, :class:`~.IsingYY`, :class:`~.IsingZZ`, :class:`~.IsingXY`, :class:`~.RX`, :class:`~.CRX`,
-      :class:`~.RY`, :class:`~.CRY`, :class:`~.QubitUnitary`, :class:`~.ControlledQubitUnitary`
-  [(#9998)](https://github.com/PennyLaneAI/pennylane/pull/9998)
-  [(#9857)](https://github.com/PennyLaneAI/pennylane/pull/9857)
-  [(#9941)](https://github.com/PennyLaneAI/pennylane/pull/9941)
-  [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
-  [(#9936)](https://github.com/PennyLaneAI/pennylane/pull/9936)
-  [(#9964)](https://github.com/PennyLaneAI/pennylane/pull/9964)
-  [(#10006)](https://github.com/PennyLaneAI/pennylane/pull/10006)
-  [(#9977)](https://github.com/PennyLaneAI/pennylane/pull/9977)
-  [(#9984)](https://github.com/PennyLaneAI/pennylane/pull/9984)
-  [(#9951)](https://github.com/PennyLaneAI/pennylane/pull/9951)
-  [(#9923)](https://github.com/PennyLaneAI/pennylane/pull/9923)
-  [(#9952)](https://github.com/PennyLaneAI/pennylane/pull/9952)
-  [(#9978)](https://github.com/PennyLaneAI/pennylane/pull/9978)
-  [(#9981)](https://github.com/PennyLaneAI/pennylane/pull/9981)
-  [(#10026)](https://github.com/PennyLaneAI/pennylane/pull/10026)
-  [(#9990)](https://github.com/PennyLaneAI/pennylane/pull/9990)
-  [(#10041)](https://github.com/PennyLaneAI/pennylane/pull/10041)
-  [(#10072)](https://github.com/PennyLaneAI/pennylane/pull/10072)
-  - Templates are ported:
-    - :class:`~.BasisRotation`, :class:`~.MultiplexerStatePreparation`, :class:`~.QROM`, :class:`~.QFT`, :class:`~.FlipSign`,
-      :class:`~.TemporaryAND`, :class:`~.SelectPauliRot`, :class:`~.GQSP`, :class:`~.AQFT`, :class:`~.SumOfSlatersPrep`,
-      :class:`~.SemiAdder`, :class:`~.OutMultiplier`, :class:`~.SignedOutMultiplier`, :class:`~.BasisState`, :class:`~.TrotterCDF`,
-      :class:`~.TrotterCGF`, :class:`~.OutSquare`, :class:`~.SignedOutSquare`, :class:`~.Incrementer`, :class:`~.TrotterVibronic`,
-      :class:`~.Select`
-  [(#9896)](https://github.com/PennyLaneAI/pennylane/pull/9896)
-  [(#9925)](https://github.com/PennyLaneAI/pennylane/pull/9925)
-  [(#9918)](https://github.com/PennyLaneAI/pennylane/pull/9918)
-  [(#9932)](https://github.com/PennyLaneAI/pennylane/pull/9932)
-  [(#9924)](https://github.com/PennyLaneAI/pennylane/pull/9924)
-  [(#9910)](https://github.com/PennyLaneAI/pennylane/pull/9910)
-  [(#9965)](https://github.com/PennyLaneAI/pennylane/pull/9965)
-  [(#9943)](https://github.com/PennyLaneAI/pennylane/pull/9943)
-  [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
-  [(#9987)](https://github.com/PennyLaneAI/pennylane/pull/9987)
-  [(#9900)](https://github.com/PennyLaneAI/pennylane/pull/9900)
-  [(#9994)](https://github.com/PennyLaneAI/pennylane/pull/9994)
-  [(#9997)](https://github.com/PennyLaneAI/pennylane/pull/9997)
-  [(#9995)](https://github.com/PennyLaneAI/pennylane/pull/9995)
-  [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
-  [(#10018)](https://github.com/PennyLaneAI/pennylane/pull/10018)
-  [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
-  [(#10042)](https://github.com/PennyLaneAI/pennylane/pull/10042)
-  [(#10052)](https://github.com/PennyLaneAI/pennylane/pull/10052)
-  [(#10054)](https://github.com/PennyLaneAI/pennylane/pull/10054)
-  [(#10029)](https://github.com/PennyLaneAI/pennylane/pull/10029)
-  [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)
-  [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
-  [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
-  [(#10069)](https://github.com/PennyLaneAI/pennylane/pull/10069)
-  [(#10085)](https://github.com/PennyLaneAI/pennylane/pull/10085)
-  [(#10020)](https://github.com/PennyLaneAI/pennylane/pull/10020)
-  - Quantum chemistry operators are ported:
-    - :class:`~.SingleExcitation`
-  [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)
-  - Miscelleneous operators are ported:
-    - :class:`~.PauliMeasure`, :class:`~.ops.MidMeasure`
-  [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)
-  [(#10115)](https://github.com/PennyLaneAI/pennylane/pull/10115)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.
@@ -1262,18 +875,11 @@
   [(#9526)](https://github.com/PennyLaneAI/pennylane/pull/9526)
   [(#9527)](https://github.com/PennyLaneAI/pennylane/pull/9527)
   [(#9649)](https://github.com/PennyLaneAI/pennylane/pull/9649)
-  [(#9658)](https://github.com/PennyLaneAI/pennylane/pull/9658)
   [(#9675)](https://github.com/PennyLaneAI/pennylane/pull/9675)
   [(#9746)](https://github.com/PennyLaneAI/pennylane/pull/9746)
   [(#9783)](https://github.com/PennyLaneAI/pennylane/pull/9783)
   [(#9851)](https://github.com/PennyLaneAI/pennylane/pull/9851)
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
-  [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
-  [(#9920)](https://github.com/PennyLaneAI/pennylane/pull/9920)
-  [(#9937)](https://github.com/PennyLaneAI/pennylane/pull/9937)
-  [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
-  [(#9926)](https://github.com/PennyLaneAI/pennylane/pull/9926)
-  [(#10077)](https://github.com/PennyLaneAI/pennylane/pull/10077)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:
@@ -1283,13 +889,10 @@
     [(#9646)](https://github.com/PennyLaneAI/pennylane/pull/9646)
     [(#9694)](https://github.com/PennyLaneAI/pennylane/pull/9694)
     [(#9744)](https://github.com/PennyLaneAI/pennylane/pull/9744)
-    [(#9788)](https://github.com/PennyLaneAI/pennylane/pull/9788)
   - Some backwards compatibility with the legacy operator interface.
     [(#9596)](https://github.com/PennyLaneAI/pennylane/pull/9596)
     [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
     [(#9820)](https://github.com/PennyLaneAI/pennylane/pull/9820)
-    [(#9756)](https://github.com/PennyLaneAI/pennylane/pull/9756)
-    [(#9976)](https://github.com/PennyLaneAI/pennylane/pull/9976)
   - Compatibility with the `drawer` module.
     [(#9849)](https://github.com/PennyLaneAI/pennylane/pull/9849)
   - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.
@@ -1298,8 +901,6 @@
   - :func:`qp.ops.functions.assert_valid` can verify that an :class:`~.Operator2` is defined properly.
     [(#9659)](https://github.com/PennyLaneAI/pennylane/pull/9659)
     [(#9842)](https://github.com/PennyLaneAI/pennylane/pull/9842)
-    [(#9898)](https://github.com/PennyLaneAI/pennylane/pull/9898)
-    [(#10058)](https://github.com/PennyLaneAI/pennylane/pull/10058)
   - :class:`~.StatePrepBase2`, based on :class:`~.Operator2`, is added.
     [(#9562)](https://github.com/PennyLaneAI/pennylane/pull/9562)
   - :meth:`~.Operator2.decomposition` falls back to registered graph decomposition rules when ``compute_decomposition`` is not overridden.
@@ -1317,16 +918,6 @@
     [(#9778)](https://github.com/PennyLaneAI/pennylane/pull/9778)
     [(#9805)](https://github.com/PennyLaneAI/pennylane/pull/9805)
     [(#9856)](https://github.com/PennyLaneAI/pennylane/pull/9856)
-    [(#9876)](https://github.com/PennyLaneAI/pennylane/pull/9876)
-    [(#9871)](https://github.com/PennyLaneAI/pennylane/pull/9871)
-    [(#9966)](https://github.com/PennyLaneAI/pennylane/pull/9966)
-  - Composite operators with :class:`~.Operator2` instances as the base.
-    [(#10027)](https://github.com/PennyLaneAI/pennylane/pull/10027)
-    [(#10047)](https://github.com/PennyLaneAI/pennylane/pull/10047)
-    [(#10113)](https://github.com/PennyLaneAI/pennylane/pull/10113)
-    [(#9999)](https://github.com/PennyLaneAI/pennylane/pull/9999)
-    [(#10125)](https://github.com/PennyLaneAI/pennylane/pull/10125)
-    [(#10124)](https://github.com/PennyLaneAI/pennylane/pull/10124)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)
@@ -1334,8 +925,6 @@
     [(#9754)](https://github.com/PennyLaneAI/pennylane/pull/9754)
     [(#9808)](https://github.com/PennyLaneAI/pennylane/pull/9808)
     [(#9834)](https://github.com/PennyLaneAI/pennylane/pull/9834)
-    [(#9908)](https://github.com/PennyLaneAI/pennylane/pull/9908)
-    [(#10066)](https://github.com/PennyLaneAI/pennylane/pull/10066)
   - Integration with measurements.
     [(#9753)](https://github.com/PennyLaneAI/pennylane/pull/9753)
   - Integration with :func:`pennylane.apply`.
@@ -1352,10 +941,6 @@
     [(#9838)](https://github.com/PennyLaneAI/pennylane/pull/9838)
     [(#9843)](https://github.com/PennyLaneAI/pennylane/pull/9843)
     [(#9866)](https://github.com/PennyLaneAI/pennylane/pull/9866)
-    [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
-    [(#9973)](https://github.com/PennyLaneAI/pennylane/pull/9973)
-  - The way that :class:`~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with :class:`~.Operator2` in the data module.
-    [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.
@@ -1403,8 +988,8 @@
   Raw numeric literals in `pennylane/math`, `pennylane/ops`, `pennylane/devices`,
   `pennylane/gradients`, `pennylane/pauli`, `pennylane/qchem`, `pennylane/liealg`,
   `pennylane/fourier`, and `pennylane/templates` are now module-level constants with
-  ``#:`` doc-comments explaining their purpose and origin. Unused constant ``eps`` in
-  :mod:`pennylane.math` is removed.
+  ``#:`` doc-comments explaining their purpose and origin. Unused constants
+  ``eps`` in :mod:`pennylane.math` and ``tolerance`` in ``default_qutrit`` are removed.
   [(#9374)](https://github.com/PennyLaneAI/pennylane/pull/9374)
 
 * Added usage of the `strict` keyword argument for `zip` throughout the codebase.
@@ -1426,10 +1011,6 @@
   from `qp.ctrl(qp.X(0), control=[1, 2])` to `Toffoli(wires=[1, 2, 0])`) is re-written to use a
   singledispatch function `custom_ctrl_dispatch` as opposed to relying on hard-coded logic.
   [(#9798)](https://github.com/PennyLaneAI/pennylane/pull/9798)
-
-* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx`
-  context manager that temporarily enables or disables capture is added.
-  [(#10016)](https://github.com/PennyLaneAI/pennylane/pull/10016)
 
 <h3>Documentation 📝</h3>
 
@@ -1464,67 +1045,12 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug in :func:`~pennylane.draw` with conditionally applied operators that do not have wires,
-  such as ``cond(condition, GlobalPhase(0.52))``.
-  [(#10132)](https://github.com/PennyLaneAI/pennylane/pull/10132)
-
-* Fix `qp.eigvals` returns `NaN` for a legal fractional power operator.
-  [(#9802)](https://github.com/PennyLaneAI/pennylane/pull/9802)
-  [(#10139)](https://github.com/PennyLaneAI/pennylane/pull/10139)
-
-* Fixed the decomposition rule of :class:`~.QROM` so that it can be captured and compiled with
-  Catalyst. Tracing the ``clean`` branch previously raised a ``TracerIntegerConversionError``
-  because :func:`~pennylane.adjoint` traced the statically known ``depth``, and passing the wires
-  as traced arrays raised a ``TracerBoolConversionError``. The NumPy calls in the decomposition
-  are also replaced with :mod:`pennylane.math` so that they work on traced bitstrings.
-  [(#10116)](https://github.com/PennyLaneAI/pennylane/pull/10116)
-
-* Fixed the Triton persistent decoder kernel so :func:`~pennylane.backline.css_bp_decoder` and
-  the other Triton decoders build on CUDA with Triton 3.8.
-  [(#10111)](https://github.com/PennyLaneAI/pennylane/pull/10111)
-
-* Fixed :class:`~.Incrementer` returning an incorrect incremented value when not enough
-  work wires are provided.
-  [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)
-
-* Converting an ``AbstractArray`` to a concrete array now raises an informative ``TypeError``
-  instead of silently producing an empty array, which previously surfaced as an obscure error
-  far from its cause.
-  [(#10083)](https://github.com/PennyLaneAI/pennylane/pull/10083)
-
-* Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
-  compiled with Catalyst when ``mod = 2 ** len(output_wires)``.
-  [(#10057)](https://github.com/PennyLaneAI/pennylane/pull/10057)
-
-* Fixed capture compatibility of the decomposition rule of `SemiAdder`.
-  [(#10068)](https://github.com/PennyLaneAI/pennylane/pull/10068)
-
-* Fixed :func:`~pennylane.backline.css_bp_decoder` and the other Triton decoders so they can be
-  compiled on a machine with no usable GPU. The ahead-of-time build called
-  ``JITFunction.create_binder()``, which asks the local machine for a target through
-  ``driver.active.get_current_target()`` and fails with ``0 active drivers`` where there is none.
-  [(#10046)](https://github.com/PennyLaneAI/pennylane/pull/10046)
-
-* Fixed a bug where the ``flip_zero_control`` decomposition modifier raised a
-  ``TracerIntegerConversionError`` under program capture, because the control-value flipping
-  loop indexed the control wires with a traced loop variable without first promoting them to a
-  JAX array.
-  [(#10036)](https://github.com/PennyLaneAI/pennylane/pull/10036)
-
-* Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
-  arithmetic operations performed on mid-circuit measurement values.
-  [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
-
-* Fixed :func:`~pennylane.backline.css_bp_decoder` so the X- and Z-specialized Triton decoders
-  stay distinct when bundled behind one dispatcher, and, for the same reason, updated
-  :func:`~pennylane.backline.triton_decoder` to own jitting of the raw Triton decoder functions.
-  [(#10040)](https://github.com/PennyLaneAI/pennylane/pull/10040)
-
-* Fixed a bug where decomposing an :class:`~.Operator2` with graph-based decomposition
-  enabled inside a :class:`~.Subroutine` with program capture leaked JAX tracers and
-  caused Catalyst compilation to fail.
-  operations.
-  [(#10023)](https://github.com/PennyLaneAI/pennylane/pull/10023)
+* Fixed a bug where ``QubitDevice.probability``, ``QubitDevice.estimate_probability``
+  and ``QutritDevice.estimate_probability`` ignored an integer wire label of ``0`` and
+  returned the full joint distribution instead of the single-wire marginal. The falsy
+  label was silently replaced by all device wires; the default is now resolved with an
+  explicit ``None`` check.
+  [(#PRNUM)](https://github.com/PennyLaneAI/pennylane/pull/PRNUM)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
@@ -1539,11 +1065,8 @@
   :class:`~.Incrementer` were also included in the target wires.
   [(#9721)](https://github.com/PennyLaneAI/pennylane/pull/9721)
 
-* Fixed a bug in :class:`~.OutMultiplier` for small output registers.
+* Fixed a bug in :class:~.OutMultiplier` for small output registers.
   [(#9759)](https://github.com/PennyLaneAI/pennylane/pull/9759)
-
-* Fixed a bug in :class:`~.labs.LeftClassicalComparator` for `L = 2^n -1`.
-  [(#9554)](https://github.com/PennyLaneAI/pennylane/pull/9554)
 
 * Fixed a bug in :class:`~.SumOfSlatersPrep` with `qjit` compilation and non-identity encoding.
   [(#9747)](https://github.com/PennyLaneAI/pennylane/pull/9747)
@@ -1629,45 +1152,26 @@
   restored as ``bytes``.
   [(#9687)](https://github.com/PennyLaneAI/pennylane/pull/9687)
 
-* Fixed a bug with :func:`~pennylane.equal` where comparing a base operator to
-  one of its subclasses returned ``True`` if they shared the same data and wires.
-  [(#9749)](https://github.com/PennyLaneAI/pennylane/pull/9749)
-
-* Qubit TCDQ expval function now returns the variance rather than standard deviation
-  of the estimator. Qubit and qudit MMD loss functions now have unbiased gradients.
-  [(#10025)](https://github.com/PennyLaneAI/pennylane/pull/10025)
-
-* Various decomposition rules are updated so that they accept positionally passed arguments.
-  [(#10088)](https://github.com/PennyLaneAI/pennylane/pull/10088)
-
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Usman Ahmed,
+Mohit Ak,
 Guillermo Alonso,
 Abdullah Al Omar Galib,
-Ali Asadi,
 Gabriel Bottrill,
-Joseph Bowles,
 Astral Cai,
 Daniel Casota,
 Miguel Cárdenas,
 Yushao Chen,
 Diksha Dhawan,
 Marcus Edwards,
-Sümeyye Nur Esin,
-Thomas C. Fraser,
-Connor Gambla,
-Sengthai Heng,
 Austin Huang,
-Harshal Janjani,
 Jacob Kitchen,
 Korbinian Kottmann,
-Isabel Nha Minh Le,
 Christina Lee,
-Joseph Lee,
-William Maxwell,
+William Maxwell
 Anton Naim Ibrahim,
 Mudit Pandey,
 Andrija Paurevic,
@@ -1678,5 +1182,4 @@ Paul Haochen Wang,
 Dennis Wayo,
 David Wierichs,
 Jake Zaia,
-Hongsheng Zheng,
 Zinan Zhou.

--- a/pennylane/devices/_qubit_device.py
+++ b/pennylane/devices/_qubit_device.py
@@ -1179,7 +1179,7 @@ class QubitDevice(Device):
             array[float]: list of the probabilities
         """
 
-        wires = wires or self.wires
+        wires = self.wires if wires is None else wires
         # convert to a Wires object
         wires = Wires(wires)
         # translate to wire labels used by device
@@ -1270,7 +1270,7 @@ class QubitDevice(Device):
         Returns:
             array[float]: list of the probabilities
         """
-        wires = wires or self.wires
+        wires = self.wires if wires is None else wires
         if self.shots is None:
             return self.analytic_probability(wires=wires)
 

--- a/pennylane/devices/_qutrit_device.py
+++ b/pennylane/devices/_qutrit_device.py
@@ -262,7 +262,7 @@ class QutritDevice(QubitDevice):
             array[float]: list of the probabilities
         """
 
-        wires = wires or self.wires
+        wires = self.wires if wires is None else wires
         # convert to a wires object
         wires = Wires(wires)
         # translate to wire labels used by device

--- a/tests/devices/test_qubit_device.py
+++ b/tests/devices/test_qubit_device.py
@@ -903,6 +903,27 @@ class TestEstimateProb:
 
     @pytest.mark.parametrize(
         "wires, expected",
+        [(0, [0.5, 0.5]), (1, [0.5, 0.5])],
+    )
+    def test_estimate_probability_integer_wire_label(
+        self, wires, expected, mock_qubit_device_with_original_statistics, monkeypatch
+    ):
+        """Tests that estimate_probability returns the single-wire marginal when
+        passed an integer wire label. Regression test for a truthiness bug where
+        the falsy label ``0`` was silently replaced by all device wires, so
+        ``estimate_probability(wires=0)`` returned the full joint distribution
+        instead of the marginal for wire 0."""
+        dev = mock_qubit_device_with_original_statistics(wires=2)
+        samples = np.array([[0, 0], [1, 1], [1, 1], [0, 0]])
+
+        with monkeypatch.context() as m:
+            m.setattr(dev, "_samples", samples)
+            res = dev.estimate_probability(wires=wires)
+
+        assert np.allclose(res, expected)
+
+    @pytest.mark.parametrize(
+        "wires, expected",
         [
             ([0], [[0.0, 0.5], [1.0, 0.5]]),
             (None, [[0.0, 0.5], [0, 0], [0, 0.5], [1.0, 0]]),


### PR DESCRIPTION
### Problem

`probability(wires=0)` on the legacy `QubitDevice` / `QutritDevice` silently
returns the **full** joint distribution instead of the marginal for wire `0`.
For a 2-qutrit device you get a 9-element array where you'd expect 3:

```python
import pennylane as qml
dev = qml.device("default.qutrit", wires=2, shots=5000)

@qml.qnode(dev)
def circuit():
    qml.THadamard(0)
    return qml.probs(wires=[0, 1])

circuit()
print(len(dev.estimate_probability(wires=None)))  # 9  (full)
print(len(dev.estimate_probability(wires=0)))      # 9  -> expected 3
print(len(dev.estimate_probability(wires=1)))      # 3  (correct, 1 is truthy)
```

The docstring promises `wires` accepts a single wire label
("*wires to return marginal probabilities for. Wires not provided are traced
out of the system.*"), so `wires=0` should give the marginal for wire 0 only.

### Root cause

Three methods default the `wires` argument with a truthiness check:

```python
wires = wires or self.wires
```

`0` is falsy in Python, so `wires=0` is indistinguishable from "no wires given"
and gets replaced by all device wires. Wire label `1` (and any non-zero label)
works, which is why this hid for so long — wire `0` is the most common first
wire. The three affected sites are:

- `QubitDevice.estimate_probability` (`pennylane/devices/_qubit_device.py`)
- `QubitDevice.probability` (`pennylane/devices/_qubit_device.py`)
- `QutritDevice.estimate_probability` (`pennylane/devices/_qutrit_device.py`)

### Fix

Resolve the default with an explicit `None` check, which is the same pattern
already used elsewhere in these files (e.g. `QutritDevice.marginal_prob`):

```python
wires = self.wires if wires is None else wires
```

`Wires(0)` already produces a valid single-wire object (`[0]`), so once the
falsy short-circuit is gone the existing marginalization code handles it
correctly. `wires=None` still returns the full distribution, and an explicit
empty request (`wires=[]`) now returns the trivial `[1.0]` marginal over zero
wires rather than silently falling back to the full distribution.

### Testing

Added a parametrized regression test
(`TestEstimateProb::test_estimate_probability_integer_wire_label`) that mirrors
the existing `test_estimate_probability` style and covers the integer wire
labels `0` and `1`. It fails on the unpatched code with the `wires=0` case
returning the full 4-element distribution instead of `[0.5, 0.5]`, and passes
after the fix.

```
$ python -m pytest tests/devices/test_qubit_device.py tests/devices/test_qutrit_device.py -q
213 passed, 4 skipped
```

The wider device suites remain green (`test_default_qutrit.py`'s
`TestTensorSample::test_hermitian` errors identically on a pristine checkout —
a pre-existing `RecursionError` at fixture setup unrelated to this change).
`black` and `isort` report no changes on the edited files.

Fixes #9653

---

*Disclosure per the PennyLane AI Tool Use Policy: this change was prepared with
AI assistance (issue triage, drafting the fix and regression test, and this
description), reviewed by a human before submission. I'm the author and can
answer questions about the change during review.*
