### PR TITLE
Preserve multi-wire Identity resource arity

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed :class:`~.estimator.ops.Identity` resource representations so multi-wire instances preserve
+  their wire count and remain distinct from identities with a different arity.
+  [(#9881)](https://github.com/PennyLaneAI/pennylane/pull/9881)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/estimator/ops/identity.py
+++ b/pennylane/estimator/ops/identity.py
@@ -70,6 +70,16 @@ class Identity(ResourceOperator):
         the operator that are needed to compute the resources."""
         return CompressedResourceOp(cls, cls.num_wires, {})
 
+    def resource_rep_from_op(self) -> CompressedResourceOp:
+        r"""Returns a compressed representation preserving the instance wire count."""
+        representation = super().resource_rep_from_op()
+        return CompressedResourceOp(
+            representation.op_type,
+            self.num_wires,
+            representation.params,
+            representation.name,
+        )
+
     @classmethod
     def resource_decomp(cls) -> list[GateCount]:
         r"""Returns a list representing the resources of the operator. Each object represents a quantum gate

--- a/tests/estimator/ops/test_estimator_identity.py
+++ b/tests/estimator/ops/test_estimator_identity.py
@@ -47,6 +47,20 @@ class TestIdentity:
         expected = CompressedResourceOp(Identity, 1, {})
         assert Identity.resource_rep() == expected
 
+    @pytest.mark.parametrize("num_wires", (1, 2, 3))
+    def test_resource_rep_from_op_preserves_num_wires(self, num_wires):
+        """Test that instance arity is preserved in the compressed representation."""
+        op = Identity(wires=range(num_wires))
+
+        assert op.resource_rep_from_op() == CompressedResourceOp(Identity, num_wires, {})
+
+    def test_resource_rep_from_op_distinguishes_arities(self):
+        """Test that different Identity arities have distinct compressed representations."""
+        two_wire_rep = Identity(wires=[0, 1]).resource_rep_from_op()
+        three_wire_rep = Identity(wires=[0, 1, 2]).resource_rep_from_op()
+
+        assert two_wire_rep != three_wire_rep
+
     def test_resource_params(self):
         """Test the resource params are correct"""
         op = Identity(0)


### PR DESCRIPTION
**Context**

`Identity.resource_rep_from_op()` inherited the class-level representation, whose fixed `num_wires = 1` collapses multi-wire Identity instances to the same compressed representation. Two- and three-wire identities then compare equal even though their resource arities differ.

**Severity:** silent incorrect resource accounting (no crash).

**User impact:** Any estimator workflow that deduplicates or compares compressed resource reps treats distinct multi-wire identities as identical. Gate counts, wire budgets, and equality checks on resource graphs can be wrong.

**Minimal repro**

```python
import pennylane.estimator as qre

two = qre.Identity(wires=[0, 1])
three = qre.Identity(wires=[0, 1, 2])
assert two.resource_rep_from_op().num_wires == 2  # fails: returns 1
assert two.resource_rep_from_op() != three.resource_rep_from_op()  # fails: equal
```

**Change**

Override the instance representation path for `Identity` so it preserves base metadata while replacing the class-level arity with the resolved instance wire count. Regression tests cover one-, two-, and three-wire instances.

**Related GitHub Issues**

Fixes #9616

Validation: 810 estimator-operator tests pass; Black, isort, Pylint, and `git diff --check` pass on changed files.

---

Assisted-by: Codex (OpenAI)