### PR TITLE
docs: document to_openqasm wires for non-contiguous labels

### DIFF
--- a/pennylane/io/to_openqasm.py
+++ b/pennylane/io/to_openqasm.py
@@ -220,6 +220,9 @@ def to_openqasm(
         circuit (QNode or QuantumScript): the quantum circuit to be serialized.
         wires (Wires or None): the wires to use when serializing the circuit.
             Default is ``None``, such that all the wires of the circuit are used for serialization.
+            When wire labels are non-contiguous or non-zero-based integers, pass the full wire
+            order explicitly (e.g. ``wires=[0, 1, 2]``) so OpenQASM qubit indices match your
+            intended mapping instead of packing to the lowest unused indices.
         rotations (bool): if ``True``, add gates that rotate the quantum state into the eigenbasis
             of the circuit's observables. Default is ``True``.
         measure_all (bool): if ``True``, add a computational basis measurement on all the qubits.
@@ -265,6 +268,26 @@ def to_openqasm(
 
     .. details::
         :title: Usage Details
+
+        **Wire order and non-contiguous labels.** OpenQASM 2.0 qubit registers are indexed from
+        zero. If the circuit only uses a subset of wires (for example wires ``0`` and ``2`` on a
+        three-wire device), leaving ``wires=None`` packs those wires into contiguous OpenQASM
+        indices ``q[0]`` and ``q[1]``. Pass the full device wire order via ``wires`` to keep a
+        stable mapping:
+
+        .. code-block:: python
+
+            dev = qp.device("default.qubit", wires=3)
+
+            @qp.qnode(dev)
+            def circuit():
+                qp.PauliX(wires=2)
+                return qp.sample()
+
+            # Packs to q[0] (only used wires):
+            # print(qp.to_openqasm(circuit)())
+            # Keeps PauliX on q[2]:
+            print(qp.to_openqasm(circuit, wires=[0, 1, 2])())
 
         By default, the resulting OpenQASM code will have terminal measurements on all qubits,
         where all the measurements are performed in the computational basis.


### PR DESCRIPTION
## Summary

Documents the `wires` argument on `qml.to_openqasm` for non-contiguous / non-packed wire labels, with a Usage Details example.

This follows maintainer guidance on #9768 that the behaviour is intentional and the missing piece is documentation (use `wires=[0, 1, 2]` rather than treating packed indices as a bug).

Fixes #9768

## Checklist

- [x] Documentation only (no API change)
- [ ] CI

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
