### PR TITLE
Fix qml.equal for opposite MeasurementValue predicates

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``qml.equal`` treating opposite ``MeasurementValue`` predicates as equal. [(#9885)](https://github.com/PennyLaneAI/pennylane/pull/9885)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/ops/functions/equal.py
+++ b/pennylane/ops/functions/equal.py
@@ -813,8 +813,17 @@ def _equal_conditional(op1: Conditional, op2: Conditional, **kwargs):
 
 @_equal_dispatch.register
 def _equal_measurement_value(op1: MeasurementValue, op2: MeasurementValue, **kwargs):
-    """Determine whether two MeasurementValue objects are equal"""
-    return op1.measurements == op2.measurements
+    """Determine whether two MeasurementValue objects are equal.
+
+    Compare underlying mid-circuit measurements *and* the branch outcomes of any
+    processing function. Comparing only ``measurements`` would treat opposite
+    predicates (e.g. ``m0 == 0`` vs ``m0 == 1``) as equal.
+    """
+    if op1.measurements != op2.measurements:
+        return False
+    # Evaluate all classical outcomes; predicates differ here without comparing
+    # opaque callables by identity.
+    return op1.branches == op2.branches
 
 
 @_equal_dispatch.register

--- a/tests/ops/functions/test_equal.py
+++ b/tests/ops/functions/test_equal.py
@@ -1739,8 +1739,18 @@ class TestMeasurementsEqual:
 
         assert qp.equal(mv1 * mv2, mv2 * mv1) is True
         assert qp.equal(mv1 + mv2, mv3 + mv2) is True
-        # NOTE: we are deliberatily just checking for measurements and not for processing_fn, such that two MeasurementValue objects composed from the same operators will be qp.equal
-        assert qp.equal(3 * mv1 + 1, 4 * mv3 + 2) is True
+        # Different processing functions yield different classical branch maps.
+        assert qp.equal(3 * mv1 + 1, 4 * mv3 + 2) is False
+        assert qp.equal(3 * mv1 + 1, 3 * mv3 + 1) is True
+
+    def test_opposite_measurement_value_predicates(self):
+        """Opposite predicates on the same measurement must not be equal (#9622)."""
+        m0 = qp.measure(0)
+        assert qp.equal(m0 == 0, m0 == 1) is False
+        assert qp.equal(m0 == 0, m0 == 0) is True
+        c0 = qp.ops.op_math.Conditional(m0 == 0, qp.X(1))
+        c1 = qp.ops.op_math.Conditional(m0 == 1, qp.X(1))
+        assert qp.equal(c0, c1) is False
 
     @pytest.mark.parametrize("mp_fn", [qp.probs, qp.sample, qp.counts])
     def test_mv_list_as_op(self, mp_fn):


### PR DESCRIPTION
## Impact

**Severity:** silent wrong equality (no crash).

**User impact:** `qml.equal` is used for operator comparison, transform deduplication, and structural checks on queued ops. Opposite mid-circuit predicates (`m0 == 0` vs `m0 == 1`) and matching `Conditional` ops were reported equal, so downstream logic could treat mutually exclusive branches as identical.

## Repro

```python
import pennylane as qml

with qml.queuing.AnnotatedQueue() as q:
    m0 = qml.measure(0)

assert qml.equal(m0 == 0, m0 == 1) is False  # was True
c0 = qml.ops.op_math.Conditional(m0 == 0, qml.X(1))
c1 = qml.ops.op_math.Conditional(m0 == 1, qml.X(1))
assert qml.equal(c0, c1) is False  # was True
```

## Change

Compare the classical branch map (`op.branches`) in addition to underlying mid-circuit measurements so equality reflects processing-function outcomes.

## Tests

- Updated composition equality expectations (different arithmetic → unequal)
- Added regression for opposite predicates and `Conditional` ops
- `TestMeasurementsEqual`: all passed locally

Fixes #9622

Related: #9652 (separate `debug_probs` truthiness bug on `MeasurementValue`; not fixed here).

---

Assisted-by: Codex (OpenAI)