### PR TITLE
Fix is_commuting for CZ and SWAP on shared wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``qml.is_commuting`` returning ``False`` for commuting ``CZ`` and ``SWAP`` operations on shared wires. [(#9886)](https://github.com/PennyLaneAI/pennylane/pull/9886)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/ops/functions/is_commuting.py
+++ b/pennylane/ops/functions/is_commuting.py
@@ -115,6 +115,23 @@ def _check_mat_commutation(op1, op2):
     return qp.math.allclose(mat_12, mat_21)
 
 
+def _maybe_matrix_commutes(op1, op2, default=False):
+    """Fall back to dense matrix multiplication when the wire-control heuristic is wrong.
+
+    The control/target lookup treats controlled ops asymmetrically (e.g. ``CZ`` as control +
+    target ``Z``). That mis-classifies some fully-overlapping two-qubit pairs such as ``CZ``
+    and ``SWAP``, which do commute. Embed both operators on a shared ``wire_order`` so the
+    comparison is basis-aligned (do not rename wires via ``map_wires``).
+    """
+    try:
+        wire_order = Wires.all_wires([op1.wires, op2.wires])
+        mat1 = qp.matrix(op1, wire_order=wire_order)
+        mat2 = qp.matrix(op2, wire_order=wire_order)
+        return qp.math.allclose(mat1 @ mat2, mat2 @ mat1)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return default
+
+
 def _create_commute_function():
     """This function constructs the ``_commutes`` helper utility function while using closure
     to hide the ``commutation_map`` data away from the global scope of the file.
@@ -331,13 +348,28 @@ def is_commuting(operation1, operation2):
     target_wires_1 = qp.wires.Wires([w for w in operation1.wires if w not in op1_control_wires])
     target_wires_2 = qp.wires.Wires([w for w in operation2.wires if w not in op2_control_wires])
 
+    involves_swap = (
+        ctrl_base_1 in SWAP_GROUP
+        or ctrl_base_2 in SWAP_GROUP
+        or operation1.name in SWAP_GROUP
+        or operation2.name in SWAP_GROUP
+    )
+
     if intersection(target_wires_1, target_wires_2) and not _commutes(ctrl_base_1, ctrl_base_2):
+        # SWAP-family vs controlled-Z style ops can be misclassified by the asymmetric
+        # control/target heuristic; verify with matrices only in that case (#9623).
+        if involves_swap:
+            return _maybe_matrix_commutes(operation1, operation2, default=False)
         return False
 
     if intersection(target_wires_1, op2_control_wires) and not _commutes("ctrl", ctrl_base_1):
+        if involves_swap:
+            return _maybe_matrix_commutes(operation1, operation2, default=False)
         return False
 
     if intersection(target_wires_2, op1_control_wires) and not _commutes("ctrl", ctrl_base_2):
+        if involves_swap:
+            return _maybe_matrix_commutes(operation1, operation2, default=False)
         return False
 
     return True

--- a/tests/ops/functions/test_is_commuting.py
+++ b/tests/ops/functions/test_is_commuting.py
@@ -901,3 +901,14 @@ class TestCommutingFunction:
 
         res = qp.is_commuting(qp.PauliX(wires=0), qp.QFT(wires=[1, 0]))
         assert res is False
+
+
+def test_cz_commutes_with_swap():
+    """CZ and SWAP on the same wires commute (matrix algebra); heuristic must agree (#9623)."""
+    cz = qp.CZ(wires=[0, 1])
+    swap = qp.SWAP(wires=[0, 1])
+    assert qp.is_commuting(cz, swap) is True
+    assert qp.is_commuting(swap, cz) is True
+    A = qp.matrix(cz)
+    B = qp.matrix(swap)
+    assert np.allclose(A @ B, B @ A)


### PR DESCRIPTION
## Impact

**Severity:** false negative (reports non-commuting when matrices commute).

**User impact:** `qml.is_commuting` gates circuit simplification, gate cancellation, and commutation-aware transforms. A false negative blocks valid reorderings of `CZ` and `SWAP` on shared wires even though `AB = BA`.

## Repro

```python
import pennylane as qml
import numpy as np

cz = qml.CZ(wires=[0, 1])
swap = qml.SWAP(wires=[0, 1])
assert qml.is_commuting(cz, swap) is True  # was False
A, B = qml.matrix(cz), qml.matrix(swap)
assert np.allclose(A @ B, B @ A)
```

Root cause: the control/target heuristic treats `CZ` as asymmetric controlled-`Z`, so SWAP on the control wire is classified as non-commuting.

## Change

When the heuristic fails and a SWAP-family operation is involved, fall back to dense matrix multiplication on a shared `wire_order` (basis-aligned; no incorrect `map_wires` renaming).

## Tests

- Full `test_is_commuting.py`: 171 passed
- Added regression `test_cz_commutes_with_swap`

Fixes #9623

Related: #9501 (enhancement for `Prod`/`Sum`/`SProd` in `is_commuting`; orthogonal to this heuristic fix).

---

Assisted-by: Codex (OpenAI)