### PR TITLE
Fix BoseWord multiplication for non-sorted construction dicts

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1080,6 +1080,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``BoseWord`` multiplication for factors constructed from non-sorted dictionaries. [(#9889)](https://github.com/PennyLaneAI/pennylane/pull/9889)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/bose/bosonic.py
+++ b/pennylane/bose/bosonic.py
@@ -232,7 +232,7 @@ class BoseWord(dict):
             dict_other = dict(
                 zip(
                     [(order_idx, other_wires[i]) for i, order_idx in enumerate(order_final)],
-                    other.values(),
+                    other.sorted_dic.values(),
                     strict=True,
                 )
             )

--- a/tests/bose/test_bosonic.py
+++ b/tests/bose/test_bosonic.py
@@ -1238,3 +1238,13 @@ class TestBoseSentenceArithmetic:
         ):
             method_to_test = getattr(bs1, method_name)
             _ = method_to_test(np.array([1, 2]))
+
+
+def test_mul_independent_of_dict_insertion_order():
+    """BoseWord multiplication must not depend on dict insertion order (#9650)."""
+    w1 = BoseWord({(0, 0): "+", (1, 1): "-"})
+    w2 = BoseWord({(1, 1): "-", (0, 0): "+"})
+    assert w1 == w2
+    assert (w1 * w1) == (w1 * w2)
+    assert (w1 * w1) == (w2 * w1)
+    assert str(w1 * w2) == str(w1 * w1)


### PR DESCRIPTION
## Impact

**Severity:** silent wrong operator product (algebra bug).

**User impact:** `BoseWord` canonicalises on construction (`sorted_dic`), so differently ordered input dicts represent the same operator and compare equal. Multiplication nonetheless paired sorted keys with `other.values()` in insertion order, yielding wrong products in bosonic Hamiltonian / open-system workflows.

## Repro

```python
from pennylane.bose import BoseWord

w1 = BoseWord({(0, 0): '+', (1, 1): '-'})
w2 = BoseWord({(1, 1): '-', (0, 0): '+'})  # same operator
assert w1 == w2
assert w1 * w2 == w2 * w1  # failed before fix
```

## Change

Use `other.sorted_dic.values()` so keys and values stay aligned.

## Tests

- `test_mul_independent_of_dict_insertion_order`
- Full `tests/bose/test_bosonic.py`: 243 passed

Fixes #9650

---

Assisted-by: Codex (OpenAI)