### PR TITLE
Validate GQSPTimeEvolution poly_approx_precision is set

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* ``GQSPTimeEvolution`` now raises a clear error when ``poly_approx_precision`` is missing or non-positive. [(#9890)](https://github.com/PennyLaneAI/pennylane/pull/9890)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/estimator/templates/qsp.py
+++ b/pennylane/estimator/templates/qsp.py
@@ -331,13 +331,16 @@ class GQSPTimeEvolution(ResourceOperator):
                 )
             )
 
-        if poly_approx_precision is not None:
-            if (not isinstance(poly_approx_precision, (int, float))) or poly_approx_precision <= 0:
-                raise (
-                    ValueError(
-                        f"Expected 'poly_approx_precision' to be a positive real number greater than zero, got {poly_approx_precision}"
-                    )
+        if poly_approx_precision is None:
+            raise ValueError(
+                "Expected 'poly_approx_precision' to be a positive real number greater than zero; got None"
+            )
+        if (not isinstance(poly_approx_precision, (int, float))) or poly_approx_precision <= 0:
+            raise (
+                ValueError(
+                    f"Expected 'poly_approx_precision' to be a positive real number greater than zero, got {poly_approx_precision}"
                 )
+            )
 
         self.walk_op = walk_op.resource_rep_from_op()
         self.time = time
@@ -477,6 +480,11 @@ class GQSPTimeEvolution(ResourceOperator):
         Returns:
             int: the minimum degree of the polynomial approximation
         """
+        if epsilon is None:
+            raise ValueError(
+                "poly_approx_precision must be a positive real number greater than zero; got None. "
+                "Pass poly_approx_precision explicitly when constructing GQSPTimeEvolution."
+            )
         N_0 = int(qnp.ceil(qnp.abs(time * one_norm)))  # initial guess for the degree
         error = qnp.abs(sps.jv(N_0 + 1, time * one_norm))  # initial error
 

--- a/tests/estimator/test_gqsp_precision.py
+++ b/tests/estimator/test_gqsp_precision.py
@@ -1,0 +1,16 @@
+
+"""Tests for GQSPTimeEvolution poly_approx_precision validation (#9618)."""
+import pytest
+import pennylane.estimator as qre
+
+
+def test_estimate_requires_poly_approx_precision():
+    """Default None precision must raise a clear error, not TypeError on None/int (#9618)."""
+    with pytest.raises(ValueError, match="poly_approx_precision"):
+        qre.GQSPTimeEvolution(qre.RX(0.1, wires=0), 1.0, 1.0)
+
+
+def test_estimate_with_explicit_precision():
+    op = qre.GQSPTimeEvolution(qre.RX(0.1, wires=0), 1.0, 1.0, 0.01)
+    res = qre.estimate(op)
+    assert res is not None


### PR DESCRIPTION
## Impact

**Severity:** crash during resource estimation (`TypeError` on `None / int`).

**User impact:** `GQSPTimeEvolution(..., poly_approx_precision=None)` is the public constructor default. Calling `pennylane.estimator.estimate` on such an instance fails deep inside `poly_approx` instead of rejecting the missing precision up front — blocking QSP time-evolution resource estimates.

## Repro

```python
import pennylane.estimator as qre

op = qre.GQSPTimeEvolution(walk_op=..., time=1.0, one_norm=1.0)
# poly_approx_precision defaults to None
qre.estimate(op)  # TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```

## Change

Require a positive `poly_approx_precision` at construction with a clear `ValueError`, and guard `poly_approx` as well.

## Tests

- New `tests/estimator/test_gqsp_precision.py`
- `TestGQSPTimeEvolution` + new tests: 16 passed

Fixes #9618

Related: #8530 (clearer `gate_set` errors in estimator; separate validation path).

---

Assisted-by: Codex (OpenAI)