### PR TITLE
Do not close caller-owned Dataset in Dataset.read

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1080,6 +1080,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* ``Dataset.read`` no longer closes a caller-owned source dataset. [(#9891)](https://github.com/PennyLaneAI/pennylane/pull/9891)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/data/base/dataset.py
+++ b/pennylane/data/base/dataset.py
@@ -293,13 +293,17 @@ class Dataset(MapperMixin, _DatasetTransform):
             overwrite: Whether to overwrite attributes that already exist in this
                 dataset.
         """
+        opened_here = False
         if not isinstance(source, Dataset):
             source = Path(source).expanduser()
             source = Dataset.open(source, mode="r")
+            opened_here = True
 
         source.write(self, attributes=attributes, overwrite=overwrite)
 
-        source.close()
+        # Only close HDF5 handles we opened from a path; caller-owned Datasets stay open.
+        if opened_here:
+            source.close()
 
     def write(
         self,

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -428,3 +428,18 @@ class TestDataset:
 
         assert isinstance(parent.child, Dataset)
         assert parent.child.list_attributes() == child.list_attributes()
+
+
+def test_read_from_dataset_keeps_source_open():
+    """Caller-owned Dataset sources must not be closed by read() (#9651)."""
+    existing = Dataset()
+    existing.x = 1
+    existing.y = "keep-open"
+
+    dest = Dataset()
+    dest.read(existing)
+
+    assert existing.x == 1
+    assert existing.y == "keep-open"
+    assert dest.x == 1
+    assert dest.y == "keep-open"


### PR DESCRIPTION
## Impact

**Severity:** destructive API misuse (closes caller-owned HDF5 handle).

**User impact:** `Dataset.read(source=open_dataset)` copied attributes then closed the caller's `Dataset`, leaving subsequent attribute access raising `RuntimeError: identifier is not open`. Pipelines that reuse an open source for multiple reads were broken after the first call.

## Repro

```python
import pennylane as qml

src = qml.data.Dataset.open(path, mode="r")
dest = qml.data.Dataset()
dest.read(src)
src.x  # RuntimeError: Unable to synchronously get dataspace (identifier is not open)
```

## Change

Only close sources opened from a path inside `read()`; leave caller-owned `Dataset` instances open.

## Tests

- `test_read_from_dataset_keeps_source_open` (+ related read tests): 3 passed

Fixes #9651

Related: #9609 (serialization strips `requires_grad`; separate Dataset bug).

---

Assisted-by: Codex (OpenAI)