### PR TITLE
Use complex power for Pow.eigvals on fractional exponents

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1080,6 +1080,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``Pow.eigvals`` returning ``nan`` for fractional powers of negative eigenvalues. [(#9892)](https://github.com/PennyLaneAI/pennylane/pull/9892)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -337,7 +337,9 @@ class Pow(ScalarSymbolicOp):
 
     def eigvals(self):
         base_eigvals = self.base.eigvals()
-        return [value**self.z for value in base_eigvals]
+        # Use complex arithmetic so negative real base eigenvalues raised to a
+        # fractional power yield finite roots (not NaN from real-power semantics).
+        return [complex(value) ** self.z for value in base_eigvals]
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -1025,3 +1025,15 @@ class TestIntegration:
 
         assert np.allclose(res, expected)
         assert np.allclose(res_grad, expected_grad)
+
+
+def test_fractional_power_negative_base_eigvals_are_finite():
+    """Fractional powers of negative real eigenvalues must not be NaN (#9632)."""
+    import numpy as np
+
+    op = qp.pow(qp.PauliZ(0), 0.5)
+    ev = np.asarray(qp.eigvals(op))
+    assert np.all(np.isfinite(ev))
+    # agree with matrix spectrum up to ordering
+    mat_ev = np.linalg.eigvals(qp.matrix(op))
+    assert np.allclose(np.sort_complex(ev), np.sort_complex(mat_ev), atol=1e-6)


### PR DESCRIPTION
## Impact

**Severity:** NaN eigenvalues for legal fractional powers (downstream math breaks).

**User impact:** `qml.pow` documents fractional exponents (e.g. `qml.pow(qml.Z(0), 0.5)`). `qml.eigvals` returned `nan` for negative real base eigenvalues because `Pow.eigvals` used real `value ** z`. Matrix eigenvalues were finite; spectrum-based paths diverged.

## Repro

```python
import pennylane as qml
import numpy as np

op = qml.pow(qml.Z(0), 0.5)
ev = np.asarray(qml.eigvals(op))
assert np.all(np.isfinite(ev))  # was [1.0, nan]
mat_ev = np.linalg.eigvals(qml.matrix(op))  # [1+0j, 0+1j]
```

## Change

Cast to complex before powering so fractional roots of negative reals stay finite and agree with `matrix` eigenvalues.

## Tests

- `test_fractional_power_negative_base_eigvals_are_finite` (+ related): 2 passed

Fixes #9632

Related: #6705 (fractional `Pow.matrix()` under JAX jit uses scipy; separate code path).

---

Assisted-by: Codex (OpenAI)