### PR TITLE
Fix default.mixed crash when readout_prob is set

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where ``default.mixed`` crashed with ``TypeError: 'float' object is not iterable``
+  when ``readout_prob`` was set. The scalar probability is now converted to the list of
+  channel callables expected by the mixed-state simulator.
+  [(#9612)](https://github.com/PennyLaneAI/pennylane/issues/9612)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1072,7 +1072,7 @@
 * Fixed a bug where ``default.mixed`` crashed with ``TypeError: 'float' object is not iterable``
   when ``readout_prob`` was set. The scalar probability is now converted to the list of
   channel callables expected by the mixed-state simulator.
-  [(#9612)](https://github.com/PennyLaneAI/pennylane/issues/9612)
+  [(#9893)](https://github.com/PennyLaneAI/pennylane/pull/9893)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/pennylane/devices/default_mixed.py
+++ b/pennylane/devices/default_mixed.py
@@ -173,6 +173,28 @@ def warn_readout_error_state(
     return (tape,), null_postprocessing
 
 
+def get_readout_errors(readout_prob) -> list[Callable] | None:
+    """Convert a scalar readout-error probability into channel callables.
+
+    ``simulate`` / ``measure`` expect ``readout_errors`` to be a list of callables that
+    take a wire label and return a channel (here :class:`~.BitFlip`). Passing the raw
+    float causes ``TypeError: 'float' object is not iterable``.
+
+    Args:
+        readout_prob (float | int | None): Probability of a bit-flip readout error.
+
+    Returns:
+        list[Callable] | None: ``[BitFlip(p, wires=·)]`` factory list, or ``None``.
+    """
+    if readout_prob is None:
+        return None
+
+    def readout_error(wires, p=readout_prob):
+        return qp.BitFlip(p, wires=wires)
+
+    return [readout_error]
+
+
 @simulator_tracking
 @single_tape_support
 class DefaultMixed(Device):
@@ -227,6 +249,8 @@ class DefaultMixed(Device):
                 )
             if self.readout_err < 0 or self.readout_err > 1:
                 raise ValueError("The readout error probability should be in the range [0,1].")
+        # Convert scalar probability into the list[Callable] expected by simulate/measure.
+        self._readout_errors = get_readout_errors(self.readout_err)
         super().__init__(wires=wires, shots=shots)
 
         # Seed setting
@@ -277,7 +301,7 @@ class DefaultMixed(Device):
                 prng_key=self._prng_key,
                 debugger=self._debugger,
                 interface=execution_config.interface,
-                readout_errors=self.readout_err,
+                readout_errors=self._readout_errors,
             )
             for c in circuits
         )

--- a/tests/devices/test_default_mixed.py
+++ b/tests/devices/test_default_mixed.py
@@ -53,6 +53,36 @@ class TestDefaultMixedInit:
         with pytest.raises(TypeError, match="readout error probability should be an integer"):
             DefaultMixed(wires=1, readout_prob=readout_prob)
 
+    def test_readout_prob_does_not_crash(self):
+        """Test that setting readout_prob applies BitFlip readout error without crashing (GH-9612)."""
+        import numpy as np
+
+        p = 0.1
+        dev = DefaultMixed(wires=1, shots=None, readout_prob=p)
+
+        # Analytic |+> state measured in X basis: ideal expval = 1, with BitFlip(p) on X → 1 - 2p
+        qs = qp.tape.QuantumScript(
+            [qp.Hadamard(0)],
+            [qp.expval(qp.PauliX(0))],
+        )
+        result = dev.execute(qs)
+        assert np.allclose(result, 1 - 2 * p)
+
+    def test_readout_prob_finite_shots(self):
+        """Test that readout_prob works with finite shots (GH-9612)."""
+        import numpy as np
+
+        p = 0.0  # no error: |0> measured in Z should give +1
+        dev = DefaultMixed(wires=1, seed=42, readout_prob=p)
+
+        @qp.set_shots(1000)
+        @qp.qnode(dev)
+        def circuit():
+            return qp.expval(qp.PauliZ(0))
+
+        result = circuit()
+        assert np.allclose(result, 1.0)
+
     def test_seed_global(self):
         """Test global seed initialization"""
         dev = DefaultMixed(wires=1, seed="global")


### PR DESCRIPTION
## Impact

**Severity:** hard crash on every execute (`TypeError: 'float' object is not iterable`).

**User impact:** `readout_prob` on `default.mixed` is documented and validated at init, but execution passed the raw float to `simulate`/`measure`, which expect a list of callables. Noisy mixed-state simulation with readout errors was completely unusable.

## Repro

```python
import pennylane as qml

dev = qml.device("default.mixed", wires=2, shots=1000, readout_prob=0.1)

@qml.qnode(dev)
def circuit():
    qml.Hadamard(0)
    return qml.expval(qml.PauliZ(0))

circuit()  # TypeError: 'float' object is not iterable
```

## Change

- Add `get_readout_errors(readout_prob)` building `[lambda wires: qml.BitFlip(p, wires=wires)]` (same pattern as `default.qutrit.mixed`)
- Store converted list on device and pass to `simulate`

## Tests

```bash
pytest tests/devices/test_default_mixed.py -k readout -q  # 8 passed
```

Fixes #9612

---

Assisted-by: Codex (OpenAI)