### PR TITLE
Fix PyNativeExec.map for single-argument callables

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1069,6 +1069,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed ``PyNativeExec.map`` so single-argument callables receive each element of
+  the iterable (matching Python's ``map``) instead of the whole sequence as one
+  argument when ``map_unpack=True``.
+  [(#9601)](https://github.com/PennyLaneAI/pennylane/issues/9601)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1072,7 +1072,7 @@
 * Fixed ``PyNativeExec.map`` so single-argument callables receive each element of
   the iterable (matching Python's ``map``) instead of the whole sequence as one
   argument when ``map_unpack=True``.
-  [(#9601)](https://github.com/PennyLaneAI/pennylane/issues/9601)
+  [(#9894)](https://github.com/PennyLaneAI/pennylane/pull/9894)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/pennylane/concurrency/executors/native/api.py
+++ b/pennylane/concurrency/executors/native/api.py
@@ -18,7 +18,6 @@ Base API for defining an executor relying on native Python standard library impl
 """
 
 import abc
-import inspect
 from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
@@ -78,8 +77,17 @@ class PyNativeExec(IntExec, abc.ABC):
         exec_be = self._get_backend()
         output = None
         fn_p = partial(fn, **kwargs)
-        if self._cfg.map_unpack and len(inspect.signature(fn).parameters) > 1:
+        # Always unpack *args when map_unpack is True so that
+        # ``executor.map(fn, iterable)`` matches Python's map(fn, iterable)
+        # for single-argument functions (GH-9601). The previous check on
+        # ``len(signature(fn).parameters) > 1`` left the single-arg path
+        # wrapping the iterable in a 1-tuple and calling ``fn`` once on the
+        # entire sequence.
+        if self._cfg.map_unpack:
             output = self._map_fn(exec_be)(fn_p, *args)
+        elif len(args) == 1:
+            # Backends such as multiprocessing.Pool.map take a single iterable.
+            output = self._map_fn(exec_be)(fn_p, args[0])
         else:
             output = self._map_fn(exec_be)(fn_p, args)
 

--- a/tests/concurrency/test_executors_local.py
+++ b/tests/concurrency/test_executors_local.py
@@ -180,8 +180,9 @@ class TestLocalExecutor:
     @pytest.mark.parametrize(
         "fn,data,result",
         [
-            (custom_func1, range(7), [custom_func1(i) for i in range(7)]),
-            (custom_func2, range(3), list(map(lambda x: x**2, range(3)))),
+            # Single-iterable: pass the iterable as one *args entry (Python map style).
+            (custom_func1, (range(7),), [custom_func1(i) for i in range(7)]),
+            (custom_func2, (range(3),), list(map(lambda x: x**2, range(3)))),
             (custom_func3, (range(3), range(3)), list(map(custom_func3, range(3), range(3)))),
             (
                 custom_func4,
@@ -201,6 +202,18 @@ class TestLocalExecutor:
 
         with create_executor(backend[0]) as executor_ctx:
             assert np.allclose(result, list(executor_ctx.map(fn, *data)))
+
+    def test_map_single_arg_iterable(self, backend):
+        """executor.map(fn, iterable) must apply fn element-wise (GH-9601)."""
+        data = [1, 2, 3, 4, 5]
+        expected = [custom_func2(x) for x in data]
+
+        executor = create_executor(backend[0])
+        assert list(executor.map(custom_func2, data)) == expected
+        executor.shutdown()
+
+        with create_executor(backend[0]) as executor_ctx:
+            assert list(executor_ctx.map(custom_func2, data)) == expected
 
     @pytest.mark.parametrize(
         "fn,data,result",


### PR DESCRIPTION
## Impact

**Severity:** crash or wrong results for the common `map(fn, iterable)` pattern.

**User impact:** `PyNativeExec.map` (and subclasses like `MPPoolExec`, `SerialExec`) failed to unpack iterables for single-argument callables. `executor.map(square, [1,2,3])` called `square([1,2,3])` once instead of mapping element-wise — breaking concurrent batch execution for unary functions.

## Repro

```python
from pennylane.concurrency.executors import SerialExec

def square(x):
    return x * x

executor = SerialExec()
list(executor.map(square, [1, 2, 3, 4, 5]))  # TypeError or wrong result
# expected: [1, 4, 9, 16, 25]
```

## Change

- If `map_unpack` is True: always call `backend_map(fn, *args)` (Python map style)
- If `map_unpack` is False and one iterable: pass `args[0]` (Pool.map style)
- Updated single-arg map tests; added explicit regression test

## Tests

```bash
pytest tests/concurrency/test_executors_local.py -k test_map -q  # 20 passed
```

Fixes #9601

---

Assisted-by: Codex (OpenAI)