### PR TITLE
Fix multi_dispatch IndexError for keyword tensor arguments

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1083,7 +1083,7 @@
 * Fixed an ``IndexError`` in :func:`~.math.multi_dispatch` / :func:`~.math.stack` when
   tensor arguments were passed by keyword (e.g. ``qml.math.stack(values=[...])``) instead
   of positionally.
-  [(#9140)](https://github.com/PennyLaneAI/pennylane/issues/9140)
+  [(#9895)](https://github.com/PennyLaneAI/pennylane/pull/9895)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1080,6 +1080,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed an ``IndexError`` in :func:`~.math.multi_dispatch` / :func:`~.math.stack` when
+  tensor arguments were passed by keyword (e.g. ``qml.math.stack(values=[...])``) instead
+  of positionally.
+  [(#9140)](https://github.com/PennyLaneAI/pennylane/issues/9140)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/math/multi_dispatch.py
+++ b/pennylane/math/multi_dispatch.py
@@ -15,6 +15,7 @@
 
 # pylint: disable=import-outside-toplevel,too-many-return-statements
 import functools
+import inspect
 from collections.abc import Sequence
 from operator import attrgetter
 
@@ -127,6 +128,8 @@ def multi_dispatch(argnum=None, tensor_list=None):
     """
 
     def decorator(fn):
+        params = list(inspect.signature(fn).parameters.keys())
+
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
             argnums = argnum if argnum is not None else list(range(len(args)))
@@ -140,12 +143,20 @@ def multi_dispatch(argnum=None, tensor_list=None):
             dispatch_args = []
 
             for a in argnums:
+                # Resolve positional or keyword argument values (GH-9140).
+                if a < len(args):
+                    arg_val = args[a]
+                elif a < len(params) and params[a] in kwargs:
+                    arg_val = kwargs[params[a]]
+                else:
+                    continue
+
                 # Only use extend if the marked argument really
                 # is a (native) python Sequence
-                if a in tensor_lists and isinstance(args[a], (list, tuple)):
-                    dispatch_args.extend(args[a])
+                if a in tensor_lists and isinstance(arg_val, (list, tuple)):
+                    dispatch_args.extend(arg_val)
                 else:
-                    dispatch_args.append(args[a])
+                    dispatch_args.append(arg_val)
 
             interface = kwargs.pop("like", None)
             interface = interface or get_interface(*dispatch_args)

--- a/tests/math/test_multi_dispatch.py
+++ b/tests/math/test_multi_dispatch.py
@@ -62,6 +62,24 @@ def test_multi_dispatch_stack(x):
     assert fn.allequal(res, [[1.0, 0.0], [2.0, 3.0]])
 
 
+def test_multi_dispatch_stack_keyword_arg():
+    """Test that multi_dispatch handles a tensor list passed as a keyword argument (GH-9140)."""
+    tensor1 = onp.array([[1, 2], [3, 4]])
+    tensor2 = onp.array([[5, 6], [7, 8]])
+    result = fn.stack(values=[tensor1, tensor2], axis=0)
+    assert fn.allequal(result, onp.stack([tensor1, tensor2], axis=0))
+
+
+def test_multi_dispatch_stack_keyword_arg_empty():
+    """Test that stack(values=[], ...) no longer raises IndexError (GH-9140).
+
+    NumPy still rejects an empty sequence; the important behavior is that
+    multi_dispatch resolves the keyword argument without a tuple-index crash.
+    """
+    with pytest.raises(ValueError, match="need at least one array to stack"):
+        fn.stack(values=[], axis=0)
+
+
 @pytest.mark.parametrize("x", test_multi_dispatch_stack_data)
 def test_multi_dispatch_decorate(x):
     """Test decorating a standard numpy function for PennyLane"""

--- a/tests/math/test_stack_keyword.py
+++ b/tests/math/test_stack_keyword.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for multi_dispatch keyword-argument handling (GH-9140)."""
+
+import numpy as onp
+import pytest
+
+from pennylane import math as fn
+
+
+def test_stack_keyword_values():
+    """stack(values=[...]) must not raise IndexError and must match positional stack."""
+    tensor1 = onp.array([[1, 2], [3, 4]])
+    tensor2 = onp.array([[5, 6], [7, 8]])
+
+    result_kw = fn.stack(values=[tensor1, tensor2], axis=0)
+    result_pos = fn.stack([tensor1, tensor2], axis=0)
+
+    assert fn.allequal(result_kw, result_pos)
+    assert fn.allequal(result_kw, onp.stack([tensor1, tensor2], axis=0))
+
+
+def test_stack_keyword_empty_no_index_error():
+    """Empty values= list should fail like NumPy, not with IndexError from multi_dispatch."""
+    with pytest.raises(ValueError, match="need at least one array to stack"):
+        fn.stack(values=[], axis=0)


### PR DESCRIPTION
### Before submitting

- [x] Unit tests included
- [x] Changelog entry added
- [x] Targeted local tests run

---

## Context

Fixes #9140

`@multi_dispatch` always indexed into the positional `args` tuple for
`argnum` / `tensor_list` entries. Calling

```python
qml.math.stack(values=[t1, t2], axis=0)
```

left `args` empty and raised `IndexError: tuple index out of range`.

A previous PR (#9253) proposed the same approach but was closed before merge.

## Solution

Resolve each `argnum` index from:

1. positional `args[a]` when present, else
2. the matching keyword parameter from `inspect.signature(fn)`.

## Tests

```bash
pytest tests/math/test_stack_keyword.py -q
# 2 passed
```

Also verified manually that positional `stack([...])` still works and that
`stack(values=[])` fails with NumPy's `ValueError` (not `IndexError`).

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.