### PR TITLE
Update how decomposition rules are tested with program capture

### DIFF
--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -31,6 +31,7 @@ from pennylane.decomposition import DecompositionRule
 from pennylane.decomposition.utils import _get_decomp_args
 from pennylane.exceptions import EigvalsUndefinedError
 from pennylane.pytrees import flatten
+from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 from pennylane.wires import Wires
 
 from .equal import assert_equal
@@ -225,10 +226,14 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
     resources = rule.compute_resources(**params)
     gate_counts = resources.gate_counts
 
-    with qp.queuing.AnnotatedQueue() as q:
-        rule(*args, **kwargs)
-
-    tape = qp.tape.QuantumScript.from_queue(q)
+    if qp.capture.enabled():
+        interpreter = CollectOpsandMeas()
+        interpreter(rule)(*args, **kwargs)
+        tape = qp.core.QuantumScript(interpreter.state["ops"], interpreter.state["measurements"])
+    else:
+        with qp.queuing.AnnotatedQueue() as q:
+            rule(*args, **kwargs)
+        tape = qp.core.QuantumScript.from_queue(q)
 
     total_work_wires = rule.get_work_wire_spec(**params).total
     if total_work_wires:


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PennyLaneAI/codesmith/pennylane/pr/9903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787496288&installation_model_id=6322&pr_number=9903&repository=PennyLaneAI%2Fpennylane&return_to=https%3A%2F%2Fgithub.com%2FPennyLaneAI%2Fpennylane%2Fpull%2F9903&signature=0aaf3bf14fce82d3652d3901d8da93fb74818f6a405c0abd6028bbba224b632b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->