### PR TITLE
Reject unsupported higher-order adjoint derivatives

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1092,6 +1092,12 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* QNodes now raise an informative error when ``adjoint`` differentiation is requested with
+  ``max_diff > 1``, preventing incomplete higher-order derivatives through classical
+  preprocessing. ``default.qubit`` also no longer advertises support for higher-order adjoint
+  derivatives.
+  [(#9904)](https://github.com/PennyLaneAI/pennylane/pull/9904)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
@@ -1203,6 +1209,7 @@ This release contains contributions from (in alphabetical order):
 Usman Ahmed,
 Guillermo Alonso,
 Abdullah Al Omar Galib,
+David Bernal,
 Gabriel Bottrill,
 Astral Cai,
 Daniel Casota,

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -608,7 +608,9 @@ class DefaultQubit(Device):
             )
 
         if execution_config.gradient_method in {"adjoint", "best"}:
-            return _supports_adjoint(circuit, device_wires=self.wires, device_name=self.name)
+            return execution_config.derivative_order == 1 and _supports_adjoint(
+                circuit, device_wires=self.wires, device_name=self.name
+            )
         return False
 
     @debug_logger

--- a/pennylane/workflow/resolution.py
+++ b/pennylane/workflow/resolution.py
@@ -220,6 +220,16 @@ def _resolve_hadamard(initial_config: ExecutionConfig, device: Device) -> Execut
     return replace(initial_config, **updated_values)
 
 
+def _validate_adjoint_derivative_order(config: ExecutionConfig) -> None:
+    """Raise an informative error for unsupported higher-order adjoint derivatives."""
+    if config.gradient_method == "adjoint" and config.derivative_order > 1:
+        raise QuantumFunctionError(
+            "The adjoint differentiation method does not support higher-order derivatives. "
+            "Set max_diff=1 or choose a differentiation method that supports higher-order "
+            "derivatives, such as 'backprop' or 'parameter-shift'."
+        )
+
+
 @debug_logger
 def _resolve_diff_method(
     initial_config: ExecutionConfig,
@@ -243,8 +253,11 @@ def _resolve_diff_method(
     if diff_method is None:
         return initial_config
 
+    _validate_adjoint_derivative_order(initial_config)
+
     if device.supports_derivatives(initial_config, circuit=tape):
         new_config = device.setup_execution_config(initial_config, tape)
+        _validate_adjoint_derivative_order(new_config)
         return new_config
 
     if diff_method in {"backprop", "adjoint", "device"}:

--- a/tests/workflow/test_adjoint_derivative_order.py
+++ b/tests/workflow/test_adjoint_derivative_order.py
@@ -1,0 +1,89 @@
+# Copyright 2018-2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for higher-order derivatives requested with the adjoint method."""
+
+from dataclasses import replace
+
+import pytest
+
+import pennylane as qp
+from pennylane.devices import DefaultQubit, Device, ExecutionConfig
+from pennylane.exceptions import QuantumFunctionError
+from pennylane.workflow import _resolve_diff_method
+
+
+# pylint: disable=unused-argument
+class DeviceResolvingBestToAdjoint(Device):
+    """Test device that advertises support before resolving ``best`` to ``adjoint``."""
+
+    def execute(self, circuits, execution_config=None):
+        return 0
+
+    def supports_derivatives(self, execution_config=None, circuit=None):
+        return True
+
+    def setup_execution_config(self, config=None, circuit=None):
+        return replace(config, gradient_method="adjoint")
+
+
+@pytest.mark.parametrize("support_method", ["supports_derivatives", "supports_jvp", "supports_vjp"])
+def test_default_qubit_does_not_advertise_higher_order_adjoint(support_method):
+    """DefaultQubit should accurately report that adjoint supports only first derivatives."""
+    config = ExecutionConfig(gradient_method="adjoint", derivative_order=2)
+
+    assert getattr(DefaultQubit(), support_method)(config) is False
+
+
+def test_explicit_higher_order_adjoint_is_rejected():
+    """An explicit request for higher-order adjoint derivatives should fail informatively."""
+    config = ExecutionConfig(gradient_method="adjoint", derivative_order=2)
+
+    with pytest.raises(QuantumFunctionError, match="adjoint.*higher-order derivatives"):
+        _resolve_diff_method(config, DefaultQubit())
+
+
+def test_higher_order_adjoint_is_rejected_after_device_resolution():
+    """A plugin must not bypass the guard by resolving ``best`` to ``adjoint``."""
+    config = ExecutionConfig(gradient_method="best", derivative_order=2)
+
+    with pytest.raises(QuantumFunctionError, match="adjoint.*higher-order derivatives"):
+        _resolve_diff_method(config, DeviceResolvingBestToAdjoint())
+
+
+def test_first_order_adjoint_remains_supported():
+    """The guard should not affect supported first-order adjoint derivatives."""
+    config = ExecutionConfig(gradient_method="adjoint", derivative_order=1)
+
+    resolved_config = _resolve_diff_method(config, DefaultQubit())
+
+    assert resolved_config.gradient_method == "adjoint"
+
+
+@pytest.mark.torch
+def test_torch_classical_preprocessing_fails_fast():
+    """Adjoint must not return an incomplete Torch Hessian through classical preprocessing."""
+    torch = pytest.importorskip("torch")
+    dev = DefaultQubit(wires=1)
+
+    @qp.qnode(dev, interface="torch", diff_method="adjoint", max_diff=2)
+    def circuit(angle):
+        qp.RY(angle, wires=0)
+        return qp.expval(qp.PauliZ(0))
+
+    x = torch.tensor(0.37, dtype=torch.float64, requires_grad=True)
+    angle = torch.tanh(1.7 * x + 0.2)
+
+    with pytest.raises(QuantumFunctionError, match="adjoint.*higher-order derivatives"):
+        circuit(angle)

--- a/tests/workflow/test_adjoint_derivative_order.py
+++ b/tests/workflow/test_adjoint_derivative_order.py
@@ -71,6 +71,14 @@ def test_first_order_adjoint_remains_supported():
     assert resolved_config.gradient_method == "adjoint"
 
 
+@pytest.mark.parametrize(("max_workers", "expected"), [(None, True), (1, False)])
+def test_default_qubit_best_reports_resolved_higher_order_capability(max_workers, expected):
+    """Higher-order ``best`` support should reflect whether it resolves to backprop or adjoint."""
+    config = ExecutionConfig(gradient_method="best", derivative_order=2)
+
+    assert DefaultQubit(max_workers=max_workers).supports_derivatives(config) is expected
+
+
 @pytest.mark.torch
 def test_torch_classical_preprocessing_fails_fast():
     """Adjoint must not return an incomplete Torch Hessian through classical preprocessing."""


### PR DESCRIPTION
**Context:**

Adjoint device Jacobians are currently first-order only. When a Torch QNode with classical preprocessing is configured with `max_diff=2`, however, the detached quantum Jacobian can be masked by the differentiable classical path and produce a plausible but incomplete Hessian instead of an error.

**Description of the Change:**

* Rejects `adjoint` configurations with `derivative_order > 1` before execution.
* Repeats the check after device setup so plugins that advertise support for `best` and resolve it to `adjoint` cannot bypass the guard.
* Makes `default.qubit` report higher-order adjoint derivative, JVP, and VJP configurations as unsupported.
* Adds isolated regression coverage for explicit adjoint, plugin method resolution, first-order compatibility, and the Torch classical-preprocessing case.

**Benefits:**

Prevents silently incomplete higher-order derivatives across core and plugin device paths while retaining supported first-order adjoint behavior. The error recommends `backprop` or `parameter-shift` when higher-order derivatives are required.

**Possible Drawbacks:**

A QNode configured with both `diff_method="adjoint"` and `max_diff > 1` now fails during execution even if a caller ultimately requests only a first derivative. This is intentional because the execution configuration explicitly requests unsupported higher-order capability.

**Related GitHub Issues:**

Fixes #9901

**Testing:**

* New regression file: 9 passed.
* Regression plus existing workflow and `default.qubit` capability tests: 40 passed.
* Exact Torch reproducer: `backprop` retained the analytic Hessian to `2.22e-16`; `default.qubit/adjoint`, `lightning.qubit/adjoint`, and `lightning.qubit/best` all failed fast.
* Black, isort, and Pylint passed on all changed Python files.

**AI assistance:**

This draft was prepared with assistance from OpenAI Codex. In accordance with PennyLane's AI policy, it must receive contributor human review before being marked ready or requesting maintainer review.
