### PR TITLE
Raise ValueError if qml.compile basis_set contains operators

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* :func:`~.compile` now raises a ``ValueError`` if a non-empty ``basis_set`` contains
+  operator types or instances instead of operation name strings.
+  [(#6132)](https://github.com/PennyLaneAI/pennylane/issues/6132)
+
 * Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
   register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.
   [(#9807)](https://github.com/PennyLaneAI/pennylane/pull/9807)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -270,7 +270,7 @@
 
 * :func:`~.compile` now raises a ``ValueError`` if a non-empty ``basis_set`` contains
   operator types or instances instead of operation name strings.
-  [(#6132)](https://github.com/PennyLaneAI/pennylane/issues/6132)
+  [(#9906)](https://github.com/PennyLaneAI/pennylane/pull/9906)
 
 * Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
   register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -186,6 +186,16 @@ def compile(
     if num_passes < 1 or not isinstance(num_passes, int):
         raise ValueError("Number of passes must be an integer with value at least 1.")
 
+    if basis_set is not None and len(basis_set) > 0:
+        # Membership checks use operation names (strings). Operator types/instances
+        # never match, so a non-empty basis_set of operators silently behaves like [].
+        non_string_gates = [gate for gate in basis_set if not isinstance(gate, str)]
+        if non_string_gates:
+            raise ValueError(
+                "basis_set must contain operation names as strings (e.g. 'RX'), "
+                f"not operator types or instances. Got: {non_string_gates}."
+            )
+
     # Expand the tape; this is done to unroll any templates that may be present,
     # as well as to decompose over a specified basis set
     # First, though, we have to stop whatever tape may be recording so that we

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -73,6 +73,32 @@ class TestCompile:
         with pytest.raises(ValueError, match="Number of passes must be an integer"):
             transformed_qnode(0.1, 0.2, 0.3)
 
+    def test_compile_basis_set_string_names_ok(self):
+        """Test that a basis_set of operation name strings is accepted."""
+        tape = qp.tape.QuantumScript([qp.Hadamard(0), qp.RX(0.5, 0)])
+        [transformed_tape], _ = compile(tape, basis_set=["CNOT", "RX", "Hadamard"], pipeline=[])
+        assert [op.name for op in transformed_tape.operations] == ["Hadamard", "RX"]
+
+    @pytest.mark.parametrize("basis_set", [[], (), {}])
+    def test_compile_empty_basis_set_accepted(self, basis_set):
+        """Test that an empty basis_set is accepted without raising."""
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)])
+        compile(tape, basis_set=basis_set, pipeline=[])
+
+    @pytest.mark.parametrize(
+        "basis_set",
+        [
+            [qp.RX, qp.Hadamard],
+            [qp.RX(0.1, 0)],
+            ["RX", qp.CNOT],
+        ],
+    )
+    def test_compile_basis_set_operators_raise(self, basis_set):
+        """Test that operator types/instances in basis_set raise ValueError."""
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)])
+        with pytest.raises(ValueError, match="basis_set must contain operation names as strings"):
+            compile(tape, basis_set=basis_set, pipeline=[])
+
     def test_compile_mixed_tape_qfunc_transform(self):
         """Test that we can interchange tape and qfunc transforms."""
 


### PR DESCRIPTION
**Context:**
`qml.compile`'s `basis_set` argument expects a sequence of operation *names* (strings). Passing operator types or instances does not raise, but membership checks use `op.name in basis_set`, so non-string entries never match and a non-empty operator basis silently behaves like `[]`.

**Description of the Change:**
- Validate that a non-empty `basis_set` contains only strings before expansion.
- Raise `ValueError` (matching nearby `pipeline` / `num_passes` validation) when operator types, instances, or other non-strings are present.
- Empty `basis_set` values (`[]`, `()`, `{}`) remain accepted.
- Add unit tests and a changelog entry.

**Benefits:**
Users get an immediate, clear error instead of unexpected full decomposition when they accidentally pass `qml.RX` instead of `"RX"`.

**Possible Drawbacks:**
Code that previously passed operator types and relied on the silent empty-basis behavior will now raise. That path was incorrect and equivalent to `basis_set=[]`.

**Related GitHub Issues:**
Fixes #6132

### Validation
- `.venv/bin/python -m pytest tests/transforms/test_compile.py::TestCompile::test_compile_basis_set_string_names_ok tests/transforms/test_compile.py::TestCompile::test_compile_empty_basis_set_accepted tests/transforms/test_compile.py::TestCompile::test_compile_basis_set_operators_raise tests/transforms/test_compile.py::TestCompile::test_compile_invalid_pipeline tests/transforms/test_compile.py::TestCompile::test_compile_invalid_num_passes tests/transforms/test_compile.py::TestCompileIntegration::test_compile_empty_basis_set -q`
- Result: 10 passed

### AI/LLM disclosure
- AI coding tools (including Cursor agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PennyLaneAI/codesmith/pennylane/pr/9906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787742398&installation_model_id=6322&pr_number=9906&repository=PennyLaneAI%2Fpennylane&return_to=https%3A%2F%2Fgithub.com%2FPennyLaneAI%2Fpennylane%2Fpull%2F9906&signature=66bd4ad6f7048d577e50abb166893fff1377f6ad212ab3efc67867dfc1f77484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->