### PR TITLE
Move fallback behaviour from Operator2.decomposition to Operator2.compute_decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -835,6 +835,7 @@
   - Templates are ported:
     - `~.BasisRotation`
   [(#9896)](https://github.com/PennyLaneAI/pennylane/pull/9896)
+  [(#9910)](https://github.com/PennyLaneAI/pennylane/pull/9910)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -803,7 +803,6 @@ class Operator2(metaclass=OperatorMeta):
         with pause(), QueuingManager.stop_recording():
             # creating dummy op means this works for adjoint and ctrl too.
             op = cls(*args, **kwargs)
-        # note that this does not work for adjoint and ctrl
         for decomp in qp.list_decomps(op):
             if decomp.is_applicable(**op.arguments):
                 with AnnotatedQueue() as q:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -838,7 +838,7 @@ class Operator2(metaclass=OperatorMeta):
                 if "compute_decomposition" in vars(klass):
                     # NOTE: If the class that defines it *isn't* Operator2, a subclass overrode it.
                     return klass is not Operator2
-                return False
+            return False
 
         return (
             defines_compute_decomposition(cls)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -780,8 +780,8 @@ class Operator2(metaclass=OperatorMeta):
         canonical_sparse_matrix = self.compute_sparse_matrix(**self.arguments, format=format)
         return self._expand_canonical_matrix(canonical_sparse_matrix, wire_order).asformat(format)
 
-    @staticmethod
-    def compute_decomposition(*args, **kwargs) -> list["Operator2"]:
+    @classmethod
+    def compute_decomposition(cls, *args, **kwargs) -> list["Operator2"]:
         r"""Representation of the operator as a product of other operators (static method).
 
         .. math:: O = O_1 O_2 \dots O_n.
@@ -800,7 +800,15 @@ class Operator2(metaclass=OperatorMeta):
         Returns:
             list[Operator2]: decomposition of the operator
         """
-        raise DecompositionUndefinedError
+        for decomp in qp.list_decomps(cls):
+            if decomp.is_applicable(*args, **kwargs):
+                with AnnotatedQueue() as q:
+                    decomp(*args, **kwargs)
+                if QueuingManager.recording():
+                    # no need for copies if we just use queue method
+                    _ = [op.queue() for op in q.queue]
+                return q.queue
+        raise DecompositionUndefinedError(f"No applicable decomposition rule for {cls}.")
 
     @classproperty
     @classmethod
@@ -812,8 +820,26 @@ class Operator2(metaclass=OperatorMeta):
         rules are registered for the operator type. Per-instance rule applicability is resolved
         in :meth:`~.Operator2.decomposition`, not here.
         """
+
+        # cant do cls.compute_decompsition != Operator2.compute_decomposition
+        # because default is now a classmethod
+        # classmethod is always different, even if not overwritten
+        # cant do getattr(cls.compute_decomposition "__func__", cls.compute_decomposition)
+        # because of an astroid/ pylint bug
+        # see https://github.com/pylint-dev/pylint/issues/11198
+
+        # Instead, walk the MRO to detect an override in a subclass.
+
+        def defines_compute_decomposition(op_type):
+            for klass in op_type.__mro__:
+                if klass is Operator2:
+                    return False
+                if "compute_decomposition" in vars(klass):
+                    return True
+            return False
+
         return (
-            cls.compute_decomposition != Operator2.compute_decomposition
+            defines_compute_decomposition(cls)
             or cls.decomposition != Operator2.decomposition
             or qp.decomposition.has_decomp(cls)
         )
@@ -830,19 +856,7 @@ class Operator2(metaclass=OperatorMeta):
         Returns:
             list[Operator2]: decomposition of the operator
         """
-        if type(self).compute_decomposition != Operator2.compute_decomposition:
-            return self.compute_decomposition(**self.arguments)
-
-        for decomp in qp.list_decomps(self):
-            if decomp.is_applicable(**self.arguments):
-                with AnnotatedQueue() as q:
-                    decomp(**self.arguments)
-                if QueuingManager.recording():
-                    # no need for copies if we just use queue method
-                    _ = [op.queue() for op in q.queue]
-                return q.queue
-
-        raise DecompositionUndefinedError
+        return self.compute_decomposition(**self.arguments)
 
     @staticmethod
     def compute_eigvals(*args, **kwargs) -> TensorLike:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -840,7 +840,9 @@ class Operator2(metaclass=OperatorMeta):
                     return False
                 if "compute_decomposition" in vars(klass):
                     return True
-            return False
+            # should always find Operator2 in the mro
+            # pragma: no cover
+            raise TypeError("This line should be impossible to hit. Something is wrong.")
 
         return (
             defines_compute_decomposition(cls)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -800,10 +800,14 @@ class Operator2(metaclass=OperatorMeta):
         Returns:
             list[Operator2]: decomposition of the operator
         """
-        for decomp in qp.list_decomps(cls):
-            if decomp.is_applicable(*args, **kwargs):
+        with pause(), QueuingManager.stop_recording():
+            # creating dummy op means this works for adjoint and ctrl too.
+            op = cls(*args, **kwargs)
+        # note that this does not work for adjoint and ctrl
+        for decomp in qp.list_decomps(op):
+            if decomp.is_applicable(**op.arguments):
                 with AnnotatedQueue() as q:
-                    decomp(*args, **kwargs)
+                    decomp(**op.arguments)
                 if QueuingManager.recording():
                     # no need for copies if we just use queue method
                     _ = [op.queue() for op in q.queue]

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -841,8 +841,8 @@ class Operator2(metaclass=OperatorMeta):
                 if "compute_decomposition" in vars(klass):
                     return True
             # should always find Operator2 in the mro
-            # pragma: no cover
-            raise TypeError("This line should be impossible to hit. Something is wrong.")
+            msg = "This line should be impossible to hit. Something is wrong."  # pragma: no cover
+            raise TypeError(msg)  # pragma: no cover
 
         return (
             defines_compute_decomposition(cls)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -832,13 +832,17 @@ class Operator2(metaclass=OperatorMeta):
         # see https://github.com/pylint-dev/pylint/issues/11198
 
         # Instead, walk the MRO to detect an override in a subclass.
+        # MRO = method resolution order determines who defines what methods
 
         def defines_compute_decomposition(op_type):
             for klass in op_type.__mro__:
+                if klass is Operator2:
+                    return False
                 if "compute_decomposition" in vars(klass):
-                    # NOTE: If the class that defines it *isn't* Operator2, a subclass overrode it.
-                    return klass is not Operator2
-            return False
+                    return True
+            # should always find Operator2 in the mro
+            msg = "This line should be impossible to hit. Something is wrong."  # pragma: no cover
+            raise TypeError(msg)  # pragma: no cover
 
         return (
             defines_compute_decomposition(cls)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -835,13 +835,10 @@ class Operator2(metaclass=OperatorMeta):
 
         def defines_compute_decomposition(op_type):
             for klass in op_type.__mro__:
-                if klass is Operator2:
-                    return False
                 if "compute_decomposition" in vars(klass):
-                    return True
-            # should always find Operator2 in the mro
-            msg = "This line should be impossible to hit. Something is wrong."  # pragma: no cover
-            raise TypeError(msg)  # pragma: no cover
+                    # NOTE: If the class that defines it *isn't* Operator2, a subclass overrode it.
+                    return klass is not Operator2
+                return False
 
         return (
             defines_compute_decomposition(cls)

--- a/pennylane/templates/subroutines/qchem/basis_rotation.py
+++ b/pennylane/templates/subroutines/qchem/basis_rotation.py
@@ -322,67 +322,6 @@ class BasisRotation(Operator2):
     def num_params(self):
         return 1
 
-    @staticmethod
-    def compute_decomposition(
-        unitary_matrix, wires, check=False
-    ):  # pylint: disable=arguments-differ
-        r"""Representation of the operator as a product of other operators.
-
-        .. math:: O = O_1 O_2 \dots O_n.
-
-        .. seealso:: :meth:`~.BasisRotation.decomposition`.
-
-        Args:
-            wires (Any or Iterable[Any]): wires that the operator acts on
-            unitary_matrix (array): matrix specifying the basis transformation
-            check (bool): test unitarity of the provided `unitary_matrix`
-
-        Returns:
-            list[.Operator]: decomposition of the operator
-        """
-
-        if check:
-            if not math.is_abstract(unitary_matrix) and not math.allclose(
-                unitary_matrix @ math.conj(unitary_matrix).T,
-                math.eye(len(unitary_matrix), dtype=complex),
-                atol=1e-4,
-            ):
-                raise ValueError("The provided transformation matrix should be unitary.")
-
-        if len(wires) < 2:
-            raise ValueError(f"This template requires at least two wires, got {len(wires)}")
-
-        op_list = []
-
-        if math.is_real_obj_or_close(unitary_matrix):
-
-            angle, mat = _adjust_determinant(unitary_matrix)
-
-            if not math.is_abstract(angle) and not math.allclose(angle, 0.0):
-                op_list.append(PhaseShift(angle, wires=wires[0]))
-
-            _, givens_list = math.decomposition.givens_decomposition(mat)
-            for grot_mat, (i, j) in givens_list:
-                theta = math.arctan2(math.real(grot_mat[0, 1]), math.real(grot_mat[0, 0]))
-                op_list.append(SingleExcitation(2 * theta, wires=[wires[i], wires[j]]))
-            return op_list
-
-        phase_list, givens_list = math.decomposition.givens_decomposition(unitary_matrix)
-
-        for idx, phase in enumerate(phase_list):
-            op_list.append(PhaseShift(math.angle(phase), wires=wires[idx]))
-
-        for grot_mat, (i, j) in givens_list:
-            theta = math.arccos(math.real(grot_mat[1, 1]))
-            phi = math.angle(grot_mat[0, 0])
-
-            op_list.append(SingleExcitation(2 * theta, wires=[wires[i], wires[j]]))
-
-            if math.is_abstract(phi) or not math.isclose(phi, phi * 0.0):
-                op_list.append(PhaseShift(phi, wires=wires[i]))
-
-        return op_list
-
 
 # pylint: disable=unused-argument
 def _basis_rotation_decomp_resources(unitary_matrix, wires, check=False):

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -2266,13 +2266,17 @@ class TestGraphDecomposition:
 
             @qp.register_resources({qp.RX: 1})
             def use_rx(phi, wires, **__):
-                qp.RX(phi, wires=wires[0])
+                qp.RX(phi, wires=wires)
 
             qp.add_decomps(Op, use_rx)
 
             decomp = Op(0.5, wires=0).decomposition()
             assert len(decomp) == 1
             assert qp.equal(decomp[0], qp.RX(0.5, wires=0))
+
+            decomp2 = Op.compute_decomposition(0.5, wires=0)
+            assert len(decomp2) == 1
+            assert qp.equal(decomp2[0], qp.RX(0.5, wires=0))
 
     def test_rule_receives_full_argument_model(self):
         """The rule is invoked with ``**op.arguments`` (dynamic, static, and wires)."""

--- a/tests/templates/subroutines/qchem/test_basis_rotation.py
+++ b/tests/templates/subroutines/qchem/test_basis_rotation.py
@@ -423,20 +423,8 @@ def test_basis_rotation_exceptions(wires, unitary_matrix, msg_match):
     """Test that BasisRotation template throws an exception if the parameters have illegal
     shapes, types or values."""
 
-    dev = qp.device("default.qubit", wires=len(wires))
-
-    @qp.qnode(dev)
-    def circuit():
+    with pytest.raises(ValueError, match=msg_match):
         qp.BasisRotation(wires=wires, unitary_matrix=unitary_matrix, check=True)
-        return qp.expval(qp.PauliZ(0))
-
-    with pytest.raises(ValueError, match=msg_match):
-        circuit()
-
-    with pytest.raises(ValueError, match=msg_match):
-        qp.BasisRotation.compute_decomposition(
-            wires=wires, unitary_matrix=unitary_matrix, check=True
-        )
 
 
 def circuit_template(unitary_matrix, check=False):


### PR DESCRIPTION
**Context:**

Looks like `BasisRotation.compute_decomposition` was kept in when the operator was ported to `Operator2`.  Just testing out to see if we need any infrastructure improvements to allow us to uniformly delete this method.

Encountered pylint issues on my initial implementation of `Operator2.has_decomposition` (https://github.com/pylint-dev/pylint/issues/11198  ), so had do to a black magic workaround that cursor helped me find.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**