### PR TITLE
Suppress `black` warning with `--fast`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,15 @@ coverage:
 	$(PYTHON) $(TESTRUNNER) $(COVERAGE)
 
 .PHONY:format
+# Remove --fast after upgrading to a Black release containing this fix:
+# https://github.com/psf/black/pull/5167
 format:
 ifdef check
 	$(PYTHON) -m isort --py 312 --profile black -l 100 -o autoray -p ./pennylane --skip __init__.py --filter-files ./pennylane ./tests --check
-	$(PYTHON) -m black -t py312 -t py313 -t py314 -l 100 ./pennylane ./tests --check
+	$(PYTHON) -m black --fast -t py312 -t py313 -t py314 -l 100 ./pennylane ./tests --check
 else
 	$(PYTHON) -m isort --py 312 --profile black -l 100 -o autoray -p ./pennylane --skip __init__.py --filter-files ./pennylane ./tests
-	$(PYTHON) -m black -t py312 -t py313 -t py314 -l 100 ./pennylane ./tests
+	$(PYTHON) -m black --fast -t py312 -t py313 -t py314 -l 100 ./pennylane ./tests
 endif
 
 .PHONY: lint


### PR DESCRIPTION
**Context:**

Annoyed by
```bash
Warning: Python 3.12 cannot parse code formatted for Python 3.14. To fix this: run Black with Python 3.14, set --target-version to py312, or use --fast to skip the safety check. Black's safety check verifies equivalence by parsing the AST, which fails when the running Python is older than the target version.
```

so following the suggestion.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PennyLaneAI/codesmith/pennylane/pr/9912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787770531&installation_model_id=6322&pr_number=9912&repository=PennyLaneAI%2Fpennylane&return_to=https%3A%2F%2Fgithub.com%2FPennyLaneAI%2Fpennylane%2Fpull%2F9912&signature=5ef01be6d9307172ad41d206e73d52f9b19a248af1d14136fc5d76dbdcca51a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->