### PR TITLE
Sort resources str produced by decompositions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Sorts the gate counts in the display of resources produced from decompositions.
+  [(#9916)](https://github.com/PennyLaneAI/pennylane/pull/9916)
+
 * Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
   register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.
   [(#9807)](https://github.com/PennyLaneAI/pennylane/pull/9807)

--- a/pennylane/decomposition/__init__.py
+++ b/pennylane/decomposition/__init__.py
@@ -224,7 +224,7 @@ operator towards a target gate set.
     CNOT(wires=[0, 1]),
     RZ(-1.5707963267948966, wires=[1])]
 >>> solution.resource_estimate(op)
-<num_gates=10, gate_counts={RZ: 6, CNOT: 2, RX: 2}, weighted_cost=10.0>
+<num_gates=10, gate_counts={CNOT: 2, RX: 2, RZ: 6}, weighted_cost=10.0>
 
 Utility Classes
 ~~~~~~~~~~~~~~~

--- a/pennylane/decomposition/decomposition_graph.py
+++ b/pennylane/decomposition/decomposition_graph.py
@@ -236,7 +236,7 @@ class DecompositionGraph:  # pylint: disable=too-many-instance-attributes,too-fe
      CNOT(wires=[0, 1]),
      RZ(-1.5707963267948966, wires=[1])]
     >>> solution.resource_estimate(op)
-    <num_gates=10, gate_counts={RZ: 6, CNOT: 2, RX: 2}, weighted_cost=10.0>
+    <num_gates=10, gate_counts={CNOT: 2, RX: 2, RZ: 6}, weighted_cost=10.0>
 
     """
 
@@ -710,7 +710,7 @@ class DecompGraphSolution:
      CNOT(wires=[0, 1]),
      RZ(-1.5707963267948966, wires=[1])]
     >>> solution.resource_estimate(op)
-    <num_gates=10, gate_counts={RZ: 6, CNOT: 2, RX: 2}, weighted_cost=10.0>
+    <num_gates=10, gate_counts={CNOT: 2, RX: 2, RZ: 6}, weighted_cost=10.0>
 
     """
 
@@ -815,7 +815,7 @@ class DecompGraphSolution:
          CNOT(wires=[0, 1]),
          RZ(-1.5707963267948966, wires=[1])]
         >>> solution.resource_estimate(op)
-        <num_gates=10, gate_counts={RZ: 6, CNOT: 2, RX: 2}, weighted_cost=10.0>
+        <num_gates=10, gate_counts={CNOT: 2, RX: 2, RZ: 6}, weighted_cost=10.0>
 
         """
         op_node_idx = self._get_best_solution(self._visitor, op, num_work_wires)

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -1052,22 +1052,22 @@ def inspect_decomps(
     Decomposition 0 (name: _crx_to_rx_cz)
     0: ───────────╭●────────────╭●─┤
     1: ──RX(0.25)─╰Z──RX(-0.25)─╰Z─┤
-    Gate Count: {RX: 2, CZ: 2}
+    Gate Count: {CZ: 2, RX: 2}
     <BLANKLINE>
     Decomposition 1 (name: _crx_to_rz_ry)
     0: ─────────────────────╭●────────────╭●────────────┤
     1: ──RZ(1.57)──RY(0.25)─╰X──RY(-0.25)─╰X──RZ(-1.57)─┤
-    Gate Count: {RZ: 2, RY: 2, CNOT: 2}
+    Gate Count: {CNOT: 2, RY: 2, RZ: 2}
     <BLANKLINE>
     Decomposition 2 (name: _crx_to_h_crz)
     0: ────╭●───────────┤
     1: ──H─╰RZ(0.50)──H─┤
-    Gate Count: {Hadamard: 2, CRZ: 1}
+    Gate Count: {CRZ: 1, Hadamard: 2}
     <BLANKLINE>
     Decomposition 3 (name: _crx_to_ppr)
     0: ───────────╭RZX(-0.25)─┤
     1: ──RX(0.25)─╰RZX(-0.25)─┤
-    Gate Count: {PauliRot(pauli_word=ZX): 1, PauliRot(pauli_word=X): 1}
+    Gate Count: {PauliRot(pauli_word=X): 1, PauliRot(pauli_word=ZX): 1}
 
     For each decomposition rule, the output includes its name, circuit diagram, gate
     count, and wire allocation (if any). Alternatively, you can inspect a single
@@ -1077,7 +1077,7 @@ def inspect_decomps(
     Decomposition 0 (name: _crx_to_h_crz)
     0: ────╭●───────────┤
     1: ──H─╰RZ(0.50)──H─┤
-    Gate Count: {Hadamard: 2, CRZ: 1}
+    Gate Count: {CRZ: 1, Hadamard: 2}
 
     Or use this tool to inspect a custom decomposition rule:
 

--- a/pennylane/decomposition/resources.py
+++ b/pennylane/decomposition/resources.py
@@ -170,7 +170,8 @@ def _combine_dict(dict1: dict, dict2: dict):
 
 
 def _gate_count_dict_to_str(gate_counts):
-    inner = ", ".join(f"{op}: {count}" for op, count in gate_counts.items())
+    str_op = ((str(op), count) for op, count in gate_counts.items())
+    inner = ", ".join(f"{op}: {count}" for op, count in sorted(str_op))
     return f"{{{inner}}}"
 
 

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -359,9 +359,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     4: ───────├●─│──────────────├●────┤
     5: ───────├●─│──────────────├●────┤
          |0>├─╰X─╰●─────────────╰X──┤
-    First-Level Expansion Gates: {MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
+    First-Level Expansion Gates: {Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
     Wire Allocations: {'zero': 1}
-    Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, RX: 8, MidMeasure: 2}
+    Full Expansion Gates: {CNOT: 34, GlobalPhase: 64, MidMeasure: 2, RX: 8, RY: 18, RZ: 58}
     Weighted Cost: 120.0
     <BLANKLINE>
     Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -374,7 +374,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     4: ─├●─├●────────├●─┤
     5: ─╰●─╰●────────╰●─┤
     First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-    Full Expansion Gates: {GlobalPhase: 76, RX: 16, MidMeasure: 4, RY: 24, RZ: 80, CNOT: 72}
+    Full Expansion Gates: {CNOT: 72, GlobalPhase: 76, MidMeasure: 4, RX: 16, RY: 24, RZ: 80}
     Weighted Cost: 196.0
 
     For applicable decompositions, the "First-Level Expansion" label refers to the operators immediately produced by the decomposition rule,
@@ -399,7 +399,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     1: ─├●─│─────────├●─┤
     2: ─╰●─╰●────────╰●─┤
     First-Level Expansion Gates: {CRZ: 1, Toffoli: 2}
-    Full Expansion Gates: {RZ: 20, CNOT: 14, GlobalPhase: 18, RY: 4}
+    Full Expansion Gates: {CNOT: 14, GlobalPhase: 18, RY: 4, RZ: 20}
     Weighted Cost: 38.0
 
     This can be useful to find out why a circuit cannot be decomposed:
@@ -421,7 +421,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     0: ──H────────╭MultiRZ(0.50)──H─────────┤
     1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤
     2: ───────────╰MultiRZ(0.50)────────────┤
-    First-Level Expansion Gates: {Hadamard: 2, RX: 2, MultiRZ(num_wires=3): 1}
+    First-Level Expansion Gates: {Hadamard: 2, MultiRZ(num_wires=3): 1, RX: 2}
     Missing Ops: {Hadamard}
 
     The message suggests that the ``PauliRot`` could not be decomposed because the graph was unable
@@ -430,12 +430,12 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     >>> inspector.inspect_decomps(qp.Hadamard(0))
     Decomposition 0 (name: _hadamard_to_rz_ry)
     0: ──RZ(3.14)──RY(1.57)──GlobalPhase(-1.57)─┤
-    First-Level Expansion Gates: {RZ: 1, RY: 1, GlobalPhase: 1}
+    First-Level Expansion Gates: {GlobalPhase: 1, RY: 1, RZ: 1}
     Missing Ops: {GlobalPhase}
     <BLANKLINE>
     Decomposition 1 (name: _hadamard_to_rz_rx)
     0: ──RZ(1.57)──RX(1.57)──RZ(1.57)──GlobalPhase(-1.57)─┤
-    First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
+    First-Level Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 2}
     Missing Ops: {GlobalPhase}
 
     Now it's finally clear that the reason why ``PauliRot`` could not be decomposed was that
@@ -453,7 +453,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         2: ───────│──╭●───│────┤
         3: ───────│──├X───│────┤
              |0>├─╰⊕─╰●──⊕╯──┤
-        Gate Count: {Toffoli: 1, TemporaryAND: 1, Adjoint(TemporaryAND): 1}
+        Gate Count: {Adjoint(TemporaryAND): 1, TemporaryAND: 1, Toffoli: 1}
         Wire Allocations: {'zero': 1}
 
         These rules can only be selected if there are enough unused wires left on the device
@@ -485,9 +485,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ───────├●─│──────────────├●────┤
         6: ───────├●─│──────────────├●────┤
              |0>├─╰X─╰●─────────────╰X──┤
-        First-Level Expansion Gates: {MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
+        First-Level Expansion Gates: {Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {RZ: 94, CNOT: 58, GlobalPhase: 104, RY: 26, RX: 12, MidMeasure: 2}
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 104, MidMeasure: 2, RX: 12, RY: 26, RZ: 94}
         Weighted Cost: 192.0
         <BLANKLINE>
         Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -501,7 +501,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ─├●─├●────────├●─┤
         6: ─╰●─╰●────────╰●─┤
         First-Level Expansion Gates: {Controlled(RZ, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-        Full Expansion Gates: {GlobalPhase: 200, RX: 32, MidMeasure: 6, RY: 54, RZ: 170, CNOT: 96}
+        Full Expansion Gates: {CNOT: 96, GlobalPhase: 200, MidMeasure: 6, RX: 32, RY: 54, RZ: 170}
         Weighted Cost: 358.0
 
         Similarly, for the ``MultiControlledX`` in the circuit:
@@ -520,8 +520,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         M0 =
         [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
-        First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-        Full Expansion Gates: {GlobalPhase: 43, RY: 14, RZ: 57, RX: 4, CNOT: 58}
+        First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, Hadamard: 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, QubitUnitary(num_wires=1): 2}
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 43, RX: 4, RY: 14, RZ: 57}
         Weighted Cost: 133.0
         <BLANKLINE>
         Decomposition 2 (name: one_zeroed_worker)
@@ -531,9 +531,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ───────│──╰●────│─────╰●───│────┤
         6: ───────│────────├X─────────│────┤
              |0>├─╰⊕───────╰●────────⊕╯──┤
-        First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
+        First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 2, TemporaryAND: 1, Toffoli: 3}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
+        Full Expansion Gates: {CNOT: 22, GlobalPhase: 43, MidMeasure: 1, RX: 6, RY: 11, RZ: 37}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)
@@ -543,9 +543,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ────│──╰●────│─────╰●─│──╰●────│─────╰●─┤
         6: ────│────────├X───────│────────├X───────┤
              ├─╰X───────╰●───────╰X───────╰●──┤
-        First-Level Expansion Gates: {Toffoli: 8, PauliX: 4}
+        First-Level Expansion Gates: {PauliX: 4, Toffoli: 8}
         Wire Allocations: {'any': 1}
-        Full Expansion Gates: {GlobalPhase: 76, RX: 4, CNOT: 48, RZ: 72, RY: 16}
+        Full Expansion Gates: {CNOT: 48, GlobalPhase: 76, RX: 4, RY: 16, RZ: 72}
         Weighted Cost: 140.0
         <BLANKLINE>
         Decomposition 4 (name: one_explicit_worker)
@@ -568,9 +568,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         6: ───────│──│──├X───│───│────┤
              |0>├─│──├⊕─╰●──⊕┤───│──┤
              |0>├─╰⊕─╰●─────●╯──⊕╯──┤
-        First-Level Expansion Gates: {TemporaryAND: 2, Adjoint(TemporaryAND): 2, Toffoli: 1}
+        First-Level Expansion Gates: {Adjoint(TemporaryAND): 2, TemporaryAND: 2, Toffoli: 1}
         Wire Allocations: {'zero': 2}
-        Full Expansion Gates: {GlobalPhase: 37, RX: 8, MidMeasure: 2, RY: 12, RZ: 29, CNOT: 14}
+        Full Expansion Gates: {CNOT: 14, GlobalPhase: 37, MidMeasure: 2, RX: 8, RY: 12, RZ: 29}
         Weighted Cost: 65.0
         <BLANKLINE>
         Decomposition 9 (name: many_borrowed_workers)
@@ -583,7 +583,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
              ├────╰●─╰X─╰●────╰●─╰X─╰●──┤
         First-Level Expansion Gates: {Toffoli: 8}
         Wire Allocations: {'any': 2}
-        Full Expansion Gates: {CNOT: 48, GlobalPhase: 72, RZ: 72, RY: 16}
+        Full Expansion Gates: {CNOT: 48, GlobalPhase: 72, RY: 16, RZ: 72}
         Weighted Cost: 136.0
         <BLANKLINE>
         Decomposition 10 (name: many_explicit_workers)
@@ -614,8 +614,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         M0 =
         [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
-        First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-        Full Expansion Gates: {GlobalPhase: 43, RY: 14, RZ: 57, RX: 4, CNOT: 58}
+        First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, Hadamard: 2, MultiControlledX(num_control_wires=2, num_work_wires=2, num_zero_control_values=0, work_wire_type=borrowed): 4, QubitUnitary(num_wires=1): 2}
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 43, RX: 4, RY: 14, RZ: 57}
         Weighted Cost: 133.0
         <BLANKLINE>
         CHOSEN: Decomposition 2 (name: one_zeroed_worker)
@@ -625,9 +625,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ───────│──╰●────│─────╰●───│────┤
         6: ───────│────────├X─────────│────┤
              |0>├─╰⊕───────╰●────────⊕╯──┤
-        First-Level Expansion Gates: {Toffoli: 3, TemporaryAND: 1, Adjoint(TemporaryAND): 1, PauliX: 2}
+        First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 2, TemporaryAND: 1, Toffoli: 3}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {GlobalPhase: 43, RX: 6, MidMeasure: 1, RY: 11, RZ: 37, CNOT: 22}
+        Full Expansion Gates: {CNOT: 22, GlobalPhase: 43, MidMeasure: 1, RX: 6, RY: 11, RZ: 37}
         Weighted Cost: 77.0
         <BLANKLINE>
         Decomposition 3 (name: one_borrowed_worker)
@@ -637,9 +637,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ────│──╰●────│─────╰●─│──╰●────│─────╰●─┤
         6: ────│────────├X───────│────────├X───────┤
              ├─╰X───────╰●───────╰X───────╰●──┤
-        First-Level Expansion Gates: {Toffoli: 8, PauliX: 4}
+        First-Level Expansion Gates: {PauliX: 4, Toffoli: 8}
         Wire Allocations: {'any': 1}
-        Full Expansion Gates: {GlobalPhase: 76, RX: 4, CNOT: 48, RZ: 72, RY: 16}
+        Full Expansion Gates: {CNOT: 48, GlobalPhase: 76, RX: 4, RY: 16, RZ: 72}
         Weighted Cost: 140.0
         <BLANKLINE>
         Decomposition 4 (name: one_explicit_worker)

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -908,12 +908,12 @@ class TestInspectDecomps:
             Decomposition 0 (name: simple)
             0: ──RZ(0.50)─╭●──RZ(0.50)─┤  
             1: ───────────╰X───────────┤  
-            Gate Count: {RZ: 2, CNOT: 1}
+            Gate Count: {CNOT: 1, RZ: 2}
 
             Decomposition 1 (name: general_decomp)
             0: ──RX(0.50)─╭●────╭●──RX(0.50)─┤  
             1: ───────────╰Z──H─╰Z───────────┤  
-            Gate Count: {RX: 2, CZ: 2, Hadamard: 1}
+            Gate Count: {CZ: 2, Hadamard: 1, RX: 2}
 
             Decomposition 2 (name: with-aux)
             Not applicable (provided operator instance does not meet all conditions for this rule).
@@ -971,7 +971,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
 
             Decomposition 2 (name: with-aux)
             0: ───────╭●────╭Z─╭●──────────────────────╭●─╭Z────╭●────┤  
@@ -982,8 +982,8 @@ class TestInspectDecomps:
                  |0>├─╰Z─╭●─│───────────RX(0.50)──────────│──╭●─╰Z──┤    
                  |0>├────╰Z─╰●──H──┤↗├──║─────────────────╰●─╰Z─────┤    
                                     ╚═══╝                                
-            Estimated Gate Count: {CZ: 6, Toffoli: 8, Hadamard: 1, RX: 1, MidMeasure: 1}
-            Actual Gate Count: {CZ: 6, Toffoli: 6, Hadamard: 1, MidMeasure: 1, RX: 1}
+            Estimated Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 8}
+            Actual Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 6}
             Wire Allocations: {'zero': 2}
             """).strip()
 
@@ -1052,12 +1052,12 @@ class TestInspectDecomps:
             Decomposition 0 (name: simple)
             0: ──RZ(0.50)─╭●──RZ(0.50)─┤  
             1: ───────────╰X───────────┤  
-            Gate Count: {RZ: 2, CNOT: 1}
+            Gate Count: {CNOT: 1, RZ: 2}
 
             Decomposition 1 (name: general_decomp)
             0: ──RX(0.50)─╭●────╭●──RX(0.50)─┤  
             1: ───────────╰Z──H─╰Z───────────┤  
-            Gate Count: {RX: 2, CZ: 2, Hadamard: 1}
+            Gate Count: {CZ: 2, Hadamard: 1, RX: 2}
             """).strip()
 
         result = qp.inspect_decomps(
@@ -1070,7 +1070,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
 
             Decomposition 2 (name: with-aux)
             0: ───────╭●────╭Z─╭●──────────────────────╭●─╭Z────╭●────┤  
@@ -1081,8 +1081,8 @@ class TestInspectDecomps:
                  |0>├─╰Z─╭●─│───────────RX(0.50)──────────│──╭●─╰Z──┤    
                  |0>├────╰Z─╰●──H──┤↗├──║─────────────────╰●─╰Z─────┤    
                                     ╚═══╝                                
-            Estimated Gate Count: {CZ: 6, Toffoli: 8, Hadamard: 1, RX: 1, MidMeasure: 1}
-            Actual Gate Count: {CZ: 6, Toffoli: 6, Hadamard: 1, MidMeasure: 1, RX: 1}
+            Estimated Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 8}
+            Actual Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 6}
             Wire Allocations: {'zero': 2}
             """).strip()
 
@@ -1102,7 +1102,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
 
             Decomposition 2 (name: with-aux)
             Insufficient work wires: requires 2 but only 1 available.
@@ -1152,7 +1152,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
             """).strip()
 
     def test_show_no_decomps(self):
@@ -1187,7 +1187,7 @@ class TestInspectDecomps:
             Decomposition 0 (name: simple)
             0: ──RZ(0.50)─╭●──RZ(0.50)─┤  
             1: ───────────╰X───────────┤  
-            Gate Count: {RZ: 2, CNOT: 1}
+            Gate Count: {CNOT: 1, RZ: 2}
             """).strip()
 
     def test_show_decomp_with_rule(self):
@@ -1202,7 +1202,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
             """).strip()
 
     def test_show_multiple_decomps(self):
@@ -1219,7 +1219,7 @@ class TestInspectDecomps:
             2: ──────────────╰Z─╭●──────────╭●─╰Z──────────────┤  
             3: ─────────────────╰Z─╭●────╭●─╰Z─────────────────┤  
             4: ────────────────────╰Z──H─╰Z────────────────────┤  
-            Gate Count: {RX: 2, CZ: 8, Hadamard: 1}
+            Gate Count: {CZ: 8, Hadamard: 1, RX: 2}
 
             Decomposition 1 (name: with-aux)
             0: ───────╭●────╭Z─╭●──────────────────────╭●─╭Z────╭●────┤  
@@ -1230,8 +1230,8 @@ class TestInspectDecomps:
                  |0>├─╰Z─╭●─│───────────RX(0.50)──────────│──╭●─╰Z──┤    
                  |0>├────╰Z─╰●──H──┤↗├──║─────────────────╰●─╰Z─────┤    
                                     ╚═══╝                                
-            Estimated Gate Count: {CZ: 6, Toffoli: 8, Hadamard: 1, RX: 1, MidMeasure: 1}
-            Actual Gate Count: {CZ: 6, Toffoli: 6, Hadamard: 1, MidMeasure: 1, RX: 1}
+            Estimated Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 8}
+            Actual Gate Count: {CZ: 6, Hadamard: 1, MidMeasure: 1, RX: 1, Toffoli: 6}
             Wire Allocations: {'zero': 2}
             """).strip()
 

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -121,7 +121,7 @@ class TestInspectDecompGraph:
             4: ─├●─├●────────├●─┤  
             5: ─╰●─╰●────────╰●─┤  
             First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-            Full Expansion Gates: {GlobalPhase: 88, RZ: 136, CNOT: 160, RY: 28, RX: 8}
+            Full Expansion Gates: {CNOT: 160, GlobalPhase: 88, RX: 8, RY: 28, RZ: 136}
             Weighted Cost: 332.0
             """).strip()
 
@@ -186,9 +186,9 @@ class TestInspectDecompGraph:
             4: ───────├●─│──────────────├●────┤  
             5: ───────├●─│──────────────├●────┤  
                  |0>├─╰X─╰●─────────────╰X──┤    
-            First-Level Expansion Gates: {MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
+            First-Level Expansion Gates: {Controlled(MultiRZ(num_wires=2), num_control_wires=1, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {RZ: 58, CNOT: 34, GlobalPhase: 64, RY: 18, RX: 8, MidMeasure: 2}
+            Full Expansion Gates: {CNOT: 34, GlobalPhase: 64, MidMeasure: 2, RX: 8, RY: 18, RZ: 58}
             Weighted Cost: 120.0
 
             Decomposition 1 (name: to_controlled_qubit_unitary)
@@ -201,7 +201,7 @@ class TestInspectDecompGraph:
             4: ─├●─├●────────├●─┤  
             5: ─╰●─╰●────────╰●─┤  
             First-Level Expansion Gates: {Controlled(RZ, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
-            Full Expansion Gates: {GlobalPhase: 76, RX: 16, MidMeasure: 4, RY: 24, RZ: 80, CNOT: 72}
+            Full Expansion Gates: {CNOT: 72, GlobalPhase: 76, MidMeasure: 4, RX: 16, RY: 24, RZ: 80}
             Weighted Cost: 196.0
             """).strip()
 
@@ -287,8 +287,8 @@ class TestInspectDecompGraph:
             M0 = 
             [[ 9.23879533e-01+0.38268343j -5.34910791e-34+0.j        ]
              [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
-            First-Level Expansion Gates: {Hadamard: 2, QubitUnitary(num_wires=1): 2, CNOT: 2, MultiControlledX(num_control_wires=2, num_work_wires=1, num_zero_control_values=0, work_wire_type=borrowed): 2, Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 25, RY: 10, RZ: 31, RX: 4}
+            First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, CNOT: 2, Controlled(GlobalPhase, num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 1, Hadamard: 2, MultiControlledX(num_control_wires=2, num_work_wires=1, num_zero_control_values=0, work_wire_type=borrowed): 2, QubitUnitary(num_wires=1): 2}
+            Full Expansion Gates: {CNOT: 24, GlobalPhase: 25, RX: 4, RY: 10, RZ: 31}
             Weighted Cost: 69.0
 
             CHOSEN: Decomposition 2 (name: one_zeroed_worker)
@@ -297,9 +297,9 @@ class TestInspectDecompGraph:
             2: ───────│──╭●───│────┤  
             3: ───────│──├X───│────┤  
                  |0>├─╰⊕─╰●──⊕╯──┤    
-            First-Level Expansion Gates: {Toffoli: 1, TemporaryAND: 1, Adjoint(TemporaryAND): 1}
+            First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, TemporaryAND: 1, Toffoli: 1}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {GlobalPhase: 23, RX: 4, MidMeasure: 1, RY: 7, RZ: 19, CNOT: 10}
+            Full Expansion Gates: {CNOT: 10, GlobalPhase: 23, MidMeasure: 1, RX: 4, RY: 7, RZ: 19}
             Weighted Cost: 41.0
 
             Decomposition 3 (name: one_borrowed_worker)
@@ -310,7 +310,7 @@ class TestInspectDecompGraph:
                  ├─╰X─╰●─╰X─╰●──┤    
             First-Level Expansion Gates: {Toffoli: 4}
             Wire Allocations: {'any': 1}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 36, RZ: 36, RY: 8}
+            Full Expansion Gates: {CNOT: 24, GlobalPhase: 36, RY: 8, RZ: 36}
             Weighted Cost: 68.0
 
             Decomposition 4 (name: one_explicit_worker)
@@ -355,7 +355,7 @@ class TestInspectDecompGraph:
             0: ──H────────╭MultiRZ(0.50)──H─────────┤  
             1: ──RX(1.57)─├MultiRZ(0.50)──RX(-1.57)─┤  
             2: ───────────╰MultiRZ(0.50)────────────┤  
-            First-Level Expansion Gates: {Hadamard: 2, RX: 2, MultiRZ(num_wires=3): 1}
+            First-Level Expansion Gates: {Hadamard: 2, MultiRZ(num_wires=3): 1, RX: 2}
             Missing Ops: {Hadamard}
             """).strip()
 
@@ -384,12 +384,12 @@ class TestInspectDecompGraph:
         assert str(inspector.inspect_decomps(qp.H(0))) == dedent("""
             Decomposition 0 (name: _hadamard_to_rz_ry)
             0: ──RZ(3.14)──RY(1.57)──GlobalPhase(-1.57)─┤  
-            First-Level Expansion Gates: {RZ: 1, RY: 1, GlobalPhase: 1}
+            First-Level Expansion Gates: {GlobalPhase: 1, RY: 1, RZ: 1}
             Missing Ops: {GlobalPhase}
 
             Decomposition 1 (name: _hadamard_to_rz_rx)
             0: ──RZ(1.57)──RX(1.57)──RZ(1.57)──GlobalPhase(-1.57)─┤  
-            First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
+            First-Level Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 2}
             Missing Ops: {GlobalPhase}
             """).strip()
 
@@ -414,37 +414,37 @@ class TestInspectDecompGraph:
 
             Decomposition 2 (name: rot)
             0: ──RZ(0.00)─┤  
-            Estimated First-Level Expansion Gates: {Rot: 1, RZ: 1, GlobalPhase: 1}
+            Estimated First-Level Expansion Gates: {GlobalPhase: 1, RZ: 1, Rot: 1}
             Actual First-Level Expansion Gates: {RZ: 1}
-            Full Expansion Gates: {GlobalPhase: 1, RZ: 5, RX: 1}
+            Full Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 5}
             Weighted Cost: 7.0
 
             Decomposition 3 (name: xyx)
             0: ──RX(0.00)──RY(0.00)──RX(0.00)─┤  
-            Estimated First-Level Expansion Gates: {RX: 2, RY: 1, GlobalPhase: 1}
+            Estimated First-Level Expansion Gates: {GlobalPhase: 1, RX: 2, RY: 1}
             Actual First-Level Expansion Gates: {RX: 2, RY: 1}
             Full Expansion Gates: {GlobalPhase: 1, RX: 3, RZ: 2}
             Weighted Cost: 6.0
 
             CHOSEN: Decomposition 4 (name: xzx)
             0: ──RX(0.00)──RZ(0.00)──RX(0.00)─┤  
-            Estimated First-Level Expansion Gates: {RX: 2, RZ: 1, GlobalPhase: 1}
+            Estimated First-Level Expansion Gates: {GlobalPhase: 1, RX: 2, RZ: 1}
             Actual First-Level Expansion Gates: {RX: 2, RZ: 1}
             Full Expansion Gates: {GlobalPhase: 1, RX: 2, RZ: 1}
             Weighted Cost: 4.0
 
             Decomposition 5 (name: zxz)
             0: ──RZ(0.00)──RX(0.00)──RZ(0.00)─┤  
-            Estimated First-Level Expansion Gates: {RZ: 2, RX: 1, GlobalPhase: 1}
-            Actual First-Level Expansion Gates: {RZ: 2, RX: 1}
+            Estimated First-Level Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 2}
+            Actual First-Level Expansion Gates: {RX: 1, RZ: 2}
             Full Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 2}
             Weighted Cost: 4.0
 
             Decomposition 6 (name: zyz)
             0: ──RZ(0.00)──RY(0.00)──RZ(0.00)─┤  
-            Estimated First-Level Expansion Gates: {RZ: 2, RY: 1, GlobalPhase: 1}
-            Actual First-Level Expansion Gates: {RZ: 2, RY: 1}
-            Full Expansion Gates: {GlobalPhase: 1, RZ: 4, RX: 1}
+            Estimated First-Level Expansion Gates: {GlobalPhase: 1, RY: 1, RZ: 2}
+            Actual First-Level Expansion Gates: {RY: 1, RZ: 2}
+            Full Expansion Gates: {GlobalPhase: 1, RX: 1, RZ: 4}
             Weighted Cost: 6.0
             """).strip()
 


### PR DESCRIPTION

**Context:**

In #9865 , there were some "null changes" where the string changed order because of other changes effecting sets.  I'm pretty sure I've seen similar things happen before. In order to prevent these types of things happening in the future, I've just added a sort step to add some predictability to the string output.

Note that I used Cursor to update the tests and docstrings so I didn't have to do so manually.

**Description of the Change:**

Adds a sort step when converting gate counts to a string.

**Benefits:**

Fewer random changes in string output.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-126018]
