### PR TITLE
feat: add `pl2do` marker 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,6 @@ Pytest configuration file for PennyLane test suite.
 # pylint: disable=unused-import
 import os
 import pathlib
-import re
 import sys
 import warnings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ Pytest configuration file for PennyLane test suite.
 # pylint: disable=unused-import
 import os
 import pathlib
+import re
 import sys
 import warnings
 
@@ -244,8 +245,24 @@ def interface(request):
 
 
 def pytest_collection_modifyitems(items, config):
+    custom_markers = {
+        "autograd",
+        "data",
+        "torch",
+        "jax",
+        "qchem",
+        "qcut",
+        "all_interfaces",
+        "finite-diff",
+        "param-shift",
+        "external",
+        "capture",
+        "catalyst",
+    }
     rootdir = pathlib.Path(config.rootdir)
+
     for item in items:
+        # Auto-assign the marker based on its file path
         rel_path = pathlib.Path(item.fspath).relative_to(rootdir)
         if "qchem" in rel_path.parts:
             mark = getattr(pytest.mark, "qchem")
@@ -260,35 +277,33 @@ def pytest_collection_modifyitems(items, config):
             mark = getattr(pytest.mark, "data")
             item.add_marker(mark)
 
-    # Tests that do not have a specific suite marker are marked `core`
-    for item in items:
-        markers = {mark.name for mark in item.iter_markers()}
-        if (
-            not any(
-                elem
-                in [
-                    "autograd",
-                    "data",
-                    "torch",
-                    "jax",
-                    "qchem",
-                    "qcut",
-                    "all_interfaces",
-                    "finite-diff",
-                    "param-shift",
-                    "external",
-                    "capture",
-                    "catalyst",
-                ]
-                for elem in markers
-            )
-            or not markers
-        ):
+        # Get all markers on the item
+        item_markers = {mark.name for mark in item.iter_markers()}
+
+        # Default to the core marker if it's missing one of our markers
+        if not item_markers or not item_markers & custom_markers:
             item.add_marker(pytest.mark.core)
-        if "capture" in markers:
+
+        # Auto add jax marker if the item is marked under capture
+        if "capture" in item_markers:
             item.fixturenames = [*item.fixturenames, "enable_disable_plxpr"]
-            if "jax" not in markers:
+            if "jax" not in item_markers:
                 item.add_marker(pytest.mark.jax)
+
+        if pl2do_marker := item.get_closest_marker("pl2do"):
+            # Allow developers to set a custom reason if they wish
+            # either through positional or keyword argument
+            custom_reason = None
+            if pl2do_marker.args:
+                custom_reason = pl2do_marker.args[0]
+            elif "reason" in pl2do_marker.kwargs:
+                custom_reason = pl2do_marker.kwargs["reason"]
+
+            reason = (
+                custom_reason
+                or "PL 2.0: Feature is deprioritized and is scheduled to be re-visited."
+            )
+            item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
 
 
 def pytest_runtest_setup(item):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -21,6 +21,7 @@ markers =
     external: marks tests that require external packages such as matplotlib and PyZX
     catalyst: marks tests for catalyst testing (select with '-m "catalyst"')
     local_salt(salt): adds a salt to the seed provided by the pytest-rng fixture
+    pl2do: marks tests for functionality temporarily disabled in PennyLane 2.0 that must be eventually restored
 filterwarnings =
     ignore:Native execution of plxpr:UserWarning
     ignore::DeprecationWarning:autograd.numpy.numpy_wrapper


### PR DESCRIPTION
**Context:**

I'm finding that keeping track of the xfail s we are introducing for todo PL2 work (like parameter broadcasting functionality) is getting difficult and it's making me nervous about how we're going to come back to this later. 

**Description of the Change:**

Adds a marker so we can do,
```python
@pytest.mark.pl2_todo(reason="PL 2.0: Parameter broadcasting not supported.")
def test_parameter_broadcasting():
    ...
```
Adding a `reason` is optional. 

**Benefits:** Easier to track the effort later - all we need to do is run `pytest -m pl2_todo`

**Possible Drawbacks:** None identified. 

[sc-125997]
