### PR TITLE
Validate work wire spec in `assert_valid`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -269,6 +269,7 @@
 <h3>Improvements 🛠</h3>
 
 * `assert_valid` now checks the fine grained work wire spec.
+  [(#9919)](https://github.com/PennyLaneAI/pennylane/pull/9919)
 
 * Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
   register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* `assert_valid` now checks the fine grained work wire spec.
+
 * Reduced the :class:`~.CNOT` overhead of :class:`~.SemiAdder` if the size of the first addend
   register, `x_wires`, is smaller than the size of the second addend register, `y_wires`.
   [(#9807)](https://github.com/PennyLaneAI/pennylane/pull/9807)

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -218,14 +218,14 @@ def _assert_counts_match(counts_0, counts_1):
 def _update_work_wires_dict(op, work_wires):
     if op.state.value == "zero":
         if op.restored:
-            work_wires["zeroed"] += 1
+            work_wires["zeroed"] += len(op.wires)
         else:
-            work_wires["burnable"] += 1
+            work_wires["burnable"] += len(op.wires)
     elif op.state.value == "any":
         if op.restored:
-            work_wires["borrowed"] += 1
+            work_wires["borrowed"] += len(op.wires)
         else:
-            work_wires["garbage"] += 1
+            work_wires["garbage"] += len(op.wires)
 
 
 def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_check: bool = False):

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -17,6 +17,7 @@ Operator class is correctly defined.
 """
 
 import copy
+import dataclasses
 import itertools
 import pickle
 from collections import defaultdict
@@ -214,6 +215,19 @@ def _assert_counts_match(counts_0, counts_1):
     raise AssertionError(assertion_error_string)
 
 
+def _update_work_wires_dict(op, work_wires):
+    if op.state.value == "zero":
+        if op.restored:
+            work_wires["zeroed"] += 1
+        else:
+            work_wires["burnable"] += 1
+    elif op.state.value == "any":
+        if op.restored:
+            work_wires["borrowed"] += 1
+        else:
+            work_wires["garbage"] += 1
+
+
 def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_check: bool = False):
     """Tests that a decomposition rule is consistent with the operator."""
 
@@ -251,17 +265,23 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
 
         tape = qp.tape.QuantumScript.from_queue(q)
 
-    total_work_wires = rule.get_work_wire_spec(**params).total
-    if total_work_wires:
-        tape = _resolve_dynamic_wires(tape, total_work_wires)
-
+    actual_work_wires = {"zeroed": 0, "borrowed": 0, "burnable": 0, "garbage": 0}
     actual_gate_counts = defaultdict(int)
     for _op in tape.operations:
-        if isinstance(_op, qp.ops.Conditional):
-            _op = _op.base
-        op_rep = abstractify(_op)
-        actual_gate_counts[op_rep] += 1
+        if isinstance(_op, qp.allocation.Allocate):
+            _update_work_wires_dict(_op, actual_work_wires)
+        elif not isinstance(_op, qp.allocation.Deallocate):
+            if isinstance(_op, qp.ops.Conditional):
+                _op = _op.base
+            op_rep = abstractify(_op)
+            actual_gate_counts[op_rep] += 1
+
     actual_gate_counts = dict(sorted(actual_gate_counts.items(), key=lambda item: str(item[0])))
+
+    work_wires = dataclasses.asdict(rule.get_work_wire_spec(**params))
+    assert (
+        work_wires == actual_work_wires
+    ), f"Mismatch in work wire spec. Got {actual_work_wires} and expected {work_wires}"
 
     if rule.exact_resources and not (
         isinstance(op, qp.templates.SubroutineOp) and not op.subroutine.exact_resources
@@ -277,6 +297,9 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
             "Missing in gate counts from resource function:\n"
             f"{[op for op in actual_gate_counts if op not in gate_counts]}"
         )
+
+    if total_work_wires := rule.get_work_wire_spec(**params).total:
+        tape = _resolve_dynamic_wires(tape, total_work_wires)
 
     # Tests that the decomposition produces the same matrix
     if op.has_matrix and not skip_decomp_matrix_check:

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -249,6 +249,44 @@ class TestDecompositionErrors:
 
         _test_decomposition_rule(OneWireDynOp(0.5, wires=0), rule)
 
+    @pytest.mark.parametrize(
+        ("name", "state", "restored"),
+        [
+            ("burnable", "zero", True),
+            ("garbage", "zero", True),
+            ("borrowed", "zero", True),
+            #
+            ("zeroed", "zero", False),
+            ("borrowed", "zero", False),
+            ("garbage", "zero", False),
+            #
+            ("zeroed", "any", True),
+            ("burnable", "any", True),
+            ("garbage", "any", True),
+            #
+            ("zeroed", "any", False),
+            ("burnable", "any", False),
+            ("borrowed", "any", False),
+        ],
+    )
+    def test_bad_work_wire_spec(self, name, state, restored):
+        """Test that _test_decomposition_rule validates the work_wires."""
+
+        class DummyOp(qp.core.Operator2):
+
+            def __init__(self, wires):
+                super().__init__(wires=wires)
+
+        @qp.register_resources({qp.X: 1, qp.Y: 1}, work_wires={name: 2})
+        def rule(wires):
+            with qp.allocate(1, state=state, restored=restored) as _wires:
+                qp.X(_wires[0])
+            with qp.allocate(1, state=state, restored=restored) as _wires:
+                qp.Y(_wires[0])
+
+        with pytest.raises(AssertionError, match="Mismatch in work wire spec."):
+            _test_decomposition_rule(DummyOp(0), rule)
+
 
 class TestBadMatrix:
     """Tests involving matrix validation."""

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -277,9 +277,9 @@ class TestDecompositionErrors:
             def __init__(self, wires):
                 super().__init__(wires=wires)
 
-        @qp.register_resources({qp.X: 1, qp.Y: 1}, work_wires={name: 2})
+        @qp.register_resources({qp.X: 1, qp.Y: 1}, work_wires={name: 3})
         def rule(wires):
-            with qp.allocate(1, state=state, restored=restored) as _wires:
+            with qp.allocate(2, state=state, restored=restored) as _wires:
                 qp.X(_wires[0])
             with qp.allocate(1, state=state, restored=restored) as _wires:
                 qp.Y(_wires[0])


### PR DESCRIPTION
**Context:**

Realized it's very easy to get the work wire spec wrong for a decomposition rule. 

**Description of the Change:**

Adds some validation to `assert_valid` to make sure the work wire spec matches which allocations actually occur.

**Benefits:**

More security in the correctness of our decomposition rules.

**Possible Drawbacks:**

**Related GitHub Issues:**