### PR TITLE
Allow AbstractWires to be understood as wire pytree leaves when hashing operator2 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -908,6 +908,7 @@
   [(#9851)](https://github.com/PennyLaneAI/pennylane/pull/9851)
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
   [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
+  [(#9920)](https://github.com/PennyLaneAI/pennylane/pull/9920)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1052,7 +1052,8 @@ class Operator2(metaclass=OperatorMeta):
         for h in self.hybrid_argnames:
             leaves, tree = flatten(self.arguments[h], is_leaf=_is_hash_leaf)
             ser_leaves = tuple(
-                l if isinstance(l, (Operator2, Wires)) else _canonicalize_dynamic(l) for l in leaves
+                l if isinstance(l, (AbstractWires, Operator2, Wires)) else _canonicalize_dynamic(l)
+                for l in leaves
             )
             serialized_hybrid.append((ser_leaves, tree))
 

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1059,6 +1059,11 @@ class TestHash:
         op = DynOp(0.5, wires=0)
         assert isinstance(hash(op), int)
 
+    def test_op_is_hashable_with_abstract_wires(self):
+        """Test that ``Operator2`` is hashable when the wires are `AbstractWires`."""
+        op = DynOp(0.5, wires=AbstractWires(1))
+        assert isinstance(hash(op), int)
+
     def test_op_can_be_dict_key(self):
         """Test that an ``Operator2`` instance can be used as a dict key."""
         op = DynOp(0.5, wires=0)

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1098,7 +1098,7 @@ class TestHash:
 
     def test_op_is_hashable_with_abstract_wires_in_hybrid(self):
         """Test that ``Operator2`` is hashable when the wires are `AbstractWires` in hybrid args."""
-        op = FullOp(phi=0.5, static="a", hybrid=[AbstractWires(1)], wires=0)
+        op = HybridWireOp([AbstractWires(1)])
         assert isinstance(hash(op), int)
 
     def test_different_types_different_hash(self):

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1096,9 +1096,10 @@ class TestHash:
         op2 = FullOp(phi=0.6, static="ab", hybrid=[1, 1], wires=1)
         assert hash(op1) != hash(op2)
 
-    def test_op_is_hashable_with_abstract_wires_in_hybrid(self):
+    @pytest.mark.parametrize("pytree_wires", ([Wire[1]], [[Wire[2]], [Wire[3]]]))
+    def test_op_is_hashable_with_abstract_wires_in_hybrid(self, pytree_wires):
         """Test that ``Operator2`` is hashable when the wires are `AbstractWires` in hybrid args."""
-        op = HybridWireOp([AbstractWires(1)])
+        op = HybridWireOp(pytree_wires)
         assert isinstance(hash(op), int)
 
     def test_different_types_different_hash(self):

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1059,11 +1059,6 @@ class TestHash:
         op = DynOp(0.5, wires=0)
         assert isinstance(hash(op), int)
 
-    def test_op_is_hashable_with_abstract_wires(self):
-        """Test that ``Operator2`` is hashable when the wires are `AbstractWires`."""
-        op = DynOp(0.5, wires=AbstractWires(1))
-        assert isinstance(hash(op), int)
-
     def test_op_can_be_dict_key(self):
         """Test that an ``Operator2`` instance can be used as a dict key."""
         op = DynOp(0.5, wires=0)
@@ -1100,6 +1095,11 @@ class TestHash:
         op1 = FullOp(phi=0.5, static="a", hybrid=[0, 1], wires=0)
         op2 = FullOp(phi=0.6, static="ab", hybrid=[1, 1], wires=1)
         assert hash(op1) != hash(op2)
+
+    def test_op_is_hashable_with_abstract_wires_in_hybrid(self):
+        """Test that ``Operator2`` is hashable when the wires are `AbstractWires` in hybrid args."""
+        op = FullOp(phi=0.5, static="a", hybrid=[AbstractWires(1)], wires=0)
+        assert isinstance(hash(op), int)
 
     def test_different_types_different_hash(self):
         """Test that operators of different types produce different hashes."""


### PR DESCRIPTION
**Context:**
Allow AbstractWires to be understood as wire pytree leaves when hashing operator2 instances.
