### PR TITLE
Add `register_signature` for precompiling decomposition rules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -819,6 +819,12 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* A :func:`pennylane.decomposition.register_signature` function is added for recording the possible signatures of
+  an operator, along with a :func:`pennylane.decomposition.signature_registry` function for retrieving the recorded
+  signatures. The resulting registry is used to identify decomposition rules that can be precompiled, improving
+  the performance of decomposition passes in :func:`~.qjit`-compiled workflows.
+  [(#9921)](https://github.com/PennyLaneAI/pennylane/pull/9921)
+
 * Adds a CI runner for catalyst tests and removes the catalyst tests from the `external` tests. Now, catalyst
   tests should only be marked `catalyst` and *not* marked `external`.
   [(#9873)](https://github.com/PennyLaneAI/pennylane/pull/9873)

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1352,6 +1352,12 @@ class Operator2(metaclass=OperatorMeta):
         _init_subclass_add_dynamic_properties(cls)
         register_pytree(cls, cls._flatten, cls._unflatten)
 
+        if cls.has_fixed_sig:
+            # pylint: disable=import-outside-toplevel
+            from pennylane.decomposition import register_signature
+
+            register_signature(cls)
+
 
 # ---------------------------------------------------------------------------------
 # ------------------------- Instance construction helpers -------------------------

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1366,10 +1366,7 @@ class Operator2(metaclass=OperatorMeta):
         register_pytree(cls, cls._flatten, cls._unflatten)
 
         if cls.has_fixed_sig:
-            # pylint: disable=import-outside-toplevel
-            from pennylane.decomposition import register_signature
-
-            register_signature(cls)
+            qp.decomposition.register_signature(cls)
 
 
 # ---------------------------------------------------------------------------------

--- a/pennylane/decomposition/__init__.py
+++ b/pennylane/decomposition/__init__.py
@@ -243,6 +243,8 @@ from .utils import (
     enable_graph,
     disable_graph,
     enabled_graph,
+    register_signature,
+    signature_registry,
     toggle_graph_ctx,
 )
 from .decomposition_graph import DecompositionGraph, DecompGraphSolution

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -191,7 +191,7 @@ def _init_signature_registration():
         spec = dict(op.arg_specs or {})
         spec.update(**kwargs)
 
-        if any(op.hybrid_argnames or op.static_argnames):
+        if op.hybrid_argnames or op.static_argnames:
             # Precompiling decomposition rules will require UID generation for operators
             # with hybrid/non-compilable static arguments. But, the UID is Python session
             # dependent, and precompilation happens in a different Python session.

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -17,10 +17,13 @@ This module implements utility functions for the decomposition module.
 """
 
 import re
+from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import singledispatch
+from typing import Any
 
+from pennylane.core import Operator2
 from pennylane.core.operator import Operator, Operator1, abstractify
 
 OP_NAME_ALIASES = {
@@ -144,3 +147,21 @@ def toggle_graph_decomposition():
 
 
 enable_graph, disable_graph, enabled_graph, toggle_graph_ctx = toggle_graph_decomposition()
+
+
+def _init_signature_registration():
+
+    _registry = defaultdict(list)
+
+    def register(op: type[Operator2], **kwargs) -> None:
+        spec = dict(op.arg_specs)
+        spec.update(**kwargs)
+        _registry[op].append(spec)
+
+    def registry() -> dict[type[Operator2], list[dict[str, Any]]]:
+        return dict(_registry)
+
+    return register, registry
+
+
+register_signature, signature_registry = _init_signature_registration()

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -188,7 +188,7 @@ def _init_signature_registration():
 
         .. seealso:: :func:`pennylane.decomposition.signature_registry`
         """
-        spec = dict(op.arg_specs)
+        spec = dict(op.arg_specs or {})
         spec.update(**kwargs)
 
         if any(op.hybrid_argnames or op.static_argnames):
@@ -241,14 +241,14 @@ def _init_signature_registration():
 
         _registry[op] += (spec,)
 
-    def registry() -> dict[type[Operator2], tuple[dict[str, Any]], ...]:
+    def registry() -> dict[type[Operator2], tuple[dict[str, Any], ...]]:
         r"""Return the operator signatures registered with :func:`~.register_signature`.
 
         Returns:
-            dict[type[~.Operator2], list[dict[str, Any]]]: a mapping from each registered
-            operator class to the list of signatures registered for it. Each signature is
-            a dictionary mapping argument names to their abstract type (for dynamic and
-            wire arguments) or value (for compilable static arguments).
+            dict[type[~.Operator2], tuple[dict[str, Any], ...]]: a mapping from each
+            registered operator class to the tuple of signatures registered for it. Each
+            signature is a dictionary mapping argument names to their abstract type (for
+            dynamic and wire arguments) or value (for compilable static arguments).
 
         .. seealso:: :func:`pennylane.decomposition.register_signature`
         """

--- a/pennylane/decomposition/utils.py
+++ b/pennylane/decomposition/utils.py
@@ -21,10 +21,12 @@ from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import singledispatch
+from numbers import Number
 from typing import Any
 
 from pennylane.core import Operator2
 from pennylane.core.operator import Operator, Operator1, abstractify
+from pennylane.typing import AbstractArray, AbstractWires
 
 OP_NAME_ALIASES = {
     "X": "PauliX",
@@ -151,14 +153,106 @@ enable_graph, disable_graph, enabled_graph, toggle_graph_ctx = toggle_graph_deco
 
 def _init_signature_registration():
 
-    _registry = defaultdict(list)
+    _registry = defaultdict(tuple)
 
     def register(op: type[Operator2], **kwargs) -> None:
+        r"""Register a possible signature for an operator.
+
+        A *signature* records the abstract type of every argument of an operator (its
+        dynamic parameters and wires), along with the values of any compilable static
+        arguments. Registered signatures are collected in :func:`~.signature_registry`
+        and are used to determine ahead of time which decomposition rules can be
+        precompiled, improving the performance of decomposition passes in
+        :func:`~.qjit`-compiled workflows.
+
+        Operators with a fixed signature (i.e., ``op.has_fixed_sig`` is ``True``) are
+        registered automatically when the class is defined. This function can be called
+        directly to register additional signatures, for example the same operator with
+        different fixed wire counts or static argument values.
+
+        Args:
+            op (type[~.Operator2]): the operator class to register a signature for.
+
+        Keyword Args:
+            **kwargs: the type or value of each argument, overriding the corresponding
+                entry in ``op.arg_specs``. Together, ``op.arg_specs`` and these keyword
+                arguments must specify every argument of ``op``. Dynamic arguments must be
+                given an abstract numeric type (a subclass of ``numbers.Number`` or an
+                :class:`~.AbstractArray`) and wire arguments an :class:`~.AbstractWires`,
+                each with a fixed shape.
+
+        Raises:
+            ValueError: if ``op`` has hybrid or non-compilable static arguments, if the
+                resulting signature does not cover every argument of ``op``, or if a
+                dynamic or wire argument is not given a fixed-shape abstract type.
+
+        .. seealso:: :func:`pennylane.decomposition.signature_registry`
+        """
         spec = dict(op.arg_specs)
         spec.update(**kwargs)
-        _registry[op].append(spec)
 
-    def registry() -> dict[type[Operator2], list[dict[str, Any]]]:
+        if any(op.hybrid_argnames or op.static_argnames):
+            # Precompiling decomposition rules will require UID generation for operators
+            # with hybrid/non-compilable static arguments. But, the UID is Python session
+            # dependent, and precompilation happens in a different Python session.
+            raise ValueError(
+                "Signatures cannot be registered for operators that contain hybrid or "
+                "non-compilable static arguments."
+            )
+
+        # pylint: disable=protected-access
+        if set(spec.keys()) != set(op._sig.parameters.keys()):
+            raise ValueError(
+                "Signatures being registered must cover all operator arguments. Expected "
+                f"{tuple(op._sig.parameters.keys())} but got {tuple(spec.keys())}."
+            )
+
+        for dname in op.dynamic_argnames:
+            aval = spec[dname]
+            if not (
+                (isinstance(aval, type) and issubclass(aval, Number))
+                or isinstance(aval, AbstractArray)
+            ):
+                raise ValueError(
+                    f"Expected an abstract type for '{dname}' when registering a signature "
+                    f"for {op.__name__}."
+                )
+            aval = abstractify(aval)
+            if not aval.shape_fixed:
+                raise ValueError(
+                    "Signatures can only be registered if dynamic data has fixed shapes, "
+                    f"but got shape {aval.shape} for '{op.__name__}.{dname}'."
+                )
+
+            spec[dname] = aval
+
+        for wname in op.wire_argnames:
+            aval = spec[wname]
+            if not isinstance(aval, AbstractWires):
+                raise ValueError(
+                    f"Expected an abstract type for '{wname}' when registering a signature "
+                    f"for {op.__name__}."
+                )
+            if not aval.shape_fixed:
+                raise ValueError(
+                    "Signatures can only be registered if all wire arguments have fixed shapes, "
+                    f"but got shape {aval.shape} for '{op.__name__}.{wname}'."
+                )
+
+        _registry[op] += (spec,)
+
+    def registry() -> dict[type[Operator2], tuple[dict[str, Any]], ...]:
+        r"""Return the operator signatures registered with :func:`~.register_signature`.
+
+        Returns:
+            dict[type[~.Operator2], list[dict[str, Any]]]: a mapping from each registered
+            operator class to the list of signatures registered for it. Each signature is
+            a dictionary mapping argument names to their abstract type (for dynamic and
+            wire arguments) or value (for compilable static arguments).
+
+        .. seealso:: :func:`pennylane.decomposition.register_signature`
+        """
+        # Create a copy so mutation doesn't affect the registry
         return dict(_registry)
 
     return register, registry

--- a/tests/core/operator/operator2_utils.py
+++ b/tests/core/operator/operator2_utils.py
@@ -87,6 +87,18 @@ class CompilableOp(Operator2):
         super().__init__(n, wires=wires)
 
 
+class CompilableDynOp(Operator2):
+    """Operator with a dynamic parameter, wires, and a compilable static argument."""
+
+    dynamic_argnames = ("phi",)
+    compilable_argnames = ("word",)
+
+    arg_specs = {"phi": Float, "wires": Wire[1]}
+
+    def __init__(self, phi, word, wires):
+        super().__init__(phi, word, wires=wires)
+
+
 class MultiWireOp(Operator2):
     """Operator with two wire arguments."""
 

--- a/tests/decomposition/test_decomp_utils.py
+++ b/tests/decomposition/test_decomp_utils.py
@@ -19,7 +19,14 @@ Unit tests for utility functions in the ``decomposition`` module.
 import pytest
 
 import pennylane as qp
+from pennylane.decomposition import register_signature, signature_registry
 from pennylane.decomposition.utils import translate_op_alias
+from pennylane.typing import Float, Wire
+from tests.core.operator.operator2_utils import (
+    CompilableDynOp,
+    OneWireDynOp,
+    ParametrizedHybridOp,
+)
 
 
 @pytest.mark.unit
@@ -90,3 +97,60 @@ def test_translate_op_error():
 
     with pytest.raises(ValueError, match="'Adj' is not a valid name for a symbolic operator"):
         translate_op_alias("Adj(X)")
+
+
+@pytest.mark.unit
+class TestSignatureRegistration:
+    """Tests for ``register_signature`` and ``signature_registry``."""
+
+    def test_fixed_signature_auto_registered(self):
+        """An operator with a fixed signature is registered automatically on definition."""
+        assert OneWireDynOp.has_fixed_sig
+        assert signature_registry()[OneWireDynOp] == (OneWireDynOp.arg_specs,)
+
+    def test_register_operator_with_compilable_arg(self):
+        """A signature can be registered manually for an operator with a compilable argument."""
+        assert not CompilableDynOp.has_fixed_sig
+        assert CompilableDynOp not in signature_registry()
+
+        register_signature(CompilableDynOp, word="XY")
+        assert signature_registry()[CompilableDynOp] == (
+            {**CompilableDynOp.arg_specs, "word": "XY"},
+        )
+
+        register_signature(CompilableDynOp, word="ZZ")
+        assert signature_registry()[CompilableDynOp][-1] == (
+            {**CompilableDynOp.arg_specs, "word": "XY"},
+            {**CompilableDynOp.arg_specs, "word": "ZZ"},
+        )
+
+    def test_registry_returns_shallow_copy(self):
+        """Mutating the returned registry does not affect the underlying registry."""
+        registry = signature_registry()
+        del registry[OneWireDynOp]
+        assert OneWireDynOp in signature_registry()
+
+    def test_error_hybrid_or_static_args(self):
+        """Signatures cannot be registered for operators with hybrid or static arguments."""
+        with pytest.raises(ValueError, match="hybrid or non-compilable static arguments"):
+            register_signature(ParametrizedHybridOp)
+
+    def test_error_incomplete_signature(self):
+        """The registered signature must cover all of the operator's arguments."""
+        with pytest.raises(ValueError, match="must cover all operator arguments"):
+            register_signature(CompilableDynOp)  # 'word' is missing
+
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"phi": "not_abstract"}, "Expected an abstract type for 'phi'"),
+            ({"phi": Float[-1]}, "dynamic data has fixed shapes"),
+            ({"wires": "not_wires"}, "Expected an abstract type for 'wires'"),
+            ({"wires": Wire[-1]}, "all wire arguments have fixed shapes"),
+        ],
+    )
+    def test_error_invalid_arg_spec(self, kwargs, match):
+        """Dynamic and wire arguments must be given fixed-shape abstract types."""
+
+        with pytest.raises(ValueError, match=match):
+            register_signature(OneWireDynOp, **kwargs)

--- a/tests/decomposition/test_decomp_utils.py
+++ b/tests/decomposition/test_decomp_utils.py
@@ -119,7 +119,7 @@ class TestSignatureRegistration:
         )
 
         register_signature(CompilableDynOp, word="ZZ")
-        assert signature_registry()[CompilableDynOp][-1] == (
+        assert signature_registry()[CompilableDynOp] == (
             {**CompilableDynOp.arg_specs, "word": "XY"},
             {**CompilableDynOp.arg_specs, "word": "ZZ"},
         )


### PR DESCRIPTION
**Context:**
The `Operator2` ADR proposed a mechanism for registering operators for pre-compilation. This PR adds that

**Description of the Change:**
* Add `qp.decomposition.register_signature` that allows users to register operator signatures which can be used to pre-compile decomposition rules.
* The signatures are saved in a dictionary which maps operator types to tuples containing the registered signatures. The registered signatures are dictionaries mapping argument names to abstract types (or concrete values for static, compilable arguments).
* Add `qp.decomposition.signature_registry` that returns the registered signatures.
* Update `Operator2.__init_subclass__` so that operators with fixed signatures are automatically registered.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


AI note:
Cursor was used to help, but mostly just for tests and the docstrings

[sc-126068]