### PR TITLE
Add `Operator2.__getattr__` to suppress Pylint `no-member` errors

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -905,6 +905,7 @@
   [(#9783)](https://github.com/PennyLaneAI/pennylane/pull/9783)
   [(#9851)](https://github.com/PennyLaneAI/pennylane/pull/9851)
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
+  [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1090,6 +1090,19 @@ class Operator2(metaclass=OperatorMeta):
             setattr(copied_op, attr, deepcopy(value, memo))
         return copied_op
 
+    def __getattr__(self, name):
+        # By default, all operator arguments are accessible as properties without needing
+        # to manually add properties. However, these properties are created dynamically in
+        # __init_subclass__. Pylint raises 'no-member' errors when trying to access these
+        # dynamically added properties. This dunder method is added to circumvent the error.
+        # Pylint does not raise the 'no-member' error for classes that contain __getattr__.
+        # The catch is that 'no-member' errors will no longer be raised for values that are
+        # _actually_ not present.
+
+        # __getattr__ is a fallback called after an attribute is not found on an object, so,
+        # unconditionally raising an AttributeError is exactly what would be expected anyway.
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
     # ------------------------------------------------------------------------
     # ------------------ Operator arithmetic dunder methods ------------------
     # ------------------------------------------------------------------------

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -1401,6 +1401,13 @@ class TestDunderMethods:
             # Deep copy so stored attributes must NOT be the same references
             assert getattr(op_deep, attr) is not getattr(op, attr)
 
+    def test_getattr(self):
+        """Test that an AttributeError is raised if trying to access an attribute that
+        does not exist."""
+        op = DynOp(1.5, 0)
+        with pytest.raises(AttributeError, match="'DynOp' object has no attribute"):
+            _ = op.non_existent_attr
+
 
 class TestPublicProperties:
     """Tests for public properties of ``Operator2``."""


### PR DESCRIPTION
Pylint raises `no-member` errors if trying to access operator arguments with the `op.some_argument` syntax. This executes correctly because all operator arguments are available as dynamically added properties, but Pylint doesn't know that.

Adding a `__getattr__` suppresses this. The downside is that `no-member` errors will not be raised if we're actually trying to access an attribute that doesn't exist.


[sc-126096]