### PR TITLE
Port `QFT` to `Operator2`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -841,6 +841,8 @@
   - Templates are ported:
     - `~.BasisRotation`
   [(#9896)](https://github.com/PennyLaneAI/pennylane/pull/9896)
+    - `~.QFT`
+  [(#9932)](https://github.com/PennyLaneAI/pennylane/pull/9932)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -840,9 +840,8 @@
   [(#9850)](https://github.com/PennyLaneAI/pennylane/pull/9850)
   [(#9784)](https://github.com/PennyLaneAI/pennylane/pull/9784)
   - Templates are ported:
-    - `~.BasisRotation`
+    - `~.BasisRotation`, `~.QFT`
   [(#9896)](https://github.com/PennyLaneAI/pennylane/pull/9896)
-    - `~.QFT`
   [(#9932)](https://github.com/PennyLaneAI/pennylane/pull/9932)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default

--- a/pennylane/templates/state_preparations/cosine_window.py
+++ b/pennylane/templates/state_preparations/cosine_window.py
@@ -22,8 +22,9 @@ from pennylane import capture, math, register_resources
 from pennylane.control_flow import for_loop
 from pennylane.core.operator import StatePrepBase
 from pennylane.decomposition import add_decomps
-from pennylane.decomposition.resources import adjoint_resource_rep
 from pennylane.exceptions import WireError
+from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
+from pennylane.typing import Wire
 from pennylane.wires import Wires
 
 
@@ -150,7 +151,7 @@ def _cosine_window_resources(num_wires):
     return {
         qp.Hadamard: 1,
         qp.RZ: 1,
-        adjoint_resource_rep(qp.QFT, {"num_wires": num_wires}): 1,
+        _adjoint_abstract(qp.QFT(Wire[num_wires])): 1,
         qp.PhaseShift: num_wires,
     }
 

--- a/pennylane/templates/subroutines/arithmetic/adder.py
+++ b/pennylane/templates/subroutines/arithmetic/adder.py
@@ -27,6 +27,7 @@ from pennylane.decomposition.resources import resource_rep
 from pennylane.ops import CNOT, MultiControlledX, PauliX
 from pennylane.ops.op_math import change_op_basis
 from pennylane.templates.subroutines.qft import QFT
+from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
 
 from .phase_adder import PhaseAdder
@@ -230,11 +231,11 @@ class Adder(Operation):
 
 
 def _adder_decomposition_resources(num_x_wires, mod) -> dict:
-    qft_wires = num_x_wires if mod == 2**num_x_wires else 1 + num_x_wires
+    num_qft_wires = num_x_wires if mod == 2**num_x_wires else 1 + num_x_wires
     return {
         change_op_basis_resource_rep(
-            resource_rep(QFT, num_wires=qft_wires),
-            resource_rep(PhaseAdder, num_x_wires=qft_wires, mod=mod),
+            QFT(Wire[num_qft_wires]),
+            resource_rep(PhaseAdder, num_x_wires=num_qft_wires, mod=mod),
         ): 1,
     }
 

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -28,6 +28,7 @@ from pennylane.decomposition import (
 from pennylane.ops import SWAP, Prod, adjoint, change_op_basis, prod
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
+from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
 
 from .phase_adder import PhaseAdder
@@ -266,26 +267,17 @@ def _multiplier_decomposition_resources(
         "num_control_wires": num_x_wires,
     }
     if num_x_wires > 1:
-        return {
-            change_op_basis_resource_rep(
-                resource_rep(QFT, num_wires=num_wires_aux),
-                resource_rep(ControlledSequence, **cs_base_params),
-            ): 1,
-            resource_rep(Prod, resources={abstractify(SWAP): num_x_wires}): 1,
-            change_op_basis_resource_rep(
-                resource_rep(QFT, num_wires=num_wires_aux),
-                adjoint_resource_rep(ControlledSequence, cs_base_params),
-            ): 1,
-        }
-
+        target_op_rep = resource_rep(Prod, resources={abstractify(SWAP): num_x_wires})
+    else:
+        target_op_rep = SWAP
     return {
         change_op_basis_resource_rep(
-            resource_rep(QFT, num_wires=num_wires_aux),
+            QFT(Wire[num_wires_aux]),
             resource_rep(ControlledSequence, **cs_base_params),
         ): 1,
-        SWAP: 1,
+        target_op_rep: 1,
         change_op_basis_resource_rep(
-            resource_rep(QFT, num_wires=num_wires_aux),
+            QFT(Wire[num_wires_aux]),
             adjoint_resource_rep(ControlledSequence, cs_base_params),
         ): 1,
     }

--- a/pennylane/templates/subroutines/arithmetic/out_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/out_adder.py
@@ -27,6 +27,7 @@ from pennylane.decomposition import (
 from pennylane.ops import Prod, change_op_basis
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
+from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
 
 from .phase_adder import PhaseAdder
@@ -285,13 +286,13 @@ class OutAdder(Operation):
 
 
 def _out_adder_decomposition_resources(num_output_wires, num_x_wires, num_y_wires, mod) -> dict:
-    qft_wires = num_output_wires if mod == 2**num_output_wires else num_output_wires + 1
+    num_qft_wires = num_output_wires if mod == 2**num_output_wires else num_output_wires + 1
     target_resources = defaultdict(int)
     target_resources[
         resource_rep(
             ControlledSequence,
             base_class=PhaseAdder,
-            base_params={"num_x_wires": qft_wires, "mod": mod},
+            base_params={"num_x_wires": num_qft_wires, "mod": mod},
             num_control_wires=num_x_wires,
         )
     ] += 1
@@ -299,14 +300,14 @@ def _out_adder_decomposition_resources(num_output_wires, num_x_wires, num_y_wire
         resource_rep(
             ControlledSequence,
             base_class=PhaseAdder,
-            base_params={"num_x_wires": qft_wires, "mod": mod},
+            base_params={"num_x_wires": num_qft_wires, "mod": mod},
             num_control_wires=num_y_wires,
         )
     ] += 1
 
     return {
         change_op_basis_resource_rep(
-            resource_rep(QFT, num_wires=qft_wires), resource_rep(Prod, resources=target_resources)
+            QFT(Wire[num_qft_wires]), resource_rep(Prod, resources=target_resources)
         ): 1
     }
 

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -30,6 +30,7 @@ from pennylane.decomposition import (
 )
 from pennylane.decomposition.resources import resource_rep
 from pennylane.ops import BasisState, H, Prod, X, adjoint, change_op_basis, ctrl, prod
+from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract
 from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
@@ -351,20 +352,20 @@ class OutMultiplier(Operation):
 def _out_multiplier_with_qft_resources(
     num_output_wires, num_x_wires, num_y_wires, mod, output_wires_zeroed, **_
 ) -> dict:
-    qft_wires = num_output_wires + 1 if mod != 2**num_output_wires else num_output_wires
+    num_qft_wires = num_output_wires + 1 if mod != 2**num_output_wires else num_output_wires
 
     if output_wires_zeroed:
-        compute_rep = resource_rep(Prod, resources={abstractify(H): qft_wires})
+        compute_rep = resource_rep(Prod, resources={abstractify(H): num_qft_wires})
     else:
-        compute_rep = resource_rep(QFT, num_wires=qft_wires)
+        compute_rep = QFT(Wire[num_qft_wires])
 
-    uncompute_rep = adjoint_resource_rep(QFT, base_params={"num_wires": qft_wires})
+    uncompute_rep = _adjoint_abstract(QFT(Wire[num_qft_wires]))
     target_rep = resource_rep(
         ControlledSequence,
         base_class=ControlledSequence,
         base_params={
             "base_class": PhaseAdder,
-            "base_params": {"num_x_wires": qft_wires, "mod": mod},
+            "base_params": {"num_x_wires": num_qft_wires, "mod": mod},
             "num_control_wires": num_x_wires,
         },
         num_control_wires=num_y_wires,

--- a/pennylane/templates/subroutines/arithmetic/out_poly.py
+++ b/pennylane/templates/subroutines/arithmetic/out_poly.py
@@ -21,13 +21,14 @@ from pennylane import math
 from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
-    adjoint_resource_rep,
     controlled_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.ops import adjoint, ctrl
+from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.templates.subroutines.qft import QFT
+from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
 
 from .phase_adder import PhaseAdder
@@ -472,11 +473,7 @@ class OutPoly(Operation):
 def _out_poly_decomposition_resources(num_output_wires, num_work_wires, mod, coeffs_list) -> dict:
     num_output_adder_mod = num_output_wires + 1 if num_work_wires else num_output_wires
 
-    resources = Counter(
-        {
-            resource_rep(QFT, num_wires=num_output_adder_mod): 1,
-        }
-    )
+    resources = Counter({QFT(Wire[num_output_adder_mod]): 1})
 
     coeffs_dic = dict(coeffs_list)
 
@@ -500,7 +497,7 @@ def _out_poly_decomposition_resources(num_output_wires, num_work_wires, mod, coe
             )
             resources[ctrl_phase_rep] += 1
 
-    resources[adjoint_resource_rep(QFT, {"num_wires": num_output_adder_mod})] = 1
+    resources[_adjoint_abstract(QFT(Wire[num_output_adder_mod]))] = 1
 
     return dict(resources)
 

--- a/pennylane/templates/subroutines/arithmetic/phase_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/phase_adder.py
@@ -24,13 +24,13 @@ from pennylane.control_flow import for_loop
 from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import (
     add_decomps,
-    adjoint_resource_rep,
     change_op_basis_resource_rep,
     register_resources,
     resource_rep,
 )
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.templates.subroutines.qft import QFT
+from pennylane.typing import Wire
 from pennylane.wires import Wires, WiresLike
 
 
@@ -279,7 +279,7 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         int,
         {
             abstractify(ops.X): 1,
-            adjoint_resource_rep(QFT, {"num_wires": num_x_wires}): 1,
+            _adjoint_abstract(QFT(Wire[num_x_wires])): 1,
             _adjoint_abstract(ops.PhaseShift): num_x_wires,
         },
     )
@@ -288,7 +288,7 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         int,
         {
             abstractify(ops.PhaseShift): num_x_wires,
-            resource_rep(QFT, num_wires=num_x_wires): 1,
+            QFT(Wire[num_x_wires]): 1,
             abstractify(ops.X): 1,
         },
     )
@@ -297,9 +297,9 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         ops.PhaseShift: num_x_wires,
         _adjoint_abstract(ops.PhaseShift): num_x_wires,
         change_op_basis_resource_rep(
-            adjoint_resource_rep(QFT, {"num_wires": num_x_wires}),
+            _adjoint_abstract(QFT(Wire[num_x_wires])),
             ops.CNOT,
-            resource_rep(QFT, num_wires=num_x_wires),
+            QFT(Wire[num_x_wires]),
         ): 1,
         ops.ControlledPhaseShift: num_x_wires,
         change_op_basis_resource_rep(

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -22,13 +22,14 @@ import numpy as np
 from pennylane import math
 from pennylane.capture import enabled
 from pennylane.control_flow import for_loop
-from pennylane.core.operator import Operation
+from pennylane.core.operator import Operator2
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.ops import SWAP, ControlledPhaseShift, Hadamard
+from pennylane.typing import AbstractWires
 from pennylane.wires import Wires, WiresLike
 
 
-class QFT(Operation):
+class QFT(Operator2):
     r"""QFT(wires)
     Apply a quantum Fourier transform (QFT).
 
@@ -126,81 +127,19 @@ class QFT(Operation):
         array([[1, 1, 1, 0]])
     """
 
-    grad_method = None
-    resource_keys = {"num_wires"}
-
     def __init__(self, wires: WiresLike):
         wires = Wires(wires)
-        self.hyperparameters["num_wires"] = len(wires)
-        super().__init__(wires=wires)
-
-    def _flatten(self):
-        return tuple(), (self.wires, tuple())
-
-    @property
-    def num_params(self):
-        return 0
-
-    def decomposition(self):
-        return self.compute_decomposition(wires=self.wires)
+        # self.hyperparameters["num_wires"] = len(wires)
+        super().__init__(wires)
 
     @staticmethod
     @functools.lru_cache
-    def compute_matrix(num_wires):  # pylint: disable=arguments-differ
-        return np.fft.ifft(np.eye(2**num_wires), norm="ortho")
-
-    @staticmethod
-    def compute_decomposition(wires: WiresLike):  # pylint: disable=arguments-differ
-        r"""Representation of the operator as a product of other operators (static method).
-
-        .. math:: O = O_1 O_2 \dots O_n.
+    def compute_matrix(wires):  # pylint: disable=arguments-differ
+        return np.fft.ifft(np.eye(2 ** len(wires)), norm="ortho")
 
 
-        .. seealso:: :meth:`~.QFT.decomposition`.
-
-        Args:
-            wires (Iterable, Wires): wires that the operator acts on
-
-        Returns:
-            list[Operator]: decomposition of the operator
-
-        **Example:**
-
-        >>> qp.QFT.compute_decomposition(wires=(0,1,2))
-        [H(0),
-         ControlledPhaseShift(1.5707963267948966, wires=[1, 0]),
-         ControlledPhaseShift(0.7853981633974483, wires=[2, 0]),
-         H(1),
-         ControlledPhaseShift(1.5707963267948966, wires=[2, 1]),
-         H(2),
-         SWAP(wires=[0, 2])]
-
-        """
-        wires = Wires(wires)
-        num_wires = len(wires)
-
-        shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
-
-        shift_len = len(shifts)
-        decomp_ops = []
-        for i, wire in enumerate(wires):
-            decomp_ops.append(Hadamard(wire))
-
-            for shift, control_wire in zip(shifts[: shift_len - i], wires[i + 1 :], strict=True):
-                op = ControlledPhaseShift(shift, wires=[control_wire, wire])
-                decomp_ops.append(op)
-
-        for i in range(num_wires // 2):
-            decomp_ops.append(SWAP(wires=[wires[i], wires[num_wires - i - 1]]))
-
-        return decomp_ops
-
-    @property
-    def resource_params(self) -> dict:
-        return {"num_wires": len(self.wires)}
-
-
-def _qft_decomposition_resources(num_wires):
+def _qft_decomposition_resources(wires: AbstractWires):
+    num_wires = len(wires)
     return {
         Hadamard: num_wires,
         SWAP: num_wires // 2,
@@ -208,10 +147,9 @@ def _qft_decomposition_resources(num_wires):
     }
 
 
-# pylint: disable=no-value-for-parameter
 @register_resources(_qft_decomposition_resources)
-def _qft_decomposition(wires: WiresLike, num_wires, **__):
-
+def _qft_decomposition(wires: AbstractWires):
+    num_wires = len(wires)
     shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
     if enabled():
         shifts = math.array(shifts, like="jax")
@@ -229,15 +167,15 @@ def _qft_decomposition(wires: WiresLike, num_wires, **__):
             def cphaseshift_loop(j):
                 ControlledPhaseShift(shifts[j], wires=[wires[i + j + 1], wires[i]])
 
-            cphaseshift_loop()
+            cphaseshift_loop()  # pylint: disable=no-value-for-parameter
 
-    outer_loop()
+    outer_loop()  # pylint: disable=no-value-for-parameter
 
     @for_loop(num_wires // 2)
     def swaps(i):
         SWAP(wires=[wires[i], wires[num_wires - i - 1]])
 
-    swaps()
+    swaps()  # pylint: disable=no-value-for-parameter
 
 
 add_decomps(QFT, _qft_decomposition)

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -15,8 +15,6 @@
 This submodule contains the template for QFT.
 """
 
-import functools
-
 import numpy as np
 
 from pennylane import compiler, math
@@ -25,8 +23,8 @@ from pennylane.control_flow import for_loop
 from pennylane.core.operator import Operator2
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.ops import SWAP, ControlledPhaseShift, Hadamard
-from pennylane.typing import AbstractWires
-from pennylane.wires import Wires, WiresLike
+from pennylane.typing import AbstractWires, Wire
+from pennylane.wires import WiresLike
 
 
 class QFT(Operator2):
@@ -127,13 +125,12 @@ class QFT(Operator2):
         array([[1, 1, 1, 0]])
     """
 
+    arg_specs = {"wires": Wire[-1]}
+
     def __init__(self, wires: WiresLike):
-        wires = Wires(wires)
-        # self.hyperparameters["num_wires"] = len(wires)
         super().__init__(wires)
 
     @staticmethod
-    @functools.lru_cache
     def compute_matrix(wires):  # pylint: disable=arguments-differ
         return np.fft.ifft(np.eye(2 ** len(wires)), norm="ortho")
 

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -19,7 +19,7 @@ import functools
 
 import numpy as np
 
-from pennylane import math
+from pennylane import compiler, math
 from pennylane.capture import enabled
 from pennylane.control_flow import for_loop
 from pennylane.core.operator import Operator2
@@ -151,7 +151,7 @@ def _qft_decomposition_resources(wires: AbstractWires):
 def _qft_decomposition(wires: AbstractWires):
     num_wires = len(wires)
     shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
-    if enabled():
+    if compiler.active() or enabled():
         shifts = math.array(shifts, like="jax")
         wires = math.array(wires, like="jax")
 

--- a/pennylane/templates/subroutines/qft.py
+++ b/pennylane/templates/subroutines/qft.py
@@ -131,7 +131,7 @@ class QFT(Operator2):
         super().__init__(wires)
 
     @staticmethod
-    def compute_matrix(wires):  # pylint: disable=arguments-differ
+    def compute_matrix(wires: WiresLike):  # pylint: disable=arguments-differ
         return np.fft.ifft(np.eye(2 ** len(wires)), norm="ortho")
 
 
@@ -145,7 +145,7 @@ def _qft_decomposition_resources(wires: AbstractWires):
 
 
 @register_resources(_qft_decomposition_resources)
-def _qft_decomposition(wires: AbstractWires):
+def _qft_decomposition(wires: WiresLike):
     num_wires = len(wires)
     shifts = [2 * np.pi * 2**-i for i in range(2, num_wires + 1)]
     if compiler.active() or enabled():

--- a/pennylane/templates/subroutines/qpe.py
+++ b/pennylane/templates/subroutines/qpe.py
@@ -23,12 +23,13 @@ from pennylane.core.operator import Operation, Operator, abstractify
 from pennylane.core.queuing import QueuingManager
 from pennylane.decomposition import (
     add_decomps,
-    adjoint_resource_rep,
     controlled_resource_rep,
     register_resources,
 )
 from pennylane.exceptions import QuantumFunctionError
 from pennylane.ops import pow as qp_pow
+from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
+from pennylane.typing import Wire
 from pennylane.wires import Wires
 
 from .qft import QFT
@@ -273,7 +274,7 @@ class QuantumPhaseEstimation(Operation):
 def _qpe_decomp_resource(base_resource_rep, num_estimation_wires):
     gate_count = {
         ops.Hadamard: num_estimation_wires,
-        adjoint_resource_rep(QFT, {"num_wires": num_estimation_wires}): 1,
+        _adjoint_abstract(QFT(Wire[num_estimation_wires])): 1,
     }
     for i in range(num_estimation_wires):
         gate_count[

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -26,6 +26,7 @@ import pytest
 
 import pennylane as qp
 from pennylane import math
+from pennylane.core.operator import Operator2
 from tests.capture.capture_utils import assert_eqn_matches_op
 
 jax = pytest.importorskip("jax")
@@ -1823,7 +1824,6 @@ unsupported_templates = [
 modified_templates = [
     t for t in all_templates if t not in unmodified_templates + unsupported_templates
 ]
-migrated_templates = [qp.BasisRotation, qp.QFT]
 
 
 @pytest.mark.parametrize("template", modified_templates)
@@ -1831,7 +1831,7 @@ def test_templates_are_modified(template):
     """Test that all templates that are not listed as unmodified in the test cases above
     actually have their _primitive_bind_call modified."""
     # Make sure the template actually is modified in its primitive binding function
-    if template == qp.templates.SubroutineOp or template in migrated_templates:
+    if template == qp.templates.SubroutineOp or issubclass(template, Operator2):
         return
     assert template._primitive_bind_call.__code__ != original_op_bind_code
 

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -185,8 +185,6 @@ unmodified_templates_cases = [
     (qp.AQFT, (1, [0, 1, 2]), {}),
     (qp.AQFT, (2,), {"wires": [0, 1, 2, 3]}),
     (qp.AQFT, (), {"order": 2, "wires": [0, 2, 3, 1]}),
-    (qp.QFT, ([0, 1],), {}),
-    (qp.QFT, (), {"wires": [0, 1]}),
     (qp.ArbitraryUnitary, (jnp.ones(15), [2, 3]), {}),
     (qp.ArbitraryUnitary, (jnp.zeros(15),), {"wires": [3, 2]}),
     pytest.param(
@@ -339,6 +337,7 @@ tested_modified_templates = [
     qp.QROMStatePreparation,
     qp.MultiplexerStatePreparation,
     qp.SelectPauliRot,
+    qp.QFT,
 ]
 
 
@@ -1778,6 +1777,28 @@ class TestModifiedTemplates:
         assert len(q) == 1
         qp.assert_equal(q.queue[0], qp.Superposition(**kwargs))
 
+    def test_qft(self):
+        """Test the primitive bind call of QFT."""
+
+        wires = [0, 5]
+
+        def qfunc(wires):
+            qp.QFT(wires)
+
+        # Validate inputs
+        qfunc(wires)
+
+        # Actually test primitive bind
+        jaxpr = jax.make_jaxpr(qfunc)(wires)
+
+        assert len(jaxpr.eqns) == 1
+
+        eqn = jaxpr.eqns[0]
+        assert_eqn_matches_op(eqn, qp.QFT)
+        assert eqn.invars == jaxpr.jaxpr.invars
+        assert len(eqn.outvars) == 1
+        assert isinstance(eqn.outvars[0], jax.core.DropVar)
+
 
 def filter_fn(member: Any) -> bool:
     """Determine whether a member of a module is a class and genuinely belongs to
@@ -1802,7 +1823,7 @@ unsupported_templates = [
 modified_templates = [
     t for t in all_templates if t not in unmodified_templates + unsupported_templates
 ]
-migrated_templates = [qp.BasisRotation]
+migrated_templates = [qp.BasisRotation, qp.QFT]
 
 
 @pytest.mark.parametrize("template", modified_templates)

--- a/tests/ops/op_math/test_decompositions.py
+++ b/tests/ops/op_math/test_decompositions.py
@@ -1470,7 +1470,7 @@ class TestTwoQubitDecompositionWarnings:
     "U, n_wires",
     [
         (qp.matrix(qp.CRX(0.123, [0, 2]) @ qp.CRY(0.456, [1, 3])), 4),
-        (qp.QFT.compute_matrix(5), 5),
+        (qp.QFT.compute_matrix(tuple(range(5))), 5),
         (qp.GroverOperator.compute_matrix(6, []), 6),
     ],
 )
@@ -1622,10 +1622,10 @@ class TestQubitUnitaryDecompositionGraph:
     @pytest.mark.parametrize(
         "U, n_wires",
         [
-            (qp.QFT.compute_matrix(2), 2),
+            (qp.QFT.compute_matrix(tuple(range(2))), 2),
             (qp.matrix(qp.CRX(0.123, [0, 2]) @ qp.CRY(0.456, [2, 0])), 2),
             (qp.matrix(qp.CRX(0.123, [0, 2]) @ qp.CRY(0.456, [1, 3])), 4),
-            (qp.QFT.compute_matrix(5), 5),
+            (qp.QFT.compute_matrix(tuple(range(5))), 5),
             (qp.GroverOperator.compute_matrix(6, []), 6),
         ],
     )

--- a/tests/ops/op_math/test_sprod.py
+++ b/tests/ops/op_math/test_sprod.py
@@ -449,7 +449,7 @@ class TestMatrix:
         assert np.allclose(mat, true_mat)
 
     templates_and_mats = (
-        (qp.QFT(wires=[0, 1, 2]), qp.QFT(wires=[0, 1, 2]).compute_matrix(3)),
+        (qp.QFT(wires=[0, 1, 2]), qp.QFT.compute_matrix(tuple(range(3)))),
         (
             qp.GroverOperator(wires=[0, 1, 2]),
             qp.GroverOperator(wires=[0, 1, 2]).compute_matrix(3, range(3)),

--- a/tests/templates/state_preparations/test_cosine_window.py
+++ b/tests/templates/state_preparations/test_cosine_window.py
@@ -23,7 +23,6 @@ import pytest
 import pennylane as qp
 from pennylane.exceptions import WireError
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
-from pennylane.transforms.decompose import DecomposeInterpreter
 
 
 @pytest.mark.jax
@@ -69,33 +68,6 @@ class TestDecomposition:
 
         for rule in qp.list_decomps(qp.CosineWindow):
             _test_decomposition_rule(op, rule)
-
-    @pytest.mark.integration
-    @pytest.mark.capture
-    @pytest.mark.usefixtures("enable_graph_decomposition")
-    def test_integration_decompose_interpreter(self):
-        """Tests that a simple circuit is correctly decomposed into different gate sets."""
-        import jax
-        from jax import numpy as jnp
-
-        from pennylane.tape.plxpr_conversion import CollectOpsandMeas
-
-        def f():
-            qp.CosineWindow(wires=[0, 1])
-
-        decomposed_f = DecomposeInterpreter(
-            gate_set={"Hadamard", "RZ", "PhaseShift", "ControlledPhaseShift", "SWAP"}
-        )(f)
-        jaxpr = jax.make_jaxpr(decomposed_f)()
-        collector = CollectOpsandMeas()
-        collector.eval(jaxpr.jaxpr, jaxpr.consts)
-        assert collector.state["ops"] == [
-            qp.Hadamard(1),
-            qp.RZ(3.141592653589793, wires=[1]),
-            qp.adjoint(qp.QFT(wires=[0, 1])),
-            qp.PhaseShift(jnp.array(-2.89760778e19), wires=[0]),
-            qp.PhaseShift(jnp.array(1.44880389e19), wires=[1]),
-        ]
 
     def test_correct_gates_single_wire(self):
         """Test that the correct gates are applied."""

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -424,12 +424,13 @@ class TestOutMultiplier:
         assert wires == qp.wires.Wires([1, 2, 3, 4, 5, 6])
 
     @pytest.mark.catalyst
+    @pytest.mark.usefixtures("enable_graph_decomposition")
     def test_qjit_compatible(self):
         """Test that the template is compatible with the QJIT compiler."""
         x, y = 2, 3
         x_list = [1, 0]
         y_list = [1, 1]
-        mod = 12
+        mod = 16
         x_wires = [0, 1]
         y_wires = [2, 3]
         output_wires = [6, 7, 8, 9]

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -425,12 +425,23 @@ class TestOutMultiplier:
 
     @pytest.mark.catalyst
     @pytest.mark.usefixtures("enable_graph_decomposition")
-    def test_qjit_compatible(self):
+    @pytest.mark.parametrize(
+        "mod",
+        [
+            16,
+            pytest.param(
+                12,
+                marks=pytest.mark.pl2do(
+                    reason="There are some downstream incompatibilities of the operators used in the QFT-based decomposition (which is chosen for mod!=2**len(output_wires))."
+                ),
+            ),
+        ],
+    )
+    def test_qjit_compatible(self, mod):
         """Test that the template is compatible with the QJIT compiler."""
         x, y = 2, 3
         x_list = [1, 0]
         y_list = [1, 1]
-        mod = 12
         x_wires = [0, 1]
         y_wires = [2, 3]
         output_wires = [6, 7, 8, 9]

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -430,7 +430,7 @@ class TestOutMultiplier:
         x, y = 2, 3
         x_list = [1, 0]
         y_list = [1, 1]
-        mod = 16
+        mod = 12
         x_wires = [0, 1]
         y_wires = [2, 3]
         output_wires = [6, 7, 8, 9]

--- a/tests/templates/subroutines/test_qft.py
+++ b/tests/templates/subroutines/test_qft.py
@@ -42,24 +42,6 @@ class TestQFT:
         assert np.allclose(res, exp)
 
     @pytest.mark.parametrize("n_qubits", range(2, 6))
-    def test_QFT_compute_decomposition(self, n_qubits):
-        """Test if the QFT operation is correctly decomposed"""
-        decomp = qp.QFT.compute_decomposition(wires=range(n_qubits))
-
-        dev = qp.device("default.qubit", wires=n_qubits)
-
-        out_states = []
-        for state in np.eye(2**n_qubits):
-            ops = [qp.StatePrep(state, wires=range(n_qubits))] + decomp
-            qs = qp.tape.QuantumScript(ops, [qp.state()])
-            out_states.append(dev.execute(qs))
-
-        reconstructed_unitary = np.array(out_states).T
-        expected_unitary = qp.QFT(wires=range(n_qubits)).matrix()
-
-        assert np.allclose(reconstructed_unitary, expected_unitary)
-
-    @pytest.mark.parametrize("n_qubits", range(2, 6))
     def test_QFT_decomposition(self, n_qubits):
         """Test if the QFT operation is correctly decomposed"""
         op = qp.QFT(wires=range(n_qubits))
@@ -99,7 +81,7 @@ class TestQFT:
     def test_matrix(self, tol):
         """Test that the matrix representation is correct."""
 
-        res_static = qp.QFT.compute_matrix(2)
+        res_static = qp.QFT.compute_matrix(tuple(range(2)))
         res_dynamic = qp.QFT(wires=[0, 1]).matrix()
         res_reordered = qp.QFT(wires=[0, 1]).matrix([1, 0])
 


### PR DESCRIPTION
**Context:**
We migrate operators to `Operator2`.

**Description of the Change:**
here we port `QFT`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-126145]