### PR TITLE
Bind operator2 primitives' dynamic args in the same order as the signature

### DIFF
--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1301,7 +1301,7 @@ class Operator2(metaclass=OperatorMeta):
         if not enabled():
             return
 
-        pos_args = [self.arguments[d] for d in self.dynamic_argnames]
+        pos_args = [self.arguments[d] for d in self._sig.parameters.keys()]
 
         wire_lens = []
         for name, value in self.wire_args.items():


### PR DESCRIPTION
**Context:**
Right now, when binding an operator 2 primitive, the dynamic args are bind-ed as jaxpr operands in the order of the `dynamic_argnames` field registered on the class, instead of the order they appear in the signature (of `__init__`). 

This goes against the philosophy of operator 2, where all relevant function-like interfaces share the same signature: that of the `__init__`. 

**Description of the Change:**
Primitive operand goes in `__init__`'s order.

**Benefits:**
Consistency; unblocks callback decomp from mlir (since custom ops only have dynamic args as a ordered list of operands, and it doesn't have the variable names).
