### PR TITLE
Always use  signature order as argname order in Operator2

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -917,6 +917,7 @@
   [(#9860)](https://github.com/PennyLaneAI/pennylane/pull/9860)
   [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
   [(#9920)](https://github.com/PennyLaneAI/pennylane/pull/9920)
+  [(#9937)](https://github.com/PennyLaneAI/pennylane/pull/9937)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -69,6 +69,15 @@ class GradMethod(StrEnum):
     FINITE_DIFF = "F"
 
 
+ARGNAME_CATEGORIES = (
+    "wire_argnames",
+    "dynamic_argnames",
+    "static_argnames",
+    "compilable_argnames",
+    "hybrid_argnames",
+)
+
+
 class Operator2(metaclass=OperatorMeta):
     r"""Base class representing quantum operators.
     TODO: [sc-120453] Fill docstring
@@ -1370,13 +1379,7 @@ class Operator2(metaclass=OperatorMeta):
             return
 
         # Argnames setup
-        for attr in (
-            "dynamic_argnames",
-            "wire_argnames",
-            "static_argnames",
-            "hybrid_argnames",
-            "compilable_argnames",
-        ):
+        for attr in ARGNAME_CATEGORIES:
             if isinstance(v := getattr(cls, attr), str):
                 setattr(cls, attr, (v,))
 
@@ -1385,6 +1388,11 @@ class Operator2(metaclass=OperatorMeta):
         _init_subclass_wire_sizes_setup(cls)
         _init_subclass_add_dynamic_properties(cls)
         register_pytree(cls, cls._flatten, cls._unflatten)
+
+        for attr in ARGNAME_CATEGORIES:
+            # enforce sorting by signature
+            sorted_names = tuple(a for a in cls._sig.parameters if a in getattr(cls, attr))
+            setattr(cls, attr, sorted_names)
 
 
 # ---------------------------------------------------------------------------------

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -76,6 +76,7 @@ class TestInitSubclass:
             static_argnames = ("s2", "s1")
             hybrid_argnames = ("h2", "h1")
 
+            # pylint: disable=useless-parent-delegation, too-many-arguments
             def __init__(self, a, reg1, s1, h1, b, reg2, s2, h2):
                 super().__init__(a, reg1, s1, h1, b, reg2, s2, h2)
 
@@ -88,6 +89,7 @@ class TestInitSubclass:
 
             compilable_argnames = ("c3", "c2", "c1")
 
+            # pylint: disable=useless-parent-delegation
             def __init__(self, c1, wires, c2, c3):
                 super().__init__(c1, wires, c2, c3)
 

--- a/tests/core/operator/test_operator2.py
+++ b/tests/core/operator/test_operator2.py
@@ -66,6 +66,33 @@ class TestInitSubclass:
         assert Op.wire_argnames == ("wires",)
         assert Op.compilable_argnames == ()
 
+    def test_sorting_argnames_order(self):
+        """Test that argnames are automatically sorted to be in signature order."""
+
+        class DummyOp(qp.core.Operator2):
+
+            wire_argnames = ("reg2", "reg1")
+            dynamic_argnames = ("b", "a")
+            static_argnames = ("s2", "s1")
+            hybrid_argnames = ("h2", "h1")
+
+            def __init__(self, a, reg1, s1, h1, b, reg2, s2, h2):
+                super().__init__(a, reg1, s1, h1, b, reg2, s2, h2)
+
+        assert DummyOp.wire_argnames == ("reg1", "reg2")
+        assert DummyOp.dynamic_argnames == ("a", "b")
+        assert DummyOp.static_argnames == ("s1", "s2")
+        assert DummyOp.hybrid_argnames == ("h1", "h2")
+
+        class DummyOp2(qp.core.Operator2):
+
+            compilable_argnames = ("c3", "c2", "c1")
+
+            def __init__(self, c1, wires, c2, c3):
+                super().__init__(c1, wires, c2, c3)
+
+        assert DummyOp2.compilable_argnames == ("c1", "c2", "c3")
+
     @pytest.mark.parametrize(
         "other_argnames",
         [
@@ -533,7 +560,7 @@ class TestOperatorInit:
         inner = [DynOp(0.1, wires=7), DynOp(0.2, wires=8)]
         op = Composite(inner, [0, [1, 2], [3, 4]], [5, 6])
         # Wires are ordered using wire_argnames, so `wires` come before `pytree_wires`
-        assert op.wires == Wires([5, 6, 0, 1, 2, 3, 4, 7, 8])
+        assert op.wires == Wires([0, 1, 2, 3, 4, 5, 6, 7, 8])
 
     def test_non_hybrid_wire_arg_auto_wrapped_in_constructor(self):
         """Test that non-hybrid wire arguments are wrapped in ``Wires`` by the
@@ -842,7 +869,7 @@ class TestProperties:
                 super().__init__(Wires(wires), Wires(wires1))
 
         op = Op([0, 1], [2, 3, 4])
-        assert op.wires == Wires([2, 3, 4, 0, 1])
+        assert op.wires == Wires([0, 1, 2, 3, 4])
 
 
 class TestBroadcasting:


### PR DESCRIPTION

**Context:**

**Description of the Change:**

Sorts the *_argnames to always match the signature order. This way we don't have to worry about mismatches between the two orders.

**Benefits:**

Unblocks catalyst work that was getting tripped up by the possibility of different orders.

**Possible Drawbacks:**

**Related GitHub Issues:**

Replaces #9934 
