### PR TITLE
Raise error for invalid basis_set entries in qml.compile

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -268,6 +268,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* `qml.compile`'s `basis_set` argument now accepts Operator subclasses (e.g. ``qml.RX``) in addition to
+  string gate names, and raises a clear ``ValueError`` for invalid entries.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Sorts the gate counts in the display of resources produced from decompositions.
   [(#9916)](https://github.com/PennyLaneAI/pennylane/pull/9916)
 
@@ -1211,3 +1215,4 @@ Dennis Wayo,
 David Wierichs,
 Jake Zaia,
 Zinan Zhou.
+Rohit David Paul

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -195,7 +195,7 @@ def compile(
     with QueuingManager.stop_recording():
         if basis_set is None:
             basis_set = gate_sets.ALL_OPS
-        
+
         for op in basis_set:
             if isinstance(op, str):
                 pass  # or just don't write anything, valid case
@@ -207,7 +207,7 @@ def compile(
                                      f"got class {(op.__name__)} which is not an Operator subclass")
             else:
                 raise ValueError(f"Elements of basis_set must be strings or Operator subclasses, {type(op).__name__} was neither")
-            
+
 
         def stop_at(obj):
             if not isinstance(obj, qp.operation.Operator):

--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -43,9 +43,9 @@ def compile(
 
     .. note::
 
-        While ``qp.compile`` is useful for initial exploration by appliying a default set of
-        transforms, the new :class:`~.CompilePipeline` class is the recommended tool for
-        constructing large & modular compilation pipelines in a natural way.
+            While ``qp.compile`` is useful for initial exploration by appliying a default set of
+            transforms, the new :class:`~.CompilePipeline` class is the recommended tool for
+            constructing large & modular compilation pipelines in a natural way.
 
     The default set of transforms includes (in order):
 
@@ -64,7 +64,8 @@ def compile(
             :func:`~.transforms.commute_controlled`,
             :func:`~.cancel_inverses`, and
             :func:`~.transforms.merge_rotations`.
-        basis_set (list[str]): A list of basis gates. When expanding the tape,
+        basis_set (list[str | type[Operator]): A list of basis gates, accepted as strings
+            as well as valid operator classes/subclasses. When expanding the tape,
             expansion will continue until gates in the specific set are
             reached. If no basis set is specified, a default of
             ``pennylane.ops.__all__`` will be used. This decomposes templates and
@@ -194,6 +195,19 @@ def compile(
     with QueuingManager.stop_recording():
         if basis_set is None:
             basis_set = gate_sets.ALL_OPS
+        
+        for op in basis_set:
+            if isinstance(op, str):
+                pass  # or just don't write anything, valid case
+            elif isinstance(op, type):
+                if issubclass(op, qp.operation.Operator):
+                    pass
+                else:
+                    raise ValueError(f"Elements of basis_set must be strings or Operator subclasses, "
+                                     f"got class {(op.__name__)} which is not an Operator subclass")
+            else:
+                raise ValueError(f"Elements of basis_set must be strings or Operator subclasses, {type(op).__name__} was neither")
+            
 
         def stop_at(obj):
             if not isinstance(obj, qp.operation.Operator):

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -220,6 +220,18 @@ class TestCompileIntegration:
         [transformed_tape], _ = qp.compile(tape, basis_set=[])
         assert not any(op.name in decomposable_ops for op in transformed_tape.operations)
 
+    def test_compile_basis_set_invalid_type_raises_error(self):
+        """Test that basis_set with a non-string, non-class value raises ValueError."""
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)])
+        with pytest.raises(ValueError, match="Elements of basis_set"):
+            qp.compile(tape, basis_set=[42])
+
+    def test_compile_basis_set_class_not_operator_raises_error(self):
+        """Test that a class which is not an Operator subclass raises ValueError."""
+        tape = qp.tape.QuantumScript([qp.Hadamard(0)])
+        with pytest.raises(ValueError, match="not an Operator subclass"):
+            qp.compile(tape, basis_set=[int])
+
     @pytest.mark.parametrize(("wires"), [["a", "b", "c"], [0, 1, 2], [3, 1, 2], [0, "a", 4]])
     def test_compile_pipeline_with_non_default_arguments(self, wires):
         """Test that using non-default arguments returns the correct results."""


### PR DESCRIPTION
**Context:**
`qml.compile`'s `basis_set` parameter expects a sequence of operation names (strings). If a user accidentally passed actual Operator classes instead, no error was raised. The basis set was silently treated as empty.

**Description of the Change:**
`basis_set` now accepts both strings (e.g. `"RX"`) and Operator subclasses (e.g. `qml.RX`).
Raises a clear `ValueError` if an entry is neither.

**Benefits:**
Prevents silent, unintended circuit decomposition when a user makes this common type mistake.

**Possible Drawbacks:**
None identified.

**Related GitHub Issues:**
Fixes #6132