### PR TITLE
Control values of `Controlled2` are traceable.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -975,6 +975,7 @@
     [(#9856)](https://github.com/PennyLaneAI/pennylane/pull/9856)
     [(#9876)](https://github.com/PennyLaneAI/pennylane/pull/9876)
     [(#9871)](https://github.com/PennyLaneAI/pennylane/pull/9871)
+    [(#9966)](https://github.com/PennyLaneAI/pennylane/pull/9966)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)

--- a/pennylane/drawer/utils.py
+++ b/pennylane/drawer/utils.py
@@ -241,7 +241,7 @@ def unwrap_controls(op):
         return control_wires, control_values, op
 
     control_wires = op.control_wires
-    control_values = op.control_values
+    control_values = list(op.control_values)
     base = op.base
 
     base_ctrl_wires, base_ctrl_values, base_base = unwrap_controls(base)

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -256,7 +256,8 @@ def _resolve_ctrl_values(control_values, base_ctrl_values, num_control: int):
     if isinstance(base_ctrl_values, AbstractArray):
         return Bool[len(control_values) + len(base_ctrl_values)]
 
-    return math.concatenate([control_values, base_ctrl_values])
+    control_values = math.array(control_values)
+    return math.array(math.concatenate([control_values, base_ctrl_values]), dtype=bool)
 
 
 def _is_empty_or_all_true(control_values):
@@ -301,7 +302,8 @@ def custom_ctrl_dispatch(base, control, control_values, work_wires, work_wire_ty
 def create_controlled_op(op, control, control_values, work_wires, work_wire_type):
     """Default ``qp.ctrl`` implementation, allowing other implementations to call it when needed."""
 
-    control = Wires(control)
+    if not isinstance(control, AbstractWires):
+        control = Wires(control)
     if isinstance(control_values, (int, bool)):
         control_values = [bool(control_values)]
     elif isinstance(control_values, tuple):

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -160,7 +160,10 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
         if len(control_values) != len(control_wires):
             raise ValueError("control_values should be the same length as control_wires")
 
-        control_values = [bool(v) for v in control_values]
+        if isinstance(control_values, (list, tuple)):
+            control_values = qp.math.asarray(control_values, like=control_values[0])
+
+        control_values = qp.math.cast(control_values, dtype=bool)
 
         self._base = base
         self._control_wires = control_wires
@@ -198,12 +201,8 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
             control_wires = abstractify(Wires(control_wires))
 
         # abstractify control values
-        if control_values is None:
+        if not isinstance(control_values, AbstractArray):
             control_values = Bool[len(control_wires)]
-        elif isinstance(control_values, (int, bool)):
-            control_values = Bool[1]
-        elif isinstance(control_values, (list, tuple, Wires)):
-            control_values = Bool[len(control_values)]
 
         # abstractify the base
         base = abstractify(base)
@@ -442,10 +441,11 @@ class Controlled2(SymbolicOp2, is_baseclass=True):  # pylint: disable=too-many-p
             if isinstance(simplified_base, qp.Identity):
                 return simplified_base
 
+            ctrl_values = qp.math.concatenate([self.control_values, self.base.control_values])
             return qp.ctrl(
                 simplified_base,
                 control=self.control_wires + self.base.control_wires,
-                control_values=self.control_values + self.base.control_values,
+                control_values=math.cast(ctrl_values, bool),
                 work_wires=self.work_wires + self.base.work_wires,
                 work_wire_type=resolve_work_wire_type(
                     self.base.work_wires,
@@ -538,8 +538,11 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
         params = [f"control_wires={self.control_wires}"]
         if self.work_wires:
             params.append(f"work_wires={self.work_wires}")
-        if self.control_values and not all(self.control_values):
-            params.append(f"control_values={self.control_values}")
+        ctrl_values = self.control_values
+        if isinstance(ctrl_values, AbstractArray) or math.is_abstract(ctrl_values):
+            params.append(f"control_values={ctrl_values}")
+        elif not all(ctrl_values):
+            params.append(f"control_values={ctrl_values.tolist()}")
         return f"Controlled({self.base}, {', '.join(params)})"
 
     @property
@@ -569,13 +572,13 @@ class ControlledOp2(Controlled2):  # pylint: disable=too-few-public-methods
         # `eqns` contains `TracingEqns`, not `JaxprEqns`, so invars during tracing will just
         # be tracers, not `Var`s wrapping abstract values.
         if n_ctrls == 0:
-            invars = eqns[0].invars + self.control_wires.tolist() + self.control_values
+            invars = eqns[0].invars + self.control_wires.tolist() + list(self.control_values)
         else:
             # invars are ordered as (*other_args, *control_wires, *control_values), so we
             # need to insert the new control wires before the old ones, and do the same
             # for control values too.
             control_wires = self.control_wires.tolist() + eqns[0].invars[-2 * n_ctrls : -n_ctrls]
-            control_values = self.control_values + eqns[0].invars[-n_ctrls:]
+            control_values = list(self.control_values) + eqns[0].invars[-n_ctrls:]
             invars = eqns[0].invars[: -2 * n_ctrls] + control_wires + control_values
 
         params["n_ctrls"] += len(self.control_wires)
@@ -760,6 +763,10 @@ def flip_zero_control(rule: DecompositionRule, name: str = "") -> DecompositionR
         # ops like MultiControlledX and ControlledQubitUnitary
         wires = arguments.get("control_wires", arguments.get("wires", None))
         assert wires is not None
+
+        if qp.compiler.active() and not qp.capture.enabled():
+            control_values = math.array(control_values, like="jax")
+            wires = math.array(wires, like="jax")
 
         @qp.for_loop(0, len(control_values))
         def _x_flips(i):

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -358,8 +358,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     4: ───────├●─│──────────────├●────┤
     5: ───────├●─│──────────────├●────┤
          |0>├─╰X─╰●─────────────╰X──┤
-    Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
-    Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+    Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
+    Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
     Wire Allocations: {'zero': 1}
     Full Expansion Gates: {CNOT: 34, GlobalPhase: 68, MidMeasure: 2, RX: 12, RY: 18, RZ: 58}
     Weighted Cost: 124.0
@@ -371,7 +371,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     4: ─├●─├●────────├●─┤
     5: ─╰●─╰●────────╰●─┤
     Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
-    Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+    Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
     Full Expansion Gates: {CNOT: 72, GlobalPhase: 82, MidMeasure: 4, RX: 22, RY: 24, RZ: 80}
     Weighted Cost: 202.0
 
@@ -480,9 +480,9 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         4: ───────├●─│──────────────├●────┤
         5: ───────├●─│──────────────├●────┤
         6: ───────├●─│──────────────├●────┤
-            |0>├─╰X─╰●─────────────╰X──┤
-        Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 4}
-        Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+             |0>├─╰X─╰●─────────────╰X──┤
+        Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 4}
+        Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
         Wire Allocations: {'zero': 1}
         Full Expansion Gates: {CNOT: 60, GlobalPhase: 107, MidMeasure: 2, RX: 17, RY: 22, RZ: 96}
         Weighted Cost: 197.0
@@ -495,7 +495,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         5: ─├●─├●────────├●─┤
         6: ─╰●─╰●────────╰●─┤
         Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 4}
-        Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+        Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
         Full Expansion Gates: {CNOT: 102, GlobalPhase: 202, MidMeasure: 6, RX: 40, RY: 42, RZ: 176}
         Weighted Cost: 366.0
 

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -372,7 +372,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     3: ─├●─├●────────├●─┤
     4: ─├●─├●────────├●─┤
     5: ─╰●─╰●────────╰●─┤
-    First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+    First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
     Full Expansion Gates: {CNOT: 76, GlobalPhase: 75, MidMeasure: 4, RX: 19, RY: 16, RZ: 84}
     Weighted Cost: 199.0
 
@@ -502,7 +502,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         4: ─├●─├●────────├●─┤
         5: ─├●─├●────────├●─┤
         6: ─╰●─╰●────────╰●─┤
-        First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4)): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+        First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=5, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
         Full Expansion Gates: {CNOT: 102, GlobalPhase: 198, MidMeasure: 6, RX: 36, RY: 42, RZ: 176}
         Weighted Cost: 362.0
 

--- a/tests/decomposition/test_symbolic_decomposition.py
+++ b/tests/decomposition/test_symbolic_decomposition.py
@@ -1124,6 +1124,30 @@ class TestControlledDecomposition:
             qp.X(3),
         ]
 
+    @pytest.mark.catalyst
+    def test_flip_zero_control_qjit(self):
+        """Tests flip_zero_control with qjit."""
+
+        @qp.register_resources({qp.CNOT: 3, qp.H: 2})
+        def _custom_controlled_rule(base, control_wires, **_):
+            qp.CNOT(control_wires[:2])
+            qp.H(control_wires[2])
+            qp.CNOT([control_wires[-1], base.wires[0]])
+            qp.H(control_wires[2])
+            qp.CNOT(control_wires[:2])
+
+        custom_rule = flip_zero_control2(_custom_controlled_rule, "custom_rule")
+        op = NonParametricOp(wires=[0])
+
+        @qp.qjit
+        @qp.qnode(qp.device("null.qubit", wires=4))
+        def circuit(cvals):
+            custom_rule(base=op, control_wires=[1, 2, 3], control_values=cvals)
+            return qp.probs()
+
+        specs = qp.specs(circuit, level="device")([1, 1, 0])
+        assert specs.resources.quantum_operations == {"CNOT": 3, "Hadamard": 2, "PauliX": 2}
+
     @pytest.mark.unit
     def test_controlled_decomp_with_work_wire(self):
         """Tests the controlled decomposition with a single work wire (Lemma 7.11 from https://arxiv.org/pdf/quant-ph/9503016)."""

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -558,6 +558,29 @@ class TestControlledOp2:
         op = ControlledOp2(DynOp(0.5, 0), control_wires=1)
         assert op == copy_fn(op)
 
+    @pytest.mark.capture
+    def test_control_values_traced(self):
+        """Tests that control values can be traced."""
+
+        import jax  # pylint: disable=import-outside-toplevel
+
+        def circ(cvals):
+            qp.ctrl(qp.H(0), control=[1, 2], control_values=cvals)
+            qp.ctrl(qp.CH([0, 1]), control=[2, 3], control_values=cvals)
+            op = qp.ctrl(qp.H(0), control=[1, 2], control_values=cvals)
+            qp.ctrl(op, control=[3, 4], control_values=[0, 1])
+            op2 = qp.ctrl(qp.H(0), control=[1, 2], control_values=[1, 0])
+            qp.ctrl(op2, control=[3, 4], control_values=cvals)
+
+        jaxpr = jax.make_jaxpr(circ)(jax.numpy.array([True, False]))
+        tape = qp.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, jax.numpy.array([False, True]))
+        assert tape.operations == [
+            qp.ctrl(qp.H(0), control=[1, 2], control_values=[0, 1]),
+            qp.ctrl(qp.H(1), control=[2, 3, 0], control_values=[0, 1, 1]),
+            qp.ctrl(qp.H(0), control=[3, 4, 1, 2], control_values=[0, 1, 0, 1]),
+            qp.ctrl(qp.H(0), control=[3, 4, 1, 2], control_values=[0, 1, 1, 0]),
+        ]
+
     def test_old_decomp_integration(self):
         """Tests that ControlledOp2 is compatible with the old decomposition convention."""
 

--- a/tests/ops/op_math/test_controlled2.py
+++ b/tests/ops/op_math/test_controlled2.py
@@ -382,7 +382,7 @@ class TestControlledOp2:
         assert op.base == base
         assert op.wires == Wires([1, 2, 0])
         assert op.control_wires == Wires([1, 2])
-        assert op.control_values == [False, True]
+        assert op.control_values.tolist() == [False, True]
         assert op.target_wires == Wires([0])
         assert op.work_wires == Wires([3])
         assert op.work_wire_type == "zeroed"
@@ -431,7 +431,7 @@ class TestControlledOp2:
 
         base = qp.H(0)
         op = ControlledOp2(base, control_wires=[1, 2])
-        assert op.control_values == [True, True]
+        assert op.control_values.tolist() == [True, True]
         assert op.work_wires == Wires([])
 
     def test_single_control_value(self):
@@ -439,7 +439,7 @@ class TestControlledOp2:
 
         base = qp.H(0)
         op = ControlledOp2(base, control_wires=[1], control_values=0)
-        assert op.control_values == [False]
+        assert op.control_values.tolist() == [False]
 
     def test_comparison(self):
         """Tests comparing the equality of controlled operators."""

--- a/tests/ops/op_math/test_symbolic_op2_capture.py
+++ b/tests/ops/op_math/test_symbolic_op2_capture.py
@@ -206,8 +206,9 @@ class TestControlledCapture:
         assert eqn.params["n_ctrls"] == 2
         assert eqn.invars[-4].val == 0
         assert eqn.invars[-3].val == 1
-        assert eqn.invars[-2].val is True
-        assert eqn.invars[-1].val is False
+        # pylint: disable=singleton-comparison
+        assert eqn.invars[-2].val == True
+        assert eqn.invars[-1].val == False
 
         [op] = jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, 0.7)
         expected = ControlledOp2(RX2(0.7, 2), [0, 1], [True, False])

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -118,7 +118,7 @@ class TestInspectDecompGraph:
             4: ─├●─├●────────├●─┤  
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
-            Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+            Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
             Full Expansion Gates: {CNOT: 160, GlobalPhase: 94, RX: 18, RY: 24, RZ: 136}
             Weighted Cost: 338.0
             """).strip()
@@ -179,8 +179,8 @@ class TestInspectDecompGraph:
             4: ───────├●─│──────────────├●────┤  
             5: ───────├●─│──────────────├●────┤  
                  |0>├─╰X─╰●─────────────╰X──┤    
-            Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
-            Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+            Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
+            Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
             Wire Allocations: {'zero': 1}
             Full Expansion Gates: {CNOT: 34, GlobalPhase: 68, MidMeasure: 2, RX: 12, RY: 18, RZ: 58}
             Weighted Cost: 124.0
@@ -192,7 +192,7 @@ class TestInspectDecompGraph:
             4: ─├●─├●────────├●─┤  
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2, PauliX: 3}
-            Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
+            Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(num_control_wires=4, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed): 2}
             Full Expansion Gates: {CNOT: 72, GlobalPhase: 82, MidMeasure: 4, RX: 22, RY: 24, RZ: 80}
             Weighted Cost: 202.0
             """).strip()
@@ -212,7 +212,7 @@ class TestInspectDecompGraph:
 
             | First-Level Expansion | Estimated | Actual |
             | :--- | :--- | :--- |
-            | Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1)) | 1 | 1 |
+            | Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool, weak_type=True)) | 1 | 1 |
             | MultiControlledX(num_control_wires=3, num_work_wires=0, num_zero_control_values=0, work_wire_type=borrowed) | 2 | 2 |
             | PauliX | 3 | 0 |
 


### PR DESCRIPTION
**Context:**
Fix errors when control values are traced.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-126812]