### PR TITLE
Update `_test_decomposition_rule` to work with COB in capture

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1000,6 +1000,7 @@
     [(#9843)](https://github.com/PennyLaneAI/pennylane/pull/9843)
     [(#9866)](https://github.com/PennyLaneAI/pennylane/pull/9866)
     [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
+    [(#9973)](https://github.com/PennyLaneAI/pennylane/pull/9973)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -309,8 +309,10 @@ def _unroll_change_op_basis(gate_counts):
     for k, count in gate_counts.items():
         if not isinstance(k, CompressedResourceOp):
             new_gate_counts[k] += count
+            continue
         if k.op_type is not qp.ops.ChangeOpBasis:
             new_gate_counts[k] += count
+            continue
         for p in ("compute_op", "target_op", "uncompute_op"):
             op_rep = k.params[p]
             if isinstance(op_rep, CompressedResourceOp) and op_rep.op_type is qp.ops.Prod:

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -31,6 +31,7 @@ from pennylane import math
 from pennylane.core.operator import Operator, Operator1, Operator2, abstractify
 from pennylane.decomposition import DecompositionRule
 from pennylane.decomposition.decomposition_rule import _decomp_contains_mcm
+from pennylane.decomposition.resources import CompressedResourceOp
 from pennylane.decomposition.utils import _get_decomp_args
 from pennylane.exceptions import EigvalsUndefinedError
 from pennylane.pytrees import flatten
@@ -226,7 +227,7 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
 
     # Test that the resource function is correct
     resources = rule.compute_resources(**params)
-    gate_counts = resources.gate_counts
+    estimated_gate_counts = resources.gate_counts
 
     if qp.capture.enabled():
         import jax  # pylint: disable=import-outside-toplevel
@@ -265,19 +266,25 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         actual_gate_counts[op_rep] += 1
     actual_gate_counts = dict(sorted(actual_gate_counts.items(), key=lambda item: str(item[0])))
 
+    if qp.capture.enabled():
+        # When capture is enabled, ChangeOpBasis is unrolled. The resource functions are typically
+        # not aware of that, and still produce resource reps of ChangeOpBasis. Therefore, we unroll
+        # the ChangeOpBasis in the resources manually so that it will match the reality.
+        estimated_gate_counts = _unroll_change_op_basis(estimated_gate_counts)
+
     if rule.exact_resources and not (
         isinstance(op, qp.templates.SubroutineOp) and not op.subroutine.exact_resources
     ):
-        non_zero_gate_counts = {k: v for k, v in gate_counts.items() if v > 0}
+        non_zero_gate_counts = {k: v for k, v in estimated_gate_counts.items() if v > 0}
         _assert_counts_match(non_zero_gate_counts, actual_gate_counts)
     else:
         # If the resource estimate is not expected to match exactly to the actual
         # decomposition, at least make sure that all gates are accounted for.
-        assert all(op in gate_counts for op in actual_gate_counts), (
+        assert all(op in estimated_gate_counts for op in actual_gate_counts), (
             "\nGate counts expected from resource function to contain actual gates:\n"
-            f"{list(gate_counts.keys())}\nActual gates:\n{list(actual_gate_counts.keys())}\n"
+            f"{list(estimated_gate_counts.keys())}\nActual gates:\n{list(actual_gate_counts.keys())}\n"
             "Missing in gate counts from resource function:\n"
-            f"{[op for op in actual_gate_counts if op not in gate_counts]}"
+            f"{[op for op in actual_gate_counts if op not in estimated_gate_counts]}"
         )
 
     # Tests that the decomposition produces the same matrix
@@ -294,6 +301,24 @@ def _test_decomposition_rule(op, rule: DecompositionRule, skip_decomp_matrix_che
         assert qp.math.allclose(
             op_matrix, decomp_matrix
         ), "decomposition must produce the same matrix as the operator."
+
+
+def _unroll_change_op_basis(gate_counts):
+    """Unroll any resource reps of ChangeOpBasis."""
+    new_gate_counts = defaultdict(int)
+    for k, count in gate_counts.items():
+        if not isinstance(k, CompressedResourceOp):
+            new_gate_counts[k] += count
+        if k.op_type is not qp.ops.ChangeOpBasis:
+            new_gate_counts[k] += count
+        for p in ("compute_op", "target_op", "uncompute_op"):
+            op_rep = k.params[p]
+            if isinstance(op_rep, CompressedResourceOp) and op_rep.op_type is qp.ops.Prod:
+                for inner_op, inner_count in op_rep.params["resources"].items():
+                    new_gate_counts[inner_op] += count * inner_count
+            else:
+                new_gate_counts[op_rep] += count
+    return new_gate_counts
 
 
 def _check_matrix(op):

--- a/tests/templates/subroutines/test_qrom.py
+++ b/tests/templates/subroutines/test_qrom.py
@@ -717,6 +717,7 @@ class TestMeasurementQROM:
             assert type(op_base) is type(op_direct)
             assert op_base.wires == op_direct.wires
 
+    @pytest.mark.pl2do("this will not work with Catalyst until the Operator2 work is complete.")
     @pytest.mark.catalyst
     @pytest.mark.parametrize(
         "L",
@@ -758,6 +759,7 @@ class TestMeasurementQROM:
             ), f"L={L}, j={j}: got {target_samples}, expected {bitstrings[j]} (x{shots})"
             assert np.allclose(work_samples, 0), f"j={j}: work wires not clean, got {work_samples}"
 
+    @pytest.mark.pl2do("this will not work with Catalyst until the Operator2 work is complete.")
     @pytest.mark.catalyst
     @pytest.mark.parametrize(
         "L", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
@@ -806,6 +808,7 @@ class TestMeasurementQROM:
         assert np.isclose(circuit()[0][0], 1.0)
         assert np.isclose(circuit()[1][0], 1.0)
 
+    @pytest.mark.pl2do("this will not work with Catalyst until the Operator2 work is complete.")
     @pytest.mark.catalyst
     @pytest.mark.parametrize(
         "L",
@@ -859,6 +862,7 @@ class TestMeasurementQROM:
                 work_samples, 0
             ), f"L={L}, out-of-range j={j}: work wires not clean, got {work_samples}"
 
+    @pytest.mark.pl2do("this will not work with Catalyst until the Operator2 work is complete.")
     @pytest.mark.catalyst
     @pytest.mark.parametrize(
         ("L", "n_extra"),

--- a/tests/transforms/decompositions/test_select_pauli_rot_phase_gradient.py
+++ b/tests/transforms/decompositions/test_select_pauli_rot_phase_gradient.py
@@ -23,7 +23,6 @@ import pytest
 
 import pennylane as qp
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
-from pennylane.transforms.decompose import DecomposeInterpreter
 from pennylane.transforms.decompositions import (
     make_selectpaulirot_to_phase_gradient_decomp,
 )
@@ -225,15 +224,9 @@ def test_integration_multi_wire(rot_axis, seed):
     assert np.allclose(out_state, expected), f"decomposition wrong for rot_axis={rot_axis}"
 
 
-@pytest.mark.usefixtures("enable_graph_decomposition")
 @pytest.mark.capture
 def test_capture_compatibility():
     """Ensures capture compatibility."""
-
-    # pylint: disable=import-outside-toplevel
-    import jax
-
-    from pennylane.tape.plxpr_conversion import CollectOpsandMeas
 
     prec = 3
     num_controls = 2
@@ -259,31 +252,8 @@ def test_capture_compatibility():
         angle_wires, phase_grad_wires, work_wires
     )
 
-    gate_set = {
-        "QROM",
-        "SemiAdder",
-        "CNOT",
-        "PauliX",
-        "GlobalPhase",
-    }
-
-    @DecomposeInterpreter(gate_set=gate_set, fixed_decomps={qp.SelectPauliRot: custom_decomp})
-    def f(angles):
-        qp.SelectPauliRot(angles, control_wires=control_wires, target_wire=target_wire)
-        return qp.state()
-
-    cjaxpr = jax.make_jaxpr(f)(angles)
-
-    collector = CollectOpsandMeas()
-    collector.eval(cjaxpr.jaxpr, cjaxpr.consts, angles)
-
-    op_names = {op.name for op in collector.state["ops"]}
-    # NOTE: Because `adjoint` is lazy in ChangeOpBasis,
-    # unsimplified operators will be collected.
-    gate_set |= {"Adjoint(CNOT)", "Adjoint(PauliX)"}
-    assert op_names.issubset(
-        gate_set
-    ), f"Following ops are present but not in gateset: {op_names - gate_set}"
+    op = qp.SelectPauliRot(angles, control_wires=control_wires, target_wire=target_wire)
+    _test_decomposition_rule(op, custom_decomp)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**

When capture is enabled, ChangeOpBasis is unrolled. The resource functions are typically not aware of that, and still produce resource reps of ChangeOpBasis. Therefore, we unroll the ChangeOpBasis in the resources manually so that it will match the reality.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-126966]