### PR TITLE
feat: add `__subclasshook__` to `StatePrepBase` for smoother migrations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -949,6 +949,7 @@
     [(#9674)](https://github.com/PennyLaneAI/pennylane/pull/9674)
     [(#9820)](https://github.com/PennyLaneAI/pennylane/pull/9820)
     [(#9756)](https://github.com/PennyLaneAI/pennylane/pull/9756)
+    [(#9976)](https://github.com/PennyLaneAI/pennylane/pull/9976)
   - Compatibility with the `drawer` module.
     [(#9849)](https://github.com/PennyLaneAI/pennylane/pull/9849)
   - :func:`qp.equal` can check equality between two :class:`~.Operator2` instances.

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1955,8 +1955,6 @@ def _abstractify_operator(op: Operator2) -> Operator2:
 class StatePrepBase2(Operator2, is_baseclass=True):
     """An interface for state-prep operations."""
 
-    _stateprep_version = 2
-
     @abstractmethod
     def state_vector(self, wire_order: WiresLike | None = None) -> TensorLike:
         """

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -1955,6 +1955,8 @@ def _abstractify_operator(op: Operator2) -> Operator2:
 class StatePrepBase2(Operator2, is_baseclass=True):
     """An interface for state-prep operations."""
 
+    _stateprep_version = 2
+
     @abstractmethod
     def state_vector(self, wire_order: WiresLike | None = None) -> TensorLike:
         """

--- a/pennylane/core/operator/state_prep.py
+++ b/pennylane/core/operator/state_prep.py
@@ -26,6 +26,7 @@ from .base import Operation
 class StatePrepBase(Operation):
     """An interface for state-prep operations."""
 
+    _stateprep_version = 1
     grad_method = None
 
     @abc.abstractmethod
@@ -48,6 +49,12 @@ class StatePrepBase(Operation):
         cache: dict | None = None,
     ) -> str:
         return "|Ψ⟩"
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if cls is StatePrepBase:
+            return getattr(subclass, "_stateprep_version", None) in {1, 2}
+        return NotImplemented
 
 
 __all__ = ["StatePrepBase"]

--- a/pennylane/core/operator/state_prep.py
+++ b/pennylane/core/operator/state_prep.py
@@ -17,6 +17,7 @@ This module defines StatePrepBase.
 
 import abc
 
+from pennylane.core.operator.operator2 import StatePrepBase2
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 
@@ -26,7 +27,6 @@ from .base import Operation
 class StatePrepBase(Operation):
     """An interface for state-prep operations."""
 
-    _stateprep_version = 1
     grad_method = None
 
     @abc.abstractmethod
@@ -52,8 +52,8 @@ class StatePrepBase(Operation):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        if cls is StatePrepBase:
-            return getattr(subclass, "_stateprep_version", None) in {1, 2}
+        if issubclass(subclass, StatePrepBase2):
+            return True
         return NotImplemented
 
 

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -43,9 +43,6 @@ def test_subclasshook_state_prep_base():
     assert isinstance(new_op, StatePrepBase)
     assert issubclass(NewOp, StatePrepBase)
 
-    assert isinstance(new_op, StatePrepBase)
-    assert issubclass(NewOp, StatePrepBase)
-
 
 def test_basis_state_input_cast_to_int():
     """Test that the input to BasisState is cast to an int."""

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -30,13 +30,13 @@ densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
 def test_subclasshook_state_prep_base():
     """Test that anything that inherits from StatePrepBase2 is a StatePrepBase."""
 
-    class NewOp(StatePrepBase2):
+    class NewOp(StatePrepBase2):  # pylint: disable=too-few-public-methods
         """dummy operator2"""
 
-        def __init__(self, wires):
+        def __init__(self, wires):  # pylint: disable=useless-parent-delegation
             super().__init__(wires)
 
-        def state_vector(self, wire_order):  # pylint: disable=signature-differs
+        def state_vector(self, wire_order):  # pylint: disable=signature-differs, unused-argument
             return [0, 1]
 
     new_op = NewOp(wires=0)

--- a/tests/ops/qubit/test_state_prep.py
+++ b/tests/ops/qubit/test_state_prep.py
@@ -21,9 +21,30 @@ import pytest
 import scipy as sp
 
 import pennylane as qp
+from pennylane.core.operator import StatePrepBase, StatePrepBase2
 from pennylane.exceptions import WireError
 
 densitymat0 = np.array([[1.0, 0.0], [0.0, 0.0]])
+
+
+def test_subclasshook_state_prep_base():
+    """Test that anything that inherits from StatePrepBase2 is a StatePrepBase."""
+
+    class NewOp(StatePrepBase2):
+        """dummy operator2"""
+
+        def __init__(self, wires):
+            super().__init__(wires)
+
+        def state_vector(self, wire_order):  # pylint: disable=signature-differs
+            return [0, 1]
+
+    new_op = NewOp(wires=0)
+    assert isinstance(new_op, StatePrepBase)
+    assert issubclass(NewOp, StatePrepBase)
+
+    assert isinstance(new_op, StatePrepBase)
+    assert issubclass(NewOp, StatePrepBase)
 
 
 def test_basis_state_input_cast_to_int():
@@ -294,7 +315,6 @@ class TestDecomposition:
 
 
 class TestStatePrepIntegration:
-
     @pytest.mark.catalyst
     @pytest.mark.parametrize("input_type", [tuple, list])
     def test_state_prep_tuple_list_capture(self, input_type):


### PR DESCRIPTION
**Context:**

Similar approach to what we did with `Operator`: https://github.com/PennyLaneAI/pennylane/pull/9596.

**Description of the Change:**

Add `__subclasshook__` so we can do,
```python 
isinstance(some_op, StatePrepBase)
```
so we don't have to do,
```python
isinstance(some_op, (StatePrepBase, StatePrepBase2)
```

**Benefits:** Don't need to make a bunch of irrelevant [changes](https://github.com/PennyLaneAI/pennylane/pull/9933/changes) when migrating operators like `BasisState`

**Possible Drawbacks:** Python black magic.

[sc-127102]
