### PR TITLE
Add eager C(U1) -> ControlledPhaseShift lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -877,6 +877,7 @@
   [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
   [(#9936)](https://github.com/PennyLaneAI/pennylane/pull/9936)
   [(#9951)](https://github.com/PennyLaneAI/pennylane/pull/9951)
+  [(#9981)](https://github.com/PennyLaneAI/pennylane/pull/9981)
   - Multi-qubit, parametric operators are ported:
   - Templates are ported:
     - :class:`~.BasisRotation`, :class:`~.MultiplexerStatePreparation`, :class:`~.QROM`, :class:`~.QFT`, :class:`~.FlipSign`
@@ -896,6 +897,7 @@
     - `~.U1`, `~.U2`, `~.U3`
   [(#9923)](https://github.com/PennyLaneAI/pennylane/pull/9923)
   [(#9952)](https://github.com/PennyLaneAI/pennylane/pull/9952)
+  [(#9981)](https://github.com/PennyLaneAI/pennylane/pull/9981)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/pennylane/ops/op_math/controlled.py
+++ b/pennylane/ops/op_math/controlled.py
@@ -1216,5 +1216,6 @@ def base_to_custom_ctrl_op():
         (qp.RZ, 1): qp.CRZ,
         (qp.Rot, 1): qp.CRot,
         (qp.PhaseShift, 1): qp.ControlledPhaseShift,
+        (qp.U1, 1): qp.ControlledPhaseShift,
     }
     return ops_with_custom_ctrl_ops

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -1345,6 +1345,13 @@ add_decomps("Adjoint(U1)", adjoint_rotation2)
 add_decomps("Pow(U1)", pow_rotation2)
 
 
+@custom_ctrl_dispatch.register
+def _ctrl_u1(base: U1, control, control_values, *_):
+    if len(control) == 1 and _is_empty_or_all_true(control_values):
+        return qp.ControlledPhaseShift(base.phi, wires=control + base.wires)
+    return NotImplemented
+
+
 class U2(Operator2):
     r"""
     U2 gate.

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -941,10 +941,14 @@ class TestControlledDecompositions:
         """Tests that the controlled form of an adjoint operator is decomposed properly."""
 
         op = qp.ctrl(qp.adjoint(qp.U1(0.5, wires=0)), control=[1])
+        # Applying ``flip_control_adjoint`` rewrites ``C(Adjoint(U1))`` as ``Adjoint(C(U1))``.
+        # With the eager ``C(U1) -> ControlledPhaseShift`` lowering, the inner ``C(U1)`` is lowered
+        # directly to ``ControlledPhaseShift``, so the result is an adjoint of a
+        # ``ControlledPhaseShift``.
         with qp.queuing.AnnotatedQueue() as q:
             _, args, kwargs = _get_decomp_args(op)
             flip_control_adjoint(*args, **kwargs)
-        assert q.queue == [qp.adjoint(qp.ops.Controlled(qp.U1(0.5, wires=0), control_wires=[1]))]
+        assert q.queue == [qp.adjoint(qp.ControlledPhaseShift(0.5, wires=[1, 0]))]
 
     def test_decompose_with_single_work_wire(self):
         """Tests that the Lemma 7.11 decomposition from https://arxiv.org/pdf/quant-ph/9503016 is applied correctly."""

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -972,7 +972,9 @@ class TestControlledDecompositions:
         graph = DecompositionGraph(
             operations=[op],
             gate_set={"ControlledPhaseShift", "PauliX"},
-            alt_decomps={"Adjoint(PauliX)": [self_adjoint]},
+            alt_decomps={
+                "Adjoint(PauliX)": [self_adjoint]
+            },  # this is necessary because all tests are patched with specific decompositions that dont include Adjoint(PauliX)
         )
         solution = graph.solve()
 

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -25,6 +25,7 @@ from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import DecompositionGraph, resource_rep
 from pennylane.decomposition.decomposition_graph import _DecompositionNode
 from pennylane.decomposition.decomposition_rule import DecompCollection, _fix_decomp
+from pennylane.decomposition.symbolic_decomposition import self_adjoint
 from pennylane.decomposition.utils import _get_decomp_args
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
@@ -948,6 +949,37 @@ class TestControlledDecompositions:
         with qp.queuing.AnnotatedQueue() as q:
             _, args, kwargs = _get_decomp_args(op)
             flip_control_adjoint(*args, **kwargs)
+        assert q.queue == [qp.adjoint(qp.ControlledPhaseShift(0.5, wires=[1, 0]))]
+
+    def test_flip_controlled_adjoint_full_solve(self):
+        """Tests that a full graph solve resolves C(Adjoint(U1)) down to
+        Adjoint(ControlledPhaseShift), without any decomposition rule registered
+        specifically for ``C(U1)``.
+
+        The controlled U1 node only appears once ``flip_control_adjoint`` is applied, and
+        it already resolves to ``ControlledPhaseShift`` through the generic mechanism that
+        applies control to U1's own (unconditional) decomposition into ``PhaseShift``,
+        combined with the pre-existing ``(PhaseShift, 1) -> ControlledPhaseShift`` mapping.
+        ``PauliX`` must be included in the target gate set because the resource estimate for
+        a controlled operator conservatively accounts for a potential zero-control flip, even
+        though none is required for this concrete, all-``True`` control case. ``self_adjoint``
+        must be supplied for ``PauliX`` via ``alt_decomps`` since the test-local decomposition
+        registry (unlike the real one) doesn't register it for ``Adjoint(PauliX)``, which is
+        pulled in when adjointing the same zero-control-flip resource estimate.
+        """
+
+        op = qp.ctrl(qp.adjoint(qp.U1(0.5, wires=0)), control=[1])
+        graph = DecompositionGraph(
+            operations=[op],
+            gate_set={"ControlledPhaseShift", "PauliX"},
+            alt_decomps={"Adjoint(PauliX)": [self_adjoint]},
+        )
+        solution = graph.solve()
+
+        with qp.queuing.AnnotatedQueue() as q:
+            _, args, kwargs = _get_decomp_args(op)
+            solution.decomposition(op)(*args, **kwargs)
+
         assert q.queue == [qp.adjoint(qp.ControlledPhaseShift(0.5, wires=[1, 0]))]
 
     def test_decompose_with_single_work_wire(self):

--- a/tests/ops/op_math/test_controlled.py
+++ b/tests/ops/op_math/test_controlled.py
@@ -1649,6 +1649,21 @@ class TestCtrl:
         assert q.queue[0] == qp.X(0)
         assert q.queue[1] == qp.Barrier()
 
+    def test_ctrl_u1_single_control(self):
+        """Test that qp.ctrl(U1) with a single, all-True control is eagerly lowered to
+        ControlledPhaseShift."""
+        op = qp.ctrl(qp.U1(0.5, wires=0), control=[1])
+        assert op == qp.ControlledPhaseShift(0.5, wires=[1, 0])
+
+    @pytest.mark.parametrize("control, control_values", [([1, 2], None), ([1], [False])])
+    def test_ctrl_u1_falls_back_to_controlled(self, control, control_values):
+        """Test that qp.ctrl(U1) falls back to a generic controlled operator instead of
+        being eagerly lowered when there is more than one control wire or a control value
+        of False."""
+        op = qp.ctrl(qp.U1(0.5, wires=0), control=control, control_values=control_values)
+        assert isinstance(op, qp.ops.ControlledOp2)
+        assert op.base == qp.U1(0.5, wires=0)
+
     @pytest.mark.parametrize("op, ctrl_wires, expected_op", custom_ctrl_ops)
     def test_custom_controlled_ops(self, op, ctrl_wires, expected_op):
         """Tests custom controlled operations are handled correctly."""


### PR DESCRIPTION
## Summary

Registers a `custom_ctrl_dispatch` handler for `U1` (mirroring `PhaseShift`) and adds
`(U1, 1) -> ControlledPhaseShift` to `base_to_custom_ctrl_op()`, so that
`qp.ctrl(qp.U1(phi, wires=0), control=[1])` is eagerly lowered to
`ControlledPhaseShift(phi, wires=[1, 0])` (for concrete and abstract wires) instead of a
generic `Controlled(U1)`, matching the existing `PhaseShift` behaviour.

Builds on the now-merged `Operator2` migrations of `U1`/`U2`/`U3`
[(#9923)](https://github.com/PennyLaneAI/pennylane/pull/9923) and of
`PhaseShift`/`ControlledPhaseShift`
[(#9951)](https://github.com/PennyLaneAI/pennylane/pull/9951).

Restores `tests/decomposition/test_decomposition_graph.py::TestControlledDecompositions::test_flip_controlled_adjoint`
to exercise the eager lowering: applying `flip_control_adjoint` to `C(Adjoint(U1))` now
yields `Adjoint(ControlledPhaseShift(0.5, wires=[1, 0]))`.

### Note on the graph solve

A full `DecompositionGraph(..., gate_set={"ControlledPhaseShift"}).solve()` for
`C(Adjoint(U1))` does **not** succeed (the same is true for the `PhaseShift` analog). The
controlled-adjoint path routes through the `Operator2` controlled-decomposition resource
heuristic, which over-counts an `X` per control value, so the target set would additionally
need `PauliX`/`Adjoint(PauliX)`; the eager lowering is also not wired into the abstract
(graph) resource path because abstract control values fail the "empty-or-all-true" guard.
The test therefore drives the `flip_control_adjoint` rule directly while asserting the
eager result.

## Test plan

- [x] `pytest tests/decomposition/test_decomposition_graph.py::TestControlledDecompositions::test_flip_controlled_adjoint` passes.
- [x] `pytest tests/ops/op_math/test_controlled.py -k "u1 or U1 or ctrl"` passes.

---
_This PR was drafted with AI-assistant help._