### PR TITLE
Fix: Raise error in qml.compile if basis_set contains non-strings

### DIFF
--- a/pennylane/transforms/compile.py
+++ b/pennylane/transforms/compile.py
@@ -186,6 +186,11 @@ def compile(
     if num_passes < 1 or not isinstance(num_passes, int):
         raise ValueError("Number of passes must be an integer with value at least 1.")
 
+    if basis_set is not None and not all(isinstance(op, str) for op in basis_set):
+        raise ValueError(
+            f"basis_set must be a sequence of strings representing operation names. Got {basis_set}"
+        )
+
     # Expand the tape; this is done to unroll any templates that may be present,
     # as well as to decompose over a specified basis set
     # First, though, we have to stop whatever tape may be recording so that we

--- a/tests/transforms/test_compile.py
+++ b/tests/transforms/test_compile.py
@@ -73,6 +73,15 @@ class TestCompile:
         with pytest.raises(ValueError, match="Number of passes must be an integer"):
             transformed_qnode(0.1, 0.2, 0.3)
 
+    def test_compile_invalid_basis_set(self):
+        """Test that error is raised for an invalid basis_set."""
+        qfunc = build_qfunc([0, 1, 2])
+        transformed_qfunc = compile(qfunc, basis_set=[qp.RX, "RY"])
+        transformed_qnode = qp.QNode(transformed_qfunc, dev_3wires)
+
+        with pytest.raises(ValueError, match="basis_set must be a sequence of strings representing operation names"):
+            transformed_qnode(0.1, 0.2, 0.3)
+
     def test_compile_mixed_tape_qfunc_transform(self):
         """Test that we can interchange tape and qfunc transforms."""
 


### PR DESCRIPTION
Fixes #6132 by adding a check in qml.compile to ensure basis_set elements are strings. Also adds a unit test for this behavior.

*Note: This PR was developed with the assistance of an AI coding agent.*