### PR TITLE
Updating check in artifact runner

### DIFF
--- a/.github/workflows/check_in_artifact.yml
+++ b/.github/workflows/check_in_artifact.yml
@@ -68,7 +68,9 @@ on:
 
 jobs:
   check_in_artifact:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: 'PennyLaneAI-Static-IP-Runners'
+      labels: ['pl-2-core-gh-runner']         
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
**Context:**
The Update durations job is failing because it can't upload files to github.

**Description of the Change:**
Update checkin_in_artifact workflow.

**Benefits:**
Workflow works.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
