### PR TITLE
Update `Operator2.wires` docstring

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -882,6 +882,7 @@
   [(#9943)](https://github.com/PennyLaneAI/pennylane/pull/9943)
   [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
   [(#9900)](https://github.com/PennyLaneAI/pennylane/pull/9900)
+  [(#9995)](https://github.com/PennyLaneAI/pennylane/pull/9995)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.
@@ -949,6 +950,7 @@
   [(#9927)](https://github.com/PennyLaneAI/pennylane/pull/9927)
   [(#9920)](https://github.com/PennyLaneAI/pennylane/pull/9920)
   [(#9937)](https://github.com/PennyLaneAI/pennylane/pull/9937)
+  [(#9950)](https://github.com/PennyLaneAI/pennylane/pull/9950)
 
   This is an internal, work-in-progress effort that is being incrementally integrated into the PennyLane
   ecosystem. Supported functionality so far:

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -294,7 +294,7 @@ class Operator2(metaclass=OperatorMeta):
     def wires(self) -> Wires:
         """Wires that the operator acts on.
 
-        By default, he returned :class:`~.Wires` are collected from the operator's arguments
+        By default, the returned :class:`~.Wires` are collected from the operator's arguments
         in the following order:
 
         1. For each name in ``wire_argnames`` (in declaration order):

--- a/pennylane/core/operator/operator2.py
+++ b/pennylane/core/operator/operator2.py
@@ -294,8 +294,8 @@ class Operator2(metaclass=OperatorMeta):
     def wires(self) -> Wires:
         """Wires that the operator acts on.
 
-        The returned :class:`~.Wires` are collected from the operator's arguments in
-        the following order:
+        By default, he returned :class:`~.Wires` are collected from the operator's arguments
+        in the following order:
 
         1. For each name in ``wire_argnames`` (in declaration order):
 
@@ -314,8 +314,13 @@ class Operator2(metaclass=OperatorMeta):
 
         .. note::
 
-            Work wires are **not included** in ``op.wires``. In particular, wire arguments
-            named ``work_wires`` or ``work_wire`` are excluded.
+            By default, work wires are **not included** in ``op.wires``. In particular, wire
+            arguments named ``work_wires`` or ``work_wire`` are excluded.
+
+        .. note::
+
+            This property may be overridden by developers if the default behaviour is not
+            desired, for reasons such as including work wires or changing the order of the wires.
 
         Returns:
             Wires: wires

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -15,8 +15,6 @@
 Contains the GQSP template.
 """
 
-from typing import override
-
 from pennylane import capture, ops
 from pennylane.core.operator import Operator2, abstractify
 from pennylane.decomposition import add_decomps, register_resources
@@ -95,11 +93,6 @@ class GQSP(Operator2):
 
     def __init__(self, unitary, angles, control):
         super().__init__(unitary, angles, control)
-
-    @property
-    @override
-    def wires(self):
-        return self.control + self.unitary.wires
 
 
 def _GQSP_resources(unitary, angles, **_):

--- a/tests/templates/subroutines/test_gqsp.py
+++ b/tests/templates/subroutines/test_gqsp.py
@@ -47,6 +47,8 @@ class TestGQSP:
         u_wires = [4]
         c_wires = [0, 1]
         op = qp.GQSP(qp.X(u_wires), angles=np.array([3, 5]), control=c_wires)
+        # Control wires from wire_argnames should be first followed by the wires of
+        # the unitary hybrid argument
         assert op.wires == qp.wires.Wires(c_wires + u_wires)
 
     @pytest.mark.parametrize(

--- a/tests/templates/subroutines/test_gqsp.py
+++ b/tests/templates/subroutines/test_gqsp.py
@@ -42,6 +42,13 @@ class TestGQSP:
         op = qp.GQSP(unitary(1), angles, control=(0,))
         qp.ops.functions.assert_valid(op, skip_differentiation=True, skip_bind_new_parameters=True)
 
+    def test_wires(self):
+        """Test that wires are in the correct order."""
+        u_wires = [4]
+        c_wires = [0, 1]
+        op = qp.GQSP(qp.X(u_wires), angles=np.array([3, 5]), control=c_wires)
+        assert op.wires == qp.wires.Wires(c_wires + u_wires)
+
     @pytest.mark.parametrize(
         ("unitary", "poly"),
         [


### PR DESCRIPTION
**Context:**
`Operator2.wires` does not include work wires by default, and also implements a default, but well documented ordering. This PR updates the docstring so that it is clearly noted that this is *default behaviour* and that developers can opt to override wires as they see fit.

**Description of the Change:**
* Update docstring for `Operator2.wires`
* GQSP was overriding wires unnecessarily, so I removed that and added a regression test

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-127385]