### PR TITLE
fix: make `GlobalPhase` decomposition rule capture compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -877,6 +877,7 @@
   [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
   [(#9936)](https://github.com/PennyLaneAI/pennylane/pull/9936)
   [(#9964)](https://github.com/PennyLaneAI/pennylane/pull/9964)
+  [(#10006)](https://github.com/PennyLaneAI/pennylane/pull/10006)
   [(#9977)](https://github.com/PennyLaneAI/pennylane/pull/9977)
   [(#9951)](https://github.com/PennyLaneAI/pennylane/pull/9951)
   - Templates are ported:

--- a/pennylane/ops/identity.py
+++ b/pennylane/ops/identity.py
@@ -20,12 +20,11 @@ from functools import lru_cache
 from scipy import sparse
 
 import pennylane as qp
-from pennylane.core.operator import Operation, Operator2
+from pennylane.core.operator import Operation, Operator2, abstractify
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.decomposition.decomposition_rule import null_decomp
 from pennylane.exceptions import SparseMatrixUndefinedError
 from pennylane.ops.op_math.adjoint2 import adjoint_rotation as adjoint_rotation2
-from pennylane.ops.op_math.controlled2 import _ctrl_abstract
 from pennylane.ops.op_math.pow2 import pow_rotation as pow_rotation2
 from pennylane.typing import Float, TensorLike, Wire
 from pennylane.wires import WiresLike
@@ -424,24 +423,34 @@ def _controlled_g_phase_resource(
     base, control_wires, control_values, work_wires, work_wire_type
 ):  # pylint: disable=unused-argument
     num_control_wires = len(control_wires)
-    num_zero_control_values = int(qp.math.sum(qp.math.logical_not(control_values)))
     num_work_wires = len(work_wires)
-    if num_control_wires == 1 and num_zero_control_values == 1:
-        return {qp.PhaseShift: 1, qp.GlobalPhase: 1}
 
-    if num_control_wires == 1:
-        return {qp.PhaseShift: 1}
+    resources = {}
+
+    if num_control_wires == 1:  # Worst-case we need a GlobalPhase if control on zero
+        resources[qp.PhaseShift] = 1
+        resources[qp.GlobalPhase] = 1
+        return resources
+
+    # NOTE: Take average case scenario for number of X required for zero control values
+    resources[qp.X] = num_control_wires
 
     if num_control_wires == 2:
-        return {qp.X: num_zero_control_values * 2, qp.ControlledPhaseShift: 1}
+        resources[qp.ControlledPhaseShift] = 1
+        return resources
 
-    return {
-        qp.X: num_zero_control_values * 2,
-        _ctrl_abstract(qp.PhaseShift, Wire[num_control_wires - 1], Wire[num_work_wires]): 1,
-    }
+    resources[
+        qp.ctrl(
+            abstractify(qp.PhaseShift),
+            control=Wire[num_control_wires - 1],
+            work_wires=Wire[num_work_wires],
+        )
+    ] = 1
+
+    return resources
 
 
-@register_resources(_controlled_g_phase_resource)
+@register_resources(_controlled_g_phase_resource, exact=False)
 def _controlled_g_phase_decomp(
     base,
     control_wires,
@@ -450,29 +459,29 @@ def _controlled_g_phase_decomp(
     work_wire_type,  # pylint: disable=unused-argument
 ):
     """The decomposition rule for a controlled global phase."""
-    wires = control_wires + base.wires
+    if len(control_wires) == 1:
 
-    if len(control_wires) == 1 and control_values[0]:
-        qp.PhaseShift(-base.phi, wires=control_wires[-1])
+        def _true():
+            qp.PhaseShift(-base.phi, wires=control_wires[-1])
+
+        def _false():
+            qp.PhaseShift(base.phi, wires=control_wires[-1])
+            qp.GlobalPhase(base.phi)
+
+        qp.cond(control_values[0], _true, _false)()
         return
 
-    if len(control_wires) == 1 and not control_values[0]:
-        qp.PhaseShift(base.phi, wires=control_wires[-1])
-        qp.GlobalPhase(base.phi)
-        return
+    @qp.for_loop(0, len(control_values))
+    def _x_flips(i):
+        qp.cond(qp.math.logical_not(control_values[i]), qp.X)(control_wires[i])
 
-    zero_control_wires = [
-        w for w, val in zip(control_wires, control_values, strict=True) if not val
-    ]
-    for w in zero_control_wires:
-        qp.PauliX(w)
+    _x_flips()  # pylint: disable=no-value-for-parameter
     qp.ctrl(
-        qp.PhaseShift(-base.phi, wires=wires[len(control_wires) - 1]),
-        control=wires[: len(control_wires) - 1],
+        qp.PhaseShift(-base.phi, wires=control_wires[-1]),
+        control=control_wires[:-1],
         work_wires=work_wires,
     )
-    for w in zero_control_wires:
-        qp.PauliX(w)
+    _x_flips()  # pylint: disable=no-value-for-parameter
 
 
 add_decomps("Adjoint(GlobalPhase)", adjoint_rotation2)

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -372,8 +372,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     5: ─╰●─╰●────────╰●─┤
     Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool, weak_type=True)): 2, PauliX: 3}
     Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-    Full Expansion Gates: {CNOT: 76, GlobalPhase: 91, MidMeasure: 4, RX: 35, RY: 16, RZ: 84}
-    Weighted Cost: 215.0
+    Full Expansion Gates: {CNOT: 76, GlobalPhase: 94, MidMeasure: 4, RX: 38, RY: 16, RZ: 84}
+    Weighted Cost: 218.0
 
     For applicable decompositions, the "First-Level Expansion" label refers to the operators immediately produced by the decomposition rule,
     whereas the "Full Expansion" refers to the circuit produced by decomposing the operator all the way
@@ -515,8 +515,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool, weak_type=True)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool, weak_type=True)): 4, PauliX: 4, QubitUnitary(num_wires=1): 2}
         Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, QubitUnitary(num_wires=1): 2}
-        Full Expansion Gates: {CNOT: 58, GlobalPhase: 58, RX: 21, RY: 12, RZ: 57}
-        Weighted Cost: 148.0
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 62, RX: 25, RY: 12, RZ: 57}
+        Weighted Cost: 152.0
         <BLANKLINE>
         Decomposition 1 (name: one_borrowed_worker)
         2: ────╭●────────────────╭●────────────────┤
@@ -621,8 +621,8 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool, weak_type=True)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool, weak_type=True)): 4, PauliX: 4, QubitUnitary(num_wires=1): 2}
         Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, QubitUnitary(num_wires=1): 2}
-        Full Expansion Gates: {CNOT: 58, GlobalPhase: 58, RX: 21, RY: 12, RZ: 57}
-        Weighted Cost: 148.0
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 62, RX: 25, RY: 12, RZ: 57}
+        Weighted Cost: 152.0
         <BLANKLINE>
         Decomposition 1 (name: one_borrowed_worker)
         2: ────╭●────────────────╭●────────────────┤

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -865,12 +865,18 @@ class TestControlledDecompositions:
 
         op1 = qp.ctrl(qp.GlobalPhase(0.5), control=[1])
         op2 = qp.ctrl(qp.GlobalPhase(0.5), control=[1, 2])
-        graph = DecompositionGraph([op1, op2], gate_set={"ControlledPhaseShift", "PhaseShift"})
-        # 4 op nodes and 2 decomposition nodes, and 1 dummy starting node.
-        assert len(graph._graph.nodes()) == 7
-        # 2 edges from decompositions to ops and 2 edges from ops to decompositions,
-        # and 2 edges from the dummy starting node to the target gate set.
-        assert len(graph._graph.edges()) == 6
+        # The decomposition rule conditionally applies X gates (and, for a single control
+        # wire, a GlobalPhase) depending on the control values, which are not concrete at
+        # resource-estimation time. Both must therefore be in the target gate set.
+        graph = DecompositionGraph(
+            [op1, op2],
+            gate_set={"ControlledPhaseShift", "PhaseShift", "GlobalPhase", "X"},
+        )
+        # 6 op nodes and 2 decomposition nodes, and 1 dummy starting node.
+        assert len(graph._graph.nodes()) == 9
+        # 2 edges from decompositions to ops and 4 edges from ops to decompositions,
+        # and 4 edges from the dummy starting node to the target gate set.
+        assert len(graph._graph.edges()) == 10
 
         # Verify the decompositions
         solution = graph.solve()
@@ -923,9 +929,11 @@ class TestControlledDecompositions:
         )
         # 18 op nodes and 24 decomposition nodes, and the dummy starting node
         assert len(graph._graph.nodes()) == 43
-        # 24 edges from decompositions to ops and 36 edges from ops to decompositions
-        # and 6 edge from the dummy starting node to the target gate set.
-        assert len(graph._graph.edges()) == 66
+        # 24 edges from decompositions to ops and 38 edges from ops to decompositions
+        # and 6 edge from the dummy starting node to the target gate set. The controlled
+        # GlobalPhase rule now always reports X gates for flipping zero control values,
+        # which adds two edges.
+        assert len(graph._graph.edges()) == 68
 
         solution = graph.solve()
 

--- a/tests/ops/functions/conftest.py
+++ b/tests/ops/functions/conftest.py
@@ -41,6 +41,8 @@ def _trotterize_qfunc_dummy(time, theta, phi, wires, flip=False):
 
 
 _INSTANCES_TO_TEST = [
+    # GlobalPhase acts on no wires, so `_check_differentiation`'s `qp.probs(wires=op.wires)` cannot be constructed
+    (qp.GlobalPhase(1.1), {"skip_differentiation": True}),
     (LabelledOp(qp.X(0), "my-x"), {}),
     (MarkedOp(qp.X(0), "my-x"), {}),
     (qp.ops.MidMeasure(wires=0), {"skip_capture": True}),
@@ -154,10 +156,6 @@ _INSTANCES_TO_FAIL = [
     (
         qp.ops.Conditional(qp.measure(1), qp.S(0)),
         AssertionError,  # needs flattening helpers to be updated, also cannot be pickled
-    ),
-    (
-        qp.GlobalPhase(1.1),
-        AssertionError,  # empty decomposition, matrix differs from decomp's matrix
     ),
     (
         qp.pulse.ParametrizedEvolution(qp.PauliX(0) + sum * qp.PauliZ(0)),

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -25,9 +25,10 @@ op_repr = ["I()", "I(0)", "I('a')", "I([0, 1])", "I(['a', 'b', 'c'])", "I([100, 
 op_params = tuple(zip(op_wires, op_repr))
 
 
-@pytest.mark.capture
+@pytest.mark.usefixtures("enable_and_disable_capture")
 @pytest.mark.parametrize("phi", (0.0, 1.0, -1.0))
 def test_global_phase_decompositions(phi):
+    """Tests that the decomposition rules of GlobalPhase are capture compatible."""
     op = GlobalPhase(phi)
     for rule in qp.list_decomps(GlobalPhase):
         _test_decomposition_rule(op, rule)

--- a/tests/ops/test_identity.py
+++ b/tests/ops/test_identity.py
@@ -17,11 +17,20 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane import Identity
+from pennylane.ops.functions.assert_valid import _test_decomposition_rule
+from pennylane.ops.identity import GlobalPhase, Identity
 
 op_wires = [[], [0], ["a"], [0, 1], ["a", "b", "c"], [100, "xasd", 12]]
 op_repr = ["I()", "I(0)", "I('a')", "I([0, 1])", "I(['a', 'b', 'c'])", "I([100, 'xasd', 12])"]
 op_params = tuple(zip(op_wires, op_repr))
+
+
+@pytest.mark.capture
+@pytest.mark.parametrize("phi", (0.0, 1.0, -1.0))
+def test_global_phase_decompositions(phi):
+    op = GlobalPhase(phi)
+    for rule in qp.list_decomps(GlobalPhase):
+        _test_decomposition_rule(op, rule)
 
 
 def test_is_verified_hermitian():

--- a/tests/transforms/test_combine_global_phases.py
+++ b/tests/transforms/test_combine_global_phases.py
@@ -174,15 +174,6 @@ def test_differentiability_tensorflow():
     assert qp.math.isclose(grad2, 0.0)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "TestPyPI Catalyst does not yet preserve Operator2 results used as observables during "
-        "capture. The expectation measurement is misrouted through the MCM path and emits a "
-        "zero-operand quantum.mcmobs, which has no runtime lowering. Remove this xfail once "
-        "Catalyst's Operator2-observable handling is released."
-    ),
-)
 @pytest.mark.catalyst
 def test_catalyst_integration():
     """Test that combine_global_phases works with catalyst."""

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -119,8 +119,8 @@ class TestInspectDecompGraph:
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool, weak_type=True)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-            Full Expansion Gates: {CNOT: 160, GlobalPhase: 129, RX: 49, RY: 24, RZ: 140}
-            Weighted Cost: 373.0
+            Full Expansion Gates: {CNOT: 160, GlobalPhase: 140, RX: 60, RY: 24, RZ: 140}
+            Weighted Cost: 384.0
             """).strip()
 
         assert result._repr_markdown_() == dedent("""
@@ -150,11 +150,11 @@ class TestInspectDecompGraph:
             | Full Expansion | Count |
             | :--- | :--- |
             | CNOT | 160 |
-            | GlobalPhase | 129 |
-            | RX | 49 |
+            | GlobalPhase | 140 |
+            | RX | 60 |
             | RY | 24 |
             | RZ | 140 |
-            | **Weighted Cost** | 373.0 |
+            | **Weighted Cost** | 384.0 |
             </details>
             """).strip()
 
@@ -193,8 +193,8 @@ class TestInspectDecompGraph:
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool, weak_type=True)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-            Full Expansion Gates: {CNOT: 76, GlobalPhase: 91, MidMeasure: 4, RX: 35, RY: 16, RZ: 84}
-            Weighted Cost: 215.0
+            Full Expansion Gates: {CNOT: 76, GlobalPhase: 94, MidMeasure: 4, RX: 38, RY: 16, RZ: 84}
+            Weighted Cost: 218.0
             """).strip()
 
         assert result._repr_markdown_() == dedent("""
@@ -253,12 +253,12 @@ class TestInspectDecompGraph:
             | Full Expansion | Count |
             | :--- | :--- |
             | CNOT | 76 |
-            | GlobalPhase | 91 |
+            | GlobalPhase | 94 |
             | MidMeasure | 4 |
-            | RX | 35 |
+            | RX | 38 |
             | RY | 16 |
             | RZ | 84 |
-            | **Weighted Cost** | 215.0 |
+            | **Weighted Cost** | 218.0 |
             </details>
             """).strip()
 
@@ -274,8 +274,8 @@ class TestInspectDecompGraph:
              [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
             Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool, weak_type=True)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool, weak_type=True)): 2, PauliX: 3, QubitUnitary(num_wires=1): 2}
             Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(num_wires=1)): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 2, QubitUnitary(num_wires=1): 2}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 34, RX: 13, RY: 8, RZ: 33}
-            Weighted Cost: 78.0
+            Full Expansion Gates: {CNOT: 24, GlobalPhase: 37, RX: 16, RY: 8, RZ: 33}
+            Weighted Cost: 81.0
 
             Decomposition 1 (name: one_borrowed_worker)
             0: ────╭●────╭●───────┤  


### PR DESCRIPTION
**Context:**

Turns out, the decomposition rule for `GlobalPhase` was never properly being tested for its capture compatibility.

**Description of the Change:**

This PR does:
1. Re-writes the rule to be capture compatible
2. Adds an intentional regression test to test its decomposition rule under capture

**Benefits:**

All operators should have a decomposition rule that is capture compatible.

**Possible Drawbacks:** Caused a few changes to decomposition costs.
