### PR TITLE
Fix Identity wire preservation in LinearCombination.simplify

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1139,6 +1139,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where :meth:`~.LinearCombination.simplify` dropped wires used only by
+  :class:`~.Identity` terms.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 
@@ -1255,6 +1259,7 @@ Guillermo Alonso,
 Abdullah Al Omar Galib,
 Gabriel Bottrill,
 Astral Cai,
+Yuji Cao,
 Daniel Casota,
 Miguel Cárdenas,
 Yushao Chen,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1141,7 +1141,7 @@
 
 * Fixed a bug where :meth:`~.LinearCombination.simplify` dropped wires used only by
   :class:`~.Identity` terms.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10007)](https://github.com/PennyLaneAI/pennylane/pull/10007)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/pennylane/ops/op_math/linear_combination.py
+++ b/pennylane/ops/op_math/linear_combination.py
@@ -290,7 +290,7 @@ class LinearCombination(Sum):
 
     @staticmethod
     @QueuingManager.stop_recording()
-    def _simplify_coeffs_ops(coeffs, ops, pr, cutoff=1.0e-12):
+    def _simplify_coeffs_ops(coeffs, ops, pr, wire_order, cutoff=1.0e-12):
         """Simplify coeffs and ops
 
         Returns:
@@ -309,7 +309,7 @@ class LinearCombination(Sum):
             new_ops = []
 
             for pw, coeff in pr.items():
-                pw_op = pw.operation(wire_order=pr.wires)
+                pw_op = pw.operation(wire_order=wire_order)
                 new_ops.append(pw_op)
                 new_coeffs.append(coeff)
 
@@ -324,7 +324,9 @@ class LinearCombination(Sum):
         return new_coeffs, new_ops, pr
 
     def simplify(self, cutoff=1.0e-12):
-        coeffs, ops, pr = self._simplify_coeffs_ops(self.coeffs, self.ops, self.pauli_rep, cutoff)
+        coeffs, ops, pr = self._simplify_coeffs_ops(
+            self.coeffs, self.ops, self.pauli_rep, self.wires, cutoff
+        )
         return LinearCombination(coeffs, ops, _pauli_rep=pr)
 
     def __matmul__(self, other: Operator) -> Operator:

--- a/tests/ops/op_math/test_linear_combination.py
+++ b/tests/ops/op_math/test_linear_combination.py
@@ -690,6 +690,19 @@ class TestLinearCombination:
         old_H = old_H.simplify()
         qp.assert_equal(old_H, new_H)
 
+    @pytest.mark.parametrize(
+        ("ops", "expected_wires"),
+        [
+            ([qp.Identity("identity")], Wires(["identity"])),
+            ([qp.Identity("identity"), qp.X("x")], Wires(["identity", "x"])),
+        ],
+    )
+    def test_simplify_preserves_identity_wires(self, ops, expected_wires):
+        """Tests that simplify preserves wires used only by Identity terms."""
+        linear_combination = qp.ops.LinearCombination([1] * len(ops), ops)
+
+        assert linear_combination.simplify().wires == expected_wires
+
     def test_simplify_while_queueing(self):
         """Tests that simplifying a LinearCombination in a tape context
         queues the simplified LinearCombination."""


### PR DESCRIPTION
**Context:**

`LinearCombination.simplify` reconstructs Pauli terms from the operator's Pauli representation. Identity-only Pauli words do not contain wire information, so using the Pauli representation's wires caused simplification to drop wires used only by `Identity` terms.

**Description of the Change:**

Pass the original `LinearCombination` wire order to `_simplify_coeffs_ops` and use it when reconstructing each Pauli word. Add regression tests for an identity-only term and for identity and non-identity terms on different string wires.

**Benefits:**

Simplification now preserves the complete wire union of a `LinearCombination`, including wires used only by `Identity` terms.

**Possible Drawbacks:**

Identity terms are reconstructed using the complete original wire order. This preserves identity semantics and the original operator's wire union.

**Related GitHub Issues:**

Fixes #8746.

**Testing:**

- Regression test: 2 passed.
- `tests/ops/op_math/test_linear_combination.py`: 175 passed, 32 skipped.
- Pylint passed for the changed source and test files.
- Black and isort checks passed.
- `tach check` passed.
- `git diff --check` passed.

**AI assistance:**

OpenAI Codex and Claude Code were used to prepare and validate this change.