### PR TITLE
Update `data` to `bitstrings` in `QROM` and `QRAM`s

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -661,6 +661,10 @@
 
 <h3>Breaking changes 💔</h3>
 
+* Renamed the `data` argument of :class:`~pennylane.QROM`, :class:`~pennylane.BBQRAM`, :class:`~pennylane.HybridQRAM`,
+  and :class:`~pennylane.SelectOnlyQRAM` to `bitstrings`.
+  [(#10010)](https://github.com/PennyLaneAI/pennylane/pull/10010)
+
 * :class:`~.BasisEmbedding` is now a direct alias of :class:`~.BasisState`.
   [(#9980)](https://github.com/PennyLaneAI/pennylane/pull/9980)
 

--- a/pennylane/io/qualtran_io.py
+++ b/pennylane/io/qualtran_io.py
@@ -192,7 +192,7 @@ def _(op: qtemps.state_preparations.QROMStatePreparation):
     def _add_qrom_and_adjoint(gate_types, bitstrings, control_wires):
         """Helper to create a QROM, count it and its adjoint."""
         qrom_op = qtemps.QROM(
-            data=bitstrings,
+            bitstrings=bitstrings,
             target_wires=precision_wires,
             control_wires=control_wires,
             work_wires=work_wires,

--- a/pennylane/labs/tests/estimator_beta/test_mapper.py
+++ b/pennylane/labs/tests/estimator_beta/test_mapper.py
@@ -28,7 +28,7 @@ from pennylane.templates.subroutines.qrom import QROM
 def test_qrom_mapping(clean):
     """Test that the qrom operator gets mapped correctly"""
     qrom = QROM(
-        data=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
+        bitstrings=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
         control_wires=[0, 1],
         target_wires=[2, 3, 4],
         work_wires=[5, 6, 7],

--- a/pennylane/templates/state_preparations/partial_unary.py
+++ b/pennylane/templates/state_preparations/partial_unary.py
@@ -707,7 +707,7 @@ def _pui_state_prep_resources(num_entries, num_wires, num_work_wires):
 
     qrom_reps = {
         p: qp.QROM(
-            data=Int[p, p],
+            bitstrings=Int[p, p],
             control_wires=Wire[n_subspace],
             target_wires=Wire[p],
             work_wires=Wire[n_subspace - 1],
@@ -778,7 +778,7 @@ def _pui_state_prep_core(coefficients, wires, indices, work_wires):
             qp.BasisState(k_start, subspace_wires)
             b = k - k_start
             qp.QROM(
-                data=np.eye(b, dtype=np.int64),
+                bitstrings=np.eye(b, dtype=np.int64),
                 control_wires=subspace_wires,
                 target_wires=nonsubspace_wires[:b],
                 work_wires=work_wires[: n_subspace - 1],

--- a/pennylane/templates/state_preparations/qrom_state_prep.py
+++ b/pennylane/templates/state_preparations/qrom_state_prep.py
@@ -219,7 +219,7 @@ class QROMStatePreparation(Operation):
             # Apply the QROM operation to encode the thetas binary representation
             decomp_ops.append(
                 qp.QROM(
-                    data=thetas_binary,
+                    bitstrings=thetas_binary,
                     target_wires=precision_wires,
                     control_wires=input_wires[:i],
                     work_wires=work_wires,
@@ -234,7 +234,7 @@ class QROMStatePreparation(Operation):
             # Clean wires used to store the theta values
             decomp_ops.append(
                 qp.adjoint(qp.QROM)(
-                    data=thetas_binary,
+                    bitstrings=thetas_binary,
                     target_wires=precision_wires,
                     control_wires=input_wires[:i],
                     work_wires=work_wires,
@@ -252,7 +252,7 @@ class QROMStatePreparation(Operation):
             # Apply the QROM operation to encode the thetas binary representation
             decomp_ops.append(
                 qp.QROM(
-                    data=thetas_binary,
+                    bitstrings=thetas_binary,
                     target_wires=precision_wires,
                     control_wires=input_wires,
                     work_wires=work_wires,
@@ -270,7 +270,7 @@ class QROMStatePreparation(Operation):
 
             decomp_ops.append(
                 qp.adjoint(qp.QROM)(
-                    data=thetas_binary,
+                    bitstrings=thetas_binary,
                     target_wires=precision_wires,
                     control_wires=input_wires,
                     work_wires=work_wires,

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -985,7 +985,7 @@ def _sos_state_prep_resources(num_entries, num_bits, num_wires):
     # Step 2 in paper (p.7)
     resources[
         qp.QROM(
-            data=Int[num_entries, num_wires],
+            bitstrings=Int[num_entries, num_wires],
             control_wires=Wire[d],
             target_wires=Wire[num_wires],
             work_wires=Wire[d - 1],

--- a/pennylane/templates/subroutines/qram.py
+++ b/pennylane/templates/subroutines/qram.py
@@ -104,17 +104,18 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
         \text{BBQRAM}|i\rangle|0\rangle = |i\rangle |b_i\rangle.
 
     Args:
-        data (TensorLike | Sequence[str]):
-            The classical data as a 2-D array.  The shape must be ``(num_data, size_data)``, where ``num_data`` is
-            :math:`2^{\texttt{len(control_wires)}}` and ``size_data = len(target_wires)``.
+        bitstrings (TensorLike | Sequence[str]):
+            The classical data as a 2-D array.  The shape must be ``(num_bitstrings, size_bitstrings)``,
+            where ``num_bitstrings`` is :math:`2^{\texttt{len(control_wires)}}` and
+            ``size_bitstrings = len(target_wires)``.
         control_wires (WiresLike):
             The register that stores the index for the entry of the classical data we want to
             access.
         target_wires (WiresLike):
             The register in which the classical data gets loaded. The size of this register must
-            equal each bitstring length in ``data``.
+            equal each bitstring length in ``bitstrings``.
         work_wires (WiresLike):
-            The additional wires required to funnel the desired entry of ``data`` into the
+            The additional wires required to funnel the desired entry of ``bitstrings`` into the
             target register. The size of the ``work_wires`` register must be
             :math:`1 + 3 ((2^\texttt{len(control_wires)}) - 1)`. More specifically, the
             ``work_wires`` register includes the bus, direction, left port and right port wires in
@@ -123,7 +124,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
             For more information, consult `arXiv:0708.1879 <https://arxiv.org/pdf/0708.1879>`__.
 
     Raises:
-        ValueError: if the ``data`` are not provided, the ``data`` are of the wrong
+        ValueError: if the ``bitstrings`` are not provided, the ``bitstrings`` are of the wrong
             length, the ``target_wires`` are of the wrong size, or the ``work_wires`` register size is not exactly
             equal to :math:`1 + 3 ((2^\texttt{len(control_wires)}) - 1)`.
 
@@ -143,7 +144,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
 
     .. code-block:: python
 
-        data = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
+        bitstrings = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
         bitstring_size = 3
 
     The number of wires needed to store a length-4 array is 2, which means that the
@@ -158,7 +159,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
     Now, we can define all three registers concretely and demonstrate ``BBQRAM`` in practice. In the
     following circuit, we prepare the state :math:`\vert 2 \rangle = \vert 10 \rangle` on the
     ``control_wires``, which indicates that we would like to access the second (zero-indexed) entry of
-    ``data`` (which is ``[1, 1, 0]``). The ``target_wires`` register should therefore store this
+    ``bitstrings`` (which is ``[1, 1, 0]``). The ``target_wires`` register should therefore store this
     state after ``BBQRAM`` is applied.
 
     .. code-block:: python
@@ -179,7 +180,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
             qp.BasisState(2, wires=reg["control"])
 
             qp.BBQRAM(
-                data,
+                bitstrings,
                 control_wires=reg["control"],
                 target_wires=reg["target"],
                 work_wires=reg["work_wires"],
@@ -208,26 +209,28 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
 
     def __init__(
         self,
-        data: TensorLike | Sequence[str],
+        bitstrings: TensorLike | Sequence[str],
         control_wires: WiresLike,
         target_wires: WiresLike,
         work_wires: WiresLike,
     ):  # pylint: disable=too-many-arguments
         control_wires = Wires(control_wires)
 
-        if isinstance(data, (list, tuple)):
-            data = math.array(data)
+        if isinstance(bitstrings, (list, tuple)):
+            bitstrings = math.array(bitstrings)
 
-        if data.shape[0] == 0:
-            raise ValueError("'data' cannot be empty.")
+        if bitstrings.shape[0] == 0:
+            raise ValueError("'bitstrings' cannot be empty.")
 
-        if isinstance(data[0], str):
-            data = math.array(list(map(lambda bitstring: [int(bit) for bit in bitstring], data)))
+        if isinstance(bitstrings[0], str):
+            bitstrings = math.array(
+                list(map(lambda bitstring: [int(bit) for bit in bitstring], bitstrings))
+            )
 
-        m = data.shape[1]
+        m = bitstrings.shape[1]
         n_k = len(control_wires)
-        if (1 << n_k) != data.shape[0]:
-            raise ValueError("data.shape[0] must be 2^(len(control_wires)).")
+        if (1 << n_k) != bitstrings.shape[0]:
+            raise ValueError("bitstrings.shape[0] must be 2^(len(control_wires)).")
 
         target_wires = Wires(target_wires)
         if m != len(target_wires):
@@ -261,7 +264,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
             "wire_manager": wire_manager,
         }
 
-        super().__init__(data, wires=all_wires)
+        super().__init__(bitstrings, wires=all_wires)
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):
@@ -270,7 +273,7 @@ class BBQRAM(Operation):  # pylint: disable=too-many-instance-attributes
 
 def _bucket_brigade_qram_resources(num_controls, num_target_wires):
     """
-    Calculates the resources, assuming the worst case where data is all ones.
+    Calculates the resources, assuming the worst case where bitstrings are all ones.
     """
     n_k = num_controls
     _ctrl_swap = _ctrl_abstract(SWAP, Wire[1], num_zero_control_values=1)
@@ -325,7 +328,7 @@ def _route_bus_down_first_k_levels(wire_manager, k_levels):
             ctrl(SWAP(wires=[in_w, L]), control=[d], control_values=[0])
 
 
-def _leaf_ops_for_bit(wire_manager, data, n_k, j):
+def _leaf_ops_for_bit(wire_manager, bitstrings, n_k, j):
     """Apply the leaf write for target bit index j."""
     ops = []
     for p in range(1 << n_k):
@@ -333,13 +336,15 @@ def _leaf_ops_for_bit(wire_manager, data, n_k, j):
             target = wire_manager.portL(n_k - 1, p >> 1)
         else:
             target = wire_manager.portR(n_k - 1, p >> 1)
-        bit = data[p, j]
+        bit = bitstrings[p, j]
         cond(bit, PauliZ)(wires=target)
     return ops
 
 
 @register_resources(_bucket_brigade_qram_resources, exact=False)
-def _bucket_brigade_qram_decomposition(data, wire_manager, **__):  # pylint: disable=unused-argument
+def _bucket_brigade_qram_decomposition(
+    bitstrings, wire_manager, **__
+):  # pylint: disable=unused-argument
     bus_wire = wire_manager.bus_wire
     control_wires = wire_manager.control_wires
     n_k = len(control_wires)
@@ -350,7 +355,7 @@ def _bucket_brigade_qram_decomposition(data, wire_manager, **__):  # pylint: dis
         Hadamard(wires=[tw])
         SWAP(wires=[tw, bus_wire[0]])
         _route_bus_down_first_k_levels(wire_manager, len(control_wires))
-        _leaf_ops_for_bit(wire_manager, data, n_k, j)
+        _leaf_ops_for_bit(wire_manager, bitstrings, n_k, j)
         adjoint(_route_bus_down_first_k_levels, lazy=False)(wire_manager, len(control_wires))
         SWAP(wires=[tw, bus_wire[0]])
         Hadamard(wires=[tw])
@@ -380,7 +385,7 @@ class HybridQRAM(Operation):
     :math:`n-k` (:math:`2^{n-k}` leaves) and reuses it :math:`2^k` times.
 
     Args:
-        data (TensorLike):
+        bitstrings (TensorLike):
             The classical data as a sequence of bitstrings. The size of the classical data must be
             :math:`2^{\texttt{len(control_wires)}}`.
         control_wires (WiresLike):
@@ -388,9 +393,9 @@ class HybridQRAM(Operation):
             access.
         target_wires (WiresLike):
             The register in which the classical data gets loaded. The size of this register must
-            equal each bitstring length in ``data``.
+            equal each bitstring length in ``bitstrings``.
         work_wires (WiresLike):
-            The additional wires required to funnel the desired entry of ``data`` into the
+            The additional wires required to funnel the desired entry of ``bitstrings`` into the
             ``target_wires`` register. The ``work_wires`` register includes the signal, bus,
             direction, left port and right port wires in that order for a tree of depth
             :math:`(n-k)`. For more details, consult
@@ -399,7 +404,7 @@ class HybridQRAM(Operation):
             The number of "select" bits taken from ``control_wires``.
 
     Raises:
-        ValueError: if the ``data`` are not provided, the ``data`` are of the wrong length, there are
+        ValueError: if the ``bitstrings`` are not provided, the ``bitstrings`` are of the wrong length, there are
             no ``control_wires``, ``k >= len(control_wires)``, the ``target_wires`` are of the wrong length, or the
             ``work_wires`` are of the wrong length.
 
@@ -419,7 +424,7 @@ class HybridQRAM(Operation):
 
     .. code-block:: python
 
-        data = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
+        bitstrings = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
         bitstring_size = 3
 
     The ``control_wires`` are split via the value of :math:`k`, which allows us to leverage
@@ -454,7 +459,7 @@ class HybridQRAM(Operation):
             qp.BasisState(2, wires=reg["control"])
 
             qp.HybridQRAM(
-                data,
+                bitstrings,
                 control_wires=reg["control"],
                 target_wires=reg["target"],
                 work_wires=reg["work"],
@@ -480,23 +485,25 @@ class HybridQRAM(Operation):
 
     def __init__(
         self,
-        data: TensorLike | Sequence[str],
+        bitstrings: TensorLike | Sequence[str],
         control_wires: WiresLike,
         target_wires: WiresLike,
         work_wires: WiresLike,
         k: int,  # define the select part size, remaining part is tree part
     ):  # pylint: disable=too-many-arguments
 
-        if isinstance(data, (list, tuple)):
-            data = math.array(data)
+        if isinstance(bitstrings, (list, tuple)):
+            bitstrings = math.array(bitstrings)
 
-        if data.shape[0] == 0:
-            raise ValueError("'data' cannot be empty.")
+        if bitstrings.shape[0] == 0:
+            raise ValueError("'bitstrings' cannot be empty.")
 
-        if isinstance(data[0], str):
-            data = math.array(list(map(lambda bitstring: [int(bit) for bit in bitstring], data)))
+        if isinstance(bitstrings[0], str):
+            bitstrings = math.array(
+                list(map(lambda bitstring: [int(bit) for bit in bitstring], bitstrings))
+            )
 
-        m = data.shape[1]
+        m = bitstrings.shape[1]
 
         control_wires = Wires(control_wires)
         target_wires = Wires(target_wires)
@@ -513,8 +520,8 @@ class HybridQRAM(Operation):
         if len(target_wires) != m:
             raise ValueError("len(target_wires) must equal bitstring length.")
 
-        if data.shape[0] != (1 << n_total):
-            raise ValueError("data.shape[0] must be 2^(len(control_wires)).")
+        if bitstrings.shape[0] != (1 << n_total):
+            raise ValueError("bitstrings.shape[0] must be 2^(len(control_wires)).")
 
         # Split control_wires into select and tree parts
         select_wires = Wires(control_wires[:k])
@@ -544,7 +551,7 @@ class HybridQRAM(Operation):
 
         all_wires = list(control_wires) + list(target_wires) + list(work_wires)
 
-        super().__init__(data, wires=all_wires)
+        super().__init__(bitstrings, wires=all_wires)
 
         self._hyperparameters = {
             "select_wires": select_wires,
@@ -618,7 +625,7 @@ def _bits(value: int, length: int) -> list[int]:
 
 
 def _tree_leaf_ops_for_bit_block_ctrl(
-    data, j, block_index, tree_wire_manager, n_tree, signal
+    bitstrings, j, block_index, tree_wire_manager, n_tree, signal
 ):  # pylint: disable=too-many-arguments
     """Leaf write for target bit j, for a given select prefix block, controlled on signal."""
 
@@ -632,7 +639,7 @@ def _tree_leaf_ops_for_bit_block_ctrl(
 
         # Global address index: (block_index << n_tree) + p
         addr = (block_index << n_tree) + p
-        bit = data[addr][j]
+        bit = bitstrings[addr][j]
         # pylint: disable=cell-var-from-loop
         cond(bit, lambda: ctrl(PauliZ(wires=target), control=[signal], control_values=[1]))()
 
@@ -699,7 +706,7 @@ def _tree_mark_routers_via_bus_ctrl(tree_wire_manager, n_tree, k, signal):
 
 
 def _block_tree_query_ops(
-    data, block_index, tree_wire_manager, n_tree, k, signal
+    bitstrings, block_index, tree_wire_manager, n_tree, k, signal
 ):  # pylint: disable=too-many-arguments
     """One BBQRAM-style query of the (n_tree)-depth tree for a fixed select prefix."""
 
@@ -718,7 +725,9 @@ def _block_tree_query_ops(
         _tree_route_bus_down_first_k_levels_ctrl(n_tree, tree_wire_manager, signal)
 
         # Leaf Z ops for this block and bit index j
-        _tree_leaf_ops_for_bit_block_ctrl(data, j, block_index, tree_wire_manager, n_tree, signal)
+        _tree_leaf_ops_for_bit_block_ctrl(
+            bitstrings, j, block_index, tree_wire_manager, n_tree, signal
+        )
 
         # Route back up
         adjoint(_tree_route_bus_down_first_k_levels_ctrl, lazy=False)(
@@ -737,7 +746,7 @@ def _block_tree_query_ops(
 
 @register_resources(_hybrid_qram_resources, exact=False)
 def _hybrid_qram_decomposition(
-    data, tree_wire_manager, select_wires, signal_wire, **_
+    bitstrings, tree_wire_manager, select_wires, signal_wire, **_
 ):  # pylint: disable=unused-argument, too-many-arguments
     k = len(select_wires)
 
@@ -755,7 +764,7 @@ def _hybrid_qram_decomposition(
 
         # Perform one tree query, driven by lower n_tree bits, controlled on signal
         _block_tree_query_ops(
-            data,
+            bitstrings,
             block_index,
             tree_wire_manager,
             len(tree_wire_manager.control_wires[k:]),
@@ -786,7 +795,7 @@ class SelectOnlyQRAM(Operation):
         \text{SelectOnlyQRAM}|i\rangle|0\rangle = |i\rangle |b_i\rangle.
 
     Args:
-        data (TensorLike | Sequence[str]):
+        bitstrings (TensorLike | Sequence[str]):
             The classical data as a sequence of bitstrings. The size of the classical data must be
             :math:`2^{\texttt{len(select_wires)}+\texttt{len(control_wires)}}`.
         control_wires (WiresLike):
@@ -794,7 +803,7 @@ class SelectOnlyQRAM(Operation):
             access.
         target_wires (WiresLike):
             The register in which the classical data gets loaded. The size of this register must
-            equal each bitstring length in ``data``.
+            equal each bitstring length in ``bitstrings``.
         select_wires (WiresLike, optional):
             Wires used to perform the selection.
         select_value (int or None, optional):
@@ -803,7 +812,7 @@ class SelectOnlyQRAM(Operation):
             and cannot be used if no ``select_wires`` are provided.
 
     Raises:
-        ValueError: if the ``data`` are of the wrong length, a ``select_value`` is provided without
+        ValueError: if the ``bitstrings`` are of the wrong length, a ``select_value`` is provided without
              ``select_wires``, or the ``select_value`` is greater than [0, (:math:`2^{\texttt{len(select_wires)}}`) - 1].
 
     .. seealso::
@@ -823,7 +832,7 @@ class SelectOnlyQRAM(Operation):
 
     .. code-block:: python
 
-        data = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
+        bitstrings = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
         bitstring_size = 3
 
     Given the number of bitstrings, the values of ``control_wires`` and ``select_wires`` can be
@@ -860,7 +869,7 @@ class SelectOnlyQRAM(Operation):
             qp.BasisState(2, wires=reg["control"])
 
             qp.SelectOnlyQRAM(
-                data,
+                bitstrings,
                 control_wires=reg["control"],
                 target_wires=reg["target"],
                 select_wires=reg["select"],
@@ -888,24 +897,26 @@ class SelectOnlyQRAM(Operation):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        data: TensorLike | Sequence[str],
+        bitstrings: TensorLike | Sequence[str],
         control_wires: WiresLike,
         target_wires: WiresLike,
         select_wires: WiresLike | None = None,
         select_value: int | None = None,
     ):
 
-        if isinstance(data, (list, tuple)):
-            data = math.array(data)
+        if isinstance(bitstrings, (list, tuple)):
+            bitstrings = math.array(bitstrings)
 
-        if data.shape[0] == 0:
-            raise ValueError("'data' cannot be empty.")
+        if bitstrings.shape[0] == 0:
+            raise ValueError("'bitstrings' cannot be empty.")
 
-        if isinstance(data[0], str):
-            data = math.array(list(map(lambda bitstring: [int(bit) for bit in bitstring], data)))
+        if isinstance(bitstrings[0], str):
+            bitstrings = math.array(
+                list(map(lambda bitstring: [int(bit) for bit in bitstring], bitstrings))
+            )
 
         target_wires = Wires(target_wires)
-        m = data.shape[1]
+        m = bitstrings.shape[1]
         if m != len(target_wires):
             raise ValueError("len(target_wires) must equal bitstring length.")
 
@@ -914,13 +925,15 @@ class SelectOnlyQRAM(Operation):
         target_wires = Wires(target_wires)
         select_wires = Wires(select_wires) if select_wires is not None else Wires([])
 
-        # ---- Validate data ----
+        # ---- Validate bitstrings ----
         num_select = len(select_wires)
         num_controls = len(control_wires)
         n_total = num_select + num_controls
 
-        if (1 << n_total) != data.shape[0]:
-            raise ValueError("data.shape[0] must be 2^(len(select_wires)+len(control_wires)).")
+        if (1 << n_total) != bitstrings.shape[0]:
+            raise ValueError(
+                "bitstrings.shape[0] must be 2^(len(select_wires)+len(control_wires))."
+            )
 
             # Validate select_value (if provided)
         if select_value is not None:
@@ -937,7 +950,9 @@ class SelectOnlyQRAM(Operation):
             "select_value": select_value,
         }
 
-        super().__init__(data, wires=list(control_wires) + list(target_wires) + list(select_wires))
+        super().__init__(
+            bitstrings, wires=list(control_wires) + list(target_wires) + list(select_wires)
+        )
 
     @classmethod
     def _primitive_bind_call(cls, *args, **kwargs):
@@ -987,7 +1002,7 @@ def _flip_controls(control_wires, control_vals):
 
 @register_resources(_select_only_qram_resources, exact=False)
 def _select_only_qram_decomposition(
-    data, select_value, select_wires, control_wires, target_wires, **_
+    bitstrings, select_value, select_wires, control_wires, target_wires, **_
 ):  # pylint: disable=unused-argument, too-many-arguments
     controls = select_wires + control_wires
     num_select = len(select_wires)
@@ -997,7 +1012,7 @@ def _select_only_qram_decomposition(
         BasisState(select_value, wires=select_wires)
 
     # Loop over all addresses (0 .. 2^(num_select+num_controls)-1)
-    for addr, bits in enumerate(data):
+    for addr, bits in enumerate(bitstrings):
         # If select_value is specified, only implement entries whose
         # high num_select bits (select part) match that value.
         if select_value is not None and num_select > 0:
@@ -1009,8 +1024,8 @@ def _select_only_qram_decomposition(
 
         _flip_controls(controls, control_values)
 
-        # For each bit position in the data
-        for j in range(data[0].shape[0]):
+        # For each bit position in the bitstrings
+        for j in range(bitstrings[0].shape[0]):
             # Multi-controlled X on target_wires[j],
             # controlled on controls matching `control_values`.
 

--- a/pennylane/templates/subroutines/qrom.py
+++ b/pennylane/templates/subroutines/qrom.py
@@ -49,15 +49,19 @@ def _multi_swap(wires1, wires2):
         qp_ops.SWAP(wires=[wire1, wire2])
 
 
-def _new_ops(depth, target_wires, control_wires, swap_wires, data):
+def _new_ops(depth, target_wires, control_wires, swap_wires, bitstrings):
 
     with QueuingManager.stop_recording():
-        ops_new = [BasisEmbedding(bits, wires=target_wires) for bits in data]
+        ops_new = [BasisEmbedding(bits, wires=target_wires) for bits in bitstrings]
         ops_identity_new = ops_new + [qp_ops.I(target_wires)] * int(
             2 ** len(control_wires) - len(ops_new)
         )
 
-    n_columns = data.shape[0] // depth if data.shape[0] % depth == 0 else data.shape[0] // depth + 1
+    n_columns = (
+        bitstrings.shape[0] // depth
+        if bitstrings.shape[0] % depth == 0
+        else bitstrings.shape[0] // depth + 1
+    )
     new_ops = []
     for i in range(n_columns):
         column_ops = []
@@ -72,19 +76,19 @@ def _new_ops(depth, target_wires, control_wires, swap_wires, data):
 
 
 def _select_ops(
-    control_wires, depth, target_wires, swap_wires, data, select_work_wires
+    control_wires, depth, target_wires, swap_wires, bitstrings, select_work_wires
 ):  # pylint:disable=too-many-arguments
     n_control_select_wires = ceil_log2(2 ** len(control_wires) / depth)
     control_select_wires = control_wires[:n_control_select_wires]
 
     if control_select_wires:
         Select(
-            _new_ops(depth, target_wires, control_wires, swap_wires, data),
+            _new_ops(depth, target_wires, control_wires, swap_wires, bitstrings),
             control=control_select_wires,
             work_wires=select_work_wires,
         )
     else:
-        _new_ops(depth, target_wires, control_wires, swap_wires, data)
+        _new_ops(depth, target_wires, control_wires, swap_wires, bitstrings)
 
 
 def _swap_ops(control_wires, depth, swap_wires, target_wires):
@@ -109,7 +113,7 @@ class QROM(Operator2):
     where :math:`b_i` is the bitstring associated with index :math:`i`.
 
     Args:
-        data (TensorLike): the data to be encoded
+        bitstrings (TensorLike): the data to be encoded
         control_wires (WiresLike):
             The register that stores the index for the entry of the classical data we want to
             read.
@@ -131,7 +135,7 @@ class QROM(Operator2):
     .. code-block:: python
 
         # a list of bitstrings is defined
-        data = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
+        bitstrings = [[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]]
 
         dev = qp.device("default.qubit")
 
@@ -141,7 +145,7 @@ class QROM(Operator2):
             # the third index is encoded in the control wires [0, 1]
             qp.BasisEmbedding(2, wires = [0,1])
 
-            qp.QROM(data = data,
+            qp.QROM(bitstrings = bitstrings,
                     control_wires = [0,1],
                     target_wires = [2,3,4],
                     work_wires = [5,6,7])
@@ -160,7 +164,7 @@ class QROM(Operator2):
         at least :math:`\lceil \log_2(m)\rceil` control wires.
 
         The second set of wires is ``target_wires`` which stores the bitstrings.
-        For instance, if the data is ``[0, 1, 1, 0]``, we will need four target wires. Internally,
+        For instance, if the bitstring is ``[0, 1, 1, 0]``, we will need four target wires. Internally,
         the bitstrings are encoded using the :class:`~.BasisEmbedding` template.
 
 
@@ -193,12 +197,12 @@ class QROM(Operator2):
 
     """
 
-    dynamic_argnames = ("data",)
+    dynamic_argnames = ("bitstrings",)
     wire_argnames = ("control_wires", "target_wires", "work_wires")
     compilable_argnames = ("clean",)
 
     arg_specs = {
-        "data": Int[-1, -1],
+        "bitstrings": Int[-1, -1],
         "control_wires": Wire[-1],
         "target_wires": Wire[-1],
         "work_wires": Wire[-1],
@@ -206,7 +210,7 @@ class QROM(Operator2):
 
     def __init__(
         self,
-        data: TensorLike | Sequence[str],
+        bitstrings: TensorLike | Sequence[str],
         control_wires: WiresLike,
         target_wires: WiresLike,
         work_wires: WiresLike,
@@ -216,11 +220,13 @@ class QROM(Operator2):
         control_wires = Wires(control_wires)
         target_wires = Wires(target_wires)
 
-        if isinstance(data[0], str):
-            data = np.array(list(map(lambda bitstring: [int(bit) for bit in bitstring], data)))
+        if isinstance(bitstrings[0], str):
+            bitstrings = np.array(
+                list(map(lambda bitstring: [int(bit) for bit in bitstring], bitstrings))
+            )
 
-        if isinstance(data, (list, tuple)):
-            data = math.array(data)
+        if isinstance(bitstrings, (list, tuple)):
+            bitstrings = math.array(bitstrings)
 
         work_wires = Wires(() if work_wires is None else work_wires)
 
@@ -241,31 +247,31 @@ class QROM(Operator2):
             if any(wire in control_wires for wire in target_wires):
                 raise ValueError("Target wires should be different from control wires.")
 
-        if 2 ** len(control_wires) < data.shape[0]:
+        if 2 ** len(control_wires) < bitstrings.shape[0]:
             raise ValueError(
                 f"Not enough control wires ({len(control_wires)}) for the desired number of "
-                + f"data ({data.shape[0]}). At least {ceil_log2(data.shape[0])} control "
-                + "wires are required."
+                f"bitstrings ({bitstrings.shape[0]}). At least {ceil_log2(bitstrings.shape[0])} "
+                "control wires are required."
             )
 
-        if data[0].shape[0] != len(target_wires):
+        if bitstrings[0].shape[0] != len(target_wires):
             raise ValueError("Bitstring length must match the number of target wires.")
 
-        super().__init__(data, control_wires, target_wires, work_wires, clean)
+        super().__init__(bitstrings, control_wires, target_wires, work_wires, clean)
 
     # pylint: disable=arguments-differ
     def __abstract_init__(
         self,
-        data: AbstractArray | TensorLike | Sequence[str],
+        bitstrings: AbstractArray | TensorLike | Sequence[str],
         control_wires: AbstractArray | WiresLike,
         target_wires: AbstractArray | WiresLike,
         work_wires: AbstractArray | WiresLike,
         clean=True,
     ):
-        if isinstance(data, Sequence) and isinstance(data[0], str):
-            data = AbstractArray(shape=(len(data), len(data[0])), dtype=np.int64)
+        if isinstance(bitstrings, Sequence) and isinstance(bitstrings[0], str):
+            bitstrings = AbstractArray(shape=(len(bitstrings), len(bitstrings[0])), dtype=np.int64)
         super().__abstract_init__(
-            data,
+            bitstrings,
             control_wires=Wire[len(control_wires)],
             target_wires=Wire[len(target_wires)],
             work_wires=Wire[len(work_wires)],
@@ -321,10 +327,10 @@ def _calculate_n_select_work_wires(terms, num_control_wires, num_target_wires, n
 
 
 def _qrom_decomposition_resources(
-    data, control_wires, target_wires, work_wires, clean
+    bitstrings, control_wires, target_wires, work_wires, clean
 ):  # pylint: disable=too-many-branches
 
-    num_bitstrings = len(data)
+    num_bitstrings = len(bitstrings)
     num_control_wires = len(control_wires)
     num_target_wires = len(target_wires)
     num_work_wires = len(work_wires)
@@ -421,13 +427,13 @@ def _qrom_decomposition_resources(
 
 @register_resources(_qrom_decomposition_resources)
 def _qrom_decomposition(
-    data, control_wires, target_wires, work_wires, clean
+    bitstrings, control_wires, target_wires, work_wires, clean
 ):  # pylint: disable=unused-argument, too-many-arguments
     if len(control_wires) == 0:
-        BasisEmbedding(data[0, :], wires=target_wires)
+        BasisEmbedding(bitstrings[0, :], wires=target_wires)
 
     n_select_work_wires = _calculate_n_select_work_wires(
-        len(data), len(control_wires), len(target_wires), len(work_wires)
+        len(bitstrings), len(control_wires), len(target_wires), len(work_wires)
     )
 
     n_swap_work_wires = len(work_wires) - n_select_work_wires
@@ -438,10 +444,10 @@ def _qrom_decomposition(
     # number of operators we store per column (power of 2)
     depth = len(swap_wires) // len(target_wires)
     depth = int(2 ** np.floor(np.log2(depth)))
-    depth = min(depth, data.shape[0])
+    depth = min(depth, bitstrings.shape[0])
 
     if not clean or depth == 1:
-        _select_ops(control_wires, depth, target_wires, swap_wires, data, select_work_wires)
+        _select_ops(control_wires, depth, target_wires, swap_wires, bitstrings, select_work_wires)
         _swap_ops(control_wires, depth, swap_wires, target_wires)
 
     else:
@@ -449,7 +455,9 @@ def _qrom_decomposition(
             for w in target_wires:
                 qp_ops.Hadamard(wires=w)
             qp_ops.adjoint(_swap_ops, lazy=False)(control_wires, depth, swap_wires, target_wires)
-            _select_ops(control_wires, depth, target_wires, swap_wires, data, select_work_wires)
+            _select_ops(
+                control_wires, depth, target_wires, swap_wires, bitstrings, select_work_wires
+            )
             _swap_ops(control_wires, depth, swap_wires, target_wires)
 
 
@@ -591,7 +599,7 @@ def _count_tempAND_in_measurement_qrom(k):
 
 
 def _qrom_measurement_resources(  # pylint: disable=too-many-arguments,unused-argument
-    data=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
+    bitstrings=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
 ):
     """Resource estimate for the measurement-based QROM decomposition.
 
@@ -602,11 +610,11 @@ def _qrom_measurement_resources(  # pylint: disable=too-many-arguments,unused-ar
     """
     # When called for Adjoint(QROM), extract params from the base parameters
     if base is not None:
-        num_bitstrings = len(base.arguments["data"])
+        num_bitstrings = len(base.bitstrings)
         num_target_wires = len(base.target_wires)
         num_control_wires = len(base.control_wires)
     else:
-        num_bitstrings = len(data)
+        num_bitstrings = len(bitstrings)
         num_target_wires = len(target_wires)
         num_control_wires = len(control_wires)
 
@@ -673,15 +681,15 @@ def _flag_resources(n_extra, num_target_wires):
 
 
 def _qrom_measurement_condition(
-    data=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
+    bitstrings=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
 ):  # pylint: disable=too-many-arguments,unused-argument
 
     if base is not None:
-        num_bitstrings = len(base.arguments["data"])
+        num_bitstrings = len(base.bitstrings)
         num_work_wires = len(base.work_wires)
         num_control_wires = len(base.control_wires)
     else:
-        num_bitstrings = len(data)
+        num_bitstrings = len(bitstrings)
         num_work_wires = len(work_wires)
         num_control_wires = len(control_wires)
 
@@ -750,7 +758,7 @@ def _build_flag(extra_wires, work_wires):
 @register_condition(_qrom_measurement_condition)
 @register_resources(_qrom_measurement_resources, exact=False)
 def _qrom_measurement_decomposition(
-    data=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
+    bitstrings=None, control_wires=None, target_wires=None, work_wires=None, clean=None, base=None
 ):  # pylint: disable=too-many-arguments,too-many-branches,unused-argument
     """QROM decomposition using measurement-based uncomputation.
 
@@ -763,7 +771,7 @@ def _qrom_measurement_decomposition(
     """
     # When called for Adjoint(QROM), extract params from the base operator
     if base is not None:
-        data = base.arguments["data"]
+        bitstrings = base.bitstrings
         control_wires = base.control_wires
         target_wires = base.target_wires
         work_wires = base.work_wires
@@ -771,9 +779,9 @@ def _qrom_measurement_decomposition(
     # Bitstrings are manipulated with integer bitwise operations (np.bitwise_xor)
     # below, but callers may pass float data (e.g. QROM(np.eye(b), ...)). Cast to
     # int so the XOR-relative encoding works regardless of the input dtype.
-    data = np.asarray(data).astype(int)
+    bitstrings = np.asarray(bitstrings).astype(int)
 
-    L = len(data)
+    L = len(bitstrings)
     n_input = len(control_wires)
 
     # Extra control wires beyond ceil_log2(L) are the most-significant address bits: the data
@@ -794,8 +802,8 @@ def _qrom_measurement_decomposition(
         flag, core_work = _build_flag(extra_wires, work_wires)
 
         # Gated base load, then the flag-gated unary iterator over the padded 2**n_active table.
-        padded = np.zeros((2**n_active, len(data[0])), dtype=int)
-        padded[:L] = data
+        padded = np.zeros((2**n_active, len(bitstrings[0])), dtype=int)
+        padded[:L] = bitstrings
         base = padded[0]
         # Fanout the base bitstring onto the target register, controlled on the flag.
         ctrl(BasisState(base, wires=target_wires), control=flag)
@@ -811,28 +819,28 @@ def _qrom_measurement_decomposition(
     # Pad data up to the next power of 2 with all-zero bitstrings
     next_pow2 = 1 << ceil_log2(L)
     if L < next_pow2:
-        width = len(data[0])
-        data = np.concatenate([data, np.zeros((next_pow2 - L, width), dtype=int)])
+        width = len(bitstrings[0])
+        bitstrings = np.concatenate([bitstrings, np.zeros((next_pow2 - L, width), dtype=int)])
         L = next_pow2
 
     if L == 1:
-        BasisState(data[0], target_wires)
+        BasisState(bitstrings[0], target_wires)
         return
 
     if L == 2:
-        BasisState(data[0], target_wires)
-        diff = np.bitwise_xor(data[0], data[1])
+        BasisState(bitstrings[0], target_wires)
+        diff = np.bitwise_xor(bitstrings[0], bitstrings[1])
         ctrl(BasisState(diff, wires=target_wires), control=control_wires[0])
         return
 
     # Load base bitstring
-    BasisState(data[0], target_wires)
+    BasisState(bitstrings[0], target_wires)
 
     # Build interleaved controls: [in[0], in[1], work[0], in[2], work[1], ...]
     controls = _interleave_controls(control_wires, work_wires)
 
-    # XOR-relative encoding: bitstrings[i] = data[i] XOR data[0]
-    bitstrings = np.bitwise_xor(data, data[0])
+    # XOR-relative encoding: bitstrings[i] = bitstrings[i] XOR bitstrings[0]
+    bitstrings = np.bitwise_xor(bitstrings, bitstrings[0])
 
     _measurement_qrom_outer(controls, list(target_wires), bitstrings, L)
 

--- a/pennylane/transforms/decompositions/select_pauli_rot_phase_gradient.py
+++ b/pennylane/transforms/decompositions/select_pauli_rot_phase_gradient.py
@@ -190,7 +190,7 @@ def make_selectpaulirot_to_phase_gradient_decomp(angle_wires, phase_grad_wires, 
 
         # 1. QROM compressed rep
         qrom_rep = qp.QROM(
-            data=Int[2**num_control_wires, len(angle_wires)],
+            bitstrings=Int[2**num_control_wires, len(angle_wires)],
             control_wires=Wire[num_control_wires],
             target_wires=Wire[len(angle_wires)],
             work_wires=Wire[num_control_wires - 1],

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -988,7 +988,7 @@ class TestModifiedTemplates:
         """Test the primitve bind call of BBQRAM."""
 
         kwargs = {
-            "data": ((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
+            "bitstrings": ((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
             "control_wires": (0, 1),
             "target_wires": (2, 3, 4),
             "work_wires": tuple([5] + [6, 7, 8] + [12, 13, 14] + [9, 10, 11]),
@@ -1022,7 +1022,7 @@ class TestModifiedTemplates:
         """Test the primitve bind call of SelectOnlyQRAM."""
 
         kwargs = {
-            "data": (
+            "bitstrings": (
                 (0, 1, 0),
                 (1, 1, 1),
                 (1, 1, 0),
@@ -1066,7 +1066,7 @@ class TestModifiedTemplates:
         """Test the primitve bind call of HybridQRAM."""
 
         kwargs = {
-            "data": ((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
+            "bitstrings": ((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
             "control_wires": (0, 1),
             "target_wires": (2, 3, 4),
             "work_wires": tuple([5, 6, 7, 8, 12, 13, 14, 15, 9, 10, 11]),
@@ -1101,7 +1101,7 @@ class TestModifiedTemplates:
         """Test the primitive bind call of QROM."""
 
         kwargs = {
-            "data": ((0,), (1,)),
+            "bitstrings": ((0,), (1,)),
             "control_wires": [0],
             "target_wires": [1],
             "work_wires": None,

--- a/tests/estimator/templates/test_estimator_subroutines.py
+++ b/tests/estimator/templates/test_estimator_subroutines.py
@@ -310,7 +310,7 @@ class TestHybridQRAM:
         @qp.qnode(dev)
         def circuit():
             HybridQRAM(
-                data=data,
+                bitstrings=data,
                 control_wires=range(num_control_wires),
                 target_wires=range(num_control_wires, num_control_wires + data.shape[1]),
                 work_wires=range(
@@ -547,7 +547,7 @@ class TestSelectOnlyQRAM:
         @qp.qnode(dev)
         def circuit():
             SelectOnlyQRAM(
-                data=data,
+                bitstrings=data,
                 control_wires=range(num_control_wires),
                 target_wires=range(num_control_wires, num_control_wires + data.shape[1]),
                 select_wires=range(

--- a/tests/estimator/test_estimator_mapping.py
+++ b/tests/estimator/test_estimator_mapping.py
@@ -189,7 +189,7 @@ class TestMapToResourceOp:
             ),
             (
                 qtemps.HybridQRAM(
-                    data=["010", "111", "110", "000"],
+                    bitstrings=["010", "111", "110", "000"],
                     control_wires=[0, 1],
                     target_wires=[2, 3, 4],
                     work_wires=[5, 6, 7, 8, 9],
@@ -207,7 +207,7 @@ class TestMapToResourceOp:
             ),
             (
                 qtemps.SelectOnlyQRAM(
-                    data=[
+                    bitstrings=[
                         "000",
                         "101",
                         "010",
@@ -260,7 +260,7 @@ class TestMapToResourceOp:
             ),
             (
                 qtemps.BBQRAM(
-                    data=["010", "111", "110", "000"],
+                    bitstrings=["010", "111", "110", "000"],
                     control_wires=[0, 1],
                     target_wires=[2, 3, 4],
                     work_wires=[5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
@@ -277,7 +277,7 @@ class TestMapToResourceOp:
             ),
             (
                 qtemps.QROM(
-                    data=[[0, 1], [1, 1], [1, 0]],
+                    bitstrings=[[0, 1], [1, 1], [1, 0]],
                     control_wires=[0, 1],
                     target_wires=[2, 3],
                     work_wires=[4],

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -664,7 +664,7 @@ class TestToBloqDecomposition:
                 {
                     (
                         qp.QROM(
-                            data=[[0, 0, 1]],
+                            bitstrings=[[0, 0, 1]],
                             control_wires=[],
                             target_wires=[1, 2, 3],
                             work_wires=[0],
@@ -675,7 +675,7 @@ class TestToBloqDecomposition:
                     (
                         qp.adjoint(
                             qp.QROM(
-                                data=[[0, 0, 1]],
+                                bitstrings=[[0, 0, 1]],
                                 control_wires=[],
                                 target_wires=[1, 2, 3],
                                 work_wires=[0],
@@ -686,7 +686,7 @@ class TestToBloqDecomposition:
                     ): 1,
                     (
                         qp.QROM(
-                            data=[[0, 0, 0], [0, 0, 1]],
+                            bitstrings=[[0, 0, 0], [0, 0, 1]],
                             control_wires=[4],
                             target_wires=[1, 2, 3],
                             work_wires=[0],
@@ -697,7 +697,7 @@ class TestToBloqDecomposition:
                     (
                         qp.adjoint(
                             qp.QROM(
-                                data=[[0, 0, 0], [0, 0, 1]],
+                                bitstrings=[[0, 0, 0], [0, 0, 1]],
                                 control_wires=[4],
                                 target_wires=[1, 2, 3],
                                 work_wires=[0],
@@ -711,7 +711,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 0], [0, 0, 1]],
+                    bitstrings=[[0, 0, 0], [0, 0, 1]],
                     control_wires=[4],
                     target_wires=[1, 2, 3],
                     work_wires=[0],
@@ -732,7 +732,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 1]],
+                    bitstrings=[[0, 0, 1]],
                     control_wires=[],
                     target_wires=[1, 2, 3],
                     work_wires=[0],
@@ -745,7 +745,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 0], [0, 0, 1]],
+                    bitstrings=[[0, 0, 0], [0, 0, 1]],
                     control_wires=[4],
                     target_wires=[1, 2, 3],
                     work_wires=[0],
@@ -770,7 +770,7 @@ class TestToBloqDecomposition:
                 {
                     (
                         qp.QROM(
-                            data=[[0, 0, 1]],
+                            bitstrings=[[0, 0, 1]],
                             control_wires=[],
                             target_wires=[1, 2, 3],
                             work_wires=[0],
@@ -781,7 +781,7 @@ class TestToBloqDecomposition:
                     (
                         qp.adjoint(
                             qp.QROM(
-                                data=[[0, 0, 1]],
+                                bitstrings=[[0, 0, 1]],
                                 control_wires=[],
                                 target_wires=[1, 2, 3],
                                 work_wires=[0],
@@ -792,7 +792,7 @@ class TestToBloqDecomposition:
                     ): 1,
                     (
                         qp.QROM(
-                            data=[[0, 0, 0], [0, 0, 1]],
+                            bitstrings=[[0, 0, 0], [0, 0, 1]],
                             control_wires=[4],
                             target_wires=[1, 2, 3],
                             work_wires=[0],
@@ -803,7 +803,7 @@ class TestToBloqDecomposition:
                     (
                         qp.adjoint(
                             qp.QROM(
-                                data=[[0, 0, 0], [0, 0, 1]],
+                                bitstrings=[[0, 0, 0], [0, 0, 1]],
                                 control_wires=[4],
                                 target_wires=[1, 2, 3],
                                 work_wires=[0],
@@ -814,7 +814,7 @@ class TestToBloqDecomposition:
                     ): 1,
                     (
                         qp.QROM(
-                            data=[[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 0, 1]],
+                            bitstrings=[[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 0, 1]],
                             control_wires=[4, 5],
                             target_wires=[1, 2, 3],
                             work_wires=[0],
@@ -825,7 +825,7 @@ class TestToBloqDecomposition:
                     (
                         qp.adjoint(
                             qp.QROM(
-                                data=[[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 0, 1]],
+                                bitstrings=[[0, 0, 0], [0, 0, 0], [0, 0, 1], [0, 0, 1]],
                                 control_wires=[4, 5],
                                 target_wires=[1, 2, 3],
                                 work_wires=[0],
@@ -973,7 +973,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
+                    bitstrings=((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
                     control_wires=[0, 1],
                     target_wires=[2, 3, 4],
                     work_wires=[5, 6, 7],
@@ -982,7 +982,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
+                    bitstrings=((0, 1, 0), (1, 1, 1), (1, 1, 0), (0, 0, 0)),
                     control_wires=[0, 1],
                     target_wires=[2, 3, 4],
                     work_wires=[5, 6, 7],
@@ -1054,7 +1054,7 @@ class TestToBloqDecomposition:
             ),
             (
                 qp.QROM(
-                    data=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
+                    bitstrings=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
                     control_wires=[0, 1],
                     target_wires=[2, 3, 4],
                     work_wires=[5, 6, 7],
@@ -1139,7 +1139,7 @@ class TestToBloqDecomposition:
                 },
                 "qrom_custom_mapping": {
                     qp.QROM(
-                        data=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
+                        bitstrings=[[0, 1, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0]],
                         control_wires=[0, 1],
                         target_wires=[2, 3, 4],
                         work_wires=[5, 6, 7],
@@ -1348,7 +1348,7 @@ class TestToBloqEstimator:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 0], [0, 0, 1]],
+                    bitstrings=[[0, 0, 0], [0, 0, 1]],
                     control_wires=[4],
                     target_wires=[1, 2, 3],
                     work_wires=[0],
@@ -1363,7 +1363,7 @@ class TestToBloqEstimator:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 1]],
+                    bitstrings=[[0, 0, 1]],
                     control_wires=[],
                     target_wires=[1, 2, 3],
                     work_wires=[0],
@@ -1375,7 +1375,7 @@ class TestToBloqEstimator:
             ),
             (
                 qp.QROM(
-                    data=[[0, 0, 0], [0, 0, 1]],
+                    bitstrings=[[0, 0, 0], [0, 0, 1]],
                     control_wires=[4],
                     target_wires=[1, 2, 3],
                     work_wires=[0],

--- a/tests/templates/subroutines/test_qram.py
+++ b/tests/templates/subroutines/test_qram.py
@@ -39,10 +39,10 @@ dev = device("default.qubit")
 
 
 @qnode(dev)
-def bb_quantum(data, control_wires, target_wires, work_wires, address):
+def bb_quantum(bitstrings, control_wires, target_wires, work_wires, address):
     BasisEmbedding(address, wires=control_wires)
     BBQRAM(
-        data,
+        bitstrings,
         control_wires=control_wires,
         target_wires=target_wires,
         work_wires=work_wires,
@@ -54,7 +54,7 @@ def bb_quantum(data, control_wires, target_wires, work_wires, address):
 @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "work_wires",
@@ -106,7 +106,7 @@ def bb_quantum(data, control_wires, target_wires, work_wires, address):
     ],
 )
 def test_bb_quantum(
-    data,
+    bitstrings,
     control_wires,
     target_wires,
     work_wires,
@@ -114,9 +114,9 @@ def test_bb_quantum(
     probabilities,
 ):  # pylint: disable=too-many-arguments
 
-    if has_jax and not isinstance(data[0], str) and not isinstance(data, np.ndarray):
-        data, control_wires, target_wires, work_wires = (
-            jnp.array(data),
+    if has_jax and not isinstance(bitstrings[0], str) and not isinstance(bitstrings, np.ndarray):
+        bitstrings, control_wires, target_wires, work_wires = (
+            jnp.array(bitstrings),
             jnp.array(control_wires),
             jnp.array(target_wires),
             jnp.array(work_wires),
@@ -125,7 +125,7 @@ def test_bb_quantum(
     assert np.allclose(
         probabilities,
         bb_quantum(
-            data,
+            bitstrings,
             control_wires,
             target_wires,
             work_wires,
@@ -145,7 +145,7 @@ def test_bb_quantum(
                 [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
             ),
             ValueError,
-            "data' cannot be empty.",
+            "bitstrings' cannot be empty.",
         ),
         (
             (
@@ -155,7 +155,7 @@ def test_bb_quantum(
                 [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
             ),
             ValueError,
-            "data.shape[0] must be 2^(len(control_wires)).",
+            "bitstrings.shape[0] must be 2^(len(control_wires)).",
         ),
         (
             (
@@ -196,7 +196,7 @@ def test_raises(params, error, match):
 
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "bus",
@@ -250,7 +250,7 @@ def test_raises(params, error, match):
     ],
 )
 def test_bbqram_decomposition_new(
-    data,
+    bitstrings,
     control_wires,
     target_wires,
     bus,
@@ -259,7 +259,7 @@ def test_bbqram_decomposition_new(
     portR_wires,
 ):  # pylint: disable=too-many-arguments
     op = BBQRAM(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         [bus] + dir_wires + portL_wires + portR_wires,
@@ -271,11 +271,11 @@ def test_bbqram_decomposition_new(
 
 @qnode(dev)
 def hybrid_quantum(
-    data, control_wires, target_wires, work_wires, k, address
+    bitstrings, control_wires, target_wires, work_wires, k, address
 ):  # pylint: disable=too-many-arguments
     BasisEmbedding(address, wires=control_wires)
     HybridQRAM(
-        data,
+        bitstrings,
         control_wires=control_wires,
         target_wires=target_wires,
         work_wires=work_wires,
@@ -288,7 +288,7 @@ def hybrid_quantum(
 @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "work_wires",
@@ -497,7 +497,7 @@ def hybrid_quantum(
     ],
 )
 def test_hybrid_quantum(
-    data,
+    bitstrings,
     control_wires,
     target_wires,
     work_wires,
@@ -507,16 +507,16 @@ def test_hybrid_quantum(
     expected_circuit,
 ):  # pylint: disable=too-many-arguments
 
-    if has_jax and not isinstance(data[0], str) and not isinstance(data, np.ndarray):
-        data, control_wires, target_wires, work_wires = (
-            jnp.array(data),
+    if has_jax and not isinstance(bitstrings[0], str) and not isinstance(bitstrings, np.ndarray):
+        bitstrings, control_wires, target_wires, work_wires = (
+            jnp.array(bitstrings),
             jnp.array(control_wires),
             jnp.array(target_wires),
             jnp.array(work_wires),
         )
 
     real_probs = hybrid_quantum(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         work_wires,
@@ -525,7 +525,7 @@ def test_hybrid_quantum(
     )
     assert np.allclose(probabilities, real_probs)
     tape = workflow.construct_tape(hybrid_quantum, level="device")(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         work_wires,
@@ -537,7 +537,7 @@ def test_hybrid_quantum(
 
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "signal",
@@ -583,7 +583,7 @@ def test_hybrid_quantum(
     ],
 )
 def test_hybrid_decomposition_new(
-    data,
+    bitstrings,
     control_wires,
     target_wires,
     signal,
@@ -594,7 +594,7 @@ def test_hybrid_decomposition_new(
     k,
 ):  # pylint: disable=too-many-arguments
     op = HybridQRAM(
-        data,
+        bitstrings,
         control_wires=control_wires,
         target_wires=target_wires,
         work_wires=[signal] + [bus] + dir_wires + portL_wires + portR_wires,
@@ -610,7 +610,7 @@ def test_hybrid_decomposition_new(
         (
             ([], [0, 1], [2, 3, 4], [5, 6, 7, 8, 9, 10, 11, 12, 13, 14], 0),
             ValueError,
-            "data' cannot be empty.",
+            "bitstrings' cannot be empty.",
         ),
         (
             (
@@ -621,7 +621,7 @@ def test_hybrid_decomposition_new(
                 0,
             ),
             ValueError,
-            "data.shape[0] must be 2^(len(control_wires)).",
+            "bitstrings.shape[0] must be 2^(len(control_wires)).",
         ),
         (
             (
@@ -696,11 +696,11 @@ def test_hybrid_raises(params, error, match):
 
 @qnode(dev)
 def select_only_quantum(
-    data, control_wires, target_wires, select_wires, select_value, address
+    bitstrings, control_wires, target_wires, select_wires, select_value, address
 ):  # pylint: disable=too-many-arguments
     BasisEmbedding(address, wires=control_wires)
     SelectOnlyQRAM(
-        data,
+        bitstrings,
         control_wires=control_wires,
         target_wires=target_wires,
         select_wires=select_wires,
@@ -713,7 +713,7 @@ def select_only_quantum(
 @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "select_wires",
@@ -996,7 +996,7 @@ def select_only_quantum(
     ],
 )
 def test_select_only_quantum(
-    data,
+    bitstrings,
     control_wires,
     target_wires,
     select_wires,
@@ -1006,16 +1006,16 @@ def test_select_only_quantum(
     expected_circuit,
 ):  # pylint: disable=too-many-arguments
 
-    if has_jax and not isinstance(data[0], str) and not isinstance(data, np.ndarray):
-        data, control_wires, target_wires, select_wires = (
-            jnp.array(data),
+    if has_jax and not isinstance(bitstrings[0], str) and not isinstance(bitstrings, np.ndarray):
+        bitstrings, control_wires, target_wires, select_wires = (
+            jnp.array(bitstrings),
             jnp.array(control_wires),
             jnp.array(target_wires),
             jnp.array(select_wires),
         )
 
     real_probs = select_only_quantum(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         select_wires,
@@ -1024,7 +1024,7 @@ def test_select_only_quantum(
     )
     assert np.allclose(probabilities, real_probs)
     tape = workflow.construct_tape(select_only_quantum, level="device")(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         select_wires,
@@ -1046,7 +1046,7 @@ def test_select_only_quantum(
                 2,
             ),
             ValueError,
-            "data.shape[0] must be 2^(len(select_wires)+len(control_wires)).",
+            "bitstrings.shape[0] must be 2^(len(select_wires)+len(control_wires)).",
         ),
         (
             (
@@ -1092,7 +1092,7 @@ def test_select_only_quantum(
                 [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
             ),
             ValueError,
-            "data' cannot be empty.",
+            "bitstrings' cannot be empty.",
         ),
         (
             (
@@ -1118,7 +1118,7 @@ def test_select_only_raises(params, error, match):
 
 @pytest.mark.parametrize(
     (
-        "data",
+        "bitstrings",
         "control_wires",
         "target_wires",
         "select_wires",
@@ -1188,10 +1188,10 @@ def test_select_only_raises(params, error, match):
     ],
 )
 def test_select_decomposition_new(
-    data, control_wires, target_wires, select_wires, select_value
+    bitstrings, control_wires, target_wires, select_wires, select_value
 ):  # pylint: disable=too-many-arguments
     op = SelectOnlyQRAM(
-        data,
+        bitstrings,
         control_wires,
         target_wires,
         select_wires,

--- a/tests/templates/subroutines/test_qrom.py
+++ b/tests/templates/subroutines/test_qrom.py
@@ -48,7 +48,7 @@ except ImportError:
 
 
 @pytest.mark.parametrize(
-    "data",
+    "bitstrings",
     [
         [[1, 0, 0, 1], [0, 1, 1, 0]],
         [
@@ -72,27 +72,27 @@ except ImportError:
         ("000", "101"),
     ],
 )
-def test_abstract_init(data):
-    """Tests that the abstract init handles Sequence[str] data and more."""
+def test_abstract_init(bitstrings):
+    """Tests that the abstract init handles Sequence[str] bitstrings and more."""
     control_wires = Wire[3]
-    if not isinstance(data, AbstractArray) and isinstance(data[0], (str, list)):
-        target_wires = Wire[len(data[0])]
+    if not isinstance(bitstrings, AbstractArray) and isinstance(bitstrings[0], (str, list)):
+        target_wires = Wire[len(bitstrings[0])]
     else:
-        target_wires = Wire[data.shape[-1]]
+        target_wires = Wire[bitstrings.shape[-1]]
     work_wires = Wire[3]
 
-    op = qp.QROM(data, control_wires, target_wires, work_wires)
+    op = qp.QROM(bitstrings, control_wires, target_wires, work_wires)
 
-    if not isinstance(data, AbstractArray) and isinstance(data[0], (str, list)):
-        assert op.arguments["data"] == AbstractArray((len(data), len(data[0])), dtype=np.int64)
+    if not isinstance(bitstrings, AbstractArray) and isinstance(bitstrings[0], (str, list)):
+        assert op.bitstrings == AbstractArray((len(bitstrings), len(bitstrings[0])), dtype=np.int64)
     else:
-        assert op.arguments["data"] == AbstractArray(shape=data.shape, dtype=np.int64)
+        assert op.bitstrings == AbstractArray(shape=bitstrings.shape, dtype=np.int64)
 
 
 @pytest.mark.jax
 def test_assert_valid_qrom():
     """Run standard validity tests."""
-    data = (
+    bitstrings = (
         (0, 0, 0),
         (0, 0, 1),
         (1, 1, 1),
@@ -103,7 +103,7 @@ def test_assert_valid_qrom():
         (1, 1, 1),
     )
 
-    op = qp.QROM(data, control_wires=[0, 1, 2], target_wires=[3, 4, 5], work_wires=[6, 7, 8])
+    op = qp.QROM(bitstrings, control_wires=[0, 1, 2], target_wires=[3, 4, 5], work_wires=[6, 7, 8])
     qp.ops.functions.assert_valid(op, skip_differentiation=True)
 
 
@@ -125,7 +125,7 @@ class TestQROM:
     @pytest.mark.jax
     @pytest.mark.usefixtures("enable_and_disable_graph_decomp")
     @pytest.mark.parametrize(
-        ("data", "target_wires", "control_wires", "work_wires", "clean"),
+        ("bitstrings", "target_wires", "control_wires", "work_wires", "clean"),
         [
             (
                 np.array(
@@ -207,14 +207,14 @@ class TestQROM:
         ],
     )
     def test_operation_result(
-        self, data, target_wires, control_wires, work_wires, clean
+        self, bitstrings, target_wires, control_wires, work_wires, clean
     ):  # pylint: disable=too-many-arguments
         """Test the correctness of the QROM template output."""
         dev = qp.device("default.qubit")
 
-        if has_jax and not isinstance(data, numpy.ndarray):
-            data, control_wires, target_wires, work_wires = (
-                jnp.array(data),
+        if has_jax and not isinstance(bitstrings, numpy.ndarray):
+            bitstrings, control_wires, target_wires, work_wires = (
+                jnp.array(bitstrings),
                 jnp.array(control_wires),
                 jnp.array(target_wires),
                 jnp.array(work_wires),
@@ -224,14 +224,14 @@ class TestQROM:
         @qp.qnode(dev)
         def circuit(j):
             qp.BasisEmbedding(j, wires=control_wires)
-            qp.QROM(data, control_wires, target_wires, work_wires, clean)
+            qp.QROM(bitstrings, control_wires, target_wires, work_wires, clean)
             return qp.sample(wires=target_wires)
 
         for j in range(2 ** len(control_wires)):
-            assert np.allclose(circuit(j), [int(bit) for bit in data[j]])
+            assert np.allclose(circuit(j), [int(bit) for bit in bitstrings[j]])
 
     @pytest.mark.parametrize(
-        ("data", "target_wires", "control_wires", "work_wires"),
+        ("bitstrings", "target_wires", "control_wires", "work_wires"),
         [
             (
                 [[1, 1], [0, 1], [0, 0], [1, 0]],
@@ -269,7 +269,7 @@ class TestQROM:
             ),
         ],
     )
-    def test_work_wires_output(self, data, target_wires, control_wires, work_wires):
+    def test_work_wires_output(self, bitstrings, target_wires, control_wires, work_wires):
         """Tests that the ``clean = True`` version don't modify the initial state in work_wires."""
         dev = qp.device("default.qubit")
 
@@ -283,7 +283,7 @@ class TestQROM:
             for wire in control_wires:
                 qp.Hadamard(wires=wire)
 
-            qp.QROM(data, control_wires, target_wires, work_wires)
+            qp.QROM(bitstrings, control_wires, target_wires, work_wires)
 
             for ind, wire in enumerate(work_wires):
                 qp.RX(-ind, wires=wire)
@@ -329,7 +329,7 @@ class TestQROM:
             qp.assert_equal(op1, op2)
 
     @pytest.mark.parametrize(
-        ("data", "control_wires", "target_wires", "work_wires", "clean"),
+        ("bitstrings", "control_wires", "target_wires", "work_wires", "clean"),
         [
             (
                 [[1, 1], [0, 1], [0, 0], [1, 0]],
@@ -377,11 +377,11 @@ class TestQROM:
         ],  # pylint: disable=too-many-arguments
     )
     def test_decomposition_new(
-        self, data, control_wires, target_wires, work_wires, clean
+        self, bitstrings, control_wires, target_wires, work_wires, clean
     ):  # pylint: disable=too-many-arguments
         """Tests the decomposition rule implemented with the new system."""
         op = qp.QROM(
-            data,
+            bitstrings,
             control_wires=control_wires,
             target_wires=target_wires,
             work_wires=work_wires,
@@ -449,18 +449,18 @@ class TestQROM:
 
         jax.config.update("jax_enable_x64", True)
 
-        def build_and_decompose(data, control_wires, target_wires, work_wires):
-            op = qp.QROM(data, control_wires, target_wires, work_wires)
+        def build_and_decompose(bitstrings, control_wires, target_wires, work_wires):
+            op = qp.QROM(bitstrings, control_wires, target_wires, work_wires)
             op.decomposition()
             return True
 
         n, m, w = 2, 2, 1
-        data = jnp.array([[1, 0], [0, 1], [1, 1], [0, 0]])
+        bitstrings = jnp.array([[1, 0], [0, 1], [1, 1], [0, 0]])
         control_wires = jnp.arange(0, n)
         target_wires = jnp.arange(n, n + m)
         work_wires = jnp.arange(n + m, n + m + w)
 
-        jax.make_jaxpr(build_and_decompose)(data, control_wires, target_wires, work_wires)
+        jax.make_jaxpr(build_and_decompose)(bitstrings, control_wires, target_wires, work_wires)
 
 
 @pytest.mark.parametrize(
@@ -493,26 +493,29 @@ def test_wires_error(control_wires, target_wires, work_wires, msg_match):
 
 
 @pytest.mark.parametrize(
-    ("data", "control_wires", "target_wires", "msg_match"),
+    ("bitstrings", "control_wires", "target_wires", "msg_match"),
     [
         (
             [[1], [0], [0], [1]],
             [0],
             [2],
-            r"Not enough control wires \(1\) for the desired number of data \(4\). At least 2 control wires are required.",
+            (
+                r"Not enough control wires \(1\) for the desired number of bitstrings \(4\). "
+                "At least 2 control wires are required."
+            ),
         ),
         (
             [[1], [0], [0], [1]],
             [0, 1],
             [2, 3],
-            r"Bitstring length must match the number of target wires.",
+            "Bitstring length must match the number of target wires.",
         ),
     ],
 )
-def test_wrong_wires_error(data, control_wires, target_wires, msg_match):
+def test_wrong_wires_error(bitstrings, control_wires, target_wires, msg_match):
     """Test that error is raised if more ops are requested than can fit in control wires"""
     with pytest.raises(ValueError, match=msg_match):
-        qp.QROM(data, control_wires, target_wires, work_wires=None)
+        qp.QROM(bitstrings, control_wires, target_wires, work_wires=None)
 
 
 def test_none_work_wires_case():
@@ -599,24 +602,24 @@ class TestMeasurementQROM:
 
         basis_state_rep = resource_rep(qp.BasisState, num_wires=3)
 
-        # Only data and target_wires are relevant
+        # Only bitstrings and target_wires are relevant
         res_one = _qrom_measurement_resources(
-            data=Int[1, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
+            bitstrings=Int[1, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
         )
         assert res_one[basis_state_rep] == 1
 
-        # Only data and target_wires are relevant
+        # Only bitstrings and target_wires are relevant
         res_two = _qrom_measurement_resources(
-            data=Int[2, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
+            bitstrings=Int[2, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
         )
         assert res_two[basis_state_rep] == 1
         assert res_two[_ctrl_abstract(basis_state_rep, Wire[1])] == 1
 
     def test_resources_general_case(self):
         """Test that the general resource estimate contains the expected gate types."""
-        # Only data and target_wires are relevant
+        # Only bitstrings and target_wires are relevant
         res = _qrom_measurement_resources(
-            data=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
+            bitstrings=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
         )
 
         ppm_counts = sum(v for k, v in res.items() if isinstance(k, PauliMeasure))
@@ -625,13 +628,13 @@ class TestMeasurementQROM:
 
     def test_resources_from_base(self):
         """Test that resources are extracted from ``base`` (Adjoint path)."""
-        # Only data and target_wires are relevant
+        # Only bitstrings and target_wires are relevant
         res_direct = _qrom_measurement_resources(
-            data=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
+            bitstrings=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
         )
 
         base = qp.QROM(
-            data=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
+            bitstrings=Int[8, 3], control_wires=Wire[1], target_wires=Wire[3], work_wires=Wire[1]
         )
         res_base = _qrom_measurement_resources(base=base)
         assert res_base == res_direct
@@ -646,7 +649,7 @@ class TestMeasurementQROM:
         """
         n_active = 2  # ceil_log2(4)
         res_extra = _qrom_measurement_resources(
-            data=Int[4, 2],
+            bitstrings=Int[4, 2],
             control_wires=Wire[n_active + n_extra],
             target_wires=Wire[2],
             work_wires=Wire[1],
@@ -654,7 +657,7 @@ class TestMeasurementQROM:
         # A single extra wire builds the flag with X gates (no ANDs from folding), so its
         # TemporaryAND count is exactly the gated inner-iterator core; use it as the baseline.
         res_one = _qrom_measurement_resources(
-            data=Int[4, 2],
+            bitstrings=Int[4, 2],
             control_wires=Wire[n_active + 1],
             target_wires=Wire[2],
             work_wires=Wire[1],
@@ -681,7 +684,10 @@ class TestMeasurementQROM:
         assert (
             _qrom_measurement_condition(
                 base=qp.QROM(
-                    Int[8, 3], work_wires=Wire[2], control_wires=Wire[3], target_wires=Wire[3]
+                    bitstrings=Int[8, 3],
+                    work_wires=Wire[2],
+                    control_wires=Wire[3],
+                    target_wires=Wire[3],
                 ),
             )
             is True
@@ -691,7 +697,7 @@ class TestMeasurementQROM:
         """Test the L == 1 branch of the measurement decomposition (no control wires)."""
         with qp.queuing.AnnotatedQueue() as q:
             _qrom_measurement_decomposition(
-                data=np.array([[1, 0, 1]]),
+                bitstrings=np.array([[1, 0, 1]]),
                 control_wires=[],
                 target_wires=[1, 2, 3],
                 work_wires=[],
@@ -706,7 +712,7 @@ class TestMeasurementQROM:
         """Test the L == 2 branch of the measurement decomposition."""
         with qp.queuing.AnnotatedQueue() as q:
             _qrom_measurement_decomposition(
-                data=np.array([[1, 0, 1], [0, 0, 1]]),
+                bitstrings=np.array([[1, 0, 1], [0, 0, 1]]),
                 control_wires=[0],
                 target_wires=[1, 2, 3],
                 work_wires=[],
@@ -730,7 +736,7 @@ class TestMeasurementQROM:
             _qrom_measurement_decomposition(base=op)
         with qp.queuing.AnnotatedQueue() as q_direct:
             _qrom_measurement_decomposition(
-                data=op.arguments["data"],
+                bitstrings=op.bitstrings,
                 control_wires=op.control_wires,
                 target_wires=op.target_wires,
                 work_wires=op.work_wires,
@@ -770,7 +776,7 @@ class TestMeasurementQROM:
         @qp.qnode(dev)
         def circuit(j):
             qp.BasisState(j, wires=wires["control_wires"])
-            _qrom_measurement_decomposition(data=bitstrings, **wires, clean=True)
+            _qrom_measurement_decomposition(bitstrings=bitstrings, **wires, clean=True)
             return qp.sample(wires=wires["target_wires"]), qp.sample(wires=wires["work_wires"])
 
         for j in range(L):
@@ -818,7 +824,7 @@ class TestMeasurementQROM:
                 qp.Hadamard(wire)
 
             _qrom_measurement_decomposition(
-                data=bitstrings,
+                bitstrings=bitstrings,
                 control_wires=control_wires,
                 target_wires=target_wires,
                 work_wires=work_wires,
@@ -871,7 +877,7 @@ class TestMeasurementQROM:
         @qp.qnode(dev)
         def circuit(j):
             qp.BasisState(j, wires=wires["control_wires"])
-            _qrom_measurement_decomposition(data=bitstrings, **wires, clean=True)
+            _qrom_measurement_decomposition(bitstrings=bitstrings, **wires, clean=True)
             return qp.sample(wires=wires["target_wires"]), qp.sample(wires=wires["work_wires"])
 
         for j in range(L, 2**n_input):
@@ -916,7 +922,7 @@ class TestMeasurementQROM:
         @qp.qnode(dev)
         def circuit(j):
             qp.BasisState(j, wires=wires["control_wires"])
-            _qrom_measurement_decomposition(data=bitstrings, **wires, clean=True)
+            _qrom_measurement_decomposition(bitstrings=bitstrings, **wires, clean=True)
             return qp.sample(wires=wires["target_wires"]), qp.sample(wires=wires["work_wires"])
 
         for j in range(2**n_input):


### PR DESCRIPTION
**Context:**
In #10005, there was mixed usage of `QROM.data` to refer to the dynamic argument and also to refer to the `Operator2.data`, which is `(dynamic_arg,)`. This was due to the fact that the argument name clashes with the legacy `data` attribute.

**Description of the Change:**
* Rename `QROM`'s `data` argument to `bitstrings`
* Rename `BBQRAM`, `HybridQRAM`, and `SelectOnlyQRAM`'s `data` argument to `bitstrings`
* Update all references in source code and tests accordingly

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-127646]