### PR TITLE
Bugfix: the data module promoting wires to `float64`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -840,6 +840,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The way that `~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with `~.Operator2` in the data module.
+  [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
+
 * Adds an `AGENTS.md` file providing guidelines and repository conventions for AI coding agents.
   [(#9929)](https://github.com/PennyLaneAI/pennylane/pull/9929)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -840,9 +840,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The way that `~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with `~.Operator2` in the data module.
-  [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
-
 * Adds an `AGENTS.md` file providing guidelines and repository conventions for AI coding agents.
   [(#9929)](https://github.com/PennyLaneAI/pennylane/pull/9929)
 
@@ -1042,6 +1039,8 @@
     [(#9866)](https://github.com/PennyLaneAI/pennylane/pull/9866)
     [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
     [(#9973)](https://github.com/PennyLaneAI/pennylane/pull/9973)
+  - The way that `~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with `~.Operator2` in the data module.
+    [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
 
 * Adds a new `pennylane/core` module.
   Moves the abstractions from `pennylane/operation` into `pennylane/core/operator`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -840,7 +840,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The way that `~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with `~.Operator2` in the data module.
+* The way that :class:`~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with :class:`~.Operator2` in the data module.
   [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
 
 * Adds an `AGENTS.md` file providing guidelines and repository conventions for AI coding agents.

--- a/pennylane/data/attributes/pytree.py
+++ b/pennylane/data/attributes/pytree.py
@@ -69,11 +69,21 @@ def _storable_as_array(leaves: list) -> bool:
     use the array path, as they did before string leaves were special-cased. ``"biufcS"`` are the
     numpy dtype ``kind`` codes that round-trip safely through an HDF5 array: boolean, signed and
     unsigned integer, float, complex, and byte string.
+
+    Also returns ``False`` when the leaves do not all share the same dtype ``kind``. Stacking
+    leaves of different kinds into one array promotes them to a common dtype, which silently
+    changes a leaf's type (e.g. an integer wire label ``0`` (kind ``"i"``) stored alongside a
+    float parameter ``0.5`` (kind ``"f"``) comes back as ``0.0``). Comparing the ``kind`` rather
+    than the full dtype still allows losslessly stackable leaves that only differ in width, such
+    as byte strings of different lengths (``"S2"`` and ``"S3"``, both kind ``"S"``) or integers of
+    different sizes, to use the efficient array path.
     """
     if any(get_interface(leaf) not in ("numpy", "autograd") for leaf in leaves):
         return False
 
     leaf_arrays = [np.asarray(leaf) for leaf in leaves]
-    return all(arr.dtype.kind in "biufcS" for arr in leaf_arrays) and (
-        len({arr.shape for arr in leaf_arrays}) <= 1
+    return (
+        all(arr.dtype.kind in "biufcS" for arr in leaf_arrays)
+        and (len({arr.shape for arr in leaf_arrays}) <= 1)
+        and (len({arr.dtype.kind for arr in leaf_arrays}) <= 1)
     )

--- a/pennylane/data/attributes/pytree.py
+++ b/pennylane/data/attributes/pytree.py
@@ -42,6 +42,9 @@ class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
             structure = serialization.pytree_structure_load(bind["treedef"][()].tobytes())
             leaves = list(AttributeTypeMapper(bind)["leaves"].get_value())
 
+            # Wires are leaves but are distinct from other array-like data. So, we
+            # cast them to Python integers explicitly to ensure that the unflattened
+            # structures have `Wires` that do not contain array data.
             leaves = [
                 _to_python_scalar(leaf) if is_wire else leaf
                 for leaf, is_wire in zip(leaves, _wire_leaf_flags(structure), strict=True)

--- a/pennylane/data/attributes/pytree.py
+++ b/pennylane/data/attributes/pytree.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Contains DatasetAttribute definition for PyTree types."""
 
-import json
 from typing import TypeVar
 
 import numpy as np
@@ -30,13 +29,6 @@ from pennylane.wires import Wires
 T = TypeVar("T")
 
 
-def _is_wires(obj) -> bool:
-    """Whether ``obj`` should be treated as a single (opaque) leaf when flattening, i.e. a
-    ``Wires`` object. This keeps wire labels out of the numeric leaves so they can be serialized
-    through the JSON path (see :func:`~.value_to_hdf5`)."""
-    return isinstance(obj, Wires)
-
-
 class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
     """Attribute type for an object that can be converted to
     a Pytree. This is the default serialization method for
@@ -50,10 +42,6 @@ class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
             structure = serialization.pytree_structure_load(bind["treedef"][()].tobytes())
             leaves = list(AttributeTypeMapper(bind)["leaves"].get_value())
 
-            # HDF5 reads scalar leaves back as numpy scalars. Restore wire labels (the leaves that
-            # live under a ``Wires`` node) to native Python scalars so that, e.g., an integer wire
-            # ``0`` comes back as ``int`` rather than ``np.int64``. Parameters are left as numpy,
-            # which is their expected representation.
             leaves = [
                 _to_python_scalar(leaf) if is_wire else leaf
                 for leaf, is_wire in zip(leaves, _wire_leaf_flags(structure), strict=True)

--- a/pennylane/data/attributes/pytree.py
+++ b/pennylane/data/attributes/pytree.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Contains DatasetAttribute definition for PyTree types."""
 
+import json
 from typing import TypeVar
 
 import numpy as np
@@ -24,8 +25,16 @@ from pennylane.data.base.hdf5 import HDF5Group
 from pennylane.data.base.mapper import AttributeTypeMapper
 from pennylane.math import get_interface
 from pennylane.pytrees import flatten, unflatten
+from pennylane.wires import Wires
 
 T = TypeVar("T")
+
+
+def _is_wires(obj) -> bool:
+    """Whether ``obj`` should be treated as a single (opaque) leaf when flattening, i.e. a
+    ``Wires`` object. This keeps wire labels out of the numeric leaves so they can be serialized
+    through the JSON path (see :func:`~.value_to_hdf5`)."""
+    return isinstance(obj, Wires)
 
 
 class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
@@ -38,10 +47,19 @@ class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
 
     def hdf5_to_value(self, bind: HDF5Group) -> T:
         with queuing.QueuingManager.stop_recording():
-            return unflatten(
-                AttributeTypeMapper(bind)["leaves"].get_value(),
-                serialization.pytree_structure_load(bind["treedef"][()].tobytes()),
-            )
+            structure = serialization.pytree_structure_load(bind["treedef"][()].tobytes())
+            leaves = list(AttributeTypeMapper(bind)["leaves"].get_value())
+
+            # HDF5 reads scalar leaves back as numpy scalars. Restore wire labels (the leaves that
+            # live under a ``Wires`` node) to native Python scalars so that, e.g., an integer wire
+            # ``0`` comes back as ``int`` rather than ``np.int64``. Parameters are left as numpy,
+            # which is their expected representation.
+            leaves = [
+                _to_python_scalar(leaf) if is_wire else leaf
+                for leaf, is_wire in zip(leaves, _wire_leaf_flags(structure), strict=True)
+            ]
+
+            return unflatten(leaves, structure)
 
     def value_to_hdf5(self, bind_parent: HDF5Group, key: str, value: T) -> HDF5Group:
         bind = bind_parent.create_group(key)
@@ -55,6 +73,33 @@ class DatasetPyTree(DatasetAttribute[HDF5Group, T, T]):
             DatasetList(leaves, parent_and_key=(bind, "leaves"))
 
         return bind
+
+
+def _to_python_scalar(leaf):
+    """Convert a 0-d numpy leaf back to a native Python scalar, leaving other leaves untouched."""
+    if isinstance(leaf, (np.generic, np.ndarray)) and np.ndim(leaf) == 0:
+        return leaf.item()
+    return leaf
+
+
+def _wire_leaf_flags(structure) -> list:
+    """Return, in leaf order, whether each leaf is a wire label (i.e. lives under a ``Wires`` node).
+
+    The traversal order matches ``unflatten``'s depth-first consumption of the leaves, so the
+    returned flags line up one-to-one with the stored leaves.
+    """
+    flags: list = []
+
+    def _walk(node, in_wires: bool) -> None:
+        if node.is_leaf:
+            flags.append(in_wires)
+            return
+        in_wires = in_wires or node.type_ is Wires
+        for child in node.children:
+            _walk(child, in_wires)
+
+    _walk(structure, False)
+    return flags
 
 
 def _storable_as_array(leaves: list) -> bool:

--- a/pennylane/data/attributes/pytree.py
+++ b/pennylane/data/attributes/pytree.py
@@ -74,7 +74,8 @@ def _wire_leaf_flags(structure) -> list:
     """Return, in leaf order, whether each leaf is a wire label (i.e. lives under a ``Wires`` node).
 
     The traversal order matches ``unflatten``'s depth-first consumption of the leaves, so the
-    returned flags line up one-to-one with the stored leaves.
+    returned flags line up one-to-one with the stored leaves. This information is necessary so
+    that any ``Wires`` present in the Pytree are not constructed with array data.
     """
     flags: list = []
 

--- a/tests/data/attributes/test_pytree.py
+++ b/tests/data/attributes/test_pytree.py
@@ -155,6 +155,31 @@ class TestDatasetPyTree:
 
         assert _storable_as_array([leaf]) is False
 
+    @pytest.mark.parametrize(
+        "op, expected_wires, expected_types",
+        [
+            (qp.RZ(0.5, wires=0), [0], [int]),
+            (qp.RZ(0.5, wires="a"), ["a"], [str]),
+            (qp.CNOT(wires=[0, 1]), [0, 1], [int, int]),
+            (qp.Rot(0.1, 0.2, 0.3, wires=2), [2], [int]),
+        ],
+    )
+    def test_wire_labels_are_native_python(self, op, expected_wires, expected_types):
+        """Test that wire labels round-trip as native Python scalars rather than numpy types."""
+        result = DatasetPyTree(op).get_value()
+
+        qp.assert_equal(result, op)
+        assert list(result.wires) == expected_wires
+        assert [type(w) for w in result.wires] == expected_types
+
+    def test_integer_wire_not_promoted_by_float_parameter(self):
+        """Test that an integer wire label is not dtype-promoted to a float by a float parameter
+        sharing the leaf storage."""
+        result = DatasetPyTree(qp.RZ(0.5, wires=0)).get_value()
+
+        assert result.wires[0] == 0
+        assert isinstance(result.wires[0], int)
+
 
 @pytest.mark.parametrize("shots", [None, 1, [1, 2]])
 def test_quantum_scripts(shots):


### PR DESCRIPTION
**Context:** Now that wires are pytree leaves, they are getting promoted internally in the data module to the types of the dynamic args.

**Description of the Change:** Changes the behaviour so that everything is not promoted to a common dtype.

**Benefits:** We can do a round-trip and get a normal operator back.

**Possible Drawbacks:** N/A

**Related GitHub Issues:** [sc-127532]

Note that cursor was used to help me figure out the data module which I was unfamiliar with overall.
