### PR TITLE
Cast builtin types for `angles` to arrays in `GQSP`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -902,6 +902,7 @@
   [(#9987)](https://github.com/PennyLaneAI/pennylane/pull/9987)
   [(#9900)](https://github.com/PennyLaneAI/pennylane/pull/9900)
   [(#9995)](https://github.com/PennyLaneAI/pennylane/pull/9995)
+  [(#10018)](https://github.com/PennyLaneAI/pennylane/pull/10018)
   - Miscelleneous operators are ported:
     - :class:`~.PauliMeasure`
   [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)

--- a/pennylane/templates/subroutines/gqsp.py
+++ b/pennylane/templates/subroutines/gqsp.py
@@ -15,11 +15,11 @@
 Contains the GQSP template.
 """
 
-from pennylane import capture, ops
+from pennylane import capture, math, ops
 from pennylane.core.operator import Operator2, abstractify
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract
-from pennylane.typing import Wire
+from pennylane.typing import Float, Wire
 
 has_jax = True
 try:
@@ -91,7 +91,11 @@ class GQSP(Operator2):
     hybrid_argnames = ("unitary",)
     wire_argnames = ("control",)
 
+    arg_specs = {"angles": Float[3, -1], "control": Wire[1]}
+
     def __init__(self, unitary, angles, control):
+        if isinstance(angles, (list, tuple)):
+            angles = math.stack(angles)
         super().__init__(unitary, angles, control)
 
 
@@ -107,18 +111,18 @@ def _GQSP_resources(unitary, angles, **_):
 
 @register_resources(_GQSP_resources)
 def _GQSP_decomposition(unitary, angles, control):
-    thetas, phis, lambds = angles[0], angles[1], angles[2]
+    thetas, phis, lambdas = angles[0], angles[1], angles[2]
 
     if has_jax and capture.enabled():
-        thetas, phis, lambds = jnp.array(thetas), jnp.array(phis), jnp.array(lambds)
+        thetas, phis, lambdas = jnp.array(thetas), jnp.array(phis), jnp.array(lambdas)
 
     # These four gates adapt PennyLane's ops.U3 to the chosen U3 format in the GQSP paper.
     ops.X(control)
-    ops.U3(2 * thetas[0], phis[0], lambds[0], wires=control)
+    ops.U3(2 * thetas[0], phis[0], lambdas[0], wires=control)
     ops.X(control)
     ops.Z(control)
 
-    for theta, phi, lamb in zip(thetas[1:], phis[1:], lambds[1:], strict=True):
+    for theta, phi, lamb in zip(thetas[1:], phis[1:], lambdas[1:], strict=True):
         ops.ctrl(unitary, control=control, control_values=[0])
 
         ops.X(control)

--- a/tests/templates/subroutines/test_gqsp.py
+++ b/tests/templates/subroutines/test_gqsp.py
@@ -17,11 +17,11 @@ Tests for the GQSP template.
 
 # pylint: disable=too-many-arguments, import-outside-toplevel, no-self-use
 
+import numpy as np
 import pytest
 from numpy.linalg import matrix_power
 
 import pennylane as qp
-from pennylane import numpy as np
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 
 
@@ -42,11 +42,26 @@ class TestGQSP:
         op = qp.GQSP(unitary(1), angles, control=(0,))
         qp.ops.functions.assert_valid(op, skip_differentiation=True, skip_bind_new_parameters=True)
 
+    @pytest.mark.parametrize(
+        "angles",
+        [
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            ((1, 2, 3), (4, 5, 6), (7, 8, 9)),
+            [np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])],
+            (np.array([1, 2, 3]), np.array([4, 5, 6]), np.array([7, 8, 9])),
+        ],
+    )
+    def test_non_array_angles_are_cast_to_arrays(self, angles):
+        """Test that angles that are not in arrays are cast to arrays."""
+        op = qp.GQSP(qp.X(0), angles, control=1)
+        assert isinstance(op.angles, np.ndarray)
+        assert np.allclose(op.angles, np.array(angles))
+
     def test_wires(self):
         """Test that wires are in the correct order."""
-        u_wires = [4]
-        c_wires = [0, 1]
-        op = qp.GQSP(qp.X(u_wires), angles=np.array([3, 5]), control=c_wires)
+        u_wires = [4, 1]
+        c_wires = [0]
+        op = qp.GQSP(qp.CNOT(u_wires), angles=np.ones([3, 5]), control=c_wires)
         # Control wires from wire_argnames should be first followed by the wires of
         # the unitary hybrid argument
         assert op.wires == qp.wires.Wires(c_wires + u_wires)


### PR DESCRIPTION
**Context:**
`GQSP`'s `angles` is a dynamic argument, but we do not canonicalize it to an array as is expected for dynamic non-hybrid arguments. This PR adds that.

**Description of the Change:**
* Add canonicalization to cast lists/tuples to arrays
* I forgot to add `arg_specs` to `GQSP`, so added that as well.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-127750]