### PR TITLE
Fix sybil doctest failure after Catalyst softens AOT failures to warnings

### DIFF
--- a/pennylane/core/transforms/transform.py
+++ b/pennylane/core/transforms/transform.py
@@ -409,6 +409,7 @@ class Transform:  # pylint: disable=too-many-instance-attributes
         ...     qp.X(0)
         ...     return qp.expval(qp.Z(0))
         ...
+        >>> c()
         Traceback (most recent call last):
             ...
         ValueError: <cancel-inverses()> without a tape definition occurs before tape transform <defer_measurements()>.


### PR DESCRIPTION
**Context:**
See [the log](https://github.com/PennyLaneAI/pennylane/actions/runs/31893115819/job/95032255888?pr=10021)

**Description of the Change:**
Didn't see any other suspicious changes from Pennylane side related to this failure. So wondering if it could be due to [Soften AOT failures to warnings](https://github.com/PennyLaneAI/catalyst/pull/3100)

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
