### PR TITLE
Fix conditional MCM bug

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1169,7 +1169,7 @@
 
 * Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when a captured
   conditional compared mid-circuit measurement values for equality.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1167,8 +1167,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when a captured
-  conditional compared mid-circuit measurement values for equality.
+* Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
+  arithmetic operations performed on mid-circuit measurement values.
   [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
 
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1167,6 +1167,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when a captured
+  conditional compared mid-circuit measurement values for equality.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Updated :class:`~.Wires` to allow unflattening pytrees with scalar JAX arrays as wire indices.
   [(#9852)](https://github.com/PennyLaneAI/pennylane/pull/9852)
 

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -268,6 +268,15 @@ def _convert_element_type(self, operand, **kwargs):
     return jax.lax.convert_element_type_p.bind(operand, **kwargs)
 
 
+@CollectOpsandMeas.register_primitive(jax.lax.eq_p)
+def _equal(self, lhs, rhs):
+    if isinstance(lhs, MeasurementValue):
+        return lhs == rhs
+    if isinstance(rhs, MeasurementValue):
+        return rhs == lhs
+    return jax.lax.eq_p.bind(lhs, rhs)
+
+
 def plxpr_to_tape(plxpr: "jax.extend.core.Jaxpr", consts, *args, shots=None) -> QuantumScript:
     """Convert a plxpr into a tape.
 

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -270,10 +270,8 @@ def _convert_element_type(self, operand, **kwargs):
 
 @CollectOpsandMeas.register_primitive(jax.lax.eq_p)
 def _equal(self, lhs, rhs):
-    if isinstance(lhs, MeasurementValue):
+    if isinstance(lhs, MeasurementValue) or isinstance(rhs, MeasurementValue):
         return lhs == rhs
-    if isinstance(rhs, MeasurementValue):
-        return rhs == lhs
     return jax.lax.eq_p.bind(lhs, rhs)
 
 

--- a/pennylane/tape/plxpr_conversion.py
+++ b/pennylane/tape/plxpr_conversion.py
@@ -275,6 +275,13 @@ def _equal(self, lhs, rhs):
     return jax.lax.eq_p.bind(lhs, rhs)
 
 
+@CollectOpsandMeas.register_primitive(jax.lax.ne_p)
+def _not_equal(self, lhs, rhs):
+    if isinstance(lhs, MeasurementValue) or isinstance(rhs, MeasurementValue):
+        return lhs != rhs
+    return jax.lax.ne_p.bind(lhs, rhs)
+
+
 def plxpr_to_tape(plxpr: "jax.extend.core.Jaxpr", consts, *args, shots=None) -> QuantumScript:
     """Convert a plxpr into a tape.
 

--- a/tests/tape/test_plxpr_conversion.py
+++ b/tests/tape/test_plxpr_conversion.py
@@ -529,6 +529,30 @@ class TestPlxprToTape:
         assert mp.mv.measurements[0] is tape.operations[0]
         qp.assert_equal(tape.operations[1], qp.ops.Conditional(mp.mv, qp.RX(x, 2)))
 
+    def test_cond_mcm_comparison(self):
+        """Test capturing a conditional that compares two mid-circuit measurements."""
+
+        def f():
+            m0 = qp.measure(0)
+            m1 = qp.measure(1)
+            qp.cond(m0 == m1, qp.X)(0)
+
+        jaxpr = jax.make_jaxpr(f)()
+        tape = qp.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts)
+
+        assert len(tape.operations) == 3
+        assert isinstance(tape.operations[0], MidMeasure)
+        assert isinstance(tape.operations[1], MidMeasure)
+        conditional = tape.operations[2]
+        assert isinstance(conditional, Conditional)
+        assert conditional.meas_val.branches == {
+            (0, 0): True,
+            (0, 1): False,
+            (1, 0): False,
+            (1, 1): True,
+        }
+        qp.assert_equal(conditional.base, qp.X(0))
+
     def test_elif_mcm(self):
         """Test that an elif mcm can be caputured."""
 

--- a/tests/tape/test_plxpr_conversion.py
+++ b/tests/tape/test_plxpr_conversion.py
@@ -16,6 +16,7 @@ Tests for CollectOpsandMeas and plxpr_to_tape
 """
 
 from functools import partial
+from operator import eq, ne
 
 import pytest
 
@@ -529,13 +530,28 @@ class TestPlxprToTape:
         assert mp.mv.measurements[0] is tape.operations[0]
         qp.assert_equal(tape.operations[1], qp.ops.Conditional(mp.mv, qp.RX(x, 2)))
 
-    def test_cond_mcm_comparison(self):
+    @pytest.mark.parametrize(
+        ("comparison", "expected_branches"),
+        (
+            pytest.param(
+                eq,
+                {(0, 0): True, (0, 1): False, (1, 0): False, (1, 1): True},
+                id="equal",
+            ),
+            pytest.param(
+                ne,
+                {(0, 0): False, (0, 1): True, (1, 0): True, (1, 1): False},
+                id="not-equal",
+            ),
+        ),
+    )
+    def test_cond_mcm_comparison(self, comparison, expected_branches):
         """Test capturing a conditional that compares two mid-circuit measurements."""
 
         def f():
             m0 = qp.measure(0)
             m1 = qp.measure(1)
-            qp.cond(m0 == m1, qp.X)(0)
+            qp.cond(comparison(m0, m1), qp.X)(0)
 
         jaxpr = jax.make_jaxpr(f)()
         tape = qp.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts)
@@ -545,12 +561,7 @@ class TestPlxprToTape:
         assert isinstance(tape.operations[1], MidMeasure)
         conditional = tape.operations[2]
         assert isinstance(conditional, Conditional)
-        assert conditional.meas_val.branches == {
-            (0, 0): True,
-            (0, 1): False,
-            (1, 0): False,
-            (1, 1): True,
-        }
+        assert conditional.meas_val.branches == expected_branches
         qp.assert_equal(conditional.base, qp.X(0))
 
     def test_elif_mcm(self):


### PR DESCRIPTION
**Context:**
This is blocking us from testing the correctness of any decomposition rules that involve combining MCMs when capture is enabled.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**
Going forward, we might need to add more and more on t he fly. However, I do think such tasks won't be a big issue with the help of agents!

**Related GitHub Issues:**
[sc-128170]