### PR TITLE
fix intersphinx mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,7 @@ copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: 
 copybutton_prompt_is_regexp = True
 
 intersphinx_mapping = {
-    "demo": ("https://pennylane.ai/qml", None),
+    "demo": ("https://pennylane.ai/demos", None),
     "catalyst": ("https://docs.pennylane.ai/projects/catalyst/en/stable", None),
 }
 


### PR DESCRIPTION
------------------------------------------------------------------------------

**Context:**

currently all :doc:`.. <demo:demos/tutorial_...>` references go through this old qml re-direct

```
intersphinx_mapping = {
    "demo": ("https://pennylane.ai/qml", None),
    "catalyst": ("https://docs.pennylane.ai/projects/catalyst/en/stable", None),
}
```

the links still work because the qml urls have their own redirects lol

**Description of the Change:**
updating this to the direct and correct url

**Benefits:**

stonks

**Possible Drawbacks:**

none

**Related GitHub Issues:**
