### PR TITLE
Fix flip_zero_control capture compatibility

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1202,7 +1202,7 @@
   ``TracerIntegerConversionError`` under program capture, because the control-value flipping
   loop indexed the control wires with a traced loop variable without first promoting them to a
   JAX array.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10036)](https://github.com/PennyLaneAI/pennylane/pull/10036)
 
 * Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
   arithmetic operations performed on mid-circuit measurement values.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1198,6 +1198,12 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the ``flip_zero_control`` decomposition modifier raised a
+  ``TracerIntegerConversionError`` under program capture, because the control-value flipping
+  loop indexed the control wires with a traced loop variable without first promoting them to a
+  JAX array.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
   arithmetic operations performed on mid-circuit measurement values.
   [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -806,7 +806,11 @@ def flip_zero_control(rule: DecompositionRule, name: str = "") -> DecompositionR
         wires = arguments.get("control_wires", arguments.get("wires", None))
         assert wires is not None
 
-        if compiler.active() and not capture.enabled():
+        # ``_x_flips`` indexes ``control_values`` and ``wires`` with the traced ``for_loop``
+        # variable ``i``. Plain Python sequences raise ``TracerIntegerConversionError`` on such
+        # indexing, so under program capture or compilation promote them to jax arrays (turning
+        # the lookups into dynamic gathers). This matches ``_make_controlled_decomp``.
+        if compiler.active() or capture.enabled():
             control_values = math.array(control_values, like="jax")
             wires = math.array(wires, like="jax")
 

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -806,10 +806,6 @@ def flip_zero_control(rule: DecompositionRule, name: str = "") -> DecompositionR
         wires = arguments.get("control_wires", arguments.get("wires", None))
         assert wires is not None
 
-        # ``_x_flips`` indexes ``control_values`` and ``wires`` with the traced ``for_loop``
-        # variable ``i``. Plain Python sequences raise ``TracerIntegerConversionError`` on such
-        # indexing, so under program capture or compilation promote them to jax arrays (turning
-        # the lookups into dynamic gathers). This matches ``_make_controlled_decomp``.
         if compiler.active() or capture.enabled():
             control_values = math.array(control_values, like="jax")
             wires = math.array(wires, like="jax")

--- a/tests/decomposition/test_symbolic_decomposition.py
+++ b/tests/decomposition/test_symbolic_decomposition.py
@@ -14,6 +14,7 @@
 
 """Tests the decomposition rules defined for symbolic operations other than controlled."""
 
+import warnings
 from textwrap import dedent
 
 import pytest
@@ -1070,6 +1071,46 @@ class TestControlledDecomposition:
 
         specs = qp.specs(circuit, level="device")([1, 1, 0])
         assert specs.resources.quantum_operations == {"CNOT": 3, "Hadamard": 2, "PauliX": 2}
+
+    @pytest.mark.capture
+    def test_flip_zero_control_capture(self):
+        """Tests flip_zero_control is capture-compatible: the ``_x_flips`` for-loop indexes the
+        control wires with a traced loop variable, which requires the wires to be promoted to a
+        jax array so structured capture does not raise ``TracerIntegerConversionError``."""
+
+        from pennylane.exceptions import CaptureWarning
+        from pennylane.tape.plxpr_conversion import CollectOpsandMeas
+
+        @qp.register_resources({qp.CNOT: 3, qp.H: 2})
+        def _custom_controlled_rule(base, control_wires, **_):
+            qp.CNOT(control_wires[:2])
+            qp.H(control_wires[2])
+            qp.CNOT([control_wires[-1], base.wires[0]])
+            qp.H(control_wires[2])
+            qp.CNOT(control_wires[:2])
+
+        custom_rule = flip_zero_control2(_custom_controlled_rule, "custom_rule")
+        op = NonParametricOp(wires=[0])
+
+        def circuit():
+            custom_rule(base=op, control_wires=[1, 2, 3], control_values=[1, 1, 0])
+
+        # Structured capture must succeed (no fallback to an unrolled Python loop).
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", CaptureWarning)
+            plxpr = qp.capture.make_plxpr(circuit)()
+
+        collector = CollectOpsandMeas()
+        collector.eval(plxpr.jaxpr, plxpr.consts)
+        assert collector.state["ops"] == [
+            qp.X(3),
+            qp.CNOT([1, 2]),
+            qp.H(3),
+            qp.CNOT([3, 0]),
+            qp.H(3),
+            qp.CNOT([1, 2]),
+            qp.X(3),
+        ]
 
     @pytest.mark.unit
     def test_controlled_decomp_with_work_wire(self):


### PR DESCRIPTION
### Context

`flip_zero_control` wraps a controlled-operator decomposition rule with `X` gates that flip
the wires whose control value is `0`. The flip loop is a `qp.for_loop` whose body indexes the
control wires with the traced loop variable:

```python
@qp.for_loop(0, len(control_values))
def _x_flips(i):
    qp.cond(qp.math.logical_not(control_values[i]), qp.X)(wires[i])
```

Under **program capture** (`qp.capture.enable()` / `make_plxpr`), `wires` / `control_values`
are still plain Python sequences, so `wires[i]` calls `__index__` on a tracer and raises
`TracerIntegerConversionError`. The structured `for_loop` capture then falls back to an unrolled
Python loop and emits a `CaptureWarning` (escalated to an error in the test suite).

The array promotion that fixes this was only applied under compilation
(`compiler.active() and not capture.enabled()`), not under plain capture.



### Fix

Promote `wires` and `control_values` to JAX arrays under capture as well, turning the lookups
into dynamic gathers. This is a one-line change confined and matches the guard
already used by the sibling `_make_controlled_decomp` (`capture.enabled() or compiler.active()`).

### Context

This came up in https://github.com/PennyLaneAI/pennylane/pull/10015 when trying to make the controlled decomposition rule capture compatible

---
This PR was authored with the assistance of an AI coding assistant (Cursor / Claude Opus 4.8) and reviewed by the author.

Made with [Cursor](https://cursor.com)