### PR TITLE
fix: update labs after `BasisState`'s breaking change

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -686,6 +686,11 @@
 
 <h3>Breaking changes 💔</h3>
 
+* :class:`~.BasisState` no longer allows integers as input. Instead, `~.math.int_to_binary` should be used to preprocess
+  the input in order to convert it to a binary array.
+  [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
+  [(#10038)](https://github.com/PennyLaneAI/pennylane/pull/10038)
+
 * Renamed the `data` argument of :class:`~pennylane.QROM`, :class:`~pennylane.BBQRAM`, :class:`~pennylane.HybridQRAM`,
   and :class:`~pennylane.SelectOnlyQRAM` to `bitstrings`.
   [(#10010)](https://github.com/PennyLaneAI/pennylane/pull/10010)

--- a/pennylane/labs/templates/sum_of_slaters2.py
+++ b/pennylane/labs/templates/sum_of_slaters2.py
@@ -20,14 +20,13 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import math
-from pennylane.decomposition.resources import resource_rep
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.templates.state_preparations.sum_of_slaters import (
     _preprocess,
     _sos_state_prep_with_wires,
     select_sos_rows,
 )
-from pennylane.typing import Complex, Int, Wire
+from pennylane.typing import Bool, Complex, Int, Wire
 from pennylane.wires import Wires
 
 
@@ -397,7 +396,7 @@ def _sos_state_prep_resources(num_entries, num_bits, num_wires):
     """Compute the resources for _sos_state_prep. It is an upper bound due to
     conditionally applied CNOT and X gates."""
     if num_entries == 1:
-        return {resource_rep(qp.BasisState, num_wires=num_wires): 1}
+        return {qp.BasisState(Bool[num_wires], Wire[num_wires]): 1}
     d = math.ceil_log2(num_entries)
     m = min(num_bits, 2 * d - 1)
 

--- a/pennylane/labs/templates/superposition_thc.py
+++ b/pennylane/labs/templates/superposition_thc.py
@@ -327,7 +327,7 @@ def _left_inequalities(
     # To do so, we use the fact that a MultiControlledX with control_values = 0 detects if
     # the register is in state 0, and we shift that state with BasisState before and after.
     # (We don't include the 'after' operation here since it will be uncomputed later.)
-    BasisState(M, wires=nu_wires)
+    BasisState(math.int_to_binary(M, len(nu_wires)), wires=nu_wires)
 
     # TODO: replace this zero-controlled MultiControlledX with MultiTemporaryAND.
     if not keep_eq:

--- a/pennylane/labs/templates/superposition_thc.py
+++ b/pennylane/labs/templates/superposition_thc.py
@@ -27,7 +27,7 @@ from pennylane.decomposition import (
 from pennylane.labs.templates import LeftClassicalComparator, LeftQuantumComparator
 from pennylane.ops import RY, BasisState, GlobalPhase, Hadamard, MultiControlledX, X, Z
 from pennylane.queuing import AnnotatedQueue, QueuingManager, apply
-from pennylane.typing import Wire
+from pennylane.typing import Bool, Wire
 from pennylane.wires import Wires, WiresLike
 
 
@@ -149,7 +149,6 @@ class SuperpositionTHC(Operation):
         nu_wires: WiresLike,
         work_wires: WiresLike,
     ):  # pylint: disable=too-many-arguments
-
         mu_wires = Wires(mu_wires)
         nu_wires = Wires(nu_wires)
         work_wires = Wires(work_wires)
@@ -370,7 +369,7 @@ def _superposition_thc_resources(num_mu_wires, num_work_wires, M, N):
     lcc_le = resource_rep(LeftClassicalComparator, num_x_wires=n, L=M, comparator="<=")
     lcc_gt = resource_rep(LeftClassicalComparator, num_x_wires=n, L=N // 2, comparator=">=")
     lqc = resource_rep(LeftQuantumComparator, num_y_wires=n, comparator="<=")
-    basis = resource_rep(BasisState, num_wires=n)
+    basis = BasisState(Bool[n], Wire[n])
     mcx = _controlled_x(n, mcx_work, control_values=[0] * n)
 
     resources = {}
@@ -381,7 +380,7 @@ def _superposition_thc_resources(num_mu_wires, num_work_wires, M, N):
     _add(GlobalPhase, 1)
     _add(Hadamard, 6 * n)
     _add(X, 4 * n + 4)
-    _add(resource_rep(RY), 3)
+    _add(RY, 3)
     _add(_controlled_x(2, ctrl_work), 4)
     _add(_controlled_x(3, ctrl_work), 1)
     _add(_controlled_z(3, ctrl_work), 1)
@@ -395,7 +394,7 @@ def _superposition_thc_resources(num_mu_wires, num_work_wires, M, N):
     _add(adjoint_resource_rep(LeftClassicalComparator, lcc_le.params), 2)
     _add(adjoint_resource_rep(LeftClassicalComparator, lcc_gt.params), 2)
     _add(adjoint_resource_rep(LeftQuantumComparator, lqc.params), 2)
-    _add(adjoint_resource_rep(BasisState, basis.params), 2)
+    _add(adjoint(BasisState(Bool[n], Wire[n])), 2)
     _add(mcx, 2)
     _add(adjoint(mcx), 1)
 

--- a/pennylane/labs/tests/templates/test_left_classical_comparator.py
+++ b/pennylane/labs/tests/templates/test_left_classical_comparator.py
@@ -63,13 +63,13 @@ class TestLeftClassicalComparator:
 
         @qp.qnode(qp.device("lightning.qubit", wires=range(13)), shots=1)
         def circuit(x_wires, L):
-            qp.BasisState(x, wires=x_wires)
+            qp.BasisState(qp.math.int_to_binary(x, len(x_wires)), wires=x_wires)
             LeftClassicalComparator(x_wires, L, target_wire, work_wires, comparator)
             qp.CNOT([11, 12])
             qp.adjoint(
                 lambda: LeftClassicalComparator(x_wires, L, target_wire, work_wires, comparator)
             )()
-            qp.BasisState(x, wires=x_wires)
+            qp.BasisState(qp.math.int_to_binary(x, len(x_wires)), wires=x_wires)
             return qp.sample(wires=[12]), qp.sample(wires=work_wires), qp.sample(wires=x_wires)
 
         if qjit:
@@ -188,7 +188,7 @@ class TestLeftClassicalComparator:
 
         @qp.qnode(dev)
         def circuit(x):
-            qp.BasisState(x, wires=x_wires)
+            qp.BasisState(qp.math.int_to_binary(x, len(x_wires)), wires=x_wires)
             LeftClassicalComparator(x_wires, L, target_wire, work_wires, comparator)
             return qp.probs(wires=[target_wire])
 

--- a/pennylane/labs/tests/templates/test_left_quantum_comparator.py
+++ b/pennylane/labs/tests/templates/test_left_quantum_comparator.py
@@ -56,8 +56,8 @@ class TestLeftQuantumComparator:
         @qp.qjit
         @qp.qnode(qp.device("lightning.qubit", wires=range(13)), shots=1)
         def circuit():
-            qp.BasisState(x, wires=x_wires)
-            qp.BasisState(y, wires=y_wires)
+            qp.BasisState(qp.math.int_to_binary(x, len(x_wires)), wires=x_wires)
+            qp.BasisState(qp.math.int_to_binary(y, len(y_wires)), wires=y_wires)
             LeftQuantumComparator(x_wires, y_wires, target_wire, work_wires, comparator)
             qp.CNOT([11, 12])
             qp.adjoint(


### PR DESCRIPTION
**Context:**

After #9933 went in, several labs tests were using old API

**Description of the Change:**

Update them to first convert their integer to a binary array.

[sc-126042]
