### PR TITLE
`Rot` resource function has full signature of positional arguments

### DIFF
--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -1136,7 +1136,8 @@ def _ctrl_rot(base: Rot, control, control_values, *_):
     return NotImplemented
 
 
-def _rot_to_rz_ry_rz_resources(**_):
+# pylint: disable-next=unused-argument
+def _rot_to_rz_ry_rz_resources(phi, theta, omega, wires):
     return {qp.RZ: 2, qp.RY: 1}
 
 


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-128328]