### PR TITLE
fix: triton decoder name clash

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1308,6 +1308,7 @@
 * Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
   arithmetic operations performed on mid-circuit measurement values.
   [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
+
 * Fixed :func:`~pennylane.backline.css_bp_decoder` so the X- and Z-specialized Triton decoders
   stay distinct when bundled behind one dispatcher, and, for the same reason, updated
   :func:`~pennylane.backline.triton_decoder` to own jitting of the raw Triton decoder functions.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1311,7 +1311,7 @@
 * Fixed :func:`~pennylane.backline.css_bp_decoder` so the X- and Z-specialized Triton decoders
   stay distinct when bundled behind one dispatcher, and, for the same reason, updated
   :func:`~pennylane.backline.triton_decoder` to own jitting of the raw Triton decoder functions.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10040)](https://github.com/PennyLaneAI/pennylane/pull/10040)
 
 * Fixed a bug where decomposing an :class:`~.Operator2` with graph-based decomposition
   enabled inside a :class:`~.Subroutine` with program capture leaked JAX tracers and

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -11,10 +11,8 @@
   ```py
   import numpy as np
   import pennylane as qp
-  import triton
   import triton.language as tl
 
-  @triton.jit
   def steane_lookup(syndrome):
       return tl.where(syndrome != 0, 1 << (syndrome - 1), 0)
 
@@ -1310,6 +1308,10 @@
 * Fixed a bug where :func:`~.tape.plxpr_to_tape` raised an error when the program contains
   arithmetic operations performed on mid-circuit measurement values.
   [(#10028)](https://github.com/PennyLaneAI/pennylane/pull/10028)
+* Fixed :func:`~pennylane.backline.css_bp_decoder` so the X- and Z-specialized Triton decoders
+  stay distinct when bundled behind one dispatcher, and, for the same reason, updated
+  :func:`~pennylane.backline.triton_decoder` to own jitting of the raw Triton decoder functions.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
 
 * Fixed a bug where decomposing an :class:`~.Operator2` with graph-based decomposition
   enabled inside a :class:`~.Subroutine` with program capture leaked JAX tracers and

--- a/pennylane/backline/decoders/triton/decoder_frontend.py
+++ b/pennylane/backline/decoders/triton/decoder_frontend.py
@@ -16,8 +16,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 import tempfile
+import types
 from pathlib import Path
 
 import numpy as np
@@ -34,6 +36,33 @@ except ImportError as exc:
     raise ImportError("Triton decoders require installed `triton` Python package.") from exc
 
 
+def _clone_with_name(fn: object, name: str) -> object:
+    """Clone a Python function object while overriding its name metadata."""
+    cloned = types.FunctionType(fn.__code__, fn.__globals__, name, fn.__defaults__, fn.__closure__)
+    cloned.__kwdefaults__ = getattr(fn, "__kwdefaults__", None)
+    cloned.__annotations__ = dict(getattr(fn, "__annotations__", {}))
+    cloned.__doc__ = getattr(fn, "__doc__", None)
+    cloned.__module__ = getattr(fn, "__module__", None)
+    cloned.__qualname__ = name
+    cloned.__dict__.update(getattr(fn, "__dict__", {}))
+    return cloned
+
+
+def _triton_jit_with_unique_names(decoder_fns: tuple[object, ...]) -> tuple[object, ...]:
+    """Return Triton JIT kernels with unique names from un-jitted Triton functions."""
+    normalized = []
+    for i, decoder_fn in enumerate(decoder_fns):
+        if not isinstance(decoder_fn, types.FunctionType):
+            raise TypeError(
+                "decoder_fns must contain Python function objects; "
+                "already-jitted Triton functions fail this check, so pass undecorated "
+                "functions to triton_decoder"
+            )
+        unique_name = f"{decoder_fn.__name__}_{i}"
+        normalized.append(triton.jit(_clone_with_name(decoder_fn, unique_name)))
+    return tuple(normalized)
+
+
 def _build_triton_decoder(  # pylint: disable=too-many-arguments
     decoder_fns: tuple[object, ...],
     *,
@@ -44,11 +73,12 @@ def _build_triton_decoder(  # pylint: disable=too-many-arguments
     compiler: str = "",
     cflags: tuple[str, ...] = (),
 ) -> tuple[Path, str]:
-    """Build a shared library based on the triton functions provided.
+    """Build a shared library based on the decoder functions provided.
 
     Args:
-        decoder_fns (tuple[object, ...]): Tuple of Triton decoder functions.
-            ``decoder_id`` is used to select the appropriate decoder function at runtime.
+        decoder_fns (tuple[object, ...]): Tuple of un-jitted Triton decoder functions. Each
+            entry is jitted with a unique generated name, and ``decoder_id`` selects the
+            appropriate decoder function at runtime.
 
     Keyword Args:
         platform (str): Required Triton platform string of the form
@@ -66,15 +96,14 @@ def _build_triton_decoder(  # pylint: disable=too-many-arguments
             returned shared library's lifetime and cleanup.
 
     Raises:
+        TypeError: If ``decoder_fns`` contains entries other than un-jitted Triton functions.
         ValueError: If the build options are invalid.
 
     **Example**
 
-    >>> import triton
     >>> import triton.language as tl
     >>> from pennylane.backline.decoders.triton.decoder_frontend import _build_triton_decoder
-    >>> @triton.jit
-    ... def steane_lookup(syndrome):
+    >>> def steane_lookup(syndrome):
     ...     one = tl.cast(1, tl.uint64)
     ...     zero = tl.cast(0, tl.uint64)
     ...     return tl.where(syndrome != 0, one << (syndrome - 1), zero)
@@ -89,6 +118,7 @@ def _build_triton_decoder(  # pylint: disable=too-many-arguments
         num_stages=num_stages,
         platform=platform,
     )
+    decoder_fns = _triton_jit_with_unique_names(decoder_fns)
     tmpdir = Path(tempfile.mkdtemp(prefix="pl_triton_decoder_"))
     out = tmpdir / "librdma_triton_decoder.so"
     try:
@@ -233,7 +263,7 @@ def _validate_build_options(
     """Validate generic Triton decoder build options.
 
     Args:
-        decoder_fns (tuple[object, ...]): Triton decoder functions to dispatch.
+        decoder_fns (tuple[object, ...]): Un-jitted Triton decoder functions to dispatch.
         num_warps (int): Triton kernel launch warp count.
         num_stages (int): Triton pipeline stage count.
         platform (str): Triton platform string of the form
@@ -243,7 +273,9 @@ def _validate_build_options(
         ValueError: If any option falls outside the supported range or format.
     """
     if not decoder_fns:
-        raise ValueError("decoder_fns must be a non-empty tuple of Triton decoder functions")
+        raise ValueError(
+            "decoder_fns must be a non-empty tuple of un-jitted Triton decoder functions"
+        )
     if num_warps <= 0:
         raise ValueError("num_warps must be > 0")
     if num_stages <= 0:
@@ -278,7 +310,7 @@ def _validate_css_options(*, postprocess: str, num_iters: int, prob: float) -> N
 def _make_css_decoder(
     matrix: np.ndarray, *, postprocess: str, num_iters: int, prob: float
 ) -> object:
-    """Specialize one Triton decoder kernel for a fixed parity-check matrix.
+    """Specialize one un-jitted Triton decoder function for a fixed parity-check matrix.
 
     Args:
         matrix (np.ndarray): Binary parity-check matrix.
@@ -287,16 +319,22 @@ def _make_css_decoder(
         prob (float): Uniform prior error probability.
 
     Returns:
-        object: Triton JIT function that maps one packed syndrome to one packed
-            correction mask.
+        object: Un-jitted Triton function that maps one packed syndrome to one packed correction
+            mask.
     """
+    kernel_key = hashlib.sha1()
+    kernel_key.update(matrix.astype(np.uint8, copy=False).tobytes())
+    kernel_key.update(postprocess.encode("utf-8"))
+    kernel_key.update(str(num_iters).encode("utf-8"))
+    kernel_key.update(repr(prob).encode("utf-8"))
+    kernel_name = f"decode_{kernel_key.hexdigest()[:12]}"
+
     matrix = tl.constexpr(tuple(tuple(int(value) for value in row) for row in matrix.tolist()))
     postprocess = tl.constexpr(postprocess)
     prob = tl.constexpr(prob)
     num_iters = tl.constexpr(num_iters)
 
-    @triton.jit
-    def decode(syndrome):  # pragma: no cover
+    def decode_impl(syndrome):  # pragma: no cover
         return _decode_one(
             syndrome,
             matrix,
@@ -305,4 +343,6 @@ def _make_css_decoder(
             num_iters=num_iters,
         )
 
-    return decode
+    decode_impl.__name__ = kernel_name
+    decode_impl.__qualname__ = kernel_name
+    return decode_impl

--- a/pennylane/backline/decoders/triton/decoder_frontend.py
+++ b/pennylane/backline/decoders/triton/decoder_frontend.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import shutil
 import tempfile
 import types
@@ -322,13 +321,6 @@ def _make_css_decoder(
         object: Un-jitted Triton function that maps one packed syndrome to one packed correction
             mask.
     """
-    kernel_key = hashlib.sha1()
-    kernel_key.update(matrix.astype(np.uint8, copy=False).tobytes())
-    kernel_key.update(postprocess.encode("utf-8"))
-    kernel_key.update(str(num_iters).encode("utf-8"))
-    kernel_key.update(repr(prob).encode("utf-8"))
-    kernel_name = f"decode_{kernel_key.hexdigest()[:12]}"
-
     matrix = tl.constexpr(tuple(tuple(int(value) for value in row) for row in matrix.tolist()))
     postprocess = tl.constexpr(postprocess)
     prob = tl.constexpr(prob)
@@ -343,6 +335,4 @@ def _make_css_decoder(
             num_iters=num_iters,
         )
 
-    decode_impl.__name__ = kernel_name
-    decode_impl.__qualname__ = kernel_name
     return decode_impl

--- a/pennylane/backline/functions.py
+++ b/pennylane/backline/functions.py
@@ -80,12 +80,12 @@ def triton_decoder(
 ) -> CoprocessorFunction:
     """Compile Triton decoder functions into a coprocessor decode function.
 
-    Accepts a tuple of Triton decoder functions and compiles them into a shared library that can be
-    used as a :class:`~.CoprocessorFunction`.
+    Accepts a tuple of un-jitted Triton decoder functions and compiles them into a shared library
+    that can be used as a :class:`~.CoprocessorFunction`.
 
     Args:
-        decoder_fns (tuple[object, ...]): Triton decoder functions. ``decoder_id`` selects the
-            tuple index at runtime.
+        decoder_fns (tuple[object, ...]): Un-jitted Triton decoder functions. Each entry is
+            jit compiled internally, and ``decoder_id`` selects the tuple index at runtime.
 
     Keyword Args:
         platform (str): Required Triton platform string of the form ``"backend:arch:warp_size"``.
@@ -103,6 +103,7 @@ def triton_decoder(
 
     Raises:
         ImportError: If Triton decoder support is unavailable.
+        TypeError: If ``decoder_fns`` contains already jit compiled Triton functions.
         ValueError: If the decoder build options are invalid.
 
     .. seealso:: :class:`~.CoprocessorFunction`, :class:`~.Coprocessor`,
@@ -111,10 +112,8 @@ def triton_decoder(
     **Example**
 
     >>> import pennylane as qp
-    >>> import triton
     >>> import triton.language as tl
-    >>> @triton.jit
-    ... def steane_lookup(syndrome):
+    >>> def steane_lookup(syndrome):
     ...     return tl.where(syndrome != 0, 1 << (syndrome - 1), 0)
     >>> decoder = qp.backline.triton_decoder(  # doctest: +SKIP
     ...     (steane_lookup, steane_lookup),

--- a/tests/backline/decoders/test_decoder_frontend.py
+++ b/tests/backline/decoders/test_decoder_frontend.py
@@ -41,7 +41,6 @@ from pennylane.backline import CoprocessorFunction, css_bp_decoder, triton_decod
 from pennylane.backline.decoders.triton import decoder_frontend as frontend
 
 
-@triton.jit
 def _echo_decoder(syndrome):
     return syndrome
 

--- a/tests/backline/decoders/test_triton_so_builder_cache.py
+++ b/tests/backline/decoders/test_triton_so_builder_cache.py
@@ -23,7 +23,10 @@ triton = pytest.importorskip("triton")
 pytestmark = [pytest.mark.gpu]
 
 from pennylane.backline.decoders.triton import triton_so_builder as builder
-from pennylane.backline.decoders.triton.decoder_frontend import _make_css_decoder
+from pennylane.backline.decoders.triton.decoder_frontend import (
+    _make_css_decoder,
+    _triton_jit_with_unique_names,
+)
 from pennylane.backline.decoders.triton.persistent_kernel import _persistent_decoder_kernel
 
 
@@ -34,8 +37,14 @@ class TestConstexprCacheKeys:
         """It should hash distinct decoder tuples differently."""
         hx = np.array([[1, 0], [0, 1]], dtype=int)
         hz = np.array([[1, 1], [0, 1]], dtype=int)
-        decode_x = _make_css_decoder(hx, postprocess="hard", num_iters=5, prob=0.1)
-        decode_z = _make_css_decoder(hz, postprocess="hard", num_iters=5, prob=0.1)
+        decoders = _triton_jit_with_unique_names(
+            (
+                _make_css_decoder(hx, postprocess="hard", num_iters=5, prob=0.1),
+                _make_css_decoder(hz, postprocess="hard", num_iters=5, prob=0.1),
+            )
+        )
+        decode_x = decoders[0]
+        decode_z = decoders[1]
         signature = {
             "ring_u64_ptr": "*u64",
             "handoff_u64_ptr": "*u64",

--- a/tests/backline/test_backline_functions.py
+++ b/tests/backline/test_backline_functions.py
@@ -18,6 +18,7 @@
 
 import importlib
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -67,6 +68,42 @@ class TestTritonDecoder:
         """The public name is exported from pennylane.backline."""
         assert qp.backline.triton_decoder is triton_decoder
 
+    def test_accepts_plain_python_functions_and_unique_names_them(self, monkeypatch):
+        """Un-jitted Triton functions are jitted internally under unique generated names."""
+        pytest.importorskip("triton")
+        from pennylane.backline.decoders.triton import decoder_frontend as frontend
+
+        captured = {}
+
+        def fake_build_so(*_args, **kwargs):
+            captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
+            return Path("/tmp/fake.so"), "fake_symbol"
+
+        monkeypatch.setattr(frontend, "_build_so", fake_build_so)
+
+        def make_decoder():
+            def decode(syndrome):
+                return syndrome
+
+            return decode
+
+        fn = triton_decoder((make_decoder(), make_decoder()), platform="cuda:80:32")
+
+        assert isinstance(fn, CoprocessorFunction)
+        assert captured["names"] == ["decode_0", "decode_1"]
+
+    def test_rejects_already_jitted_functions(self):
+        """The public API owns jitting and rejects pre-jitted kernels."""
+        triton = pytest.importorskip("triton")
+        import triton.language as tl
+
+        @triton.jit
+        def decode(syndrome):
+            return tl.where(syndrome != 0, 1 << (syndrome - 1), 0)
+
+        with pytest.raises(TypeError, match="already-jitted Triton functions"):
+            triton_decoder((decode,), platform="cuda:80:32")
+
 
 class TestCssBpDecoder:
     """The CSS belief-propagation decoder compilation entry point."""
@@ -81,6 +118,27 @@ class TestCssBpDecoder:
     def test_the_wrapper_reexports_from_backline(self):
         """The public name is exported from pennylane.backline."""
         assert qp.backline.css_bp_decoder is css_bp_decoder
+
+    def test_same_shape_matrices_get_distinct_decoder_names(self, monkeypatch):
+        """Hx and Hz specializations stay distinct even when their shapes match."""
+        pytest.importorskip("triton")
+        from pennylane.backline.decoders.triton import decoder_frontend as frontend
+
+        captured = {}
+
+        def fake_build_so(*_args, **kwargs):
+            captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
+            return Path("/tmp/fake.so"), "fake_symbol"
+
+        monkeypatch.setattr(frontend, "_build_so", fake_build_so)
+
+        hx = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.uint8)
+        hz = np.array([[1, 1, 0], [1, 0, 1]], dtype=np.uint8)
+
+        fn = css_bp_decoder(hx, hz, platform="cuda:80:32")
+
+        assert isinstance(fn, CoprocessorFunction)
+        assert len(set(captured["names"])) == 2
 
 
 class TestTritonSubmoduleImportGuards:

--- a/tests/backline/test_backline_functions.py
+++ b/tests/backline/test_backline_functions.py
@@ -18,7 +18,6 @@
 
 import importlib
 import sys
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -68,17 +67,27 @@ class TestTritonDecoder:
         """The public name is exported from pennylane.backline."""
         assert qp.backline.triton_decoder is triton_decoder
 
-    def test_accepts_plain_python_functions_and_unique_names_them(self, monkeypatch):
+    def test_accepts_plain_python_functions_and_unique_names_them(self, monkeypatch, tmp_path):
         """Un-jitted Triton functions are jitted internally under unique generated names."""
         pytest.importorskip("triton")
         from pennylane.backline.decoders.triton import decoder_frontend as frontend
 
         captured = {}
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        real_mkdtemp = frontend.tempfile.mkdtemp
+
+        def fake_mkdtemp(*args, **kwargs):
+            prefix = kwargs.get("prefix")
+            if prefix is None and len(args) >= 2:
+                prefix = args[1]
+            return str(scratch) if prefix == "pl_triton_decoder_" else real_mkdtemp(*args, **kwargs)
 
         def fake_build_so(*_args, **kwargs):
             captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
-            return Path("/tmp/fake.so"), "fake_symbol"
+            return scratch / "fake.so", "fake_symbol"
 
+        monkeypatch.setattr(frontend.tempfile, "mkdtemp", fake_mkdtemp)
         monkeypatch.setattr(frontend, "_build_so", fake_build_so)
 
         def make_decoder():
@@ -119,17 +128,27 @@ class TestCssBpDecoder:
         """The public name is exported from pennylane.backline."""
         assert qp.backline.css_bp_decoder is css_bp_decoder
 
-    def test_same_shape_matrices_get_distinct_decoder_names(self, monkeypatch):
+    def test_same_shape_matrices_get_distinct_decoder_names(self, monkeypatch, tmp_path):
         """Hx and Hz specializations stay distinct even when their shapes match."""
         pytest.importorskip("triton")
         from pennylane.backline.decoders.triton import decoder_frontend as frontend
 
         captured = {}
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        real_mkdtemp = frontend.tempfile.mkdtemp
+
+        def fake_mkdtemp(*args, **kwargs):
+            prefix = kwargs.get("prefix")
+            if prefix is None and len(args) >= 2:
+                prefix = args[1]
+            return str(scratch) if prefix == "pl_triton_decoder_" else real_mkdtemp(*args, **kwargs)
 
         def fake_build_so(*_args, **kwargs):
             captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
-            return Path("/tmp/fake.so"), "fake_symbol"
+            return scratch / "fake.so", "fake_symbol"
 
+        monkeypatch.setattr(frontend.tempfile, "mkdtemp", fake_mkdtemp)
         monkeypatch.setattr(frontend, "_build_so", fake_build_so)
 
         hx = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.uint8)

--- a/tests/backline/test_backline_functions.py
+++ b/tests/backline/test_backline_functions.py
@@ -84,7 +84,9 @@ class TestTritonDecoder:
             return str(scratch) if prefix == "pl_triton_decoder_" else real_mkdtemp(*args, **kwargs)
 
         def fake_build_so(*_args, **kwargs):
-            captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
+            captured["qualnames"] = [
+                fn.fn.__qualname__ for fn in kwargs["constexpr"]["decoder_fns"]
+            ]
             return scratch / "fake.so", "fake_symbol"
 
         monkeypatch.setattr(frontend.tempfile, "mkdtemp", fake_mkdtemp)
@@ -99,7 +101,7 @@ class TestTritonDecoder:
         fn = triton_decoder((make_decoder(), make_decoder()), platform="cuda:80:32")
 
         assert isinstance(fn, CoprocessorFunction)
-        assert captured["names"] == ["decode_0", "decode_1"]
+        assert captured["qualnames"] == ["decode_0", "decode_1"]
 
     def test_rejects_already_jitted_functions(self):
         """The public API owns jitting and rejects pre-jitted kernels."""
@@ -145,7 +147,9 @@ class TestCssBpDecoder:
             return str(scratch) if prefix == "pl_triton_decoder_" else real_mkdtemp(*args, **kwargs)
 
         def fake_build_so(*_args, **kwargs):
-            captured["names"] = [fn.fn.__name__ for fn in kwargs["constexpr"]["decoder_fns"]]
+            captured["qualnames"] = [
+                fn.fn.__qualname__ for fn in kwargs["constexpr"]["decoder_fns"]
+            ]
             return scratch / "fake.so", "fake_symbol"
 
         monkeypatch.setattr(frontend.tempfile, "mkdtemp", fake_mkdtemp)
@@ -157,7 +161,7 @@ class TestCssBpDecoder:
         fn = css_bp_decoder(hx, hz, platform="cuda:80:32")
 
         assert isinstance(fn, CoprocessorFunction)
-        assert len(set(captured["names"])) == 2
+        assert len(set(captured["qualnames"])) == 2
 
 
 class TestTritonSubmoduleImportGuards:


### PR DESCRIPTION
Fixes silent issue where the triton decoder factories could map multiple coprocessor_fn to the same one.
This occurs when their `__name__` coincided.

This PR avoids this issue by assigning unique distinct names to the triton functions within the `css_bp_decoder` and `triton_decoder` factories. 

Breaking change:
`triton_decoder` no longer accepts jit-compiled triton functions and instead accepts the raw triton functions (undecorated). It then takes care of jit compiling the provided functions with triton

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Add a new entry to the `doc/releases/changelog-dev.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The PennyLane source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint pennylane/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
