### PR TITLE
fix incorrectly resolved merge conflicts between RY and RX migration

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1028,6 +1028,7 @@
   [(#9978)](https://github.com/PennyLaneAI/pennylane/pull/9978)
   [(#9981)](https://github.com/PennyLaneAI/pennylane/pull/9981)
   [(#10026)](https://github.com/PennyLaneAI/pennylane/pull/10026)
+  [(#10041)](https://github.com/PennyLaneAI/pennylane/pull/10041)
   - Templates are ported:
     - :class:`~.BasisRotation`, :class:`~.MultiplexerStatePreparation`, :class:`~.QROM`, :class:`~.QFT`, :class:`~.FlipSign`,
       :class:`~.TemporaryAND`, :class:`~.SelectPauliRot`, :class:`~.GQSP`, :class:`~.AQFT`, :class:`~.SumOfSlatersPrep`,

--- a/pennylane/devices/default_qubit.py
+++ b/pennylane/devices/default_qubit.py
@@ -307,12 +307,7 @@ def _supports_adjoint(circuit, device_wires, device_name):
 
     try:
         program((circuit,))
-    except (
-        DecompositionUndefinedError,
-        DeviceError,
-        AttributeError,
-        ValueError,
-    ):
+    except (DecompositionUndefinedError, DeviceError, AttributeError):
         return False
     return True
 

--- a/tests/workflow/interfaces/qnode/test_autograd_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_autograd_qnode.py
@@ -539,8 +539,6 @@ class TestQubitIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single prob output"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("lightning does not support measuring probabilities with adjoint.")
         if diff_method == "adjoint":
@@ -583,8 +581,6 @@ class TestQubitIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with multiple prob outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("lightning does not support measuring probabilities with adjoint.")
         if diff_method == "adjoint":
@@ -656,8 +652,6 @@ class TestQubitIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("lightning does not support measuring probabilities with adjoint.")
         if diff_method == "adjoint":
@@ -715,8 +709,6 @@ class TestQubitIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and variance outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("lightning does not support measuring probabilities with adjoint.")
         if diff_method == "adjoint":
@@ -1327,8 +1319,6 @@ class TestQubitIntegration:
     def test_state(self, interface, dev, diff_method, grad_on_execution, device_vjp, tol):
         """Test that the state can be returned and differentiated"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("Lightning does not support state adjoint diff.")
         if diff_method == "adjoint":
@@ -1913,8 +1903,6 @@ class TestReturn:
     ):
         """For a multi dimensional measurement (probs), check that a single tuple is returned containing arrays with
         the correct dimension"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
@@ -1951,8 +1939,6 @@ class TestReturn:
         self, dev, diff_method, grad_on_execution, device_vjp
     ):
         """For a multi dimensional measurement (probs), check that a single array is returned."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
@@ -1982,8 +1968,7 @@ class TestReturn:
         self, dev, diff_method, grad_on_execution, device_vjp
     ):
         """The jacobian of multiple measurements with a single params return an array."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
+
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
@@ -1999,7 +1984,7 @@ class TestReturn:
         def circuit(a):
             qp.RY(a, wires=0)
             qp.RX(0.2, wires=0)
-            return qp.expval(qp.PauliZ(0)), qp.probs(wires=[0, 1])
+            return qp.expval(qp.Z(0)), qp.expval(qp.Z(0) @ qp.Y(1))
 
         a = np.array(0.1, requires_grad=True)
 
@@ -2009,14 +1994,13 @@ class TestReturn:
         jac = qp.jacobian(cost)(a)
 
         assert isinstance(jac, np.ndarray)
-        assert jac.shape == (5,)
+        assert jac.shape == (2,)
 
     def test_jacobian_multiple_measurement_multiple_param(
         self, dev, diff_method, grad_on_execution, device_vjp
     ):
         """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
+
         gradient_kwargs = {}
         if diff_method == "hadamard":
             gradient_kwargs["aux_wire"] = 2
@@ -2055,8 +2039,6 @@ class TestReturn:
         self, dev, diff_method, grad_on_execution, device_vjp
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
 
         gradient_kwargs = {}
         if diff_method == "hadamard":

--- a/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_jit_qnode.py
@@ -468,8 +468,6 @@ class TestVectorValuedQNode:
         """Tests correct output shape and evaluation for a tape
         with a single prob output"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -525,15 +523,12 @@ class TestVectorValuedQNode:
         assert np.allclose(res[0], expected.T[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected.T[1], atol=tol, rtol=0)
 
-    # pylint: disable-next = too-many-statements
     def test_diff_multi_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
     ):
         """Tests correct output shape and evaluation for a tape
         with multiple prob outputs"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -622,15 +617,12 @@ class TestVectorValuedQNode:
         assert jac[1][1].shape == (4,)
         assert np.allclose(jac[1][1], expected_1[1], atol=tol, rtol=0)
 
-    # pylint: disable-next = too-many-statements
     def test_diff_expval_probs(
         self, dev_name, diff_method, grad_on_execution, device_vjp, interface, tol, seed
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -715,8 +707,6 @@ class TestVectorValuedQNode:
         """Tests correct output shape and evaluation for a tape with prob and expval outputs with less
         trainable parameters (argnums) than parameters."""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -780,8 +770,6 @@ class TestVectorValuedQNode:
         """Tests correct output shape and evaluation for a tape
         with prob and variance outputs"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -1564,8 +1552,6 @@ class TestQubitIntegrationHigherOrder:
     ):
         """Test that the state can be returned and differentiated"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "lightning.qubit" and diff_method == "adjoint":
             pytest.xfail("lightning.qubit does not support adjoint with the state.")
 
@@ -2156,8 +2142,6 @@ class TestJIT:
         """Test derivative calculation of a scalar valued cost function that
         uses the output of a vector-valued QNode"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         gradient_kwargs = {}
 
         if dev_name == "param_shift.qubit":
@@ -2407,6 +2391,7 @@ class TestReturn:
 
         if diff_method == "adjoint":
             pytest.skip("adjoint state differentiation is not supported in pl2")
+
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -2450,8 +2435,6 @@ class TestReturn:
         """For a multi-dimensional measurement (probs), check that a single tuple is returned
         containing arrays with the correct dimension"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -2504,8 +2487,6 @@ class TestReturn:
         """For a multi-dimensional measurement (probs), check that a single tuple is returned
         containing arrays with the correct dimension"""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -2757,8 +2738,6 @@ class TestReturn:
     ):
         """The jacobian of multiple measurements with a single params return an array."""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention")
 
@@ -2787,7 +2766,7 @@ class TestReturn:
         def circuit(a):
             qp.RY(a, wires=0)
             qp.RX(0.2, wires=0)
-            return qp.expval(qp.PauliZ(0)), qp.probs(wires=[0, 1])
+            return qp.expval(qp.Z(0)), qp.expval(qp.Z(0) @ qp.X(1))
 
         a = jax.numpy.array(0.1)
 
@@ -2800,15 +2779,13 @@ class TestReturn:
         assert jac[0].shape == ()
 
         assert isinstance(jac[1], jax.numpy.ndarray)
-        assert jac[1].shape == (4,)
+        assert jac[1].shape == ()
 
     def test_jacobian_multiple_measurement_multiple_param(
         self, dev_name, diff_method, grad_on_execution, device_vjp, jacobian, shots, interface, seed
     ):
         """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 
@@ -2866,8 +2843,6 @@ class TestReturn:
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
 
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if dev_name == "param_shift.qubit":
             pytest.xfail("gradient transforms have a different vjp shape convention.")
 

--- a/tests/workflow/interfaces/qnode/test_jax_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_jax_qnode.py
@@ -421,8 +421,6 @@ class TestVectorValuedQNode:
     ):
         """Tests correct output shape and evaluation for a tape
         with a single prob output"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         kwargs = {
             "diff_method": diff_method,
             "interface": interface,
@@ -476,8 +474,6 @@ class TestVectorValuedQNode:
     ):
         """Tests correct output shape and evaluation for a tape
         with multiple prob outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         kwargs = {
             "diff_method": diff_method,
             "interface": interface,
@@ -565,8 +561,6 @@ class TestVectorValuedQNode:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         kwargs = {
             "diff_method": diff_method,
             "interface": interface,
@@ -642,8 +636,6 @@ class TestVectorValuedQNode:
     ):
         """Tests correct output shape and evaluation for a tape with prob and expval outputs with less
         trainable parameters (argnums) than parameters."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         kwargs = {}
         if diff_method == "spsa":
             kwargs["sampler_rng"] = np.random.default_rng(seed)
@@ -702,8 +694,6 @@ class TestVectorValuedQNode:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and variance outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         kwargs = {
             "diff_method": diff_method,
             "interface": interface,
@@ -2072,8 +2062,6 @@ class TestReturn:  # pylint:disable=too-many-public-methods
         self, dev_name, diff_method, grad_on_execution, jacobian, device_vjp, shots, interface, seed
     ):
         """The jacobian of multiple measurements with a single params return an array."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
         if "lightning" in dev_name:
@@ -2097,7 +2085,7 @@ class TestReturn:  # pylint:disable=too-many-public-methods
         def circuit(a):
             qp.RY(a, wires=0)
             qp.RX(0.2, wires=0)
-            return qp.expval(qp.PauliZ(0)), qp.probs(wires=[0, 1])
+            return qp.expval(qp.PauliZ(0)), qp.expval(qp.PauliX(0))
 
         a = jax.numpy.array(0.1)
 
@@ -2110,15 +2098,13 @@ class TestReturn:  # pylint:disable=too-many-public-methods
         assert jac[0].shape == ()
 
         assert isinstance(jac[1], jax.numpy.ndarray)
-        assert jac[1].shape == (4,)
+        assert jac[1].shape == ()
 
     @pytest.mark.parametrize("jacobian", jacobian_fn)
     def test_jacobian_multiple_measurement_multiple_param(
         self, dev_name, diff_method, grad_on_execution, jacobian, device_vjp, shots, interface, seed
     ):
         """The jacobian of multiple measurements with a multiple params return a tuple of arrays."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
         if "lightning" in dev_name:
@@ -2173,8 +2159,6 @@ class TestReturn:  # pylint:disable=too-many-public-methods
         self, dev_name, diff_method, grad_on_execution, jacobian, device_vjp, shots, interface, seed
     ):
         """The jacobian of multiple measurements with a multiple params array return a single array."""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if shots is not None and diff_method in ("backprop", "adjoint"):
             pytest.skip("Test does not support finite shots and adjoint/backprop")
         if "lightning" in dev_name:

--- a/tests/workflow/interfaces/qnode/test_torch_qnode.py
+++ b/tests/workflow/interfaces/qnode/test_torch_qnode.py
@@ -667,8 +667,6 @@ class TestQubitIntegration:
     ):
         """Tests correct output shape and evaluation for a tape
         with prob and expval outputs"""
-        if diff_method == "adjoint":
-            pytest.skip("adjoint state differentiation is not supported in pl2")
         if "lightning" in getattr(dev, "name", "").lower():
             pytest.xfail("lightning does not support measureing probabilities with adjoint.")
         if diff_method == "adjoint":


### PR DESCRIPTION
**Context:**

Many duplicate xfails in tests that involve adjoint differentiation of state measurements, among a few other things.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
