### PR TITLE
Support structured and symbolic Operator2 rules in capture-mode graph decomposition

### DIFF
--- a/pennylane/transforms/decompose.py
+++ b/pennylane/transforms/decompose.py
@@ -25,7 +25,7 @@ from functools import lru_cache, partial
 from pennylane import math, ops
 from pennylane.allocation import Allocate, Deallocate
 from pennylane.core import queuing
-from pennylane.core.operator import Operator
+from pennylane.core.operator import Operator, Operator2
 from pennylane.decomposition import DecompositionGraph, GateSet, enabled_graph, gate_sets
 from pennylane.decomposition.decomposition_graph import DecompGraphSolution
 from pennylane.decomposition.utils import _get_decomp_args
@@ -187,18 +187,39 @@ def _get_plxpr_decompose():  # pylint: disable=too-many-statements
             rule = self._decomp_graph_solution.decomposition(
                 op, num_work_wires=self._num_work_wires
             )
-            num_wires = len(op.wires)
 
-            def compute_qfunc_decomposition(*_args, **_kwargs):
-                wires = _args[-num_wires:]
-                if not any(is_abstract_qubit(w) for w in wires):
-                    wires = math.array(wires, like="jax")
-                rule(*_args[:-num_wires], wires=wires, **_kwargs)
+            if isinstance(op, Operator2):
+                # ``Operator2`` decomposition rules are invoked with the operator's own
+                # arguments by name (the canonical ``rule(**op.arguments)`` convention, see
+                # ``Operator2.compute_decomposition``). This covers rules with structured wire
+                # arguments (e.g. ``SelectPauliRot``'s ``control_wires``/``target_wire``) and
+                # symbolic operators that take a nested ``base`` (e.g. ``Controlled``), neither
+                # of which fits a single flat ``wires`` argument. Flatten the operator to its
+                # traceable leaves (all wires and dynamic data, including those of a nested
+                # ``base``) so the decomposition is captured against freshly-traced wires, then
+                # rebuild the operator inside the trace and dispatch on its arguments.
+                leaves, treedef = jax.tree_util.tree_flatten(op)
 
-            args = (*op.parameters, *op.wires)
+                def compute_qfunc_decomposition(*_leaves):
+                    traced_op = jax.tree_util.tree_unflatten(treedef, _leaves)
+                    rule(**traced_op.arguments)
 
-            decomp_fn = partial(compute_qfunc_decomposition, **op.hyperparameters)
-            jaxpr_decomp = make_plxpr(decomp_fn)(*args)
+                args = leaves
+            else:
+                num_wires = len(op.wires)
+
+                def compute_qfunc_decomposition(*_args, **_kwargs):
+                    wires = _args[-num_wires:]
+                    if not any(is_abstract_qubit(w) for w in wires):
+                        wires = math.array(wires, like="jax")
+                    rule(*_args[:-num_wires], wires=wires, **_kwargs)
+
+                args = (*op.parameters, *op.wires)
+                compute_qfunc_decomposition = partial(
+                    compute_qfunc_decomposition, **op.hyperparameters
+                )
+
+            jaxpr_decomp = make_plxpr(compute_qfunc_decomposition)(*args)
 
             self._current_depth += 1
             # We don't need to copy the interpreter here, as the jaxpr of the decomposition


### PR DESCRIPTION
dispatch Operator2 decomposition rules via `rule(**op.arguments)` instead of a flat `wires=` argument in the plxpr `DecomposeInterpreter`.

**Context:**

trying to set up the [vibronic workflow](https://github.com/XanaduAI/application-algos/pull/52) with capture enabled and using [TrotterVibronic(Operator2)](https://github.com/PennyLaneAI/pennylane/pull/10029)

```python
import jax, jax.numpy as jnp, pennylane as qp
qp.decomposition.enable_graph()
qp.capture.enable()

from pennylane.transforms.decompose import _get_plxpr_decompose
DecomposeInterpreter, _ = _get_plxpr_decompose()

GATE_SET = {"CNOT", "RZ", "RX", "RY", "Hadamard", "GlobalPhase",
            "PhaseShift", "T", "Adjoint(T)", "S", "Adjoint(S)", "PauliX"}

def qfunc(angles):
    qp.ctrl(qp.QFT(wires=[1, 2, 3]), control=0)                                   # symbolic Operator2 rule (base, control_wires, ...)
    qp.SelectPauliRot(angles, control_wires=[0, 1], target_wire=2, rot_axis="Z")  # structured wire args
    return qp.probs()

qnode = qp.qnode(qp.device("default.qubit", wires=4))(DecomposeInterpreter(gate_set=GATE_SET)(qfunc))

print(jax.make_jaxpr(qnode)(jnp.array([0.1, 0.2, 0.3, 0.4])))  # before: TypeError; after: builds
```

**Description of the Change:**

Under program capture + graph decomposition, the plxpr `DecomposeInterpreter` called every rule
with a flat `wires=` argument, which only fits `(*params, wires)` gates and raised `TypeError` for
`Operator2` rules taking structured wire args or a nested `base` (`SelectPauliRot`, `Controlled`,
`Adjoint`, `Pow`, ...). It now dispatches `Operator2` rules via the canonical `rule(**op.arguments)`
convention: flatten the op to traceable leaves, re-trace, rebuild a traced op, and call
`rule(**traced_op.arguments)`. Legacy `Operator` keeps the old path.

**Benefits:**

One step closer to capture=True in the workflow

**Possible Drawbacks:**

- Assumes rules follow `rule(**op.arguments)` (already required by non-capture decomposition).
- Does not fix the separate nested-`ctrl_transform` blocker under `qjit(capture=True)`:
```python
import pennylane as qp
qp.decomposition.enable_graph()
from pennylane.transforms.decompose import _get_plxpr_decompose
DecomposeInterpreter, _ = _get_plxpr_decompose()
W = [1, 2, 3]
@qp.qjit(capture=True, target="mlir")
@qp.qnode(qp.device("null.qubit", wires=4))
@DecomposeInterpreter(gate_set={"CNOT","RZ","RY","Hadamard","GlobalPhase",
                                "T","Adjoint(T)","S","Adjoint(S)","PauliX","Toffoli"})
def circuit():
    qp.ctrl(lambda: qp.QFT(wires=W), control=0)()   # closure block -> fails
    # qp.ctrl(qp.QFT(wires=W), control=0)            # op instance  -> works
    return qp.probs(wires=W)
qp.specs(circuit)()
```

**Related GitHub Issues:**

Co-produced with cursor (Claude Opus 4.8)