### PR TITLE
Make `None` a pytree

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -217,8 +217,8 @@
   ```
 
   ```pycon
-  >>> specs_result = qp.specs(circuit, level=0)(5) 
-  >>> print(specs_result) 
+  >>> specs_result = qp.specs(circuit, level=0)(5)
+  >>> print(specs_result)
   Device: lightning.qubit
   Device wires: 1
   Shots: Shots(total=None)
@@ -239,8 +239,8 @@
   These symbolic resources include expressions with variables which can substituted for concrete values to compute the associated resources for a circuit, via the ``subs`` method.
 
   ```pycon
-  >>> res = specs_result.resources 
-  >>> print(res.subs(a=5)) 
+  >>> res = specs_result.resources
+  >>> print(res.subs(a=5))
   Quantum operations:
   - Total: 7
     - Hadamard: 1
@@ -971,6 +971,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Updated :mod:`pennylane.pytrees` to consider `None` a Pytree. This makes PennyLane Pytrees more
+  consistent with JAX Pytrees.
+  [(#10045)](https://github.com/PennyLaneAI/pennylane/pull/10045)
+
 * The resource module JSON parser used by :func:`~.specs` to read Catalyst data has been revamped to match the new JSON structure produced by Catalyst.
   [(#9942)](https://github.com/PennyLaneAI/pennylane/pull/9942)
   [(#9969)](https://github.com/PennyLaneAI/pennylane/pull/9969)
@@ -1267,7 +1271,7 @@
   singledispatch function `custom_ctrl_dispatch` as opposed to relying on hard-coded logic.
   [(#9798)](https://github.com/PennyLaneAI/pennylane/pull/9798)
 
-* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx` 
+* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx`
   context manager that temporarily enables or disables capture is added.
   [(#10016)](https://github.com/PennyLaneAI/pennylane/pull/10016)
 
@@ -1432,7 +1436,7 @@
   one of its subclasses returned ``True`` if they shared the same data and wires.
   [(#9749)](https://github.com/PennyLaneAI/pennylane/pull/9749)
 
-* Qubit TCDQ expval function now returns the variance rather than standard deviation 
+* Qubit TCDQ expval function now returns the variance rather than standard deviation
   of the estimator. Qubit and qudit MMD loss functions now have unbiased gradients.
   [(#10025)](https://github.com/PennyLaneAI/pennylane/pull/10025)
 

--- a/pennylane/pytrees/pytrees.py
+++ b/pennylane/pytrees/pytrees.py
@@ -49,10 +49,16 @@ def flatten_dict(obj: dict):
     return obj.values(), tuple(obj.keys())
 
 
+def flatten_none(obj: None):  # pylint: disable=unused-argument
+    """Flatten a None value."""
+    return [], None
+
+
 flatten_registrations: dict[type, FlattenFn] = {
     list: flatten_list,
     tuple: flatten_tuple,
     dict: flatten_dict,
+    type(None): flatten_none,
 }
 
 
@@ -71,16 +77,23 @@ def unflatten_dict(data, metadata) -> dict:
     return dict(zip(metadata, data, strict=True))
 
 
+def unflatten_none(data, metadata) -> None:  # pylint: disable=unused-argument
+    """Unflatten a None value."""
+    return None
+
+
 unflatten_registrations: dict[type, UnflattenFn] = {
     list: unflatten_list,
     tuple: unflatten_tuple,
     dict: unflatten_dict,
+    type(None): unflatten_none,
 }
 
 type_to_typename: dict[type, str] = {
     list: "builtins.list",
     dict: "builtins.dict",
     tuple: "builtins.tuple",
+    type(None): "builtins.NoneType",
 }
 
 typename_to_type: dict[str, type] = {name: type_ for type_, name in type_to_typename.items()}

--- a/tests/data/attributes/test_serialization.py
+++ b/tests/data/attributes/test_serialization.py
@@ -177,6 +177,25 @@ def test_pytree_structure_load():
     )
 
 
+def test_pytree_structure_dump_load_none():
+    """Test that ``None`` serializes as an empty node (distinct from a leaf ``null``)
+    and round-trips through dump/load."""
+    obj = {"a": None, "b": [1, None]}
+    data, struct = flatten(obj)
+
+    assert json.loads(pytree_structure_dump(struct)) == [
+        "builtins.dict",
+        ["a", "b"],
+        [
+            ["builtins.NoneType", None, []],
+            ["builtins.list", None, [None, ["builtins.NoneType", None, []]]],
+        ],
+    ]
+
+    obj_out = unflatten(data, pytree_structure_load(pytree_structure_dump(struct)))
+    assert obj_out == obj
+
+
 H_ONE_QUBIT = np.array([[1.0, 0.5j], [-0.5j, 2.5]])
 H_TWO_QUBITS = np.array(
     [[0.5, 1.0j, 0.0, -3j], [-1.0j, -1.1, 0.0, -0.1], [0.0, 0.0, -0.9, 12.0], [3j, -0.1, 12.0, 0.0]]

--- a/tests/pytrees/test_pytrees.py
+++ b/tests/pytrees/test_pytrees.py
@@ -108,6 +108,36 @@ def test_dict():
     assert new_x == {"a": 5, "b": {"c": 6, "d": 7}}
 
 
+def test_none():
+    """Test that pennylane treats ``None`` as an empty pytree node rather than a leaf."""
+
+    data, structure = flatten(None)
+    assert data == []
+    assert not structure.is_leaf
+    assert structure == PyTreeStructure(type(None), None, ())
+
+    assert unflatten([], structure) is None
+
+
+def test_none_nested_in_container():
+    """Test that ``None`` inside a pytree contributes no leaves and round-trips."""
+
+    x = {"a": None, "b": [1, None, 2]}
+
+    data, structure = flatten(x)
+    assert data == [1, 2]
+    assert structure == PyTreeStructure(
+        dict,
+        ("a", "b"),
+        (
+            PyTreeStructure(type(None), None, ()),
+            PyTreeStructure(list, None, (leaf, PyTreeStructure(type(None), None, ()), leaf)),
+        ),
+    )
+
+    assert unflatten([3, 4], structure) == {"a": None, "b": [3, None, 4]}
+
+
 def test_nested_pl_object():
     """Test that we can flatten and unflatten nested pennylane object."""
 
@@ -119,9 +149,10 @@ def test_nested_pl_object():
     )
 
     data, structure = flatten(tape)
-    assert data == [0.1, 0, 2, 0, None]
+    assert data == [0.1, 0, 2, 0]
 
     list_struct = PyTreeStructure(list, None, ())
+    none_struct = PyTreeStructure(type(None), None, ())
     leaf_struct = PyTreeStructure(list, None, (leaf,))
     wire_struct = PyTreeStructure(Wires, (), (leaf,))
     wire_args_struct = PyTreeStructure(list, None, (wire_struct,))
@@ -140,7 +171,7 @@ def test_nested_pl_object():
 
     paulix_struct = PyTreeStructure(qp.PauliX, (), (list_struct, wire_args_struct, list_struct))
     sprod_struct = PyTreeStructure(qp.ops.SProd, (), (leaf, paulix_struct))
-    expval_struct = PyTreeStructure(ExpectationMP, (("wires", None),), (sprod_struct, leaf))
+    expval_struct = PyTreeStructure(ExpectationMP, (("wires", None),), (sprod_struct, none_struct))
     measurements_struct = PyTreeStructure(list, None, (expval_struct,))
 
     tape_struct = PyTreeStructure(
@@ -150,7 +181,7 @@ def test_nested_pl_object():
     )
     assert structure == tape_struct
 
-    new_tape = unflatten([3, 2, 4, 1, None], structure)
+    new_tape = unflatten([3, 2, 4, 1], structure)
     expected_new_tape = qp.tape.QuantumScript(
         [qp.adjoint(qp.RX(3, wires=2))],
         [qp.expval(4 * qp.X(1))],
@@ -160,7 +191,14 @@ def test_nested_pl_object():
     qp.assert_equal(new_tape, expected_new_tape)
 
 
-@pytest.mark.parametrize("type_,typename", [(list, "builtins.list"), (qp.Hadamard, "qp.Hadamard")])
+@pytest.mark.parametrize(
+    "type_,typename",
+    [
+        (list, "builtins.list"),
+        (type(None), "builtins.NoneType"),
+        (qp.Hadamard, "qp.Hadamard"),
+    ],
+)
 def test_get_typename(type_, typename):
     """Test for ``get_typename()``."""
 
@@ -175,7 +213,14 @@ def test_get_typename_invalid():
         get_typename(int)
 
 
-@pytest.mark.parametrize("type_,typename", [(list, "builtins.list"), (qp.Hadamard, "qp.Hadamard")])
+@pytest.mark.parametrize(
+    "type_,typename",
+    [
+        (list, "builtins.list"),
+        (type(None), "builtins.NoneType"),
+        (qp.Hadamard, "qp.Hadamard"),
+    ],
+)
 def test_get_typename_type(type_, typename):
     """Tests for ``get_typename_type()``."""
     assert get_typename_type(typename) is type_

--- a/tests/pytrees/test_pytrees.py
+++ b/tests/pytrees/test_pytrees.py
@@ -108,7 +108,7 @@ def test_dict():
     assert new_x == {"a": 5, "b": {"c": 6, "d": 7}}
 
 
-def test_none():
+def test_none_is_an_empty_pytree_node():
     """Test that pennylane treats ``None`` as an empty pytree node rather than a leaf."""
 
     data, structure = flatten(None)


### PR DESCRIPTION
**Context:**
JAX considers `None` a pytree. This PR makes the same change for pennylane pytrees as well.

**Description of the Change:**
* Add functions to flatten and unflatten `None` as a pytree which flattens to empty leaves
* Update the `types_to_typenames` dictionary which is needed for correct serialization with `qp.data`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-128463]

Cursor was used for help with updates related to `qp.data`