### PR TITLE
Fix triton requiring device to have GPU even for x-compiling

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -217,8 +217,8 @@
   ```
 
   ```pycon
-  >>> specs_result = qp.specs(circuit, level=0)(5) 
-  >>> print(specs_result) 
+  >>> specs_result = qp.specs(circuit, level=0)(5)
+  >>> print(specs_result)
   Device: lightning.qubit
   Device wires: 1
   Shots: Shots(total=None)
@@ -239,8 +239,8 @@
   These symbolic resources include expressions with variables which can substituted for concrete values to compute the associated resources for a circuit, via the ``subs`` method.
 
   ```pycon
-  >>> res = specs_result.resources 
-  >>> print(res.subs(a=5)) 
+  >>> res = specs_result.resources
+  >>> print(res.subs(a=5))
   Quantum operations:
   - Total: 7
     - Hadamard: 1
@@ -1267,7 +1267,7 @@
   singledispatch function `custom_ctrl_dispatch` as opposed to relying on hard-coded logic.
   [(#9798)](https://github.com/PennyLaneAI/pennylane/pull/9798)
 
-* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx` 
+* `capture.enable()`, `capture.disable()` are updated to use `ContextVar` for thread safety. A `capture.toggle_ctx`
   context manager that temporarily enables or disables capture is added.
   [(#10016)](https://github.com/PennyLaneAI/pennylane/pull/10016)
 
@@ -1303,6 +1303,12 @@
   [(#9621)](https://github.com/PennyLaneAI/pennylane/pull/9621)
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed :func:`~pennylane.backline.css_bp_decoder` and the other Triton decoders so they can be
+  compiled on a machine with no usable GPU. The ahead-of-time build called
+  ``JITFunction.create_binder()``, which asks the local machine for a target through
+  ``driver.active.get_current_target()`` and fails with ``0 active drivers`` where there is none.
+  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
 
 * Fixed a bug where the ``flip_zero_control`` decomposition modifier raised a
   ``TracerIntegerConversionError`` under program capture, because the control-value flipping
@@ -1432,7 +1438,7 @@
   one of its subclasses returned ``True`` if they shared the same data and wires.
   [(#9749)](https://github.com/PennyLaneAI/pennylane/pull/9749)
 
-* Qubit TCDQ expval function now returns the variance rather than standard deviation 
+* Qubit TCDQ expval function now returns the variance rather than standard deviation
   of the estimator. Qubit and qudit MMD loss functions now have unbiased gradients.
   [(#10025)](https://github.com/PennyLaneAI/pennylane/pull/10025)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1308,7 +1308,7 @@
   compiled on a machine with no usable GPU. The ahead-of-time build called
   ``JITFunction.create_binder()``, which asks the local machine for a target through
   ``driver.active.get_current_target()`` and fails with ``0 active drivers`` where there is none.
-  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
+  [(#10046)](https://github.com/PennyLaneAI/pennylane/pull/10046)
 
 * Fixed a bug where the ``flip_zero_control`` decomposition modifier raised a
   ``TracerIntegerConversionError`` under program capture, because the control-value flipping

--- a/pennylane/backline/decoders/triton/triton_so_builder.py
+++ b/pennylane/backline/decoders/triton/triton_so_builder.py
@@ -54,6 +54,7 @@ from pathlib import Path
 try:
     import triton
     from triton.backends.compiler import GPUTarget
+    from triton.compiler import ASTSource
     from triton.tools import compile as triton_compile_tool
 except ImportError as exc:
     raise ImportError("Triton decoders require installed `triton` Python package.") from exc
@@ -304,9 +305,17 @@ def _compile_kernel(  # pylint: disable=too-many-arguments
     # Wrap tuples so nested JIT functions contribute their own cache keys.
     constants = {name: _wrap_constexpr(value) for name, value in constexpr.items()}
 
-    # Adapted from Triton's python/triton/tools/compile.py:compile_kernel
-    kernel.create_binder()
-    ast_source = kernel.ASTSource(fn=kernel, constexprs=constants, signature=signature, attrs={})
+    # Adapted from Triton's python/triton/tools/compile.py:compile_kernel, but without
+    # JITFunction.create_binder(). That call asks the local machine for a target, through
+    # driver.active.get_current_target(), which requires a usable GPU on the machine doing
+    # the compiling and fails with "0 active drivers" where there is none. It contributes
+    # nothing else that is used here: it assigns JITFunction.ASTSource, which is exactly
+    # triton.compiler.ASTSource imported above, and the target and binder it computes are
+    # discarded, because the target below comes from the caller's platform string instead.
+    #
+    # Compiling ahead of time for a card the local machine does not have is the point of
+    # taking an explicit platform, so this build must not depend on one being present.
+    ast_source = ASTSource(fn=kernel, constexprs=constants, signature=signature, attrs={})
 
     target_arch = int(arch) if backend == "cuda" and arch.isdigit() else arch
     target_obj = GPUTarget(backend, target_arch, warp_size)

--- a/pennylane/backline/decoders/triton/triton_so_builder.py
+++ b/pennylane/backline/decoders/triton/triton_so_builder.py
@@ -305,16 +305,7 @@ def _compile_kernel(  # pylint: disable=too-many-arguments
     # Wrap tuples so nested JIT functions contribute their own cache keys.
     constants = {name: _wrap_constexpr(value) for name, value in constexpr.items()}
 
-    # Adapted from Triton's python/triton/tools/compile.py:compile_kernel, but without
-    # JITFunction.create_binder(). That call asks the local machine for a target, through
-    # driver.active.get_current_target(), which requires a usable GPU on the machine doing
-    # the compiling and fails with "0 active drivers" where there is none. It contributes
-    # nothing else that is used here: it assigns JITFunction.ASTSource, which is exactly
-    # triton.compiler.ASTSource imported above, and the target and binder it computes are
-    # discarded, because the target below comes from the caller's platform string instead.
-    #
-    # Compiling ahead of time for a card the local machine does not have is the point of
-    # taking an explicit platform, so this build must not depend on one being present.
+    # Adapted from Triton's python/triton/tools/compile.py:compile_kernel
     ast_source = ASTSource(fn=kernel, constexprs=constants, signature=signature, attrs={})
 
     target_arch = int(arch) if backend == "cuda" and arch.isdigit() else arch

--- a/tests/backline/decoders/test_triton_so_builder.py
+++ b/tests/backline/decoders/test_triton_so_builder.py
@@ -97,8 +97,6 @@ def stub_triton_compile_fixture(monkeypatch):
             {
                 "__name__": "decoder_kernel",
                 "arg_names": ["ring_u64_ptr"],
-                "ASTSource": fake_ast_source,
-                "create_binder": lambda _self: None,
             },
         )()
         fake_backend = type(
@@ -112,6 +110,7 @@ def stub_triton_compile_fixture(monkeypatch):
             metadata=SimpleNamespace(**metadata_kwargs),
             asm={"cubin": b"\x00\x01"},
         )
+        monkeypatch.setattr(builder, "ASTSource", fake_ast_source)
         monkeypatch.setattr(builder.triton.compiler, "make_backend", lambda _: fake_backend)
         monkeypatch.setattr(builder.triton, "compile", lambda *args, **kwargs: compile_result)
         return fake_kernel

--- a/tests/backline/decoders/test_triton_so_builder_cache.py
+++ b/tests/backline/decoders/test_triton_so_builder_cache.py
@@ -53,11 +53,12 @@ class TestConstexprCacheKeys:
             "total": "u64",
         }
 
-        _persistent_decoder_kernel.create_binder()
-
         def ast_hash(decoder_fns):
             wrapped = builder._wrap_constexpr(decoder_fns)
-            src = _persistent_decoder_kernel.ASTSource(
+            # builder.ASTSource, not kernel.ASTSource via create_binder(): the latter asks
+            # the local machine for a target and so needs a usable GPU, which hashing an
+            # AST does not.
+            src = builder.ASTSource(
                 fn=_persistent_decoder_kernel,
                 constexprs={"decoder_fns": wrapped},
                 signature=signature,


### PR DESCRIPTION
**Context:**
Previously to use triton for backline decoder, we require the compiling machine to have a GPU. However, for remote deployment this is not a strict requirement.

**Description of the Change:**
This PR removes the requirement for the host compiling machine to have a GPU (and pytorch) for it to compile the decoder library for the remote coprocessor. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
