### PR TITLE
Share code between OutSquare and SignedOutSquare

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1054,7 +1054,7 @@
   [(#10018)](https://github.com/PennyLaneAI/pennylane/pull/10018)
   [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
   [(#10052)](https://github.com/PennyLaneAI/pennylane/pull/10052)
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10054)](https://github.com/PennyLaneAI/pennylane/pull/10054)
   - Quantum chemistry operators are ported:
     - :class:`~.SingleExcitation`
   [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1061,6 +1061,10 @@
     - :class:`~.PauliMeasure`
   [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)
 
+* `SignedOutSquare` now directly subclasses `OutSquare`, removing duplicated wire-validation
+  boilerplate between the two templates.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.
   [(#9815)](https://github.com/PennyLaneAI/pennylane/pull/9815)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1054,16 +1054,13 @@
   [(#10018)](https://github.com/PennyLaneAI/pennylane/pull/10018)
   [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
   [(#10052)](https://github.com/PennyLaneAI/pennylane/pull/10052)
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
   - Quantum chemistry operators are ported:
     - :class:`~.SingleExcitation`
   [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)
   - Miscelleneous operators are ported:
     - :class:`~.PauliMeasure`
   [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)
-
-* `OutSquare` and `SignedOutSquare` now share a private `_SquareArithmeticOp` base class,
-  removing duplicated wire-validation boilerplate between the two templates.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default
   else branch.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1061,8 +1061,8 @@
     - :class:`~.PauliMeasure`
   [(#10005)](https://github.com/PennyLaneAI/pennylane/pull/10005)
 
-* `SignedOutSquare` now directly subclasses `OutSquare`, removing duplicated wire-validation
-  boilerplate between the two templates.
+* `OutSquare` and `SignedOutSquare` now share a private `_SquareArithmeticOp` base class,
+  removing duplicated wire-validation boilerplate between the two templates.
   [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
 
 * The `cond` primitive no longer adds an artificial `True` Literal for the predicate of the default

--- a/pennylane/templates/subroutines/arithmetic/out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/out_square.py
@@ -36,7 +36,76 @@ from .semi_adder import SemiAdder, _semi_adder_resources
 from .temporary_and import TemporaryAND
 
 
-class OutSquare(Operator2):
+class _SquareArithmeticOp(Operator2, is_baseclass=True):
+    """Shared ``Operator2`` boilerplate for :class:`~.OutSquare` and :class:`~.SignedOutSquare`."""
+
+    wire_argnames = ("x_wires", "output_wires", "work_wires")
+    compilable_argnames = ("output_wires_zeroed",)
+
+    arg_specs = {
+        "x_wires": Wire[-1],
+        "output_wires": Wire[-1],
+        "work_wires": Wire[-1],
+    }
+
+    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
+        """Validate the number of work wires. Must be overridden by subclasses."""
+        raise NotImplementedError
+
+    def __init__(
+        self,
+        x_wires: WiresLike,
+        output_wires: WiresLike,
+        work_wires: WiresLike,
+        output_wires_zeroed: bool = False,
+    ):
+        x_wires = Wires(x_wires)
+        output_wires = Wires(output_wires)
+        work_wires = Wires(work_wires)
+
+        self._check_work_wires(len(x_wires), len(output_wires), work_wires, output_wires_zeroed)
+
+        wires_list = [x_wires, output_wires, work_wires]
+
+        _wires_are_traced = any(math.is_abstract(w) for ws in wires_list for w in ws)
+
+        if not _wires_are_traced:
+            wires_dict = dict(zip(self.wire_argnames, wires_list, strict=True))
+            for name0, name1 in combinations(self.wire_argnames, r=2):
+                if wires_dict[name0].intersection(wires_dict[name1]):
+                    raise ValueError(f"None of the wires in {name1} should be included in {name0}.")
+
+        super().__init__(
+            x_wires,
+            output_wires,
+            work_wires,
+            output_wires_zeroed=output_wires_zeroed,
+        )
+
+    # pylint: disable=arguments-differ
+    def __abstract_init__(
+        self,
+        x_wires: AbstractWires | WiresLike,
+        output_wires: AbstractWires | WiresLike,
+        work_wires: AbstractWires | WiresLike,
+        output_wires_zeroed: bool = False,
+    ):
+        self._check_work_wires(len(x_wires), len(output_wires), work_wires, output_wires_zeroed)
+
+        super().__abstract_init__(
+            x_wires,
+            output_wires,
+            work_wires,
+            output_wires_zeroed=output_wires_zeroed,
+        )
+
+    @property
+    def wires(self):
+        """All wires involved in the operation."""
+        return self.x_wires + self.output_wires + self.work_wires
+
+
+class OutSquare(_SquareArithmeticOp):
     r"""Performs out-of-place squaring.
 
     This operator performs the squaring of an :math:`n`-qubit integer :math:`x` modulo
@@ -207,89 +276,13 @@ class OutSquare(Operator2):
 
     """
 
-    wire_argnames = ("x_wires", "output_wires", "work_wires")
-    compilable_argnames = ("output_wires_zeroed",)
-
-    arg_specs = {
-        "x_wires": Wire[-1],
-        "output_wires": Wire[-1],
-        "work_wires": Wire[-1],
-    }
-
-    @staticmethod
-    def _min_work_wires(n, m, output_wires_zeroed):
-        """The minimum number of work wires required for the given register sizes."""
-        return min(n + 1, m) if output_wires_zeroed else m
-
-    def __init__(
-        self,
-        x_wires: WiresLike,
-        output_wires: WiresLike,
-        work_wires: WiresLike,
-        output_wires_zeroed: bool = False,
-    ):
-        x_wires = Wires(x_wires)
-        output_wires = Wires(output_wires)
-        work_wires = Wires(work_wires)
-
-        n = len(x_wires)
-        m = len(output_wires)
-
-        num_required_work_wires = self._min_work_wires(n, m, output_wires_zeroed)
+    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
+        num_required_work_wires = min(n + 1, m) if output_wires_zeroed else m
         if len(work_wires) < num_required_work_wires:
             raise ValueError(
-                f"{type(self).__name__} requires at least {num_required_work_wires} work wires "
-                f"for {n} input wires, {m} output wires and {output_wires_zeroed=}. "
-                f"Got {len(work_wires)} work wires instead."
+                f"OutSquare requires at least {num_required_work_wires} work wires for "
+                f"{n} input wires, {m} output wires and {output_wires_zeroed=}."
             )
-
-        wires_list = [x_wires, output_wires, work_wires]
-
-        _wires_are_traced = any(math.is_abstract(w) for ws in wires_list for w in ws)
-
-        if not _wires_are_traced:
-            wires_dict = dict(zip(self.wire_argnames, wires_list, strict=True))
-            for name0, name1 in combinations(self.wire_argnames, r=2):
-                if wires_dict[name0].intersection(wires_dict[name1]):
-                    raise ValueError(f"None of the wires in {name1} should be included in {name0}.")
-
-        super().__init__(
-            x_wires,
-            output_wires,
-            work_wires,
-            output_wires_zeroed=output_wires_zeroed,
-        )
-
-    # pylint: disable=arguments-differ
-    def __abstract_init__(
-        self,
-        x_wires: AbstractWires | WiresLike,
-        output_wires: AbstractWires | WiresLike,
-        work_wires: AbstractWires | WiresLike,
-        output_wires_zeroed: bool = False,
-    ):
-        n = len(x_wires)
-        m = len(output_wires)
-
-        num_required_work_wires = self._min_work_wires(n, m, output_wires_zeroed)
-        if len(work_wires) < num_required_work_wires:
-            raise ValueError(
-                f"{type(self).__name__} requires at least {num_required_work_wires} work wires "
-                f"for {n} input wires, {m} output wires and {output_wires_zeroed=}. "
-                f"Got {len(work_wires)} work wires instead."
-            )
-
-        super().__abstract_init__(
-            x_wires,
-            output_wires,
-            work_wires,
-            output_wires_zeroed=output_wires_zeroed,
-        )
-
-    @property
-    def wires(self):
-        """All wires involved in the operation."""
-        return self.x_wires + self.output_wires + self.work_wires
 
 
 def _out_square_with_adder_condition(

--- a/pennylane/templates/subroutines/arithmetic/out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/out_square.py
@@ -216,6 +216,11 @@ class OutSquare(Operator2):
         "work_wires": Wire[-1],
     }
 
+    @staticmethod
+    def _min_work_wires(n, m, output_wires_zeroed):
+        """The minimum number of work wires required for the given register sizes."""
+        return min(n + 1, m) if output_wires_zeroed else m
+
     def __init__(
         self,
         x_wires: WiresLike,
@@ -230,11 +235,12 @@ class OutSquare(Operator2):
         n = len(x_wires)
         m = len(output_wires)
 
-        num_required_work_wires = min(n + 1, m) if output_wires_zeroed else m
+        num_required_work_wires = self._min_work_wires(n, m, output_wires_zeroed)
         if len(work_wires) < num_required_work_wires:
             raise ValueError(
-                f"OutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}."
+                f"{type(self).__name__} requires at least {num_required_work_wires} work wires "
+                f"for {n} input wires, {m} output wires and {output_wires_zeroed=}. "
+                f"Got {len(work_wires)} work wires instead."
             )
 
         wires_list = [x_wires, output_wires, work_wires]
@@ -265,11 +271,12 @@ class OutSquare(Operator2):
         n = len(x_wires)
         m = len(output_wires)
 
-        num_required_work_wires = min(n + 1, m) if output_wires_zeroed else m
+        num_required_work_wires = self._min_work_wires(n, m, output_wires_zeroed)
         if len(work_wires) < num_required_work_wires:
             raise ValueError(
-                f"OutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}."
+                f"{type(self).__name__} requires at least {num_required_work_wires} work wires "
+                f"for {n} input wires, {m} output wires and {output_wires_zeroed=}. "
+                f"Got {len(work_wires)} work wires instead."
             )
 
         super().__abstract_init__(

--- a/pennylane/templates/subroutines/arithmetic/out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/out_square.py
@@ -48,9 +48,20 @@ class _SquareArithmeticOp(Operator2, is_baseclass=True):
         "work_wires": Wire[-1],
     }
 
-    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
-        """Validate the number of work wires. Must be overridden by subclasses."""
+    @staticmethod
+    def _min_work_wires(n, m, output_wires_zeroed):
+        """The minimum number of work wires required for the given register sizes. Must be
+        overridden by subclasses."""
         raise NotImplementedError
+
+    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
+        num_required_work_wires = self._min_work_wires(n, m, output_wires_zeroed)
+        if len(work_wires) < num_required_work_wires:
+            raise ValueError(
+                f"{type(self).__name__} requires at least {num_required_work_wires} work wires "
+                f"for {n} input wires, {m} output wires and {output_wires_zeroed=}. "
+                f"Got {len(work_wires)} work wires instead."
+            )
 
     def __init__(
         self,
@@ -276,13 +287,9 @@ class OutSquare(_SquareArithmeticOp):
 
     """
 
-    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
-        num_required_work_wires = min(n + 1, m) if output_wires_zeroed else m
-        if len(work_wires) < num_required_work_wires:
-            raise ValueError(
-                f"OutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}."
-            )
+    @staticmethod
+    def _min_work_wires(n, m, output_wires_zeroed):
+        return min(n + 1, m) if output_wires_zeroed else m
 
 
 def _out_square_with_adder_condition(

--- a/pennylane/templates/subroutines/arithmetic/signed_out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/signed_out_square.py
@@ -212,17 +212,12 @@ class SignedOutSquare(_SquareArithmeticOp):
 
     """
 
-    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
+    @staticmethod
+    def _min_work_wires(n, m, output_wires_zeroed):
         # Work wires required for the unsigned square (its input is reduced by one)
-        num_required_work_wires = min(n, m) if output_wires_zeroed else m
         # Work wires required for the first correction adder are `min(m-n, n)-1`, which is smaller
         # than `m` and smaller than `n`, so that the unsigned square always needs more work wires.
-        if len(work_wires) < num_required_work_wires:
-            raise ValueError(
-                f"SignedOutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}. "
-                f"Got {len(work_wires)} work wires instead."
-            )
+        return min(n, m) if output_wires_zeroed else m
 
 
 def _c_subtract_then_add_one_resources(n, m, num_work_wires, output_wires_zeroed):

--- a/pennylane/templates/subroutines/arithmetic/signed_out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/signed_out_square.py
@@ -16,21 +16,18 @@ Contains the SignedOutSquare template.
 """
 
 from collections import defaultdict
-from itertools import combinations
 
-from pennylane import math
-from pennylane.core.operator import Operator2
 from pennylane.core.queuing import AnnotatedQueue, QueuingManager, apply
 from pennylane.decomposition import add_decomps, register_resources
 from pennylane.ops import BasisState, X
 from pennylane.templates.subroutines.arithmetic import OutSquare, SemiAdder
-from pennylane.typing import AbstractWires, Bool, Wire
-from pennylane.wires import Wires, WiresLike
+from pennylane.typing import Bool, Wire
+from pennylane.wires import WiresLike
 
 from .semi_adder import _controlled_semi_adder, _controlled_semi_adder_resource
 
 
-class SignedOutSquare(Operator2):
+class SignedOutSquare(OutSquare):
     r"""Performs out-of-place squaring of a signed integer.
 
     This operator performs the squaring of a signed integer :math:`x` in 2s complement
@@ -214,91 +211,12 @@ class SignedOutSquare(Operator2):
 
     """
 
-    wire_argnames = ("x_wires", "output_wires", "work_wires")
-    compilable_argnames = ("output_wires_zeroed",)
-
-    arg_specs = {
-        "x_wires": Wire[-1],
-        "output_wires": Wire[-1],
-        "work_wires": Wire[-1],
-    }
-
-    def __init__(
-        self,
-        x_wires: WiresLike,
-        output_wires: WiresLike,
-        work_wires: WiresLike,
-        output_wires_zeroed: bool = False,
-    ):
-
-        x_wires = Wires(x_wires)
-        output_wires = Wires(output_wires)
-        work_wires = Wires(work_wires)
-
-        n = len(x_wires)
-        m = len(output_wires)
-
+    @staticmethod
+    def _min_work_wires(n, m, output_wires_zeroed):
         # Work wires required for the unsigned square (its input is reduced by one)
-        num_required_work_wires = min(n, m) if output_wires_zeroed else m
         # Work wires required for the first correction adder are `min(m-n, n)-1`, which is smaller
         # than `m` and smaller than `n`, so that the unsigned square always needs more work wires.
-        if len(work_wires) < num_required_work_wires:
-            raise ValueError(
-                f"SignedOutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}. "
-                f"Got {len(work_wires)} work wires instead."
-            )
-
-        wires_list = [x_wires, output_wires, work_wires]
-
-        _wires_are_traced = any(math.is_abstract(w) for ws in wires_list for w in ws)
-
-        if not _wires_are_traced:
-            wires_dict = dict(zip(self.wire_argnames, wires_list, strict=True))
-            for name0, name1 in combinations(self.wire_argnames, r=2):
-                if wires_dict[name0].intersection(wires_dict[name1]):
-                    raise ValueError(f"None of the wires in {name1} should be included in {name0}.")
-
-        super().__init__(
-            x_wires,
-            output_wires,
-            work_wires,
-            output_wires_zeroed=output_wires_zeroed,
-        )
-
-    # pylint: disable=arguments-differ
-    def __abstract_init__(
-        self,
-        x_wires: AbstractWires | WiresLike,
-        output_wires: AbstractWires | WiresLike,
-        work_wires: AbstractWires | WiresLike,
-        output_wires_zeroed: bool = False,
-    ):
-        n = len(x_wires)
-        m = len(output_wires)
-
-        # Work wires required for the unsigned square (its input is reduced by one)
-        num_required_work_wires = min(n, m) if output_wires_zeroed else m
-        # Work wires required for the first correction adder are `min(m-n, n)-1`, which is smaller
-        # than `m` and smaller than `n`, so that the unsigned square always needs more work wires.
-        if len(work_wires) < num_required_work_wires:
-            raise ValueError(
-                f"SignedOutSquare requires at least {num_required_work_wires} work wires for "
-                f"{n} input wires, {m} output wires and {output_wires_zeroed=}. "
-                f"Got {len(work_wires)} work wires instead."
-            )
-
-        super().__abstract_init__(
-            x_wires,
-            output_wires,
-            work_wires,
-            output_wires_zeroed=output_wires_zeroed,
-        )
-
-    @property
-    def wires(self):
-        """All wires involved in the operation."""
-        return self.x_wires + self.output_wires + self.work_wires
+        return min(n, m) if output_wires_zeroed else m
 
 
 def _c_subtract_then_add_one_resources(n, m, num_work_wires, output_wires_zeroed):

--- a/pennylane/templates/subroutines/arithmetic/signed_out_square.py
+++ b/pennylane/templates/subroutines/arithmetic/signed_out_square.py
@@ -24,10 +24,11 @@ from pennylane.templates.subroutines.arithmetic import OutSquare, SemiAdder
 from pennylane.typing import Bool, Wire
 from pennylane.wires import WiresLike
 
+from .out_square import _SquareArithmeticOp
 from .semi_adder import _controlled_semi_adder, _controlled_semi_adder_resource
 
 
-class SignedOutSquare(OutSquare):
+class SignedOutSquare(_SquareArithmeticOp):
     r"""Performs out-of-place squaring of a signed integer.
 
     This operator performs the squaring of a signed integer :math:`x` in 2s complement
@@ -211,12 +212,17 @@ class SignedOutSquare(OutSquare):
 
     """
 
-    @staticmethod
-    def _min_work_wires(n, m, output_wires_zeroed):
+    def _check_work_wires(self, n, m, work_wires, output_wires_zeroed):
         # Work wires required for the unsigned square (its input is reduced by one)
+        num_required_work_wires = min(n, m) if output_wires_zeroed else m
         # Work wires required for the first correction adder are `min(m-n, n)-1`, which is smaller
         # than `m` and smaller than `n`, so that the unsigned square always needs more work wires.
-        return min(n, m) if output_wires_zeroed else m
+        if len(work_wires) < num_required_work_wires:
+            raise ValueError(
+                f"SignedOutSquare requires at least {num_required_work_wires} work wires for "
+                f"{n} input wires, {m} output wires and {output_wires_zeroed=}. "
+                f"Got {len(work_wires)} work wires instead."
+            )
 
 
 def _c_subtract_then_add_one_resources(n, m, num_work_wires, output_wires_zeroed):

--- a/tests/templates/subroutines/arithmetic/test_out_square.py
+++ b/tests/templates/subroutines/arithmetic/test_out_square.py
@@ -27,6 +27,7 @@ from pennylane.templates.subroutines.arithmetic.out_square import (
     _out_square_with_adder,
     _out_square_with_caddsub,
 )
+from pennylane.templates.subroutines.arithmetic.signed_out_square import SignedOutSquare
 from pennylane.typing import Wire
 
 
@@ -84,6 +85,15 @@ def test_wires_property():
     """Test that wires includes all registers, including work wires."""
     op = OutSquare([0, 1, 2], [3, 4, 5], [6, 7, 8])
     assert op.wires == qp.wires.Wires([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+
+def test_isinstance_relationship():
+    """Test that OutSquare is not an instance of SignedOutSquare, despite sharing a common
+    private base class."""
+    out_square = OutSquare([0, 1], [2, 3, 4], [5, 6, 7])
+
+    assert not isinstance(out_square, SignedOutSquare)
+    assert isinstance(out_square, qp.core.operator.Operator2)
 
 
 def _test_square_correctness(all_wires, rule, seed, output_wires_zeroed, use_jit):

--- a/tests/templates/subroutines/arithmetic/test_signed_out_square.py
+++ b/tests/templates/subroutines/arithmetic/test_signed_out_square.py
@@ -87,15 +87,12 @@ def test_wires_property():
     assert op.wires == qp.wires.Wires([0, 1, 2, 3, 4, 5, 6, 7, 8])
 
 
-def test_isinstance_relationships():
-    """Test that OutSquare and SignedOutSquare are siblings sharing a common private base
-    class, and are not instances of one another despite the shared boilerplate."""
-    out_square = OutSquare([0, 1], [2, 3, 4], [5, 6, 7])
+def test_isinstance_relationship():
+    """Test that SignedOutSquare is not an instance of OutSquare, despite sharing a common
+    private base class."""
     signed_out_square = SignedOutSquare([0, 1], [2, 3, 4], [5, 6, 7])
 
-    assert not isinstance(out_square, SignedOutSquare)
     assert not isinstance(signed_out_square, OutSquare)
-    assert isinstance(out_square, qp.core.operator.Operator2)
     assert isinstance(signed_out_square, qp.core.operator.Operator2)
 
 

--- a/tests/templates/subroutines/arithmetic/test_signed_out_square.py
+++ b/tests/templates/subroutines/arithmetic/test_signed_out_square.py
@@ -87,6 +87,18 @@ def test_wires_property():
     assert op.wires == qp.wires.Wires([0, 1, 2, 3, 4, 5, 6, 7, 8])
 
 
+def test_isinstance_relationships():
+    """Test that OutSquare and SignedOutSquare are siblings sharing a common private base
+    class, and are not instances of one another despite the shared boilerplate."""
+    out_square = OutSquare([0, 1], [2, 3, 4], [5, 6, 7])
+    signed_out_square = SignedOutSquare([0, 1], [2, 3, 4], [5, 6, 7])
+
+    assert not isinstance(out_square, SignedOutSquare)
+    assert not isinstance(signed_out_square, OutSquare)
+    assert isinstance(out_square, qp.core.operator.Operator2)
+    assert isinstance(signed_out_square, qp.core.operator.Operator2)
+
+
 @pytest.mark.parametrize("output_wires_zeroed", [False, True])
 def test_signed_out_square_resources(output_wires_zeroed):
     """Test that the resource function declares the expected abstract OutSquare operator."""


### PR DESCRIPTION
Follow-up to #10052, implementing David's suggestion to reduce duplication between OutSquare and SignedOutSquare.

Non-standard: introduces a private `_SquareArithmeticOp(Operator2, is_baseclass=True)` base class.
Both `OutSquare` and `SignedOutSquare` now only implement a small `_check_work_wires` override. No behavior or error-message changes.

Stacked on #10052 (base branch `outsquare-operator2-migration`); merge after/with it.

*Drafted with AI assistance (Cursor).*

Made with [Cursor](https://cursor.com)