### PR TITLE
Make `controlled_two_qubit_unitary_rule`, `ctrl_decomp_bisect_rule` capture compatible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1040,6 +1040,7 @@
   [(#10026)](https://github.com/PennyLaneAI/pennylane/pull/10026)
   [(#9990)](https://github.com/PennyLaneAI/pennylane/pull/9990)
   [(#10041)](https://github.com/PennyLaneAI/pennylane/pull/10041)
+  [(#10072)](https://github.com/PennyLaneAI/pennylane/pull/10072)
   - Templates are ported:
     - :class:`~.BasisRotation`, :class:`~.MultiplexerStatePreparation`, :class:`~.QROM`, :class:`~.QFT`, :class:`~.FlipSign`,
       :class:`~.TemporaryAND`, :class:`~.SelectPauliRot`, :class:`~.GQSP`, :class:`~.AQFT`, :class:`~.SumOfSlatersPrep`,

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 """This submodule defines functions to decompose controlled operations."""
-from functools import partial
 
+from functools import partial
 from typing import Literal
 
 import numpy as np
 
 import pennylane as qp
 from pennylane import capture, compiler, control_flow, math, ops
-from pennylane.control_flow.for_loop import for_loop
 from pennylane.core import queuing
 from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """This submodule defines functions to decompose controlled operations."""
+from functools import partial
 
 from typing import Literal
 
@@ -276,7 +277,8 @@ def ctrl_decomp_bisect_rule(U, wires, **__):
             )
         ],
     )(su2_U, wires)
-    ops.cond(_not_zero(phase), _ctrl_global_phase)(phase, wires[:-1], wires[-1], "borrowed")
+    fn = partial(_ctrl_global_phase, work_wire_type="borrowed")
+    ops.cond(_not_zero(phase), fn)(phase, wires[:-1], wires[-1])
 
 
 def _single_ctrl_decomp_zyz_condition(U, wires, **__):
@@ -346,7 +348,8 @@ def multi_control_decomp_zyz_rule(U, wires, work_wires, work_wire_type, **__):
         work_wires=work_wires,
         work_wire_type=work_wire_type,
     )
-    ops.cond(_not_zero(phase), _ctrl_global_phase)(phase, wires[:-1], wires[-1], "borrowed")
+    fn = partial(_ctrl_global_phase, work_wire_type="borrowed")
+    ops.cond(_not_zero(phase), fn)(phase, wires[:-1], wires[-1])
 
 
 def _controlled_two_qubit_unitary_resource(U, wires, work_wires, work_wire_type, **__):
@@ -381,13 +384,12 @@ def controlled_two_qubit_unitary_rule(U, wires, control_values, work_wires, work
 
     if compiler.active() or capture.enabled():
         control_values = math.array(control_values, like="jax")
-        wires = math.array(wires, like="jax")
 
-    @for_loop(0, len(wires) - 2)
-    def _zero_control_wires(i):
-        cond(control_values[i], ops.PauliX)(wires[i])
+    def _zero_control_wires():
+        for i in range(len(wires) - 2):
+            cond(control_values[i], ops.PauliX)(wires[i])
 
-    _zero_control_wires()  # pylint: disable=no-value-for-parameter
+    _zero_control_wires()
 
     ops.ctrl(
         two_qubit_decomp_rule._impl,  # pylint: disable=protected-access
@@ -396,7 +398,7 @@ def controlled_two_qubit_unitary_rule(U, wires, control_values, work_wires, work
         work_wire_type=work_wire_type,
     )(U, wires=wires[-2:])
 
-    _zero_control_wires()  # pylint: disable=no-value-for-parameter
+    _zero_control_wires()
 
 
 def augment_with_allocation(base_rule, num_work_wires, work_wire_type, name=""):

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import pennylane as qp
 from pennylane import capture, compiler, control_flow, math, ops
+from pennylane.control_flow.for_loop import for_loop
 from pennylane.core import queuing
 from pennylane.core.operator import Operation, Operator
 from pennylane.decomposition import (
@@ -27,6 +28,7 @@ from pennylane.decomposition import (
     register_resources,
 )
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
+from pennylane.ops.op_math.condition import cond
 from pennylane.ops.op_math.controlled2 import _ctrl_abstract, flip_zero_control
 from pennylane.ops.op_math.decompositions.unitary_decompositions import two_qubit_decomp_rule
 from pennylane.typing import Complex, Float, Wire
@@ -376,17 +378,25 @@ def _controlled_two_qubit_unitary_resource(U, wires, work_wires, work_wire_type,
 @register_resources(_controlled_two_qubit_unitary_resource, exact=False)
 def controlled_two_qubit_unitary_rule(U, wires, control_values, work_wires, work_wire_type, **__):
     """A controlled two-qubit unitary is decomposed by applying ctrl to the base decomposition."""
-    zero_control_wires = [w for w, val in zip(wires[:-2], control_values, strict=True) if not val]
-    for w in zero_control_wires:
-        ops.PauliX(w)
+
+    if compiler.active() or capture.enabled():
+        control_values = math.array(control_values, like="jax")
+        wires = math.array(wires, like="jax")
+
+    @for_loop(0, len(wires) - 2)
+    def _zero_control_wires(i):
+        cond(control_values[i], ops.PauliX)(wires[i])
+
+    _zero_control_wires()  # pylint: disable=no-value-for-parameter
+
     ops.ctrl(
         two_qubit_decomp_rule._impl,  # pylint: disable=protected-access
         control=wires[:-2],
         work_wires=work_wires,
         work_wire_type=work_wire_type,
     )(U, wires=wires[-2:])
-    for w in zero_control_wires:
-        ops.PauliX(w)
+
+    _zero_control_wires()  # pylint: disable=no-value-for-parameter
 
 
 def augment_with_allocation(base_rule, num_work_wires, work_wire_type, name=""):

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -812,6 +812,7 @@ class TestControlledUnitaryRecursive:
         assert np.allclose(res, expected, atol=tol, rtol=tol)
 
 
+# pylint: disable-next=too-few-public-methods
 class TestControlledTwoQubitUnitary:
 
     @pytest.mark.capture

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -820,6 +820,7 @@ class TestControlledTwoQubitUnitary:
         """Test that the controlled two qubit unitary rule is captured correctly."""
         from jax import make_jaxpr
         from jax import numpy as jnp
+
         from pennylane.capture.primitives import cond_prim, ctrl_transform_prim
 
         kwargs = {

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -838,8 +838,8 @@ class TestControlledTwoQubitUnitary:
 
         assert len(jaxpr.jaxpr.invars) == 4
 
-        loop_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "for_loop"])
-        assert loop_count == 2
+        cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "cond"])
+        assert cond_count == 2
 
         ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "ctrl_transform"])
         assert ctrl_count == 1

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -48,6 +48,7 @@ from pennylane.ops.op_math.decompositions.controlled_decompositions import (
     decompose_mcx_one_worker,
 )
 from pennylane.wires import Wires
+from pennylane.capture.primitives import cond_prim, ctrl_transform_prim
 
 cw5 = tuple(list(range(1, 1 + n)) for n in range(2, 6))
 
@@ -839,10 +840,10 @@ class TestControlledTwoQubitUnitary:
 
         assert len(jaxpr.jaxpr.invars) == 4
 
-        cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "cond"])
+        cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive == cond_prim])
         assert cond_count == 2
 
-        ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "ctrl_transform"])
+        ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive == ctrl_transform_prim])
         assert ctrl_count == 1
 
         assert len(jaxpr.jaxpr.outvars) == 0

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -843,7 +843,7 @@ class TestControlledTwoQubitUnitary:
         cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive == cond_prim])
         assert cond_count == 2
 
-        ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive == ctrl_transform_prim])
+        ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive is ctrl_transform_prim])
         assert ctrl_count == 1
 
         assert len(jaxpr.jaxpr.outvars) == 0

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -48,7 +48,6 @@ from pennylane.ops.op_math.decompositions.controlled_decompositions import (
     decompose_mcx_one_worker,
 )
 from pennylane.wires import Wires
-from pennylane.capture.primitives import cond_prim, ctrl_transform_prim
 
 cw5 = tuple(list(range(1, 1 + n)) for n in range(2, 6))
 
@@ -821,6 +820,7 @@ class TestControlledTwoQubitUnitary:
         """Test that the controlled two qubit unitary rule is captured correctly."""
         from jax import make_jaxpr
         from jax import numpy as jnp
+        from pennylane.capture.primitives import cond_prim, ctrl_transform_prim
 
         kwargs = {
             "wires": jnp.array([0, 1, 2]),

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -840,7 +840,7 @@ class TestControlledTwoQubitUnitary:
 
         assert len(jaxpr.jaxpr.invars) == 4
 
-        cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive == cond_prim])
+        cond_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive is cond_prim])
         assert cond_count == 2
 
         ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive is ctrl_transform_prim])

--- a/tests/ops/op_math/test_controlled_decompositions.py
+++ b/tests/ops/op_math/test_controlled_decompositions.py
@@ -43,6 +43,7 @@ from pennylane.ops.op_math.decompositions.controlled_decompositions import (
     _ctrl_decomp_bisect_od,
     _decompose_mcx_with_no_worker,
     _mcx_two_workers,
+    controlled_two_qubit_unitary_rule,
     decompose_mcx_many_workers,
     decompose_mcx_one_worker,
 )
@@ -809,6 +810,41 @@ class TestControlledUnitaryRecursive:
         expected = expected_op.matrix()
 
         assert np.allclose(res, expected, atol=tol, rtol=tol)
+
+
+class TestControlledTwoQubitUnitary:
+
+    @pytest.mark.capture
+    def test_controlled_two_qubit_unitary_rule_capture(self):
+        """Test that the controlled two qubit unitary rule is captured correctly."""
+        from jax import make_jaxpr
+        from jax import numpy as jnp
+
+        kwargs = {
+            "wires": jnp.array([0, 1, 2]),
+            "U": jnp.eye(4),
+            "control_values": jnp.array([False], dtype=bool),
+            "work_wires": jnp.array([]),
+            "work_wire_type": "borrowed",
+        }
+
+        jaxpr = make_jaxpr(controlled_two_qubit_unitary_rule, static_argnums=(4,))(
+            kwargs["U"],
+            kwargs["wires"],
+            kwargs["control_values"],
+            kwargs["work_wires"],
+            kwargs["work_wire_type"],
+        )
+
+        assert len(jaxpr.jaxpr.invars) == 4
+
+        loop_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "for_loop"])
+        assert loop_count == 2
+
+        ctrl_count = sum([1 for eqn in jaxpr.eqns if eqn.primitive.name == "ctrl_transform"])
+        assert ctrl_count == 1
+
+        assert len(jaxpr.jaxpr.outvars) == 0
 
 
 class TestMCXDecomposition:

--- a/tests/ops/op_math/test_controlled_ops.py
+++ b/tests/ops/op_math/test_controlled_ops.py
@@ -66,7 +66,7 @@ class TestControlledQubitUnitary:
         with pytest.raises(qp.operation.DecompositionUndefinedError):
             op.decomposition()
 
-    @pytest.mark.jax
+    @pytest.mark.capture
     @pytest.mark.parametrize(
         "op",
         [


### PR DESCRIPTION
**Context:** Capture of this rule was failing when integrating with Catalyst.

**Description of the Change:** Updates the rule to be capture compatible.

**Benefits:** We can lower the rule.

**Possible Drawbacks:** N/A

**Related GitHub Issues:** [sc-128744] [sc-128492]
