### PR TITLE
Fix SumOfSlatersPrep capture with dynamic wires

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1095,6 +1095,7 @@
   [(#9933)](https://github.com/PennyLaneAI/pennylane/pull/9933)
   [(#10042)](https://github.com/PennyLaneAI/pennylane/pull/10042)
   [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
+  [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
   - Quantum chemistry operators are ported:
     - :class:`~.SingleExcitation`
   [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)
@@ -1351,10 +1352,6 @@
   [(#9621)](https://github.com/PennyLaneAI/pennylane/pull/9621)
 
 <h3>Bug fixes 🐛</h3>
-
-* Fixed :class:`~.SumOfSlatersPrep` so its decomposition supports dynamic wire arguments and
-  returns Python integer resource counts, allowing it to be compiled with Catalyst.
-  [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
 
 * Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
   compiled with Catalyst when ``mod = 2 ** len(output_wires)``.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1354,7 +1354,7 @@
 
 * Fixed :class:`~.SumOfSlatersPrep` so its decomposition supports dynamic wire arguments and
   returns Python integer resource counts, allowing it to be compiled with Catalyst.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
 
 * Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
   compiled with Catalyst when ``mod = 2 ** len(output_wires)``.
@@ -1520,6 +1520,7 @@ Yushao Chen,
 Diksha Dhawan,
 Marcus Edwards,
 Thomas C. Fraser,
+Sengthai Heng,
 Austin Huang,
 Harshal Janjani,
 Jacob Kitchen,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1352,6 +1352,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed :class:`~.SumOfSlatersPrep` so its decomposition supports dynamic wire arguments and
+  returns Python integer resource counts, allowing it to be compiled with Catalyst.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
   compiled with Catalyst when ``mod = 2 ** len(output_wires)``.
   [(#10057)](https://github.com/PennyLaneAI/pennylane/pull/10057)

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1074,7 +1074,7 @@ def _sos_state_prep_resources(coefficients, wires, indices, **_):
     resources[_adjoint_abstract(qp.TemporaryAND)] += (num_entries - 1) * (m - 1)
 
     # Calculate the bit counts of all integers that need to be uncomputed and sum them up.
-    number_of_bits_to_unset = int(np.sum(np.bitwise_count(np.arange(1, num_entries)).astype(int)))
+    number_of_bits_to_unset = int(np.sum(np.bitwise_count(np.arange(1, num_entries))))
     resources[qp.CNOT] += number_of_bits_to_unset
 
     # We have to flip at most m control bits between any pair of the `num_entries-1` uncomputing

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1074,9 +1074,7 @@ def _sos_state_prep_resources(coefficients, wires, indices, **_):
     resources[_adjoint_abstract(qp.TemporaryAND)] += (num_entries - 1) * (m - 1)
 
     # Calculate the bit counts of all integers that need to be uncomputed and sum them up.
-    number_of_bits_to_unset = int(
-        np.sum(np.bitwise_count(np.arange(1, num_entries)).astype(int))
-    )
+    number_of_bits_to_unset = int(np.sum(np.bitwise_count(np.arange(1, num_entries)).astype(int)))
     resources[qp.CNOT] += number_of_bits_to_unset
 
     # We have to flip at most m control bits between any pair of the `num_entries-1` uncomputing

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1074,7 +1074,9 @@ def _sos_state_prep_resources(coefficients, wires, indices, **_):
     resources[_adjoint_abstract(qp.TemporaryAND)] += (num_entries - 1) * (m - 1)
 
     # Calculate the bit counts of all integers that need to be uncomputed and sum them up.
-    number_of_bits_to_unset = np.sum(np.bitwise_count(np.arange(1, num_entries)).astype(int))
+    number_of_bits_to_unset = int(
+        np.sum(np.bitwise_count(np.arange(1, num_entries)).astype(int))
+    )
     resources[qp.CNOT] += number_of_bits_to_unset
 
     # We have to flip at most m control bits between any pair of the `num_entries-1` uncomputing
@@ -1176,7 +1178,7 @@ def _sos_state_prep_with_wires(
     mcx_ctrl_wires = selected_wires if identity_encoding else identification_wires
 
     # Create wires for elbow ladder
-    elbow_wires = mcx_ctrl_wires[:1] + [
+    elbow_wires = [mcx_ctrl_wires[0]] + [
         _wires[k] for k in range(data.m - 1) for _wires in [mcx_ctrl_wires[1:], mcx_cache_wires]
     ]
     elbow_triples = [elbow_wires[2 * k : 2 * k + 3] for k in range(data.m - 1)]

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -28,6 +28,10 @@ import pennylane as qp
 from pennylane import math
 from pennylane.core import Operator1
 from pennylane.core.operator import Operator2
+from pennylane.templates.state_preparations.sum_of_slaters import (
+    _preprocess,
+    _sos_state_prep_with_wires,
+)
 
 jax = pytest.importorskip("jax")
 jnp = jax.numpy
@@ -290,6 +294,29 @@ def test_unmodified_templates(template, args, kwargs):
     # Check outvars; there should only be the DropVar returned by the template
     assert len(eqn.outvars) == 1
     assert isinstance(eqn.outvars[0], jax.core.DropVar)
+
+
+def test_sum_of_slaters_subroutine_with_dynamic_wires():
+    """Test that the SumOfSlatersPrep subroutine supports dynamic wire arguments."""
+    indices = (0, 1, 2, 4, 8, 16, 32, 64)
+    num_wires = 7
+    coefficients = np.zeros(len(indices), dtype=complex)
+    v_bits = qp.math.int_to_binary(np.array(indices), num_wires).T
+    selected_wires, *data = _preprocess(v_bits, range(num_wires))
+    data = (coefficients, v_bits, *data)
+    all_wires = qp.registers(qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires))
+    all_wires["selected_wires"] = selected_wires
+
+    @qp.capture.subroutine
+    def subroutine(*wire_args):
+        dynamic_wires = dict(zip(all_wires, wire_args, strict=True))
+        _sos_state_prep_with_wires(data, **dynamic_wires)
+
+    jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
+
+    assert [var.aval.shape for var in jaxpr.jaxpr.invars] == [
+        (len(wires),) for wires in all_wires.values()
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -314,9 +314,10 @@ def test_sum_of_slaters_subroutine_with_dynamic_wires():
 
     jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
 
-    assert [var.aval.shape for var in jaxpr.jaxpr.invars] == [
-        (len(wires),) for wires in all_wires.values()
-    ]
+    jaxpr_text = str(jaxpr)
+    assert "MultiplexerStatePreparation" in jaxpr_text
+    assert "QROM" in jaxpr_text
+    assert "TemporaryAND" in jaxpr_text
 
 
 @pytest.mark.parametrize(

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -28,10 +28,6 @@ import pennylane as qp
 from pennylane import math
 from pennylane.core import Operator1
 from pennylane.core.operator import Operator2
-from pennylane.templates.state_preparations.sum_of_slaters import (
-    _preprocess,
-    _sos_state_prep_with_wires,
-)
 
 jax = pytest.importorskip("jax")
 jnp = jax.numpy
@@ -294,31 +290,6 @@ def test_unmodified_templates(template, args, kwargs):
     # Check outvars; there should only be the DropVar returned by the template
     assert len(eqn.outvars) == 1
     assert isinstance(eqn.outvars[0], jax.core.DropVar)
-
-
-def test_sum_of_slaters_subroutine_with_dynamic_wires():
-    """Test that the SumOfSlatersPrep subroutine supports dynamic wire arguments."""
-    indices = (0, 1, 2, 4, 8, 16, 32, 64)
-    num_wires = 7
-    coefficients = np.zeros(len(indices), dtype=complex)
-    v_bits = qp.math.int_to_binary(np.array(indices), num_wires).T
-    selected_wires, *data = _preprocess(v_bits, range(num_wires))
-    data = (coefficients, v_bits, *data)
-    all_wires = qp.registers(qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires))
-    all_wires["selected_wires"] = selected_wires
-
-    @qp.capture.subroutine
-    def subroutine(*wire_args):
-        dynamic_wires = dict(zip(all_wires, wire_args, strict=True))
-        _sos_state_prep_with_wires(data, **dynamic_wires)
-
-    jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
-
-    jaxpr_text = str(jaxpr)
-    assert "MultiplexerStatePreparation" in jaxpr_text
-    assert "QROM" in jaxpr_text
-    assert "TemporaryAND" in jaxpr_text
-
 
 @pytest.mark.parametrize(
     "args, kwargs",

--- a/tests/capture/test_templates.py
+++ b/tests/capture/test_templates.py
@@ -291,6 +291,7 @@ def test_unmodified_templates(template, args, kwargs):
     assert len(eqn.outvars) == 1
     assert isinstance(eqn.outvars[0], jax.core.DropVar)
 
+
 @pytest.mark.parametrize(
     "args, kwargs",
     (

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -703,6 +703,33 @@ class TestSumOfSlatersPrep:
                 out_state = out_state[::2]
             assert np.allclose([out_state[key] for key in indices], coefficients)
 
+    @pytest.mark.capture
+    def test_subroutine_with_dynamic_wires(self):
+        """Test that the SumOfSlatersPrep subroutine supports dynamic wire arguments."""
+        jax = pytest.importorskip("jax")
+        jnp = jax.numpy
+
+        indices = (0, 1, 2, 4, 8, 16, 32, 64)
+        num_wires = 7
+        coefficients = np.zeros(len(indices), dtype=complex)
+        v_bits = qp.math.int_to_binary(np.array(indices), num_wires).T
+        selected_wires, *data = _preprocess(v_bits, range(num_wires))
+        data = (coefficients, v_bits, *data)
+        all_wires = qp.registers(SumOfSlatersPrep.required_register_sizes(indices, num_wires))
+        all_wires["selected_wires"] = selected_wires
+
+        @qp.capture.subroutine
+        def subroutine(*wire_args):
+            dynamic_wires = dict(zip(all_wires, wire_args, strict=True))
+            _sos_state_prep_with_wires(data, **dynamic_wires)
+
+        jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
+
+        jaxpr_text = str(jaxpr)
+        assert "MultiplexerStatePreparation" in jaxpr_text
+        assert "QROM" in jaxpr_text
+        assert "TemporaryAND" in jaxpr_text
+
     @pytest.mark.catalyst
     @pytest.mark.parametrize("force_non_id_encoding", (False, True))
     def test_qjit_on_subroutine(self, seed, force_non_id_encoding):

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -725,10 +725,10 @@ class TestSumOfSlatersPrep:
 
         jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
 
-        jaxpr_text = str(jaxpr)
-        assert "MultiplexerStatePreparation" in jaxpr_text
-        assert "QROM" in jaxpr_text
-        assert "TemporaryAND" in jaxpr_text
+        eqn_names = {eqn.primitive.name for eqn in jaxpr.eqns}
+        assert "MultiplexerStatePreparation" in eqn_names
+        assert "QROM" in eqn_names
+        assert "TemporaryAND" in eqn_names
 
     @pytest.mark.catalyst
     @pytest.mark.parametrize("force_non_id_encoding", (False, True))

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -570,7 +570,7 @@ class TestSumOfSlatersPrep:
         )
 
         # Ensure they are Python integers, not other (NumPy) integers.
-        assert all(type(count) is int for count in resources.gate_counts.values())
+        assert all(isinstance(count, int) for count in resources.gate_counts.values())
 
     @pytest.mark.usefixtures("enable_graph_decomposition")
     @pytest.mark.parametrize(

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -724,8 +724,12 @@ class TestSumOfSlatersPrep:
             _sos_state_prep_with_wires(data, **dynamic_wires)
 
         jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
-        
-        jaxpr_text = str(jaxpr.eqns[0].params["jaxpr"])
+
+        subroutine_eqn = jaxpr.eqns[0]
+        assert subroutine_eqn.primitive == qp.capture.primitives.quantum_subroutine_prim
+
+        subroutine_jaxpr = subroutine_eqn.params["jaxpr"]
+        jaxpr_text = str(subroutine_jaxpr)
         assert "MultiplexerStatePreparation" in jaxpr_text
         assert "QROM" in jaxpr_text
         assert "TemporaryAND" in jaxpr_text

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -724,11 +724,11 @@ class TestSumOfSlatersPrep:
             _sos_state_prep_with_wires(data, **dynamic_wires)
 
         jaxpr = jax.make_jaxpr(subroutine)(*(jnp.asarray(wires) for wires in all_wires.values()))
-
-        eqn_names = {eqn.primitive.name for eqn in jaxpr.eqns}
-        assert "MultiplexerStatePreparation" in eqn_names
-        assert "QROM" in eqn_names
-        assert "TemporaryAND" in eqn_names
+        
+        jaxpr_text = str(jaxpr.eqns[0].params["jaxpr"])
+        assert "MultiplexerStatePreparation" in jaxpr_text
+        assert "QROM" in jaxpr_text
+        assert "TemporaryAND" in jaxpr_text
 
     @pytest.mark.catalyst
     @pytest.mark.parametrize("force_non_id_encoding", (False, True))

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -562,6 +562,16 @@ class TestSumOfSlatersPrep:
         registered_work_wires = _sos_state_prep.get_work_wire_spec(coefficients, range(n), indices)
         assert sum(sizes.values()) - n == registered_work_wires.total
 
+    def test_resource_counts_are_python_integers(self):
+        """Test that decomposition resource counts are Python integers."""
+        indices = (0, 1, 2, 4, 8, 16, 32, 64)
+        resources = _sos_state_prep.compute_resources(
+            np.zeros(len(indices), dtype=complex), range(7), indices
+        )
+
+        # Ensure they are Python integers, not other (NumPy) integers.
+        assert all(type(count) is int for count in resources.gate_counts.values())
+
     @pytest.mark.usefixtures("enable_graph_decomposition")
     @pytest.mark.parametrize(
         "num_wires,num_entries",


### PR DESCRIPTION
This PR fixes `SumOfSlatersPrep` compilation with Catalyst by supporting dynamic JAX wire arguments and converting NumPy (`np.int`) resource counts to Python `int` instead.