### PR TITLE
bug fix: set `grad_method=None` on `MultiX` rather than `num_params=0`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -618,6 +618,7 @@
   to a bitstring array.
   [(#10033)](https://github.com/PennyLaneAI/pennylane/pull/10033)
   [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
+  [(#10079)](https://github.com/PennyLaneAI/pennylane/pull/10079)
 
 <h3>Labs: a place for unified and rapid prototyping of research software 🧪</h3>
 

--- a/pennylane/templates/subroutines/multix.py
+++ b/pennylane/templates/subroutines/multix.py
@@ -79,8 +79,7 @@ class MultiX(Operator2):
 
     is_verified_hermitian = True
 
-    num_params = 0
-    """int: Number of trainable parameters that the operator depends on."""
+    grad_method = None
 
     def __init__(self, bitstring: TensorLike, wires: WiresLike) -> None:
         bitstring, wires = MultiX._canonicalize_validate_and_cast_inputs(bitstring, wires)

--- a/tests/templates/subroutines/test_multix.py
+++ b/tests/templates/subroutines/test_multix.py
@@ -57,7 +57,7 @@ class TestInitialization:
         assert op.dynamic_args == {"bitstring": op.bitstring}
         assert op.wire_args == {"wires": op.wires}
         assert op.num_wires == len(wires_input)
-        assert op.num_params == 0
+        assert op.num_params == 1
         assert op.grad_method is None
 
     def test_canonicalize_inputs_does_not_validate_or_cast(self):


### PR DESCRIPTION
**Context:**

This surfaced as a bug when using the op in prod and having to call `bind_new_parameters`,

```python
import pennylane as qp
from pennylane import math
from pennylane.ops.functions import bind_new_parameters

# Works: standalone MultiX passes its full data, num_params never consulted.
single = qp.MultiX([1, 0], wires=[0, 1])
bind_new_parameters(single, math.unwrap(single.data))      

# Fails: nested in a composite op, params are split by operand.num_params (== 0),
# so the bitstring is dropped on reconstruction.
prod = qp.MultiX([1], wires=[0]) @ qp.MultiX([0], wires=[1])
bind_new_parameters(prod, math.unwrap(prod.data))              # TypeError: missing a required argument: 'bitstring'
```

**Description of the Change:**

Let `num_params` be automatically set and turn off `grad_method` to achieve same functionality.

