### PR TITLE
Migrate private methods in `TrotterCDF/CGF` to `CDF/CGFHamiltonian` class methods

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -143,6 +143,7 @@
   [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
   [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
   [(#10074)](https://github.com/PennyLaneAI/pennylane/pull/10074)
+  [(#???)](https://github.com/PennyLaneAI/pennylane/pull/???)
 
 * A new arithmetic template called :class:`~.SignedOutMultiplier` has been added that multiplies numbers encoded in the
   input registers using a two's complement.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -143,7 +143,7 @@
   [(#9789)](https://github.com/PennyLaneAI/pennylane/pull/9789)
   [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
   [(#10074)](https://github.com/PennyLaneAI/pennylane/pull/10074)
-  [(#???)](https://github.com/PennyLaneAI/pennylane/pull/???)
+  [(#10081)](https://github.com/PennyLaneAI/pennylane/pull/10081)
 
 * A new arithmetic template called :class:`~.SignedOutMultiplier` has been added that multiplies numbers encoded in the
   input registers using a two's complement.

--- a/pennylane/numeric_hamiltonians.py
+++ b/pennylane/numeric_hamiltonians.py
@@ -505,7 +505,7 @@ class CGFHamiltonian(NumericHamiltonian):
     leaf_tensors: Any
     nuc_constant: Any = None
 
-    def normalize_leaf_determinant(self) -> "CDFHamiltonian":
+    def normalize_leaf_determinant(self) -> "CGFHamiltonian":
         r"""Force every per-mode leaf to determinant ``+1`` so :class:`~.BasisRotation`'s real-orthogonal
         sign gauge is identical across fragments.
 
@@ -527,7 +527,7 @@ class CGFHamiltonian(NumericHamiltonian):
 
         return replace(self, leaf_tensors=math.concatenate([one_body, two_body], axis=0))
 
-    def align_one_body_leaf(self) -> "CDFHamiltonian":
+    def align_one_body_leaf(self) -> "CGFHamiltonian":
         """Transpose the one-body leaf so both sectors share the scaffolding's row convention.
 
         The scaffolding assumes each ``leaf_tensors[nu][l]`` stores its per-mode diagonalizing

--- a/pennylane/numeric_hamiltonians.py
+++ b/pennylane/numeric_hamiltonians.py
@@ -32,7 +32,7 @@ class derives the named dimensions from the shapes and reports them as attribute
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from numbers import Number
 from typing import Any, ClassVar
 
@@ -346,6 +346,29 @@ class CDFHamiltonian(NumericHamiltonian):
     leaf_tensors: Any
     nuc_constant: Any = None
 
+    def normalize_leaf_determinant(self) -> "CDFHamiltonian":
+        r"""Force every leaf to determinant ``+1`` so :class:`~.BasisRotation`'s real-orthogonal sign
+        gauge is identical across fragments.
+
+        :class:`~.BasisRotation` realizes a real orthogonal ``leaf`` only up to a determinant-dependent
+        :math:`\pm 1` gauge, so leaves with *mixed* determinants -- e.g. an ``eigh`` one-body leaf with
+        ``det = -1`` next to ``expm`` two-body leaves with ``det = +1``, as produced by
+        :func:`~pennylane.qchem.factorize` for many molecules -- would be rotated into inconsistent bases
+        and realize a different Hamiltonian. Here :math:`v` is a single column of the leaf, i.e. one of
+        the fragment's diagonalizing orbitals; the fragment only depends on it through the projector
+        :math:`|v\rangle\langle v|` (the number operator built from that orbital), and negating the
+        column leaves this projector unchanged since :math:`|-v\rangle\langle -v| = |v\rangle\langle v|`.
+        So flipping one column's sign is a physical no-op on the fragment -- it only flips the leaf's
+        determinant.
+        """
+        leaves = self.leaf_tensors
+        signs = math.sign(math.linalg.det(leaves))  # (num_fragments,)
+        col_scale = math.concatenate(
+            [signs[..., None], math.ones_like(leaves[..., 0, 1:])], axis=-1
+        )  # (num_fragments, N): +/-1 in the first column slot, 1 elsewhere
+
+        return replace(self, leaf_tensors=leaves * col_scale[..., None, :])
+
 
 @dataclass(frozen=True, eq=False, repr=False)
 class CGFHamiltonian(NumericHamiltonian):
@@ -481,3 +504,42 @@ class CGFHamiltonian(NumericHamiltonian):
     core_tensors: Any
     leaf_tensors: Any
     nuc_constant: Any = None
+
+    def normalize_leaf_determinant(self) -> "CDFHamiltonian":
+        r"""Force every per-mode leaf to determinant ``+1`` so :class:`~.BasisRotation`'s real-orthogonal
+        sign gauge is identical across fragments.
+
+        :class:`~.BasisRotation` realizes a real orthogonal leaf only up to a determinant-dependent
+        :math:`\pm 1` gauge, so leaves with *mixed* determinants (e.g. an ``eigh`` one-body leaf with
+        ``det = -1`` next to ``expm`` two-body leaves with ``det = +1``) would be rotated into
+        inconsistent bases and realize a different Hamiltonian. Negating one orbital line leaves the
+        projector :math:`|v\rangle\langle v|`, and hence the fragment, unchanged, so this is a physical
+        no-op. The orbital is stored on the *columns* of the one-body leaf and on the *rows* of the
+        two-body leaves, so the two sectors negate a column and a row respectively.
+        """
+        leaves = self.leaf_tensors
+        signs = math.sign(math.linalg.det(leaves))  # (L+1, M)
+        line = math.concatenate(
+            [signs[..., None], math.ones_like(leaves[..., 0, 1:])], axis=-1
+        )  # (L+1, M, N): +/-1 in the first slot, 1 elsewhere
+        one_body = leaves[:1] * line[:1][..., None, :]  # eigenvectors on columns -> scale column 0
+        two_body = leaves[1:] * line[1:][..., :, None]  # modal index on rows -> scale row 0
+
+        return replace(self, leaf_tensors=math.concatenate([one_body, two_body], axis=0))
+
+    def align_one_body_leaf(self) -> "CDFHamiltonian":
+        """Transpose the one-body leaf so both sectors share the scaffolding's row convention.
+
+        The scaffolding assumes each ``leaf_tensors[nu][l]`` stores its per-mode diagonalizing
+        rotation with the modal index on the *rows* (the two-body :math:`U^{(l)}_{pa}` convention
+        of `arXiv:2508.11865 <https://arxiv.org/abs/2508.11865>`__). The one-body leaf, however,
+        is the eigenvector matrix of the effective one-body integrals and stores its eigenvectors
+        as *columns*, so it is transposed here to match. Leaves are (special) orthogonal, so this
+        is the inverse rotation.
+        """
+        leaves = self.leaf_tensors
+
+        return replace(
+            self,
+            leaf_tensors=math.concatenate([math.swapaxes(leaves[:1], -2, -1), leaves[1:]], axis=0),
+        )

--- a/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
@@ -531,7 +531,7 @@ def _controlled_trotter_cdf_decomp(base, control_wires, control_values, work_wir
         return
 
     phi = (_energy_shift(hamiltonian) * evolution_time) % (4 * np.pi)
-    hamiltonian.normalize_leaf_determinant()
+    hamiltonian = hamiltonian.normalize_leaf_determinant()
 
     if double_phase:
         # Double-phase (Fig. 6 in https://arxiv.org/abs/2506.15784) circuit: each full-time diagonal block is CNOT-sandwiched by

--- a/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
@@ -331,35 +331,6 @@ def _transpose_leaf(U):
     return U.conj().T
 
 
-def _normalize_leaf_determinant(hamiltonian):
-    r"""Force every leaf to determinant ``+1`` so :class:`~.BasisRotation`'s real-orthogonal sign
-    gauge is identical across fragments.
-
-    :class:`~.BasisRotation` realizes a real orthogonal ``leaf`` only up to a determinant-dependent
-    :math:`\pm 1` gauge, so leaves with *mixed* determinants -- e.g. an ``eigh`` one-body leaf with
-    ``det = -1`` next to ``expm`` two-body leaves with ``det = +1``, as produced by
-    :func:`~pennylane.qchem.factorize` for many molecules -- would be rotated into inconsistent bases
-    and realize a different Hamiltonian. Here :math:`v` is a single column of the leaf, i.e. one of
-    the fragment's diagonalizing orbitals; the fragment only depends on it through the projector
-    :math:`|v\rangle\langle v|` (the number operator built from that orbital), and negating the
-    column leaves this projector unchanged since :math:`|-v\rangle\langle -v| = |v\rangle\langle v|`.
-    So flipping one column's sign is a physical no-op on the fragment -- it only flips the leaf's
-    determinant.
-    """
-    leaves = hamiltonian.leaf_tensors
-    signs = math.sign(math.linalg.det(leaves))  # (num_fragments,)
-    col_scale = math.concatenate(
-        [signs[..., None], math.ones_like(leaves[..., 0, 1:])], axis=-1
-    )  # (num_fragments, N): +/-1 in the first column slot, 1 elsewhere
-    leaf_tensors = leaves * col_scale[..., None, :]
-    new_hamiltonian = CDFHamiltonian(
-        core_tensors=hamiltonian.core_tensors,
-        leaf_tensors=leaf_tensors,
-        nuc_constant=hamiltonian.nuc_constant,
-    )
-    return new_hamiltonian
-
-
 def _apply_two_body_diagonal(Z, wires, first_order_time_step, control_wires, double_phase):
     r"""Apply the two-body ``IsingZZ`` layer (base / double-phase / genuine controlled).
 
@@ -524,7 +495,7 @@ def _trotter_cdf_decomposition(evolution_time, num_trotter_steps, hamiltonian, w
         _run_trotter_steps(
             evolution_time,
             num_trotter_steps,
-            _normalize_leaf_determinant(hamiltonian),
+            hamiltonian.normalize_leaf_determinant(),
             wires,
             (),
             **_CDF_HELPERS,
@@ -560,7 +531,7 @@ def _controlled_trotter_cdf_decomp(base, control_wires, control_values, work_wir
         return
 
     phi = (_energy_shift(hamiltonian) * evolution_time) % (4 * np.pi)
-    hamiltonian = _normalize_leaf_determinant(hamiltonian)
+    hamiltonian.normalize_leaf_determinant()
 
     if double_phase:
         # Double-phase (Fig. 6 in https://arxiv.org/abs/2506.15784) circuit: each full-time diagonal block is CNOT-sandwiched by

--- a/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
@@ -558,7 +558,7 @@ def _controlled_trotter_cgf_decomp(base, control_wires, control_values, work_wir
         return
 
     phi = (_energy_shift(hamiltonian) * evolution_time) % (4 * np.pi)
-    hamiltonian.normalize_leaf_determinant().align_one_body_leaf()
+    hamiltonian = hamiltonian.normalize_leaf_determinant().align_one_body_leaf()
 
     if double_phase:
         # Double-phase (Fig. 6 https://arxiv.org/abs/2506.15784) circuit: each full-time diagonal block is CNOT-sandwiched by

--- a/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
@@ -363,51 +363,6 @@ def _transpose_leaf(U):
     return math.swapaxes(U, -2, -1)
 
 
-def _align_one_body_leaf(hamiltonian):
-    """Transpose the one-body leaf so both sectors share the scaffolding's row convention.
-
-    The scaffolding assumes each ``leaf_tensors[nu][l]`` stores its per-mode diagonalizing
-    rotation with the modal index on the *rows* (the two-body :math:`U^{(l)}_{pa}` convention
-    of `arXiv:2508.11865 <https://arxiv.org/abs/2508.11865>`__). The one-body leaf, however,
-    is the eigenvector matrix of the effective one-body integrals and stores its eigenvectors
-    as *columns*, so it is transposed here to match. Leaves are (special) orthogonal, so this
-    is the inverse rotation.
-    """
-    leaves = hamiltonian.leaf_tensors
-    leaves = math.concatenate([math.swapaxes(leaves[:1], -2, -1), leaves[1:]], axis=0)
-    return CGFHamiltonian(
-        core_tensors=hamiltonian.core_tensors,
-        leaf_tensors=leaves,
-        nuc_constant=hamiltonian.nuc_constant,
-    )
-
-
-def _normalize_leaf_determinant(hamiltonian):
-    r"""Force every per-mode leaf to determinant ``+1`` so :class:`~.BasisRotation`'s real-orthogonal
-    sign gauge is identical across fragments.
-
-    :class:`~.BasisRotation` realizes a real orthogonal leaf only up to a determinant-dependent
-    :math:`\pm 1` gauge, so leaves with *mixed* determinants (e.g. an ``eigh`` one-body leaf with
-    ``det = -1`` next to ``expm`` two-body leaves with ``det = +1``) would be rotated into
-    inconsistent bases and realize a different Hamiltonian. Negating one orbital line leaves the
-    projector :math:`|v\rangle\langle v|`, and hence the fragment, unchanged, so this is a physical
-    no-op. The orbital is stored on the *columns* of the one-body leaf and on the *rows* of the
-    two-body leaves, so the two sectors negate a column and a row respectively.
-    """
-    leaves = hamiltonian.leaf_tensors
-    signs = math.sign(math.linalg.det(leaves))  # (L+1, M)
-    line = math.concatenate(
-        [signs[..., None], math.ones_like(leaves[..., 0, 1:])], axis=-1
-    )  # (L+1, M, N): +/-1 in the first slot, 1 elsewhere
-    one_body = leaves[:1] * line[:1][..., None, :]  # eigenvectors on columns -> scale column 0
-    two_body = leaves[1:] * line[1:][..., :, None]  # modal index on rows -> scale row 0
-    return CGFHamiltonian(
-        core_tensors=hamiltonian.core_tensors,
-        leaf_tensors=math.concatenate([one_body, two_body], axis=0),
-        nuc_constant=hamiltonian.nuc_constant,
-    )
-
-
 def _apply_two_body_diagonal(Z, wires, first_order_time_step, control_wires, double_phase):
     """Apply the two-body ``IsingZZ`` layer (base / double-phase / genuine controlled).
 
@@ -567,7 +522,7 @@ def _trotter_cgf_decomposition(evolution_time, num_trotter_steps, hamiltonian, w
         _run_trotter_steps(
             evolution_time,
             num_trotter_steps,
-            _align_one_body_leaf(_normalize_leaf_determinant(hamiltonian)),
+            hamiltonian.normalize_leaf_determinant().align_one_body_leaf(),
             wires,
             (),
             **_CGF_HELPERS,
@@ -603,7 +558,7 @@ def _controlled_trotter_cgf_decomp(base, control_wires, control_values, work_wir
         return
 
     phi = (_energy_shift(hamiltonian) * evolution_time) % (4 * np.pi)
-    hamiltonian = _align_one_body_leaf(_normalize_leaf_determinant(hamiltonian))
+    hamiltonian.normalize_leaf_determinant().align_one_body_leaf()
 
     if double_phase:
         # Double-phase (Fig. 6 https://arxiv.org/abs/2506.15784) circuit: each full-time diagonal block is CNOT-sandwiched by

--- a/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
@@ -258,31 +258,6 @@ class TestCGFScheme:
         expected = np.stack([U_curr[l] @ U_prev[l].T for l in range(num_modes)])
         assert np.allclose(_merge_leaves(U_prev, U_curr), expected)
 
-    def test_align_one_body_leaf(self, seed):
-        """The one-body leaf (eigenvectors stored as columns) is transposed per mode to match
-        the two-body row convention; the two-body leaves are returned untouched."""
-        from pennylane.templates.subroutines.time_evolution.trotter_cgf import (  # pylint: disable=import-outside-toplevel
-            _align_one_body_leaf,
-        )
-
-        rng = np.random.default_rng(seed)
-        num_modes, n_states, L = 2, 3, 2
-        leaf = np.stack(
-            [
-                np.stack([random_orthogonal(n_states, rng) for _ in range(num_modes)])
-                for _ in range(L + 1)
-            ]
-        )
-
-        ham = CGFHamiltonian(
-            core_tensors=np.zeros((L + 1, num_modes, num_modes, n_states, n_states)),
-            leaf_tensors=leaf,
-            nuc_constant=0.0,
-        )
-        aligned = _align_one_body_leaf(ham).leaf_tensors
-        assert np.allclose(aligned[0], np.swapaxes(leaf[0], -2, -1))
-        assert np.allclose(aligned[1:], leaf[1:])
-
     def test_apply_system_basis_rotation(self, seed):
         """Test that per-mode leaves are applied as (transposed) BasisRotations and that a
         mode whose rotation is the identity is skipped."""

--- a/tests/test_numeric_hamiltonians.py
+++ b/tests/test_numeric_hamiltonians.py
@@ -24,6 +24,8 @@ import pennylane as qp
 from pennylane.numeric_hamiltonians import CDFHamiltonian, CGFHamiltonian, NumericHamiltonian
 from pennylane.typing import AbstractArray, Float
 
+from tests.templates.subroutines.time_evolution.trotter_test_helpers import random_orthogonal
+
 L, M, N = 2, 2, 3
 
 
@@ -416,11 +418,10 @@ class TestConcrete:
         """Force every per-mode leaf to determinant ``+1``"""
 
         rng = np.random.default_rng(seed)
-        _, n_states, L = 2, 3, 2
-        leaves = rng.random((L + 1, n_states, n_states))
+        leaves = rng.random((L + 1, N, N))
 
         ham = CDFHamiltonian(
-            core_tensors=np.zeros((L + 1, n_states, n_states)),
+            core_tensors=np.zeros((L + 1, N, N)),
             leaf_tensors=leaves,
             nuc_constant=0.0,
         )
@@ -433,11 +434,10 @@ class TestConcrete:
         """Force every per-mode leaf to determinant ``+1``"""
 
         rng = np.random.default_rng(seed)
-        num_modes, n_states, L = 2, 3, 2
-        leaves = rng.random((L + 1, num_modes, n_states, n_states))
+        leaves = rng.random((L + 1, M, N, N))
 
         ham = CGFHamiltonian(
-            core_tensors=np.zeros((L + 1, num_modes, num_modes, n_states, n_states)),
+            core_tensors=np.zeros((L + 1, M, M, N, N)),
             leaf_tensors=leaves,
             nuc_constant=0.0,
         )

--- a/tests/test_numeric_hamiltonians.py
+++ b/tests/test_numeric_hamiltonians.py
@@ -23,7 +23,6 @@ import pytest
 import pennylane as qp
 from pennylane.numeric_hamiltonians import CDFHamiltonian, CGFHamiltonian, NumericHamiltonian
 from pennylane.typing import AbstractArray, Float
-
 from tests.templates.subroutines.time_evolution.trotter_test_helpers import random_orthogonal
 
 L, M, N = 2, 2, 3

--- a/tests/test_numeric_hamiltonians.py
+++ b/tests/test_numeric_hamiltonians.py
@@ -451,16 +451,12 @@ class TestConcrete:
         the two-body row convention; the two-body leaves are returned untouched."""
 
         rng = np.random.default_rng(seed)
-        num_modes, n_states, L = 2, 3, 2
         leaf = np.stack(
-            [
-                np.stack([random_orthogonal(n_states, rng) for _ in range(num_modes)])
-                for _ in range(L + 1)
-            ]
+            [np.stack([random_orthogonal(N, rng) for _ in range(M)]) for _ in range(L + 1)]
         )
 
         ham = CGFHamiltonian(
-            core_tensors=np.zeros((L + 1, num_modes, num_modes, n_states, n_states)),
+            core_tensors=np.zeros((L + 1, M, M, N, N)),
             leaf_tensors=leaf,
             nuc_constant=0.0,
         )

--- a/tests/test_numeric_hamiltonians.py
+++ b/tests/test_numeric_hamiltonians.py
@@ -412,6 +412,62 @@ class TestConcrete:
         with pytest.raises(ValueError, match="inconsistent 'tensor_rank'"):
             THCHamiltonian(np.zeros((7, 7)), np.zeros((6, 4)))
 
+    def test_cdf_normalize_leaf_determinant(self, seed):
+        """Force every per-mode leaf to determinant ``+1``"""
+
+        rng = np.random.default_rng(seed)
+        _, n_states, L = 2, 3, 2
+        leaves = rng.random((L + 1, n_states, n_states))
+
+        ham = CDFHamiltonian(
+            core_tensors=np.zeros((L + 1, n_states, n_states)),
+            leaf_tensors=leaves,
+            nuc_constant=0.0,
+        )
+
+        normalized = ham.normalize_leaf_determinant().leaf_tensors
+        dets = qp.math.sign(qp.math.linalg.det(normalized))
+        assert np.allclose(dets, np.ones_like(dets))
+
+    def test_cgf_normalize_leaf_determinant(self, seed):
+        """Force every per-mode leaf to determinant ``+1``"""
+
+        rng = np.random.default_rng(seed)
+        num_modes, n_states, L = 2, 3, 2
+        leaves = rng.random((L + 1, num_modes, n_states, n_states))
+
+        ham = CGFHamiltonian(
+            core_tensors=np.zeros((L + 1, num_modes, num_modes, n_states, n_states)),
+            leaf_tensors=leaves,
+            nuc_constant=0.0,
+        )
+
+        normalized = ham.normalize_leaf_determinant().leaf_tensors
+        dets = qp.math.sign(qp.math.linalg.det(normalized))
+        assert np.allclose(dets, np.ones_like(dets))
+
+    def test_cgf_align_one_body_leaf(self, seed):
+        """The one-body leaf (eigenvectors stored as columns) is transposed per mode to match
+        the two-body row convention; the two-body leaves are returned untouched."""
+
+        rng = np.random.default_rng(seed)
+        num_modes, n_states, L = 2, 3, 2
+        leaf = np.stack(
+            [
+                np.stack([random_orthogonal(n_states, rng) for _ in range(num_modes)])
+                for _ in range(L + 1)
+            ]
+        )
+
+        ham = CGFHamiltonian(
+            core_tensors=np.zeros((L + 1, num_modes, num_modes, n_states, n_states)),
+            leaf_tensors=leaf,
+            nuc_constant=0.0,
+        )
+        aligned = ham.align_one_body_leaf().leaf_tensors
+        assert np.allclose(aligned[0], np.swapaxes(leaf[0], -2, -1))
+        assert np.allclose(aligned[1:], leaf[1:])
+
 
 class TestAbstract:
     """Tests for Hamiltonians built from ``qp.typing.Float[...]`` specifications."""


### PR DESCRIPTION
**Context:** The [trotter_fragmented function](https://docs.pennylane.ai/en/latest/code/api/api/pennylane.labs.templates.trotter_fragmented.html) is used in many important algorithms and was recently ported into two Operator2 subclasses. Ideally it should use dedicated Hamiltonian classes for better longterm handling of large data and integration with resource estimation workflows.

**Description of the Change:** 
- Moves `align_one_body_leaf` and `normalize_leaf_determinant` private methods in `TrotterCDF/CGF` to class methods in Hamiltonian classes.

**Benefits:** Better location for these features.

**Possible Drawbacks:** 

**Related GitHub Issues:** [sc-127430](https://app.shortcut.com/xanaduai/story/127430/port-trottercdf-cgf-using-new-hamiltonian-classes)
