### PR TITLE
Raise an error when converting an abstract array to concrete array

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1364,6 +1364,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Converting an ``AbstractArray`` to a concrete array now raises an informative ``TypeError``
+  instead of silently producing an empty array, which previously surfaced as an obscure error
+  far from its cause.
+  [(#10083)](https://github.com/PennyLaneAI/pennylane/pull/10083)
+
 * Fixed the QFT-based decomposition of :class:`~.OutMultiplier` so it can be captured and
   compiled with Catalyst when ``mod = 2 ** len(output_wires)``.
   [(#10057)](https://github.com/PennyLaneAI/pennylane/pull/10057)

--- a/pennylane/typing.py
+++ b/pennylane/typing.py
@@ -343,6 +343,16 @@ class AbstractArray:
     def __setitem__(self, *_, **__):
         raise IndexError("Cannot index into an AbstractArray.")
 
+    def __array__(self, *_, **__):
+        # Without this, np.asarray treats an AbstractArray as a sequence: it reads
+        # __len__ but __getitem__ raises, so numpy silently produces an empty
+        # array. Callers then fail far away with a confusing message, e.g.
+        # np.linalg.det reporting "1-dim array given". Fail here instead.
+        raise TypeError(
+            "An AbstractArray cannot be converted to a concrete array: it carries only a "
+            "shape and dtype, not values."
+        )
+
     def __len__(self) -> int:
         if not self.shape or self.shape is Ellipsis:
             raise TypeError("len() of unsized object.")

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -336,6 +336,26 @@ class TestAbstractArray:
         with pytest.raises(IndexError, match="Cannot index into an AbstractArray."):
             a[1] = 2
 
+    def test_error_converting_to_concrete_array(self):
+        """Test that numpy coercion raises instead of silently producing an empty array.
+
+        ``AbstractArray`` reports a ``__len__`` but raises on ``__getitem__``, so without a
+        guard numpy reads it as an empty sequence: ``np.asarray`` returned ``array([])``
+        and callers failed far away with misleading messages, such as ``np.linalg.det``
+        complaining about a 1-dim input.
+        """
+        a = AbstractArray((3, 2, 2), float)
+
+        with pytest.raises(TypeError, match="cannot be converted to a concrete array"):
+            np.asarray(a)
+
+        with pytest.raises(TypeError, match="cannot be converted to a concrete array"):
+            np.linalg.det(a)
+
+        # Shape and dtype access is unaffected.
+        assert a.shape == (3, 2, 2)
+        assert len(a) == 3
+
     def test_error_len_on_scalar(self):
         """Test that requesting the len of a scalar results in an error."""
         a = AbstractArray((), int)


### PR DESCRIPTION
**Context:**
``AbstractArray`` reports a ``__len__`` but raises on ``__getitem__``, so without a guard numpy reads it as an empty sequence: ``np.asarray`` returned ``array([])`` and callers failed far away with misleading messages, such as ``np.linalg.det`` complaining about a 1-dim input. This PR adds the guard to raise an error instead of silently produces an empty array that causes obscure failure messages.

**Related Story:**
[sc-129184]