### PR TITLE
Fix capture of OutMultiplier decomp with qft

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1105,6 +1105,7 @@
   [(#10042)](https://github.com/PennyLaneAI/pennylane/pull/10042)
   [(#10073)](https://github.com/PennyLaneAI/pennylane/pull/10073)
   [(#10078)](https://github.com/PennyLaneAI/pennylane/pull/10078)
+  [(#10085)](https://github.com/PennyLaneAI/pennylane/pull/10085)
   - Quantum chemistry operators are ported:
     - :class:`~.SingleExcitation`
   [(#9944)](https://github.com/PennyLaneAI/pennylane/pull/9944)

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -364,7 +364,9 @@ def _out_multiplier_with_qft(
 
     if mod != 2 ** len(output_wires):
         if capture.enabled() or compiler.active():
-            qft_output_wires = math.concatenate([math.array([work_wires[0]], like="jax"), output_wires])
+            qft_output_wires = math.concatenate(
+                [math.array([work_wires[0]], like="jax"), output_wires]
+            )
         else:
             qft_output_wires = [work_wires[0]] + output_wires
         work_wire = work_wires[1]

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -18,7 +18,7 @@ Contains the OutMultiplier template.
 from collections import defaultdict
 from itertools import combinations
 
-from pennylane import math
+from pennylane import capture, compiler, math
 from pennylane.core.operator import Operator2, abstractify
 from pennylane.decomposition import (
     add_decomps,
@@ -357,9 +357,17 @@ def _out_multiplier_with_qft(
     work_wires: WiresLike,
     output_wires_zeroed: bool,
 ):  # pylint: disable=too-many-arguments, unused-argument
+
+    if capture.enabled() or compiler.active():
+        work_wires = math.array(work_wires, like="jax")
+        output_wires = math.array(output_wires, like="jax")
+
     if mod != 2 ** len(output_wires):
-        qft_output_wires = work_wires[:1] + output_wires
-        work_wire = work_wires[1:2]
+        if capture.enabled() or compiler.active():
+            qft_output_wires = math.concatenate([math.array([work_wires[0]], like="jax"), output_wires])
+        else:
+            qft_output_wires = [work_wires[0]] + output_wires
+        work_wire = work_wires[1]
     else:
         qft_output_wires = output_wires
         # Keep the empty register traceable instead of passing a literal tuple to JAX.
@@ -369,7 +377,7 @@ def _out_multiplier_with_qft(
         compute_op = prod(*(H(w) for w in qft_output_wires))
     else:
         compute_op = QFT(qft_output_wires)
-    uncompute_op = adjoint(QFT)(qft_output_wires)
+    uncompute_op = adjoint(QFT(qft_output_wires))
 
     target_op = ControlledSequence(
         ControlledSequence(PhaseAdder(1, qft_output_wires, mod, work_wire), control=x_wires),

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -207,6 +207,18 @@ def test_standard_validity_out_multiplier():
     qp.ops.functions.assert_valid(op)
 
 
+@pytest.mark.usefixtures("enable_capture")
+def test_standard_validity_out_multiplier_capture():
+    """Check the operation using the assert_valid function."""
+    mod = 12
+    x_wires = [0, 1]
+    y_wires = [2, 3, 4]
+    output_wires = [6, 7, 8, 9]
+    work_wires = [5, 10]
+    op = OutMultiplier(x_wires, y_wires, output_wires, mod, work_wires)
+    qp.ops.functions.assert_valid(op)
+
+
 def test_wires_property():
     """Test that wires includes all registers, including work wires."""
     op = OutMultiplier([0, 1], [2, 3], [4, 5, 6], mod=8, work_wires=[7, 8])

--- a/tests/templates/subroutines/arithmetic/test_out_multiplier.py
+++ b/tests/templates/subroutines/arithmetic/test_out_multiplier.py
@@ -194,20 +194,7 @@ def test_abstract_init_validation(mod, work_wires, msg_match):
         )
 
 
-@PL2DO_QFT_CAPTURE
 @pytest.mark.usefixtures("enable_and_disable_capture")
-def test_standard_validity_out_multiplier():
-    """Check the operation using the assert_valid function."""
-    mod = 12
-    x_wires = [0, 1]
-    y_wires = [2, 3, 4]
-    output_wires = [6, 7, 8, 9]
-    work_wires = [5, 10]
-    op = OutMultiplier(x_wires, y_wires, output_wires, mod, work_wires)
-    qp.ops.functions.assert_valid(op)
-
-
-@pytest.mark.usefixtures("enable_capture")
 def test_standard_validity_out_multiplier_capture():
     """Check the operation using the assert_valid function."""
     mod = 12


### PR DESCRIPTION
**Context:** We would like to capture our key templates.

**Description of the Change:** Makes the QFT based decomp of OutMultiplier capture compatible.

**Benefits:** We can capture this decomp.

**Possible Drawbacks:** N/A

**Related GitHub Issues:** [sc-128408]
