### PR TITLE
GQSP tracer leak fix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1375,6 +1375,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed an issue where tracers were set on sub-operators and leaked out of the tracing context.
+  [(#10086)](https://github.com/PennyLaneAI/pennylane/pull/10086)
+
 * Fixed :class:`~.Incrementer` returning an incorrect incremented value when not enough
   work wires are provided.
   [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)

--- a/pennylane/ops/functions/assert_valid.py
+++ b/pennylane/ops/functions/assert_valid.py
@@ -256,6 +256,31 @@ def _make_wrapped_decomp_rule(rule, op, capture_kwargs):
     return _wrapped
 
 
+def _reset_operator_tracers(op):
+    """Reset the transient ``tracer`` left on ``op`` and its shared sub-operators after a capture
+    trace. Tracing a decomposition re-applies the op's (shared) sub-operators, binding them into the
+    trace and setting a ``tracer`` that goes stale once the trace ends; reusing such an operator
+    afterwards (eigendecomposition, copy/pickle, rebuilding a composite) raises an
+    ``UnexpectedTracerError``.
+
+    This is not composite-specific. An ``Operator2`` exposes its sub-operators through its hybrid
+    args (the accessor also used by ``queue`` / ``map_wires``), while a legacy ``Operator1`` surfaces
+    them through ``operands`` (composite) or ``base`` (symbolic)."""
+    if isinstance(op, Operator2):
+        op.tracer = None
+        subs = []
+        for arg in op.hybrid_args.values():
+            leaves, _ = flatten(arg, is_leaf=lambda v: isinstance(v, Operator))
+            subs.extend(leaf for leaf in leaves if isinstance(leaf, Operator))
+    else:
+        subs = list(getattr(op, "operands", None) or ())
+        base = getattr(op, "base", None)
+        if isinstance(base, Operator):
+            subs.append(base)
+    for sub in subs:
+        _reset_operator_tracers(sub)
+
+
 def _capture_decomp_rule_to_tape(rule, op):
 
     import jax  # pylint: disable=import-outside-toplevel
@@ -276,6 +301,7 @@ def _capture_decomp_rule_to_tape(rule, op):
         decomposition = _make_wrapped_decomp_rule(decomposition, op, capture_kwargs)
 
     plxpr = qp.capture.make_plxpr(decomposition, autograph=False)(*capture_args, **capture_kwargs)
+    _reset_operator_tracers(op)
     flat_capture_args = jax.tree.leaves((capture_args, capture_kwargs))
     return qp.tape.plxpr_to_tape(plxpr.jaxpr, plxpr.consts, *flat_capture_args)
 

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -31,10 +31,11 @@ from pennylane.ops.functions import assert_valid
 from pennylane.ops.functions.assert_valid import (
     _check_eigendecomposition,
     _check_pytree,
+    _reset_operator_tracers,
     _test_decomposition_rule,
 )
 from pennylane.wires import Wires
-from tests.core.operator.operator2_utils import DynOp, OneWireDynOp
+from tests.core.operator.operator2_utils import DynOp, HybridOp, OneWireDynOp
 
 
 class TestDecompositionErrors:
@@ -878,3 +879,42 @@ def test_explicit_list_of_failing_ops(invalid_instance_and_error):
     op, exc_type = invalid_instance_and_error
     with pytest.raises(exc_type):
         assert_valid(op)
+
+
+@pytest.mark.parametrize("child_attr", ["base", "operands"])
+def test_reset_operator_tracers(child_attr):
+    """
+    Test that _reset_operator_tracers resets the tracer of an operator and all its sub-operators.
+    """
+
+    sub_op = qp.RX(0.5, wires=0)
+    sub_op.tracer = "stale-tracer"
+
+    class Symbolic(Operator):
+        """Minimal legacy operator that stores its child under ``base`` or ``operands``."""
+
+        def __init__(self, child, wires):
+            setattr(self, child_attr, child if child_attr == "base" else [child])
+            super().__init__(wires=wires)
+
+    op = Symbolic(sub_op, wires=0)
+
+    _reset_operator_tracers(op)
+    assert sub_op.tracer is None
+
+
+def test_reset_operator_tracers_operator2():
+    """
+    Test that _reset_operator_tracers resets the tracer of an operator2 and all its sub-operators.
+    """
+
+    sub_op = qp.RX(0.5, wires=0)
+    sub_op.tracer = "stale-tracer"
+
+    op = HybridOp([sub_op], wires=0)
+    op.tracer = "stale-tracer"
+
+    _reset_operator_tracers(op)
+
+    assert op.tracer is None
+    assert sub_op.tracer is None

--- a/tests/ops/functions/test_assert_valid.py
+++ b/tests/ops/functions/test_assert_valid.py
@@ -785,7 +785,7 @@ class TestOperator2AssertValid:
             def __init__(self, gamma, wires):
                 super().__init__(gamma, wires=wires)
 
-        class HybridOp(Operator2):
+        class Hybrid(Operator2):
             dynamic_argnames = ("phi",)
             wire_argnames = ("wires",)
             hybrid_argnames = ("ops",)
@@ -795,7 +795,7 @@ class TestOperator2AssertValid:
 
         with pytest.raises(AssertionError, match=r"copied op must be a separate instance"):
             assert_valid(
-                HybridOp(np.pi, wires=0, ops=[0.2, NoCopyOp(0.25, 1), SingleRZ(0.5, 0)]),
+                Hybrid(np.pi, wires=0, ops=[0.2, NoCopyOp(0.25, 1), SingleRZ(0.5, 0)]),
                 skip_pickle=True,
             )
 

--- a/tests/templates/subroutines/test_gqsp.py
+++ b/tests/templates/subroutines/test_gqsp.py
@@ -28,7 +28,7 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 class TestGQSP:
     """Test the qp.GQSP template."""
 
-    @pytest.mark.jax
+    @pytest.mark.capture
     def test_standard_validity(self):
         """Test standard validity criteria with assert_valid."""
 


### PR DESCRIPTION
**Context:** We are getting leaked tracers when capturing `GQSP`.

**Description of the Change:** Tries to refresh tracers that are set on sub-ops.

**Benefits:** We don't error out when tracing.

**Possible Drawbacks:** Not 100% sure about this.

**Related GitHub Issues:** [sc-128409]

Note: cursor was used to figure out what was going on.

"During `assert_valid`'s capture check, `_prod_decomp` calls `qp.apply(op)` on the `Prod`'s shared operand objects while tracing the decomposition. This mutates each operand's transient `.tracer` attribute (`None` → `JitTracer`). That tracer is scoped to the trace, but the same operand objects are reused afterward. When `diagonalizing_gates` later rebuilds a composite from those operands `(tmp_sum = self.__class__(*ops))`, `_primitive_bind_call` picks up the now-stale tracer and raises `UnexpectedTracerError`"
