### PR TITLE
Skip identity (zero-angle) Givens gates in BasisRotation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -420,11 +420,7 @@
 <h3>Improvements 🛠</h3>
 
 * :class:`~.BasisRotation` now omits identity (zero-angle) ``SingleExcitation`` and ``PhaseShift``
-  gates from its decomposition. For a structurally sparse orbital rotation (leaf tensors with exact
-  zeros, e.g. a decoupled/frozen orbital) this lowers the gate count, including under program
-  capture where the reduction is applied statically. Templates that decompose via
-  :class:`~.BasisRotation`, such as :class:`~.TrotterCDF` and :class:`~.TrotterCGF`, inherit the
-  reduction; dense rotations are unaffected.
+  gates from its decomposition, leading to lower quantum resources.
   [(#10097)](https://github.com/PennyLaneAI/pennylane/pull/10097)
 
 * :class:`~.IsingZZ`'s decomposition is now expressed as a :func:`~.change_op_basis` (``CNOT``

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -425,7 +425,7 @@
   capture where the reduction is applied statically. Templates that decompose via
   :class:`~.BasisRotation`, such as :class:`~.TrotterCDF` and :class:`~.TrotterCGF`, inherit the
   reduction; dense rotations are unaffected.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10097)](https://github.com/PennyLaneAI/pennylane/pull/10097)
 
 * :class:`~.IsingZZ`'s decomposition is now expressed as a :func:`~.change_op_basis` (``CNOT``
   compute/uncompute around the ``RZ``) instead of three bare gates. This lets PennyLane's generic

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -419,6 +419,14 @@
 
 <h3>Improvements 🛠</h3>
 
+* :class:`~.BasisRotation` now omits identity (zero-angle) ``SingleExcitation`` and ``PhaseShift``
+  gates from its decomposition. For a structurally sparse orbital rotation (leaf tensors with exact
+  zeros, e.g. a decoupled/frozen orbital) this lowers the gate count, including under program
+  capture where the reduction is applied statically. Templates that decompose via
+  :class:`~.BasisRotation`, such as :class:`~.TrotterCDF` and :class:`~.TrotterCGF`, inherit the
+  reduction; dense rotations are unaffected.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * :class:`~.IsingZZ`'s decomposition is now expressed as a :func:`~.change_op_basis` (``CNOT``
   compute/uncompute around the ``RZ``) instead of three bare gates. This lets PennyLane's generic
   ``C(ChangeOpBasis)`` rule automatically control only the ``RZ`` for any number of control wires,

--- a/pennylane/templates/subroutines/qchem/basis_rotation.py
+++ b/pennylane/templates/subroutines/qchem/basis_rotation.py
@@ -327,12 +327,42 @@ def _basis_rotation_decomp_resources(unitary_matrix, wires, check=False):
     return {PhaseShift: ps_count, SingleExcitation: se_count}
 
 
-# Not exact because PhaseShift(s) might be skipped
+def _has_readable_angles(unitary_matrix):
+    """Whether the Givens angles can be read eagerly to skip identity gates without
+    breaking tracing or differentiation.
+
+    True for plain numpy, an eager (non-traced) jax array, or a concrete constant inside a
+    capture/qjit program. False for traced inputs (``jax.jit``/``jax.grad``) and for other
+    autodiff interfaces (autograd/torch/tf), where reading the value would detach gradients.
+    """
+    if math.is_abstract(unitary_matrix):
+        return False
+    if _qjit_or_capture():
+        return True
+    interface = math.get_interface(unitary_matrix)
+    if interface == "numpy":
+        return True
+    if interface == "jax":
+        import jax  # pylint: disable=import-outside-toplevel
+
+        return not isinstance(unitary_matrix, jax.core.Tracer)
+    return False
+
+
+# Not exact: identity (zero-angle) PhaseShift/SingleExcitation gates may be skipped -
+# conditionally for traced unitaries, statically for concrete ones.
 @register_resources(_basis_rotation_decomp_resources, exact=False)
 def _basis_rotation_decomp(unitary_matrix, wires, **__):
 
     if isinstance(wires, Wires):
         wires = wires.labels
+
+    # When the Givens angles are known (a constant unitary), compute them eagerly and skip
+    # the identity (zero-angle) gates - a static gate-count reduction that also holds under
+    # capture. Traced/differentiated inputs fall through to the rolled for_loop below.
+    if _has_readable_angles(unitary_matrix):
+        _basis_rotation_concrete(math.toarray(unitary_matrix), wires)
+        return
 
     if _qjit_or_capture():
         unitary_matrix, wires = math.array(unitary_matrix, like="jax"), math.array(
@@ -397,6 +427,44 @@ def _basis_rotation_decomp(unitary_matrix, wires, **__):
 
     is_real = math.is_real_obj_or_close(unitary_matrix)
     cond(is_real, real_unitary, complex_unitary)(unitary=unitary_matrix, wires=wires)
+
+
+def _basis_rotation_concrete(unitary_matrix, wires):
+    """Concrete-unitary path for ``_basis_rotation_decomp``.
+
+    The unitary is a concrete (non-traced) array, so the Givens angles are computed
+    eagerly in numpy and only the non-identity (non-zero-angle) gates are queued. This
+    is capture-safe: the queued gates carry constant angles and no python branch is taken
+    on a traced value.
+    """
+    if isinstance(wires, Wires):
+        wires = wires.labels
+
+    if math.is_real_obj_or_close(unitary_matrix):
+        angle, unitary_matrix = _adjust_determinant(unitary_matrix)
+        if not math.allclose(angle, 0.0):
+            PhaseShift(angle, wires[0])
+
+        _, givens_list = math.decomposition.givens_decomposition(unitary_matrix)
+        for grot_mat, (i, j) in givens_list:
+            theta = math.arctan2(math.real(grot_mat[0, 1]), math.real(grot_mat[0, 0]))
+            if not math.allclose(theta, 0.0):
+                SingleExcitation(2 * theta, wires=[wires[i], wires[j]])
+        return
+
+    phase_list, givens_list = math.decomposition.givens_decomposition(unitary_matrix)
+    for idx, phase in enumerate(phase_list):
+        phase_angle = math.angle(phase)
+        if not math.allclose(phase_angle, 0.0):
+            PhaseShift(phase_angle, wires=wires[idx])
+
+    for grot_mat, (i, j) in givens_list:
+        theta = math.arccos(math.real(grot_mat[1, 1]))
+        phi = math.angle(grot_mat[0, 0])
+        if not math.allclose(theta, 0.0):
+            SingleExcitation(2 * theta, wires=[wires[i], wires[j]])
+        if not math.allclose(phi, 0.0):
+            PhaseShift(phi, wires[i])
 
 
 add_decomps(BasisRotation, _basis_rotation_decomp)

--- a/tests/templates/subroutines/qchem/test_basis_rotation.py
+++ b/tests/templates/subroutines/qchem/test_basis_rotation.py
@@ -229,6 +229,54 @@ class TestDecomposition:
         for rule in qp.list_decomps(qp.BasisRotation):
             _test_decomposition_rule(op, rule)
 
+    def test_basis_rotation_skips_zero_angle_givens(self):
+        """A structurally sparse orthogonal matrix (a decoupled orbital) must not emit
+        identity SingleExcitation/PhaseShift gates, while still reconstructing the operator."""
+        # 4x4 orthogonal with orbital 0 decoupled (row/col 0 = e_0), like a CDF two-body
+        # leaf with a frozen orbital, so some Givens rotations are exact identities.
+        unitary = np.eye(4)
+        unitary[1:, 1:] = np.array(
+            [
+                [-0.25619233, 0.81407233, 0.52120219],
+                [-0.72789572, -0.5172592, 0.45012302],
+                [0.63602933, -0.26406278, 0.72507761],
+            ]
+        )
+
+        op = qp.BasisRotation(wires=range(4), unitary_matrix=unitary)
+        queue = op.decomposition()
+
+        num_single_excitations = sum(isinstance(g, qp.SingleExcitation) for g in queue)
+        assert num_single_excitations < 4 * 3 // 2  # fewer than the dense N(N-1)/2
+        # no identity gates remain in the decomposition
+        assert all(not np.isclose(g.parameters[0], 0.0) for g in queue)
+        # the pruned decomposition still equals the operator
+        decomp_matrix = qp.matrix(op.decomposition, wire_order=range(4))()
+        assert np.allclose(decomp_matrix, qp.matrix(op))
+
+    @pytest.mark.jax
+    @pytest.mark.usefixtures("enable_capture")
+    def test_basis_rotation_skips_zero_angle_givens_capture(self):
+        """The zero-angle skip must be reflected statically under program capture: a
+        concrete (constant) sparse unitary yields a captured program with strictly fewer
+        SingleExcitation gates, not runtime-guarded ones."""
+        unitary = np.eye(4)
+        unitary[1:, 1:] = np.array(
+            [
+                [-0.25619233, 0.81407233, 0.52120219],
+                [-0.72789572, -0.5172592, 0.45012302],
+                [0.63602933, -0.26406278, 0.72507761],
+            ]
+        )
+        op = qp.BasisRotation(wires=range(4), unitary_matrix=unitary)
+
+        plxpr = qp.capture.make_plxpr(op.decomposition, autograph=False)()
+        tape = qp.tape.plxpr_to_tape(plxpr.jaxpr, plxpr.consts)
+
+        num_single_excitations = sum(isinstance(g, qp.SingleExcitation) for g in tape.operations)
+        assert 0 < num_single_excitations < 4 * 3 // 2
+        assert all(not np.isclose(g.parameters[0], 0.0) for g in tape.operations)
+
     def test_custom_wire_labels(self, tol):
         """Test that BasisRotation template can deal with non-numeric, nonconsecutive wire labels."""
 


### PR DESCRIPTION
**Context:**

`BasisRotation` decomposes into a Givens network of `SingleExcitation`/`PhaseShift` gates. When the rotation is structurally sparse (leaf tensors with exact zeros, e.g. a frozen/decoupled orbital), some Givens angles are exactly zero and the decomposition emits identity gates. This is data-dependent (dense rotations, such as a NIRS `TrotterCGF`, are unaffected), but common in CDF-Trotter workflows.

**Description of the Change:**

`BasisRotation` now skips identity (zero-angle) `SingleExcitation`/`PhaseShift` gates when the angles are known at construction time: for a constant unitary (numpy, eager jax, or a concrete constant under capture/qjit) the angles are computed eagerly and only non-identity gates are queued. Traced/differentiated inputs (`jax.jit`/`jax.grad`, autograd/torch/tf) are unchanged and still emit the full `for_loop`, preserving differentiability. `TrotterCDF`/`TrotterCGF` inherit the reduction; the resource function stays `exact=False`.

**Benefits:**

Fewer gates for sparse orbital rotations, applied statically (including under program capture), with no change to correctness or differentiability.

**Possible Drawbacks:**

None. The `exact=False` estimate remains an upper bound, so decomposition planning is unaffected.

**Related GitHub Issues:**

N/A