### PR TITLE
Complete abstract and optional `indices` for `SumOfSlatersPrep`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -427,7 +427,7 @@
   chose.
   [(#10084)](https://github.com/PennyLaneAI/pennylane/pull/10084)
   [(#10102)](https://github.com/PennyLaneAI/pennylane/pull/10102)
-  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
+  [(#10105)](https://github.com/PennyLaneAI/pennylane/pull/10105)
 
   ```pycon
   >>> op = qp.SumOfSlatersPrep(qp.typing.Complex[16], wires=range(8))

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -429,7 +429,7 @@
   [(#10105)](https://github.com/PennyLaneAI/pennylane/pull/10105)
 
   :func:`~.SumOfSlatersPrep.required_register_sizes` also accepts abstract ``indices``, and
-  reports the largest register sizes across any set of indices of that length:
+  reports the largest possible register sizes across any set of indices of that length:
 
   ```pycon
   >>> num_wires = 8

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -421,7 +421,7 @@
 
 * The ``indices`` of :class:`~.SumOfSlatersPrep` are now optional, and may also be given as an
   abstract type. In both cases a worst-case set of indices of the appropriate length is generated
-  with the new :func:`~.SumOfSlatersPrep.worst_case_indices`, so that the operator can be costed
+  with the new :func:`~.SumOfSlatersPrep.generate_indices`, so that the operator can be costed
   when only the number of Slater determinants is known. Note that the generated indices are a
   resource-estimation stand-in: the operator is valid, but does not prepare a state the caller
   chose.
@@ -438,7 +438,7 @@
 
   :func:`~.SumOfSlatersPrep.required_register_sizes` also accepts abstract ``indices``, and
   reports the largest register sizes across any set of indices of that length. Those sizes are
-  attained exactly, by ``worst_case_indices`` of the same length:
+  attained exactly, by ``generate_indices`` of the same length:
 
   ```pycon
   >>> num_wires = 8

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -419,26 +419,17 @@
 
 <h3>Improvements 🛠</h3>
 
-* The ``indices`` of :class:`~.SumOfSlatersPrep` are now optional, and may also be given as an
-  abstract type. In both cases a worst-case set of indices of the appropriate length is generated
-  with the new :func:`~.SumOfSlatersPrep.generate_indices`, so that the operator can be costed
-  when only the number of Slater determinants is known. Note that the generated indices are a
-  resource-estimation stand-in: the operator is valid, but does not prepare a state the caller
-  chose.
+* The ``indices`` of :class:`~.SumOfSlatersPrep` may now be given as an abstract type, in which
+  case a worst-case set of indices of that length is generated with the new
+  :func:`~.SumOfSlatersPrep.generate_indices`, so that the operator can be costed when only the
+  number of Slater determinants is known. The generated indices are a resource-estimation
+  stand-in: the operator is valid, but does not prepare a state the caller provided.
   [(#10084)](https://github.com/PennyLaneAI/pennylane/pull/10084)
   [(#10102)](https://github.com/PennyLaneAI/pennylane/pull/10102)
   [(#10105)](https://github.com/PennyLaneAI/pennylane/pull/10105)
 
-  ```pycon
-  >>> op = qp.SumOfSlatersPrep(qp.typing.Complex[16], wires=range(8))
-  >>> op.indices
-  (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 32, 64, 128)
-
-  ```
-
   :func:`~.SumOfSlatersPrep.required_register_sizes` also accepts abstract ``indices``, and
-  reports the largest register sizes across any set of indices of that length. Those sizes are
-  attained exactly, by ``generate_indices`` of the same length:
+  reports the largest register sizes across any set of indices of that length:
 
   ```pycon
   >>> num_wires = 8

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1411,17 +1411,6 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* :func:`~.SumOfSlatersPrep.required_register_sizes` no longer returns negative register sizes for
-  a single-entry state. ``ceil_log2(1)`` is ``0``, so the abstract computation evaluated
-  :math:`2d-1` and :math:`2d-2` as ``-1`` and ``-2``.
-  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
-
-  ```pycon
-  >>> qp.SumOfSlatersPrep.required_register_sizes(qp.typing.Int[1], 4)
-  {'wires': 4, 'enumeration_wires': 0, 'identification_wires': 0, 'qrom_work_wires': 0, 'mcx_cache_wires': 0}
-
-  ```
-
 * Fixed :class:`~.Incrementer` returning an incorrect incremented value when not enough
   work wires are provided.
   [(#10062)](https://github.com/PennyLaneAI/pennylane/pull/10062)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -419,12 +419,26 @@
 
 <h3>Improvements 🛠</h3>
 
-* Initialization of :class:`~.SumOfSlatersPrep`, as well as 
-  :func:`~.SumOfSlatersPrep.required_register_sizes` now work with abstract ``indices`` as input.
-  The latter returns an upper bound for the register sizes for abstract ``indices``, across any 
-  set of indices of the provided length.
+* The ``indices`` of :class:`~.SumOfSlatersPrep` are now optional, and may also be given as an
+  abstract type. In both cases a worst-case set of indices of the appropriate length is generated
+  with the new :func:`~.SumOfSlatersPrep.worst_case_indices`, so that the operator can be costed
+  when only the number of Slater determinants is known. Note that the generated indices are a
+  resource-estimation stand-in: the operator is valid, but does not prepare a state the caller
+  chose.
   [(#10084)](https://github.com/PennyLaneAI/pennylane/pull/10084)
   [(#10102)](https://github.com/PennyLaneAI/pennylane/pull/10102)
+  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
+
+  ```pycon
+  >>> op = qp.SumOfSlatersPrep(qp.typing.Complex[16], wires=range(8))
+  >>> op.indices
+  (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 16, 32, 64, 128)
+
+  ```
+
+  :func:`~.SumOfSlatersPrep.required_register_sizes` also accepts abstract ``indices``, and
+  reports the largest register sizes across any set of indices of that length. Those sizes are
+  attained exactly, by ``worst_case_indices`` of the same length:
 
   ```pycon
   >>> num_wires = 8
@@ -1396,6 +1410,17 @@
   [(#9621)](https://github.com/PennyLaneAI/pennylane/pull/9621)
 
 <h3>Bug fixes 🐛</h3>
+
+* :func:`~.SumOfSlatersPrep.required_register_sizes` no longer returns negative register sizes for
+  a single-entry state. ``ceil_log2(1)`` is ``0``, so the abstract computation evaluated
+  :math:`2d-1` and :math:`2d-2` as ``-1`` and ``-2``.
+  [(#XXXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXXX)
+
+  ```pycon
+  >>> qp.SumOfSlatersPrep.required_register_sizes(qp.typing.Int[1], 4)
+  {'wires': 4, 'enumeration_wires': 0, 'identification_wires': 0, 'qrom_work_wires': 0, 'mcx_cache_wires': 0}
+
+  ```
 
 * Fixed :class:`~.Incrementer` returning an incorrect incremented value when not enough
   work wires are provided.

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -987,8 +987,7 @@ class SumOfSlatersPrep(Operator2):
 
         This function supports an abstract input for ``indices``, in which case the largest
         register sizes across all possible sets of basis states of the given length are
-        returned. These sizes are attained exactly, by
-        :func:`~.SumOfSlatersPrep.generate_indices` of the same length:
+        returned:
 
         >>> indices = qp.typing.Int[45]
         >>> qp.SumOfSlatersPrep.required_register_sizes(indices, 18)

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1060,10 +1060,11 @@ class SumOfSlatersPrep(Operator2):
         if num_bits < 1:  # a single index needs no distinguishing bits
             return (0,)
 
+        # Pin all num_bits rows with the fewest indices: each pair (0, 2**i) differs in
+        # bit i alone, so row i can never be dropped.
         indices = {0} | {1 << i for i in range(num_bits)}
-        # Pad with the smallest unused indices, which keeps every index inside the low
-        # num_bits bits. The remaining wires are then constant across all indices, so
-        # select_sos_rows discards them and exactly num_bits rows survive.
+        # That is only num_bits + 1 indices; top up to the required num_entries. r is
+        # already maximal, so these values are arbitrary.
         candidate = 2
         while len(indices) < num_entries:
             indices.add(candidate)

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -929,8 +929,7 @@ class SumOfSlatersPrep(Operator2):
         mcx_cache_wires: WiresLike = (),
     ):
         n = 1 if isinstance(wires, int) else len(wires)
-        # Trailing axis, not len(), so broadcast coefficients report entries, not batch size.
-        num_entries = math.shape(coefficients)[-1]
+        num_entries = len(coefficients)
         if indices is not None and not isinstance(indices, AbstractArray):
             if len(indices) != num_entries:
                 raise ValueError(

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -659,7 +659,7 @@ class SumOfSlatersPrep(Operator2):
         coefficients (np.ndarray): Coefficients of the sparse state to prepare. The ordering should
             match that in ``indices``.
         wires (~.WiresLike): Wires on which to prepare the state.
-        indices (tuple[int] or AbstractArray or None): Indices of the sparse state to prepare.
+        indices (tuple[int] or AbstractArray): Indices of the sparse state to prepare.
             The ordering should match that in ``coefficients``. May also be an abstract type
             such as ``qp.typing.Int[len(coefficients)]``, in which case the indices are
             generated with :func:`~.SumOfSlatersPrep.generate_indices`.
@@ -956,7 +956,7 @@ class SumOfSlatersPrep(Operator2):
                     _name = name.replace("_", " ")
                     raise ValueError(
                         f"Number of {_name} {len(reg)} does not match the "
-                        f"required number of {_name} {expected_size}"
+                        f"required number of {_name} ({expected_size})"
                     )
 
         super().__init__(

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -919,7 +919,14 @@ class SumOfSlatersPrep(Operator2):
         mcx_cache_wires: WiresLike = (),
     ):
         n = 1 if isinstance(wires, int) else len(wires)
-        num_entries = len(coefficients)
+        # Use the trailing axis, not len(), so that broadcast coefficients report the number of
+        # entries rather than the batch size.
+        num_entries = math.shape(coefficients)[-1]
+        if indices is not None and not isinstance(indices, AbstractArray):
+            if len(indices) != num_entries:
+                raise ValueError(
+                    "The number of coefficients and the number of state indices must match."
+                )
         if isinstance(indices, AbstractArray) or indices is None:
             k = min(n, num_entries - 1)
             # Set of powers of 2 from 2^0 up to 2^(k-1), as well as 0

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -928,18 +928,7 @@ class SumOfSlatersPrep(Operator2):
                     "The number of coefficients and the number of state indices must match."
                 )
         if isinstance(indices, AbstractArray) or indices is None:
-            k = min(n, num_entries - 1)
-            # Set of powers of 2 from 2^0 up to 2^(k-1), as well as 0
-            indices = {1 << i for i in range(k)}
-            indices.add(0)
-            # Fill remaining capacity with consecutive integers starting from 2
-            # (0, 1, 2 already contained)
-            curr = 2
-            while len(indices) < num_entries:
-                indices.add(curr)
-                curr += 1
-
-            indices = tuple(sorted(indices))
+            indices = self.worst_case_indices(num_entries, n)
         else:
             v_bits = math.int_to_binary(np.array(indices), n).T  # Shape (n, num_entries)
 
@@ -1007,6 +996,77 @@ class SumOfSlatersPrep(Operator2):
         _, vtilde_bits = select_sos_rows(math.int_to_binary(np.array(indices), num_wires).T)
         num_bits, num_entries = vtilde_bits.shape
         return SumOfSlatersPrep._required_register_sizes_from_nums(num_entries, num_bits, num_wires)
+
+    @staticmethod
+    def worst_case_indices(num_entries: int, num_wires: int) -> tuple[int]:
+        r"""Compute a set of ``num_entries`` computational basis states on ``num_wires`` wires
+        that maximizes the register sizes and gate counts of ``SumOfSlatersPrep``.
+
+        Args:
+            num_entries (int): Number of computational basis states in the sparse state.
+            num_wires (int): Number of target wires the state is prepared on.
+
+        Returns:
+            tuple[int]: Indices attaining the largest register sizes of any set of
+            ``num_entries`` indices on ``num_wires`` wires.
+
+        Raises:
+            ValueError: If ``num_entries`` exceeds ``2**num_wires``.
+
+        This is the index set that ``SumOfSlatersPrep`` synthesizes when ``indices`` is abstract
+        or omitted, and the one that realizes
+        :func:`~.SumOfSlatersPrep.required_register_sizes` for abstract ``indices``.
+
+        .. warning::
+
+            The returned indices are a resource-estimation stand-in. An operator built from them
+            is perfectly valid, but prepares *these* basis states, not any the caller has in mind.
+
+        All register sizes are non-decreasing in :math:`r`, the number of bits retained by
+        :func:`~.select_sos_rows`, so a single index set maximizes all of them at once. The
+        largest attainable :math:`r` is :math:`\min(\text{num\_wires}, \text{num\_entries}-1)`:
+        it cannot exceed the number of wires, and ``select_sos_rows`` returns an *irredundant*
+        set of rows, of which there can be at most :math:`\text{num\_entries}-1` because each
+        retained row must split at least one group of otherwise-identical indices. That bound is
+        attained by pairing the all-zero index with each power of two, as every such pair differs
+        in exactly one bit and therefore pins the corresponding row.
+
+        **Example**
+
+        >>> qp.SumOfSlatersPrep.worst_case_indices(5, 4)
+        (0, 1, 2, 4, 8)
+
+        The register sizes these indices require match the upper bound reported for an abstract
+        ``indices`` input of the same length:
+
+        >>> indices = qp.SumOfSlatersPrep.worst_case_indices(16, 8)
+        >>> sizes = qp.SumOfSlatersPrep.required_register_sizes(indices, 8)
+        >>> sizes == qp.SumOfSlatersPrep.required_register_sizes(qp.typing.Int[16], 8)
+        True
+
+        """
+        if num_entries > 2**num_wires:
+            raise ValueError(
+                f"Number of coefficients {num_entries} cannot be greater than 2^num_wires, "
+                f"{2**num_wires}."
+            )
+
+        num_bits = min(num_wires, num_entries - 1)
+        if num_bits < 1:
+            # A single index needs no distinguishing bits at all.
+            return (0,)
+
+        # The all-zero index together with each power of two. Every such pair is at Hamming
+        # distance one, so ``select_sos_rows`` cannot drop the corresponding row.
+        indices = {0} | {1 << i for i in range(num_bits)}
+        # Top up with the smallest unused indices. Confining them to the same ``num_bits`` bits
+        # leaves the remaining rows constant, so they are dropped and r == num_bits exactly.
+        candidate = 2
+        while len(indices) < num_entries:
+            indices.add(candidate)
+            candidate += 1
+
+        return tuple(sorted(indices))
 
     @staticmethod
     def _required_register_sizes_from_nums(num_entries: int, num_bits: int, num_wires: int):

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -660,10 +660,9 @@ class SumOfSlatersPrep(Operator2):
             match that in ``indices``.
         wires (~.WiresLike): Wires on which to prepare the state.
         indices (tuple[int] or AbstractArray or None): Indices of the sparse state to prepare.
-            The ordering should match that in ``coefficients``. May also be given as an abstract
-            type from :mod:`~.typing`, such as ``qp.typing.Int[len(coefficients)]``, or omitted
-            altogether; in both of those cases a worst-case set of indices of the appropriate
-            length is generated with :func:`~.SumOfSlatersPrep.worst_case_indices`.
+            The ordering should match that in ``coefficients``. May also be an abstract type
+            such as ``qp.typing.Int[len(coefficients)]``, or omitted; in both cases the indices
+            are generated with :func:`~.SumOfSlatersPrep.generate_indices`.
         enumeration_wires (~.WiresLike): Work wires used for the enumeration register. For
             :math:`d` entries in the state, :math:`\lceil \log_2 (d)\rceil` qubits are required.
         identification_wires (~.WiresLike): Work wires used for the identification register.
@@ -690,11 +689,9 @@ class SumOfSlatersPrep(Operator2):
     .. warning::
 
         If ``indices`` is abstract or omitted, the generated indices are a resource-estimation
-        stand-in, chosen to maximize the register sizes and gate counts. The resulting operator
-        is perfectly valid and will decompose and execute, but it prepares *those* basis states,
-        not any that the caller has in mind. In particular the generated indices are **not**
-        ``(0, 1, ..., len(coefficients) - 1)``. Pass ``indices`` explicitly to prepare a
-        specific state.
+        stand-in that maximizes the register sizes and gate counts. The operator is valid and
+        will execute, but prepares *those* basis states -- in particular **not**
+        ``(0, 1, ..., len(coefficients) - 1)``. Pass ``indices`` to prepare a specific state.
 
     **Example**
 
@@ -932,8 +929,7 @@ class SumOfSlatersPrep(Operator2):
         mcx_cache_wires: WiresLike = (),
     ):
         n = 1 if isinstance(wires, int) else len(wires)
-        # Use the trailing axis, not len(), so that broadcast coefficients report the number of
-        # entries rather than the batch size.
+        # Trailing axis, not len(), so broadcast coefficients report entries, not batch size.
         num_entries = math.shape(coefficients)[-1]
         if indices is not None and not isinstance(indices, AbstractArray):
             if len(indices) != num_entries:
@@ -941,10 +937,9 @@ class SumOfSlatersPrep(Operator2):
                     "The number of coefficients and the number of state indices must match."
                 )
         if isinstance(indices, AbstractArray) or indices is None:
-            indices = self.worst_case_indices(num_entries, n)
+            indices = self.generate_indices(num_entries, n)
 
-        # ``indices`` is concrete from here on, whether it was given or synthesized, so the
-        # work-wire registers can be validated either way.
+        # indices is concrete from here on, so the registers are validated either way.
         v_bits = math.int_to_binary(np.array(indices), n).T  # Shape (n, num_entries)
 
         if num_entries != 1:
@@ -995,7 +990,7 @@ class SumOfSlatersPrep(Operator2):
         This function supports an abstract input for ``indices``, in which case the largest
         register sizes across all possible sets of basis states of the given length are
         returned. These sizes are attained exactly, by
-        :func:`~.SumOfSlatersPrep.worst_case_indices` of the same length:
+        :func:`~.SumOfSlatersPrep.generate_indices` of the same length:
 
         >>> indices = qp.typing.Int[45]
         >>> qp.SumOfSlatersPrep.required_register_sizes(indices, 18)
@@ -1014,7 +1009,7 @@ class SumOfSlatersPrep(Operator2):
         return SumOfSlatersPrep._required_register_sizes_from_nums(num_entries, num_bits, num_wires)
 
     @staticmethod
-    def worst_case_indices(num_entries: int, num_wires: int) -> tuple[int]:
+    def generate_indices(num_entries: int, num_wires: int) -> tuple[int]:
         r"""Compute a set of ``num_entries`` computational basis states on ``num_wires`` wires
         that maximizes the register sizes and gate counts of ``SumOfSlatersPrep``.
 
@@ -1038,24 +1033,21 @@ class SumOfSlatersPrep(Operator2):
             The returned indices are a resource-estimation stand-in. An operator built from them
             is perfectly valid, but prepares *these* basis states, not any the caller has in mind.
 
-        All register sizes are non-decreasing in :math:`r`, the number of bits retained by
-        :func:`~.select_sos_rows`, so a single index set maximizes all of them at once. The
-        largest attainable :math:`r` is :math:`\min(\text{num\_wires}, \text{num\_entries}-1)`:
-        it cannot exceed the number of wires, and ``select_sos_rows`` returns an *irredundant*
-        set of rows, of which there can be at most :math:`\text{num\_entries}-1` because each
-        retained row must split at least one group of otherwise-identical indices. That bound is
-        attained by pairing the all-zero index with each power of two, as every such pair differs
-        in exactly one bit and therefore pins the corresponding row.
+        Every register size is non-decreasing in :math:`r`, the number of bits retained by
+        :func:`~.select_sos_rows`, so one index set maximizes all of them at once. The largest
+        attainable :math:`r` is :math:`\min(\text{num\_wires}, \text{num\_entries}-1)`, and
+        pairing the all-zero index with each power of two attains it: every such pair differs in
+        exactly one bit, so that bit cannot be dropped.
 
         **Example**
 
-        >>> qp.SumOfSlatersPrep.worst_case_indices(5, 4)
+        >>> qp.SumOfSlatersPrep.generate_indices(5, 4)
         (0, 1, 2, 4, 8)
 
-        The register sizes these indices require match the upper bound reported for an abstract
-        ``indices`` input of the same length:
+        These indices require exactly the sizes reported for abstract ``indices`` of the same
+        length:
 
-        >>> indices = qp.SumOfSlatersPrep.worst_case_indices(16, 8)
+        >>> indices = qp.SumOfSlatersPrep.generate_indices(16, 8)
         >>> sizes = qp.SumOfSlatersPrep.required_register_sizes(indices, 8)
         >>> sizes == qp.SumOfSlatersPrep.required_register_sizes(qp.typing.Int[16], 8)
         True
@@ -1068,15 +1060,11 @@ class SumOfSlatersPrep(Operator2):
             )
 
         num_bits = min(num_wires, num_entries - 1)
-        if num_bits < 1:
-            # A single index needs no distinguishing bits at all.
+        if num_bits < 1:  # a single index needs no distinguishing bits
             return (0,)
 
-        # The all-zero index together with each power of two. Every such pair is at Hamming
-        # distance one, so ``select_sos_rows`` cannot drop the corresponding row.
         indices = {0} | {1 << i for i in range(num_bits)}
-        # Top up with the smallest unused indices. Confining them to the same ``num_bits`` bits
-        # leaves the remaining rows constant, so they are dropped and r == num_bits exactly.
+        # Top up within the same num_bits bits, so the other rows stay constant and get dropped.
         candidate = 2
         while len(indices) < num_entries:
             indices.add(candidate)
@@ -1136,14 +1124,10 @@ class SumOfSlatersPrep(Operator2):
     @staticmethod
     def _required_register_sizes_abstract(num_entries: int, num_wires: int) -> dict:
         """Compute the largest required register sizes, if only the number of basis states,
-        but not the concrete states to be prepared, is known.
-
-        All register sizes are non-decreasing in the number of retained bits, so feeding the
-        largest attainable value produces the largest sizes. That value is
-        ``min(num_wires, num_entries - 1)``, and it is attained by
-        :func:`~.SumOfSlatersPrep.worst_case_indices`, which makes these sizes exact rather
-        than merely an upper bound.
+        but not the concrete states to be prepared, is known. Exact, not just an upper bound:
+        :func:`~.SumOfSlatersPrep.generate_indices` attains these sizes.
         """
+        # num_bits <= num_wires, and <= num_entries-1 as select_sos_rows drops redundant rows.
         return SumOfSlatersPrep._required_register_sizes_from_nums(
             num_entries, min(num_wires, num_entries - 1), num_wires
         )

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -986,7 +986,7 @@ class SumOfSlatersPrep(Operator2):
             of ``SumOfSlatersPrep``.
 
         This function supports an abstract input for ``indices``, in which case the largest
-        register sizes across all possible sets of basis states of the given length are
+        possible register sizes across all possible sets of basis states of the given length are
         returned:
 
         >>> indices = qp.typing.Int[45]
@@ -1027,7 +1027,7 @@ class SumOfSlatersPrep(Operator2):
 
         .. warning::
 
-            The returned indices are a resource-estimation stand-in. An operator built from them
+            The returned indices are a stand-in for resource estimation. An operator built from them
             is perfectly valid, but prepares *these* basis states, not any the caller has provided.
 
         Every register size is non-decreasing in :math:`r`, the number of bits retained by

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -929,27 +929,29 @@ class SumOfSlatersPrep(Operator2):
                 )
         if isinstance(indices, AbstractArray) or indices is None:
             indices = self.worst_case_indices(num_entries, n)
-        else:
-            v_bits = math.int_to_binary(np.array(indices), n).T  # Shape (n, num_entries)
 
-            if num_entries != 1:
-                _, data = _preprocess(v_bits, wires)
+        # ``indices`` is concrete from here on, whether it was given or synthesized, so the
+        # work-wire registers can be validated either way.
+        v_bits = math.int_to_binary(np.array(indices), n).T  # Shape (n, num_entries)
 
-                # pylint: disable-next=protected-access
-                sizes = self._required_register_sizes_from_nums(num_entries, data.r, n)
-                registers = {
-                    "enumeration_wires": enumeration_wires,
-                    "identification_wires": identification_wires,
-                    "qrom_work_wires": qrom_work_wires,
-                    "mcx_cache_wires": mcx_cache_wires,
-                }
-                for name, reg in registers.items():
-                    if len(reg) > 0 and len(reg) != (expected_size := sizes[name]):
-                        _name = name.replace("_", " ")
-                        raise ValueError(
-                            f"Number of {_name} {len(reg)} does not match the "
-                            f"required number of {_name} {expected_size}"
-                        )
+        if num_entries != 1:
+            _, data = _preprocess(v_bits, wires)
+
+            # pylint: disable-next=protected-access
+            sizes = self._required_register_sizes_from_nums(num_entries, data.r, n)
+            registers = {
+                "enumeration_wires": enumeration_wires,
+                "identification_wires": identification_wires,
+                "qrom_work_wires": qrom_work_wires,
+                "mcx_cache_wires": mcx_cache_wires,
+            }
+            for name, reg in registers.items():
+                if len(reg) > 0 and len(reg) != (expected_size := sizes[name]):
+                    _name = name.replace("_", " ")
+                    raise ValueError(
+                        f"Number of {_name} {len(reg)} does not match the "
+                        f"required number of {_name} {expected_size}"
+                    )
 
         super().__init__(
             coefficients,

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -659,6 +659,11 @@ class SumOfSlatersPrep(Operator2):
         coefficients (np.ndarray): Coefficients of the sparse state to prepare. The ordering should
             match that in ``indices``.
         wires (~.WiresLike): Wires on which to prepare the state.
+        indices (tuple[int] or AbstractArray or None): Indices of the sparse state to prepare.
+            The ordering should match that in ``coefficients``. May also be given as an abstract
+            type from :mod:`~.typing`, such as ``qp.typing.Int[len(coefficients)]``, or omitted
+            altogether; in both of those cases a worst-case set of indices of the appropriate
+            length is generated with :func:`~.SumOfSlatersPrep.worst_case_indices`.
         enumeration_wires (~.WiresLike): Work wires used for the enumeration register. For
             :math:`d` entries in the state, :math:`\lceil \log_2 (d)\rceil` qubits are required.
         identification_wires (~.WiresLike): Work wires used for the identification register.
@@ -670,11 +675,10 @@ class SumOfSlatersPrep(Operator2):
             the enumeration register with multicontrolled bit flips.
             The required number of qubits depends on the particular ``indices`` of the sparse state,
             but it is at most :math:`2d-2` for :math:`d` entries in the state.
-        indices (tuple[int]): Indices of the sparse state to prepare. The ordering should match
-            that in ``coefficients``.
 
     The sizes for the numerous optional work wire registers can be computed with
-    ``SumOfSlatersPrep.required_register_sizes(indices, wires)``.
+    ``SumOfSlatersPrep.required_register_sizes(indices, wires)``, which also accepts an abstract
+    ``indices`` input and then reports the sizes for the worst case.
 
     .. warning::
 
@@ -682,6 +686,15 @@ class SumOfSlatersPrep(Operator2):
         array, whereas the ``indices`` need to be hashable, and thus will be treated as static
         information. This is because ``indices`` significantly impacts the structure and size of
         the circuit that realizes the state preparation.
+
+    .. warning::
+
+        If ``indices`` is abstract or omitted, the generated indices are a resource-estimation
+        stand-in, chosen to maximize the register sizes and gate counts. The resulting operator
+        is perfectly valid and will decompose and execute, but it prepares *those* basis states,
+        not any that the caller has in mind. In particular the generated indices are **not**
+        ``(0, 1, ..., len(coefficients) - 1)``. Pass ``indices`` explicitly to prepare a
+        specific state.
 
     **Example**
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -930,11 +930,10 @@ class SumOfSlatersPrep(Operator2):
     ):
         n = 1 if isinstance(wires, int) else len(wires)
         num_entries = len(coefficients)
-        if not isinstance(indices, AbstractArray):
-            if len(indices) != num_entries:
-                raise ValueError(
-                    "The number of coefficients and the number of state indices must match."
-                )
+        if len(indices) != num_entries:
+            raise ValueError(
+                "The number of coefficients and the number of state indices must match."
+            )
         if isinstance(indices, AbstractArray):
             indices = self.generate_indices(num_entries, n)
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -958,7 +958,7 @@ class SumOfSlatersPrep(Operator2):
                     if len(reg) > 0 and len(reg) != (expected_size := sizes[name]):
                         _name = name.replace("_", " ")
                         raise ValueError(
-                            f"Number of {_name} {len(enumeration_wires)} does not match the "
+                            f"Number of {_name} {len(reg)} does not match the "
                             f"required number of {_name} {expected_size}"
                         )
 

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -912,7 +912,7 @@ class SumOfSlatersPrep(Operator2):
         self,
         coefficients: TensorLike,
         wires: WiresLike,
-        indices: tuple,
+        indices: tuple[int] | AbstractArray | None = None,
         enumeration_wires: WiresLike = (),
         identification_wires: WiresLike = (),
         qrom_work_wires: WiresLike = (),

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1061,7 +1061,9 @@ class SumOfSlatersPrep(Operator2):
             return (0,)
 
         indices = {0} | {1 << i for i in range(num_bits)}
-        # Top up within the same num_bits bits, so the other rows stay constant and get dropped.
+        # Pad with the smallest unused indices, which keeps every index inside the low
+        # num_bits bits. The remaining wires are then constant across all indices, so
+        # select_sos_rows discards them and exactly num_bits rows survive.
         candidate = 2
         while len(indices) < num_entries:
             indices.add(candidate)

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1038,8 +1038,8 @@ class SumOfSlatersPrep(Operator2):
 
         **Example**
 
-        >>> qp.SumOfSlatersPrep.generate_indices(5, 4)
-        (0, 1, 2, 4, 8)
+        >>> qp.SumOfSlatersPrep.generate_indices(7, 4)
+        (0, 1, 2, 3, 4, 5, 8)
 
         These indices require exactly the sizes reported for abstract ``indices`` of the same
         length:

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1028,7 +1028,7 @@ class SumOfSlatersPrep(Operator2):
         .. warning::
 
             The returned indices are a resource-estimation stand-in. An operator built from them
-            is perfectly valid, but prepares *these* basis states, not any the caller has in mind.
+            is perfectly valid, but prepares *these* basis states, not any the caller has provided.
 
         Every register size is non-decreasing in :math:`r`, the number of bits retained by
         :func:`~.select_sos_rows`, so one index set maximizes all of them at once. The largest

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -977,9 +977,10 @@ class SumOfSlatersPrep(Operator2):
             of length ``num_wires`` with the label ``"wires"``, matching the call signature
             of ``SumOfSlatersPrep``.
 
-        This function supports an abstract input for ``indices``, in which case an upper bound
-        for the register sizes, across all possible sets of basis states of the given length, is
-        returned:
+        This function supports an abstract input for ``indices``, in which case the largest
+        register sizes across all possible sets of basis states of the given length are
+        returned. These sizes are attained exactly, by
+        :func:`~.SumOfSlatersPrep.worst_case_indices` of the same length:
 
         >>> indices = qp.typing.Int[45]
         >>> qp.SumOfSlatersPrep.required_register_sizes(indices, 18)
@@ -1119,25 +1120,18 @@ class SumOfSlatersPrep(Operator2):
 
     @staticmethod
     def _required_register_sizes_abstract(num_entries: int, num_wires: int) -> dict:
-        """Compute the upper bound of the required register sizes, if only the number of
-        basis states, but not the concrete states to be prepared, is known."""
-        if num_entries == 1:
-            # Simple computational basis state preparation, does not require auxiliary qubits
-            return {
-                "wires": num_wires,
-                "enumeration_wires": 0,
-                "identification_wires": 0,
-                "qrom_work_wires": 0,
-                "mcx_cache_wires": 0,
-            }
-        d = math.ceil_log2(num_entries)
-        return {
-            "wires": num_wires,
-            "enumeration_wires": d,
-            "identification_wires": 2 * d - 1,
-            "qrom_work_wires": d - 1,
-            "mcx_cache_wires": 2 * d - 2,
-        }
+        """Compute the largest required register sizes, if only the number of basis states,
+        but not the concrete states to be prepared, is known.
+
+        All register sizes are non-decreasing in the number of retained bits, so feeding the
+        largest attainable value produces the largest sizes. That value is
+        ``min(num_wires, num_entries - 1)``, and it is attained by
+        :func:`~.SumOfSlatersPrep.worst_case_indices`, which makes these sizes exact rather
+        than merely an upper bound.
+        """
+        return SumOfSlatersPrep._required_register_sizes_from_nums(
+            num_entries, min(num_wires, num_entries - 1), num_wires
+        )
 
 
 # pylint: disable-next=unused-argument

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -661,8 +661,8 @@ class SumOfSlatersPrep(Operator2):
         wires (~.WiresLike): Wires on which to prepare the state.
         indices (tuple[int] or AbstractArray or None): Indices of the sparse state to prepare.
             The ordering should match that in ``coefficients``. May also be an abstract type
-            such as ``qp.typing.Int[len(coefficients)]``, or omitted; in both cases the indices
-            are generated with :func:`~.SumOfSlatersPrep.generate_indices`.
+            such as ``qp.typing.Int[len(coefficients)]``, in which case the indices are
+            generated with :func:`~.SumOfSlatersPrep.generate_indices`.
         enumeration_wires (~.WiresLike): Work wires used for the enumeration register. For
             :math:`d` entries in the state, :math:`\lceil \log_2 (d)\rceil` qubits are required.
         identification_wires (~.WiresLike): Work wires used for the identification register.
@@ -688,10 +688,10 @@ class SumOfSlatersPrep(Operator2):
 
     .. warning::
 
-        If ``indices`` is abstract or omitted, the generated indices are a resource-estimation
-        stand-in that maximizes the register sizes and gate counts. The operator is valid and
-        will execute, but prepares *those* basis states -- in particular **not**
-        ``(0, 1, ..., len(coefficients) - 1)``. Pass ``indices`` to prepare a specific state.
+        If ``indices`` is abstract, the generated indices are a resource-estimation stand-in
+        that maximizes the register sizes and gate counts. The operator is valid and will
+        execute, but prepares *those* basis states. Pass ``indices`` concretely to prepare a
+        specific state.
 
     **Example**
 
@@ -922,7 +922,7 @@ class SumOfSlatersPrep(Operator2):
         self,
         coefficients: TensorLike,
         wires: WiresLike,
-        indices: tuple[int] | AbstractArray | None = None,
+        indices: tuple[int] | AbstractArray,
         enumeration_wires: WiresLike = (),
         identification_wires: WiresLike = (),
         qrom_work_wires: WiresLike = (),
@@ -930,12 +930,12 @@ class SumOfSlatersPrep(Operator2):
     ):
         n = 1 if isinstance(wires, int) else len(wires)
         num_entries = len(coefficients)
-        if indices is not None and not isinstance(indices, AbstractArray):
+        if not isinstance(indices, AbstractArray):
             if len(indices) != num_entries:
                 raise ValueError(
                     "The number of coefficients and the number of state indices must match."
                 )
-        if isinstance(indices, AbstractArray) or indices is None:
+        if isinstance(indices, AbstractArray):
             indices = self.generate_indices(num_entries, n)
 
         # indices is concrete from here on, so the registers are validated either way.
@@ -1023,8 +1023,8 @@ class SumOfSlatersPrep(Operator2):
         Raises:
             ValueError: If ``num_entries`` exceeds ``2**num_wires``.
 
-        This is the index set that ``SumOfSlatersPrep`` synthesizes when ``indices`` is abstract
-        or omitted, and the one that realizes
+        This is the index set that ``SumOfSlatersPrep`` synthesizes when ``indices`` is
+        abstract, and the one that realizes
         :func:`~.SumOfSlatersPrep.required_register_sizes` for abstract ``indices``.
 
         .. warning::

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -399,18 +399,17 @@ class TestComputeSosEncoding:
         assert _columns_differ(b)
 
 
-class TestWorstCaseIndices:
-    """Tests for ``SumOfSlatersPrep.worst_case_indices``."""
+class TestGenerateIndices:
+    """Tests for ``SumOfSlatersPrep.generate_indices``."""
 
     @pytest.mark.parametrize("num_wires", [2, 3, 4, 5, 8])
     @pytest.mark.parametrize("num_entries", [1, 2, 4, 5, 16])
-    def test_worst_case_indices_is_a_valid_index_set(self, num_wires, num_entries):
-        """Test that the generated indices are usable: the right number of distinct values,
-        all addressable by ``num_wires`` wires."""
+    def test_generate_indices_is_a_valid_index_set(self, num_wires, num_entries):
+        """Test that the generated indices are distinct and addressable."""
         if num_entries > 2**num_wires:
             pytest.skip("not representable on this many wires")
 
-        indices = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+        indices = SumOfSlatersPrep.generate_indices(num_entries, num_wires)
 
         assert len(indices) == num_entries
         assert len(set(indices)) == num_entries
@@ -418,16 +417,16 @@ class TestWorstCaseIndices:
         assert max(indices) < 2**num_wires
 
     @pytest.mark.parametrize("num_wires", [1, 3, 5])
-    def test_worst_case_indices_saturated(self, num_wires):
+    def test_generate_indices_saturated(self, num_wires):
         """Test the generator where it has no slack, i.e. every index is used."""
-        indices = SumOfSlatersPrep.worst_case_indices(2**num_wires, num_wires)
+        indices = SumOfSlatersPrep.generate_indices(2**num_wires, num_wires)
         assert set(indices) == set(range(2**num_wires))
 
-    def test_worst_case_indices_too_many_entries(self):
+    def test_generate_indices_too_many_entries(self):
         """Test that more entries than the wires can address is rejected."""
         match = "Number of coefficients 9 cannot be greater than 2\\^num_wires, 8."
         with pytest.raises(ValueError, match=match):
-            SumOfSlatersPrep.worst_case_indices(9, 3)
+            SumOfSlatersPrep.generate_indices(9, 3)
         with pytest.raises(ValueError, match=match):
             SumOfSlatersPrep(Complex[9], Wire[3])
 
@@ -442,10 +441,9 @@ class TestSumOfSlatersPrep:
             ([7, 8, 9], [10, 11, 12, 13, 14], [15, 16], [17, 18, 19, 20], None),
             # Valid: the optional work registers may be left empty (the default).
             ((), (), (), (), None),
-            # Each of the following provides a single work register with the wrong
-            # (non-zero) size, triggering one of the register-size validations. The match
-            # includes the supplied count, so that the message must report the offending
-            # register's length and not some other register's.
+            # One work register at the wrong (non-zero) size, triggering its validation.
+            # The match includes the supplied count, so the message must report the
+            # offending register's length rather than some other register's.
             (
                 [7, 8],
                 (),
@@ -556,8 +554,7 @@ class TestSumOfSlatersPrep:
         assert len(op.indices) == num_entries
 
     def test_broadcast_coefficients(self):
-        """Test that the number of entries is read off the trailing axis, so that broadcast
-        coefficients are not mistaken for a shorter state."""
+        """Test that broadcast coefficients are not mistaken for a shorter state."""
         num_wires, num_entries, batch_size = 5, 8, 3
         indices = tuple(range(num_entries))
         coefficients = np.ones((batch_size, num_entries), dtype=complex) / np.sqrt(num_entries)
@@ -569,8 +566,7 @@ class TestSumOfSlatersPrep:
     @pytest.mark.parametrize("num_wires", [4, 6, 8])
     @pytest.mark.parametrize("num_entries", [2, 5, 8, 16])
     def test_abstract_indices_accept_reported_registers(self, num_wires, num_entries):
-        """Test that the registers reported for abstract ``indices`` are exactly the ones the
-        synthesized indices need -- accepted at the reported size, rejected one wire off."""
+        """Test that the reported registers are exactly what the generated indices need."""
         if num_entries > 2**num_wires:
             pytest.skip("not representable on this many wires")
 
@@ -693,11 +689,9 @@ class TestSumOfSlatersPrep:
     @pytest.mark.parametrize(
         "num_wires, num_entries, expected",
         [
-            # Hand-checked anchors, so that the abstract computation and the concrete one
-            # cannot silently drift together.
+            # Hand-checked, so the two computations cannot drift together.
             (8, 16, {"enumeration": 4, "identification": 7, "qrom_work": 3, "mcx_cache": 6}),
-            # Narrow registers cap the number of retained bits, so the identification
-            # register is not needed at all.
+            # Few wires cap the retained bits, so no identification register is needed.
             (3, 16, {"enumeration": 4, "identification": 0, "qrom_work": 3, "mcx_cache": 2}),
             (4, 4, {"enumeration": 2, "identification": 0, "qrom_work": 1, "mcx_cache": 2}),
             (4, 1, {"enumeration": 0, "identification": 0, "qrom_work": 0, "mcx_cache": 0}),
@@ -719,15 +713,14 @@ class TestSumOfSlatersPrep:
     @pytest.mark.parametrize("num_wires", [3, 4, 5, 6, 8])
     @pytest.mark.parametrize("num_entries", [1, 2, 4, 5, 8, 16])
     def test_register_sizes_abstract(self, num_wires, num_entries):
-        """Test that the sizes reported for abstract ``indices`` are exactly those required by
-        ``worst_case_indices`` of the same length -- i.e. that they are attainable, not merely
-        an upper bound."""
+        """Test that the sizes reported for abstract ``indices`` are attainable, i.e. exactly
+        those required by ``generate_indices`` of the same length."""
 
         if num_entries > 2**num_wires:
             pytest.skip("not representable on this many wires")
 
         abstract = SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
-        indices = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+        indices = SumOfSlatersPrep.generate_indices(num_entries, num_wires)
         attained = SumOfSlatersPrep.required_register_sizes(indices, num_wires)
 
         assert abstract == attained
@@ -737,7 +730,7 @@ class TestSumOfSlatersPrep:
     @pytest.mark.parametrize("num_entries", [2, 4, 5, 6])
     def test_register_sizes_abstract_is_upper_bound(self, num_wires, num_entries, seed):
         """Test that the abstract register sizes bound the concrete ones for indices of the
-        same length, and that the bound is attained by ``worst_case_indices``."""
+        same length, and that the bound is attained by ``generate_indices``."""
 
         _, indices = self.make_random_data(num_wires, num_entries, seed)
 
@@ -747,7 +740,7 @@ class TestSumOfSlatersPrep:
         assert concrete.keys() == abstract.keys()
         assert all(size <= abstract[key] for key, size in concrete.items())
 
-        worst_case = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+        worst_case = SumOfSlatersPrep.generate_indices(num_entries, num_wires)
         assert SumOfSlatersPrep.required_register_sizes(worst_case, num_wires) == abstract
 
     def test_resource_counts_are_python_integers(self):

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -428,7 +428,7 @@ class TestGenerateIndices:
         with pytest.raises(ValueError, match=match):
             SumOfSlatersPrep.generate_indices(9, 3)
         with pytest.raises(ValueError, match=match):
-            SumOfSlatersPrep(Complex[9], Wire[3])
+            SumOfSlatersPrep(Complex[9], Wire[3], Int[9])
 
 
 class TestSumOfSlatersPrep:
@@ -532,7 +532,7 @@ class TestSumOfSlatersPrep:
         )
 
     def test_abstract_init(self):
-        """Test that abstract values (or None, for indices) can be passed to the constructor."""
+        """Test that abstract values can be passed to the constructor."""
         num_wires = 14
         num_entries = 15
         sizes = qp.SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
@@ -543,15 +543,6 @@ class TestSumOfSlatersPrep:
         }
         op = qp.SumOfSlatersPrep(**kwargs)
         assert len(op.coefficients) == len(op.indices) == num_entries
-        kwargs["indices"] = None
-        op = qp.SumOfSlatersPrep(**kwargs)
-        assert len(op.coefficients) == len(op.indices) == num_entries
-
-    @pytest.mark.parametrize("num_wires, num_entries", [(5, 8), (14, 15)])
-    def test_indices_omitted(self, num_wires, num_entries):
-        """Test that ``indices`` can be left out entirely, not just passed as ``None``."""
-        op = qp.SumOfSlatersPrep(Complex[num_entries], Wire[num_wires])
-        assert len(op.indices) == num_entries
 
     @pytest.mark.parametrize("num_wires", [4, 6, 8])
     @pytest.mark.parametrize("num_entries", [2, 5, 8, 16])
@@ -563,7 +554,7 @@ class TestSumOfSlatersPrep:
         sizes = qp.SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
         registers = qp.registers(sizes)
 
-        qp.SumOfSlatersPrep(Complex[num_entries], **registers)
+        qp.SumOfSlatersPrep(Complex[num_entries], indices=Int[num_entries], **registers)
 
         for name in (
             "enumeration_wires",
@@ -574,7 +565,7 @@ class TestSumOfSlatersPrep:
             oversized = dict(registers)
             oversized[name] = list(oversized[name]) + [f"extra_{name}"]
             with pytest.raises(ValueError, match="does not match the required number"):
-                qp.SumOfSlatersPrep(Complex[num_entries], **oversized)
+                qp.SumOfSlatersPrep(Complex[num_entries], indices=Int[num_entries], **oversized)
 
     def test_coefficients_indices_length_mismatch(self):
         """Test that mismatched ``coefficients`` and ``indices`` lengths are rejected."""

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -568,10 +568,13 @@ class TestSumOfSlatersPrep:
                 qp.SumOfSlatersPrep(Complex[num_entries], indices=Int[num_entries], **oversized)
 
     def test_coefficients_indices_length_mismatch(self):
-        """Test that mismatched ``coefficients`` and ``indices`` lengths are rejected."""
+        """Test that mismatched ``coefficients`` and ``indices`` lengths are rejected, both
+        concretely and at the abstract level."""
         match = "The number of coefficients and the number of state indices must match."
         with pytest.raises(ValueError, match=match):
             qp.SumOfSlatersPrep(np.ones(3) / np.sqrt(3), wires=range(5), indices=(0, 3, 4, 17))
+        with pytest.raises(ValueError, match=match):
+            qp.SumOfSlatersPrep(Complex[8], wires=Wire[5], indices=Int[5])
 
     def make_random_data(self, num_wires, num_entries, seed):
         """Produce some random input data for ``SumOfSlatersPrep`` with given specs."""

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -37,7 +37,7 @@ from pennylane.templates.state_preparations.sum_of_slaters import (
     compute_sos_encoding,
     select_sos_rows,
 )
-from pennylane.typing import Float, Int, Wire
+from pennylane.typing import Complex, Float, Int, Wire
 from pennylane.wires import Wires
 
 
@@ -485,6 +485,12 @@ class TestSumOfSlatersPrep:
         kwargs["indices"] = None
         op = qp.SumOfSlatersPrep(**kwargs)
         assert len(op.coefficients) == len(op.indices) == num_entries
+
+    @pytest.mark.parametrize("num_wires, num_entries", [(5, 8), (14, 15)])
+    def test_indices_omitted(self, num_wires, num_entries):
+        """Test that ``indices`` can be left out entirely, not just passed as ``None``."""
+        op = qp.SumOfSlatersPrep(Complex[num_entries], Wire[num_wires])
+        assert len(op.indices) == num_entries
 
     def make_random_data(self, num_wires, num_entries, seed):
         """Produce some random input data for ``SumOfSlatersPrep`` with given specs."""

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -566,6 +566,30 @@ class TestSumOfSlatersPrep:
         op = qp.SumOfSlatersPrep(coefficients, indices=indices, **qp.registers(sizes))
         assert len(op.indices) == num_entries
 
+    @pytest.mark.parametrize("num_wires", [4, 6, 8])
+    @pytest.mark.parametrize("num_entries", [2, 5, 8, 16])
+    def test_abstract_indices_accept_reported_registers(self, num_wires, num_entries):
+        """Test that the registers reported for abstract ``indices`` are exactly the ones the
+        synthesized indices need -- accepted at the reported size, rejected one wire off."""
+        if num_entries > 2**num_wires:
+            pytest.skip("not representable on this many wires")
+
+        sizes = qp.SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
+        registers = qp.registers(sizes)
+
+        qp.SumOfSlatersPrep(Complex[num_entries], **registers)
+
+        for name in (
+            "enumeration_wires",
+            "identification_wires",
+            "qrom_work_wires",
+            "mcx_cache_wires",
+        ):
+            oversized = dict(registers)
+            oversized[name] = list(oversized[name]) + [f"extra_{name}"]
+            with pytest.raises(ValueError, match="does not match the required number"):
+                qp.SumOfSlatersPrep(Complex[num_entries], **oversized)
+
     def test_coefficients_indices_length_mismatch(self):
         """Test that mismatched ``coefficients`` and ``indices`` lengths are rejected."""
         match = "The number of coefficients and the number of state indices must match."

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -666,29 +666,54 @@ class TestSumOfSlatersPrep:
         registered_work_wires = _sos_state_prep.get_work_wire_spec(coefficients, range(n), indices)
         assert sum(sizes.values()) - n == registered_work_wires.total
 
-    @pytest.mark.parametrize("num_wires", [3, 5, 8])
-    @pytest.mark.parametrize("num_entries", [1, 2, 4, 5, 16])
-    def test_register_sizes_abstract(self, num_wires, num_entries):
-        """Test that ``required_register_sizes`` dispatches to the abstract computation when
-        given an abstract ``indices`` input, returning the expected upper-bound sizes."""
+    @pytest.mark.parametrize(
+        "num_wires, num_entries, expected",
+        [
+            # Hand-checked anchors, so that the abstract computation and the concrete one
+            # cannot silently drift together.
+            (8, 16, {"enumeration": 4, "identification": 7, "qrom_work": 3, "mcx_cache": 6}),
+            # Narrow registers cap the number of retained bits, so the identification
+            # register is not needed at all.
+            (3, 16, {"enumeration": 4, "identification": 0, "qrom_work": 3, "mcx_cache": 2}),
+            (4, 4, {"enumeration": 2, "identification": 0, "qrom_work": 1, "mcx_cache": 2}),
+            (4, 1, {"enumeration": 0, "identification": 0, "qrom_work": 0, "mcx_cache": 0}),
+        ],
+    )
+    def test_register_sizes_abstract_values(self, num_wires, num_entries, expected):
+        """Test the sizes reported for abstract ``indices`` against hand-checked values."""
 
-        indices = Int[num_entries]
-        sizes = SumOfSlatersPrep.required_register_sizes(indices, num_wires)
+        sizes = SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
 
-        d = ceil_log2(num_entries)
         assert sizes == {
             "wires": num_wires,
-            "enumeration_wires": d,
-            "identification_wires": max(2 * d - 1, 0),
-            "qrom_work_wires": max(d - 1, 0),
-            "mcx_cache_wires": max(2 * d - 2, 0),
+            "enumeration_wires": expected["enumeration"],
+            "identification_wires": expected["identification"],
+            "qrom_work_wires": expected["qrom_work"],
+            "mcx_cache_wires": expected["mcx_cache"],
         }
+
+    @pytest.mark.parametrize("num_wires", [3, 4, 5, 6, 8])
+    @pytest.mark.parametrize("num_entries", [1, 2, 4, 5, 8, 16])
+    def test_register_sizes_abstract(self, num_wires, num_entries):
+        """Test that the sizes reported for abstract ``indices`` are exactly those required by
+        ``worst_case_indices`` of the same length -- i.e. that they are attainable, not merely
+        an upper bound."""
+
+        if num_entries > 2**num_wires:
+            pytest.skip("not representable on this many wires")
+
+        abstract = SumOfSlatersPrep.required_register_sizes(Int[num_entries], num_wires)
+        indices = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+        attained = SumOfSlatersPrep.required_register_sizes(indices, num_wires)
+
+        assert abstract == attained
+        assert all(size >= 0 for size in abstract.values())
 
     @pytest.mark.parametrize("num_wires", [3, 4, 5])
     @pytest.mark.parametrize("num_entries", [2, 4, 5, 6])
     def test_register_sizes_abstract_is_upper_bound(self, num_wires, num_entries, seed):
-        """Test that the abstract register sizes upper-bound the concrete ones for indices
-        of the same length."""
+        """Test that the abstract register sizes bound the concrete ones for indices of the
+        same length, and that the bound is attained by ``worst_case_indices``."""
 
         _, indices = self.make_random_data(num_wires, num_entries, seed)
 
@@ -697,6 +722,9 @@ class TestSumOfSlatersPrep:
 
         assert concrete.keys() == abstract.keys()
         assert all(size <= abstract[key] for key, size in concrete.items())
+
+        worst_case = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+        assert SumOfSlatersPrep.required_register_sizes(worst_case, num_wires) == abstract
 
     def test_resource_counts_are_python_integers(self):
         """Test that decomposition resource counts are Python integers."""

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -450,7 +450,7 @@ class TestSumOfSlatersPrep:
                 (),
                 (),
                 "Number of enumeration wires 2 does not match the required number of "
-                "enumeration wires 3",
+                r"enumeration wires \(3\)",
             ),
             (
                 (),
@@ -458,7 +458,7 @@ class TestSumOfSlatersPrep:
                 (),
                 (),
                 "Number of identification wires 2 does not match the required number of "
-                "identification wires 5",
+                r"identification wires \(5\)",
             ),
             (
                 (),
@@ -466,7 +466,7 @@ class TestSumOfSlatersPrep:
                 [15],
                 (),
                 "Number of qrom work wires 1 does not match the required number of "
-                "qrom work wires 2",
+                r"qrom work wires \(2\)",
             ),
             (
                 (),
@@ -474,7 +474,7 @@ class TestSumOfSlatersPrep:
                 (),
                 [17, 18],
                 "Number of mcx cache wires 2 does not match the required number of "
-                "mcx cache wires 4",
+                r"mcx cache wires \(4\)",
             ),
         ],
     )

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -399,6 +399,39 @@ class TestComputeSosEncoding:
         assert _columns_differ(b)
 
 
+class TestWorstCaseIndices:
+    """Tests for ``SumOfSlatersPrep.worst_case_indices``."""
+
+    @pytest.mark.parametrize("num_wires", [2, 3, 4, 5, 8])
+    @pytest.mark.parametrize("num_entries", [1, 2, 4, 5, 16])
+    def test_worst_case_indices_is_a_valid_index_set(self, num_wires, num_entries):
+        """Test that the generated indices are usable: the right number of distinct values,
+        all addressable by ``num_wires`` wires."""
+        if num_entries > 2**num_wires:
+            pytest.skip("not representable on this many wires")
+
+        indices = SumOfSlatersPrep.worst_case_indices(num_entries, num_wires)
+
+        assert len(indices) == num_entries
+        assert len(set(indices)) == num_entries
+        assert min(indices) >= 0
+        assert max(indices) < 2**num_wires
+
+    @pytest.mark.parametrize("num_wires", [1, 3, 5])
+    def test_worst_case_indices_saturated(self, num_wires):
+        """Test the generator where it has no slack, i.e. every index is used."""
+        indices = SumOfSlatersPrep.worst_case_indices(2**num_wires, num_wires)
+        assert set(indices) == set(range(2**num_wires))
+
+    def test_worst_case_indices_too_many_entries(self):
+        """Test that more entries than the wires can address is rejected."""
+        match = "Number of coefficients 9 cannot be greater than 2\\^num_wires, 8."
+        with pytest.raises(ValueError, match=match):
+            SumOfSlatersPrep.worst_case_indices(9, 3)
+        with pytest.raises(ValueError, match=match):
+            SumOfSlatersPrep(Complex[9], Wire[3])
+
+
 class TestSumOfSlatersPrep:
     """Test the quantum template ``SumOfSlatersPrep``."""
 

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -553,16 +553,6 @@ class TestSumOfSlatersPrep:
         op = qp.SumOfSlatersPrep(Complex[num_entries], Wire[num_wires])
         assert len(op.indices) == num_entries
 
-    def test_broadcast_coefficients(self):
-        """Test that broadcast coefficients are not mistaken for a shorter state."""
-        num_wires, num_entries, batch_size = 5, 8, 3
-        indices = tuple(range(num_entries))
-        coefficients = np.ones((batch_size, num_entries), dtype=complex) / np.sqrt(num_entries)
-        sizes = qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires)
-
-        op = qp.SumOfSlatersPrep(coefficients, indices=indices, **qp.registers(sizes))
-        assert len(op.indices) == num_entries
-
     @pytest.mark.parametrize("num_wires", [4, 6, 8])
     @pytest.mark.parametrize("num_entries", [2, 5, 8, 16])
     def test_abstract_indices_accept_reported_registers(self, num_wires, num_entries):

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -410,11 +410,41 @@ class TestSumOfSlatersPrep:
             # Valid: the optional work registers may be left empty (the default).
             ((), (), (), (), None),
             # Each of the following provides a single work register with the wrong
-            # (non-zero) size, triggering one of the register-size validations.
-            ([7, 8], (), (), (), "does not match the required number of enumeration wires"),
-            ((), [10, 11], (), (), "does not match the required number of identification wires"),
-            ((), (), [15], (), "does not match the required number of qrom work wires"),
-            ((), (), (), [17, 18], "does not match the required number of mcx cache wires"),
+            # (non-zero) size, triggering one of the register-size validations. The match
+            # includes the supplied count, so that the message must report the offending
+            # register's length and not some other register's.
+            (
+                [7, 8],
+                (),
+                (),
+                (),
+                "Number of enumeration wires 2 does not match the required number of "
+                "enumeration wires 3",
+            ),
+            (
+                (),
+                [10, 11],
+                (),
+                (),
+                "Number of identification wires 2 does not match the required number of "
+                "identification wires 5",
+            ),
+            (
+                (),
+                (),
+                [15],
+                (),
+                "Number of qrom work wires 1 does not match the required number of "
+                "qrom work wires 2",
+            ),
+            (
+                (),
+                (),
+                (),
+                [17, 18],
+                "Number of mcx cache wires 2 does not match the required number of "
+                "mcx cache wires 4",
+            ),
         ],
     )
     def test_init(

--- a/tests/templates/state_preparations/test_sum_of_slaters.py
+++ b/tests/templates/state_preparations/test_sum_of_slaters.py
@@ -492,6 +492,23 @@ class TestSumOfSlatersPrep:
         op = qp.SumOfSlatersPrep(Complex[num_entries], Wire[num_wires])
         assert len(op.indices) == num_entries
 
+    def test_broadcast_coefficients(self):
+        """Test that the number of entries is read off the trailing axis, so that broadcast
+        coefficients are not mistaken for a shorter state."""
+        num_wires, num_entries, batch_size = 5, 8, 3
+        indices = tuple(range(num_entries))
+        coefficients = np.ones((batch_size, num_entries), dtype=complex) / np.sqrt(num_entries)
+        sizes = qp.SumOfSlatersPrep.required_register_sizes(indices, num_wires)
+
+        op = qp.SumOfSlatersPrep(coefficients, indices=indices, **qp.registers(sizes))
+        assert len(op.indices) == num_entries
+
+    def test_coefficients_indices_length_mismatch(self):
+        """Test that mismatched ``coefficients`` and ``indices`` lengths are rejected."""
+        match = "The number of coefficients and the number of state indices must match."
+        with pytest.raises(ValueError, match=match):
+            qp.SumOfSlatersPrep(np.ones(3) / np.sqrt(3), wires=range(5), indices=(0, 3, 4, 17))
+
     def make_random_data(self, num_wires, num_entries, seed):
         """Produce some random input data for ``SumOfSlatersPrep`` with given specs."""
         rng = np.random.default_rng(seed)


### PR DESCRIPTION
[sc-129640]

Stacked on #10102 (base branch `abstract-sos-init`) — merge after/with it.

**Context:**

#10102 lets `SumOfSlatersPrep.indices` be a concrete tuple, an abstract `qp.typing.Int[D]`, synthesizing an index set in the latter two cases.

**Description of the Change:**

`sum_of_slaters.py`

This PR improves the `indices` generator and corrects missing edge cases in `_required_register_sizes_abstract`.

**Benefits:**

Easier usage of `SumOfSlatersPrep` with abstract inputs, for resource estimation.

**Possible Drawbacks:**

Generated indices prepare a valid but arbitrary state. This is documented with a `.. warning::` on the class, and is why the default is *not* `(0, 1, ..., D-1)`.

**Related GitHub Issues:** #10102, #10084

---

Parts of this PR were written with AI assistance; see the `Assisted-by` trailers on the individual commits.
