### PR TITLE
[WIP] Wrapper decomposition rules that canonicalize the signature

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1289,6 +1289,7 @@
     [(#9866)](https://github.com/PennyLaneAI/pennylane/pull/9866)
     [(#9897)](https://github.com/PennyLaneAI/pennylane/pull/9897)
     [(#9973)](https://github.com/PennyLaneAI/pennylane/pull/9973)
+    [(#10110)](https://github.com/PennyLaneAI/pennylane/pull/10110)
   - The way that :class:`~.Wires` arguments in pytree leaves are read out of HDF5 was changed to be compatible with :class:`~.Operator2` in the data module.
     [(#10012)](https://github.com/PennyLaneAI/pennylane/pull/10012)
 

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -596,6 +596,44 @@ _fixed_decomps_private = {}
 _fixed_decomps_var = ContextVar("_fixed_decomps", default=_fixed_decomps_private)
 
 
+def _canonicalize_signature(op_type, rule):
+    """Wraps a decomposition rule in an interface that accepts positionally passed arguments."""
+
+    # pylint: disable=protected-access
+
+    if not (isinstance(op_type, type) and issubclass(op_type, Operator2)):
+        return rule
+
+    def _get_arguments(*args, **kwargs):
+        bound_args = op_type._sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        return bound_args.arguments
+
+    def _get_work_wire_spec():
+
+        if isinstance(rule._work_wire_spec, dict):
+            return rule._work_wire_spec
+
+        def _wrapper(*args, **kwargs):
+            return rule._work_wire_spec(**_get_arguments(*args, **kwargs))
+
+        return _wrapper
+
+    def _resource_fn(*args, **kwargs):
+        return rule._compute_resources(**_get_arguments(*args, **kwargs))
+
+    def _condition_fn(*args, **kwargs):
+        return rule.is_applicable(**_get_arguments(*args, **kwargs))
+
+    @register_condition(_condition_fn)
+    @register_resources(_resource_fn, work_wires=_get_work_wire_spec(), name=rule.name)
+    def _impl(*args, **kwargs):
+        rule._impl(**_get_arguments(*args, **kwargs))
+
+    _impl._source = rule._source
+    return _impl
+
+
 def add_decomps(op_type: type[Operator | Operator2] | str, *decomps: DecompositionRule) -> None:
     """Globally registers new decomposition rules with an operator class.
 
@@ -656,8 +694,8 @@ def add_decomps(op_type: type[Operator | Operator2] | str, *decomps: Decompositi
     .. code-block:: python
 
         @register_resources({qp.RY: 1})
-        def adjoint_ry(phi, wires, **_):
-            qp.RY(-phi, wires=wires)
+        def adjoint_ry(base):
+            qp.RY(-base.phi, wires=wires)
 
         qp.add_decomps("Adjoint(RY)", adjoint_ry)
 
@@ -669,6 +707,7 @@ def add_decomps(op_type: type[Operator | Operator2] | str, *decomps: Decompositi
             "A decomposition rule must be a qfunc with a resource estimate "
             "registered using qp.register_resources"
         )
+    decomps = tuple(_canonicalize_signature(op_type, rule) for rule in decomps)
     _decompositions_var.get()[to_name(op_type)].extend(decomps)
 
 

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -783,7 +783,8 @@ def to_controlled_unitary(base, control_wires, control_values, work_wires, work_
 def flip_zero_control(inner_decomp: DecompositionRule, name: str = "") -> DecompositionRule:
     """Wraps a decomposition for a controlled operator with X gates to flip zero control wires."""
 
-    sig = inspect.signature(inner_decomp)
+    # pylint: disable=protected-access
+    sig = inspect.signature(inner_decomp._impl)
 
     def _get_arguments(*args, **kwargs):
         bound_args = sig.bind(*args, **kwargs)
@@ -802,7 +803,6 @@ def flip_zero_control(inner_decomp: DecompositionRule, name: str = "") -> Decomp
             gate_counts[qp.X] = gate_counts.get(qp.X, 0) + len(ctrl_values)
         return gate_counts
 
-    # pylint: disable=protected-access
     @register_condition(_condition_fn)
     @register_resources(
         _resource_fn,
@@ -829,7 +829,7 @@ def flip_zero_control(inner_decomp: DecompositionRule, name: str = "") -> Decomp
             qp.cond(qp.math.logical_not(_cvals[i]), qp.X)(_cwires[i])
 
         _x_flips()
-        inner_decomp(**(arguments | {"control_values": None}))
+        inner_decomp._impl(**(arguments | {"control_values": None}))
         _x_flips()
 
     base_source = inner_decomp._source

--- a/pennylane/ops/op_math/controlled2.py
+++ b/pennylane/ops/op_math/controlled2.py
@@ -14,6 +14,7 @@
 
 """Defines the base class for controlled operators."""
 
+import inspect
 from collections.abc import Sequence
 from functools import partial
 from inspect import signature
@@ -779,37 +780,42 @@ def to_controlled_unitary(base, control_wires, control_values, work_wires, work_
     )
 
 
-def flip_zero_control(rule: DecompositionRule, name: str = "") -> DecompositionRule:
+def flip_zero_control(inner_decomp: DecompositionRule, name: str = "") -> DecompositionRule:
     """Wraps a decomposition for a controlled operator with X gates to flip zero control wires."""
 
-    def _condition_fn(*args, **kwargs):
-        return rule.is_applicable(*args, **kwargs)
+    sig = inspect.signature(inner_decomp)
 
-    def _resource_fn(base, control_wires, control_values, work_wires, work_wire_type):
-        base_resources = rule.compute_resources(
-            base,
-            control_wires,
-            control_values=None,
-            work_wires=work_wires,
-            work_wire_type=work_wire_type,
-        )
-        gate_counts = base_resources.gate_counts
-        base_x_count = gate_counts.get(qp.X, 0)
-        gate_counts[qp.X] = base_x_count + len(control_values)
+    def _get_arguments(*args, **kwargs):
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        return bound_args.arguments
+
+    def _condition_fn(*args, **kwargs):
+        arguments = _get_arguments(*args, **kwargs) | {"control_values": None}
+        return inner_decomp.is_applicable(**arguments)
+
+    def _resource_fn(*args, **kwargs):
+        arguments = _get_arguments(*args, **kwargs)
+        new_arguments = arguments | {"control_values": None}
+        gate_counts = inner_decomp.compute_resources(**new_arguments).gate_counts
+        if ctrl_values := arguments["control_values"]:
+            gate_counts[qp.X] = gate_counts.get(qp.X, 0) + len(ctrl_values)
         return gate_counts
 
     # pylint: disable=protected-access
     @register_condition(_condition_fn)
     @register_resources(
         _resource_fn,
-        work_wires=rule._work_wire_spec,
+        work_wires=inner_decomp._work_wire_spec,
         exact=False,
-        name=name or f"flip_zero_ctrl_values({rule.name})",
+        name=name or f"flip_zero_ctrl_values({inner_decomp.name})",
     )
-    def _impl(base, control_wires, control_values, work_wires, work_wire_type):
+    def _impl(*args, **kwargs):
 
-        _cwires = control_wires
-        _cvals = control_values
+        arguments = _get_arguments(*args, **kwargs)
+
+        _cwires = arguments["control_wires"]
+        _cvals = arguments["control_values"]
         if compiler.active() or capture.enabled():
             # We perform the cast on these temporary variables for the sole purpose
             # of indexing into them with tracers. the inner wrapper rule may still
@@ -823,16 +829,10 @@ def flip_zero_control(rule: DecompositionRule, name: str = "") -> DecompositionR
             qp.cond(qp.math.logical_not(_cvals[i]), qp.X)(_cwires[i])
 
         _x_flips()
-        rule(
-            base,
-            control_wires,
-            control_values=None,
-            work_wires=work_wires,
-            work_wire_type=work_wire_type,
-        )
+        inner_decomp(**(arguments | {"control_values": None}))
         _x_flips()
 
-    base_source = rule._source
+    base_source = inner_decomp._source
     _impl._source = (
         dedent(_impl._source).strip()
         + "\n\nwhere inner_decomp is defined as:\n\n"

--- a/pennylane/ops/op_math/controlled_ops.py
+++ b/pennylane/ops/op_math/controlled_ops.py
@@ -58,7 +58,7 @@ from .controlled import (
     custom_ctrl_dispatch,
 )
 from .decompositions.controlled_decompositions import (
-    _wrap_mcx_rule_w_alloc,
+    augment_with_alloc,
     controlled_two_qubit_unitary_rule,
     ctrl_decomp_bisect_rule,
     decompose_mcx_many_workers,
@@ -1429,14 +1429,14 @@ def _list_mcx_no_work_wire_decomps(op: MultiControlledX):
         return [mcx_to_cnot_or_toffoli]
 
     if len(op.wires) == 3:
-        elbow_rule = _wrap_mcx_rule_w_alloc(decompose_mcx_two_controls_elbows, 1, "zeroed")
+        elbow_rule = augment_with_alloc(decompose_mcx_two_controls_elbows, 1, "zeroed")
         return [mcx_to_cnot_or_toffoli, elbow_rule]
 
     capture_compatible_rules = [
-        _wrap_mcx_rule_w_alloc(decompose_mcx_two_workers, 2, "zeroed", "two_zeroed_workers"),
-        _wrap_mcx_rule_w_alloc(decompose_mcx_two_workers, 2, "borrowed", "two_borrowed_workers"),
-        _wrap_mcx_rule_w_alloc(decompose_mcx_one_worker, 1, "zeroed", "one_zeroed_worker"),
-        _wrap_mcx_rule_w_alloc(decompose_mcx_one_worker, 1, "borrowed", "one_borrowed_worker"),
+        augment_with_alloc(decompose_mcx_two_workers, 2, "zeroed", "two_zeroed_workers"),
+        augment_with_alloc(decompose_mcx_two_workers, 2, "borrowed", "two_borrowed_workers"),
+        augment_with_alloc(decompose_mcx_one_worker, 1, "zeroed", "one_zeroed_worker"),
+        augment_with_alloc(decompose_mcx_one_worker, 1, "borrowed", "one_borrowed_worker"),
         decompose_mcx_with_no_worker,
     ]
     if qp.capture.enabled():
@@ -1444,13 +1444,13 @@ def _list_mcx_no_work_wire_decomps(op: MultiControlledX):
 
     # TODO: the following decomposition rules are not capture compatible [sc-129521]
     return [
-        _wrap_mcx_rule_w_alloc(
+        augment_with_alloc(
             decompose_mcx_many_workers,
             len(op.control_wires) - 2,
             "zeroed",
             "many_zeroed_workers",
         ),
-        _wrap_mcx_rule_w_alloc(
+        augment_with_alloc(
             decompose_mcx_many_workers,
             len(op.control_wires) - 2,
             "borrowed",

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -14,7 +14,9 @@
 
 """This submodule defines functions to decompose controlled operations."""
 
+import inspect
 from functools import partial
+from textwrap import dedent
 from typing import Literal
 
 import numpy as np
@@ -417,26 +419,25 @@ def controlled_two_qubit_unitary_rule(U, wires, control_values, work_wires, work
 ########################################
 
 
-def _wrap_mcx_rule_w_alloc(base_rule, num_work_wires, work_wire_type, name=""):
-    """Given a MCX decomposition rule that takes explicit work wires, populate the same
+def augment_with_alloc(base_rule, num_work_wires, work_wire_type, name=""):
+    """Given a decomposition rule that takes explicit work wires, populate the same
     decomposition rule that uses dynamic work wire allocation instead."""
 
-    def _resource_fn(wires, control_values, *_, **__):
-        # pylint: disable-next=protected-access
-        return base_rule._compute_resources(
-            wires,
-            control_values,
-            Wire[num_work_wires],
-            work_wire_type=work_wire_type,
-        )
+    signature = inspect.signature(base_rule)
+    abstract_sub = {"work_wires": Wire[num_work_wires], "work_wire_type": work_wire_type}
 
-    def _condition_fn(wires, control_values, *_, **__):
-        return base_rule.is_applicable(
-            wires,
-            control_values,
-            Wire[num_work_wires],
-            work_wire_type=work_wire_type,
-        )
+    def _get_arguments(*args, **kwargs):
+        bound_args = signature.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        return bound_args.arguments
+
+    def _resource_fn(*args, **kwargs):
+        arguments = _get_arguments(*args, **kwargs) | abstract_sub
+        return base_rule._compute_resources(**arguments)  # pylint: disable=protected-access
+
+    def _condition_fn(*args, **kwargs):
+        arguments = _get_arguments(*args, **kwargs) | abstract_sub
+        return base_rule.is_applicable(**arguments)
 
     @register_condition(_condition_fn)
     @register_resources(
@@ -445,11 +446,19 @@ def _wrap_mcx_rule_w_alloc(base_rule, num_work_wires, work_wire_type, name=""):
         exact=base_rule.exact_resources,
         name=name or f"use_allocation({base_rule.name})",
     )
-    def _impl(wires, control_values, *_, **__):
+    def _impl(*args, **kwargs):
+        arguments = _get_arguments(*args, **kwargs)
         state = "zero" if work_wire_type == "zeroed" else "any"
         with qp.allocation.allocate(num_work_wires, state, restored=True) as work_wires:
-            # pylint: disable-next=protected-access
-            base_rule._impl(wires, control_values, work_wires, work_wire_type=work_wire_type)
+            arguments |= {"work_wires": work_wires, "work_wire_type": work_wire_type}
+            base_rule._impl(**arguments)  # pylint: disable=protected-access
+
+    base_source = base_rule._source
+    _impl._source = (
+        dedent(_impl._source).strip()
+        + "\n\nwhere base_rule is defined as:\n\n"
+        + dedent(base_source).strip()
+    )
 
     return _impl
 

--- a/pennylane/ops/op_math/decompositions/controlled_decompositions.py
+++ b/pennylane/ops/op_math/decompositions/controlled_decompositions.py
@@ -423,7 +423,8 @@ def augment_with_alloc(base_rule, num_work_wires, work_wire_type, name=""):
     """Given a decomposition rule that takes explicit work wires, populate the same
     decomposition rule that uses dynamic work wire allocation instead."""
 
-    signature = inspect.signature(base_rule)
+    # pylint: disable=protected-access
+    signature = inspect.signature(base_rule._impl)
     abstract_sub = {"work_wires": Wire[num_work_wires], "work_wire_type": work_wire_type}
 
     def _get_arguments(*args, **kwargs):
@@ -433,7 +434,7 @@ def augment_with_alloc(base_rule, num_work_wires, work_wire_type, name=""):
 
     def _resource_fn(*args, **kwargs):
         arguments = _get_arguments(*args, **kwargs) | abstract_sub
-        return base_rule._compute_resources(**arguments)  # pylint: disable=protected-access
+        return base_rule._compute_resources(**arguments)
 
     def _condition_fn(*args, **kwargs):
         arguments = _get_arguments(*args, **kwargs) | abstract_sub

--- a/tests/decomposition/test_decomposition_graph.py
+++ b/tests/decomposition/test_decomposition_graph.py
@@ -130,9 +130,8 @@ class TestDecompGraphConstruction:
         h_rep = abstractify(qp.H)
 
         graph = DecompositionGraph(operations=[qp.Hadamard(0)], gate_set={"RX", "RY", "RZ"})
-        assert (
-            graph._get_decompositions(h_rep)._decomps == decompositions.get()["Hadamard"]._decomps
-        )
+        expected = decompositions.get()["Hadamard"]._decomps
+        assert graph._get_decompositions(h_rep)._decomps == expected
 
         graph = DecompositionGraph(
             operations=[qp.Hadamard(0)],


### PR DESCRIPTION
**Context:**

As promised in the `Operator2` specifications, decomposition rules for an operator must be able to accept the same call signature as the operator itself. For convenience, many decomposition rules have associated resource and condition functions that take a simplified signature (e.g., `(**_)`, or `(control_wires, **_)`) that works when all arguments are passed as keyword arguments (easily achievable in Python but difficult to implement in Catalyst) but breaks when arguments are passed positionally.

**Description of the Change:**

- Update `flip_zero_control` and `augment_with_work_wires` to return wrapper rules with the generic `(*args, **kwargs)` signature, and use `inspect.signature` and `signature.bind` to pass everything to the inner wrapped rule as keyword arguments.
- Adds a `_canonicalize_signature` helper function that wraps a decomposition rule for an operator. The wrapper rule that is returned takes the generic `(*args, **kwargs)` signature, but uses `op_type._sig.bind` to pass everything to the inner wrapped rule as keyword arguments. This helper function is used to wrap every decomposition rule as they're provided to `qp.add_decomps`.

**Benefits:**

Decomposition rules does not need to be defined in a way that always accepts positionally passed arguments.

**Possible Drawbacks:**

Hopefully none.

**Related GitHub Issues:**

[sc-129641] [sc-129731]