### PR TITLE
Fix DoubleExcitation qubit indices typo in AllSinglesDoubles docstring

### DIFF
--- a/pennylane/templates/subroutines/qchem/all_singles_doubles.py
+++ b/pennylane/templates/subroutines/qchem/all_singles_doubles.py
@@ -67,7 +67,7 @@ class AllSinglesDoubles(Operation):
     projection of the Hartree-Fock state. The :class:`~.pennylane.SingleExcitation` gate
     :math:`G` act on the qubits ``[0, 2], [0, 4], [1, 3], [1, 5]`` as indicated by the
     squares, while the :class:`~.pennylane.DoubleExcitation` operation :math:`G^{(2)}` is
-    applied to the qubits ``[0, 1, 2, 3], [0, 1, 2, 5], [0, 1, 2, 4], [0, 1, 4, 5]``.
+    applied to the qubits ``[0, 1, 2, 3], [0, 1, 2, 5], [0, 1, 3, 4], [0, 1, 4, 5]``.
 
     The resulting unitary conserves the number of particles and prepares the
     :math:`n`-qubit system in a superposition of the initial Hartree-Fock state and


### PR DESCRIPTION
## Summary

While reviewing the `AllSinglesDoubles` template documentation, I noticed a typo in the example showing the `DoubleExcitation` qubit indices. The third entry was listed as `[0, 1, 2, 4]` but should be `[0, 1, 3, 4]` to match the actual output of `excitations()` for 2 electrons in 6 orbitals.

## Changes

- Fixed the typo in `pennylane/templates/subroutines/qchem/all_singles_doubles.py` line 65

## Verification

I verified the fix by checking against the `excitations()` function output:

```python
>>> from pennylane.qchem import excitations
>>> singles, doubles = excitations(2, 6)
>>> print(doubles)
[[0, 1, 2, 3], [0, 1, 2, 5], [0, 1, 3, 4], [0, 1, 4, 5]]
```

The documentation now correctly shows `[0, 1, 3, 4]` instead of `[0, 1, 2, 4]`.

## Related Issue

Fixes #10034