### PR TITLE
Merge adjacent H1 half-steps in TrotterCDF and TrotterCGF

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -151,6 +151,7 @@
   [(#10015)](https://github.com/PennyLaneAI/pennylane/pull/10015)
   [(#10074)](https://github.com/PennyLaneAI/pennylane/pull/10074)
   [(#10081)](https://github.com/PennyLaneAI/pennylane/pull/10081)
+  [(#10120)](https://github.com/PennyLaneAI/pennylane/pull/10120)
 
 * A new arithmetic template called :class:`~.SignedOutMultiplier` has been added that multiplies numbers encoded in the
   input registers using a two's complement.

--- a/pennylane/templates/subroutines/time_evolution/_trotter_utils.py
+++ b/pennylane/templates/subroutines/time_evolution/_trotter_utils.py
@@ -16,7 +16,7 @@
 
 from pennylane import capture, compiler, math
 from pennylane.control_flow import for_loop
-from pennylane.ops import RZ, IsingZZ, cond
+from pennylane.ops import RZ, IsingZZ
 from pennylane.ops.op_math import ctrl
 
 # pylint: disable=too-many-arguments
@@ -110,48 +110,65 @@ def _run_trotter_steps(
 
     num_two_body_fragments = hamiltonian.leaf_tensors.shape[0] - 1
 
-    def _trotter_step(step_idx, hamiltonian):
-        # ``hamiltonian`` is carried through the for-loop (rather than closed over)
-        # so the traced tensors remain valid loop-body inputs under jax capture.
+    def _initial_fragment(_, hamiltonian):
         U_tensor = hamiltonian.leaf_tensors
         Z_tensor = hamiltonian.core_tensors
+        apply_system_basis_rotation(U_tensor[1], wires)
+        apply_two_body_diagonal(
+            Z_tensor[1], wires, first_order_time_step, control_wires, double_phase
+        )
+        return hamiltonian
 
-        def two_body_fragments(fragment_idx, prev_fragment_idx):
-            # The first fragment of the circuit (prev_fragment_idx < 0) uses its own leaf; later
-            # fragments merge with the previous fragment's leaf so consecutive basis rotations
-            # telescope into a single one. This is classical array selection (no quantum ops in
-            # either branch), branching on the loop-carried ``prev_fragment_idx``.
-            U = cond(
-                prev_fragment_idx < 0,
-                lambda: U_tensor[fragment_idx],
-                lambda: merge_leaves(U_tensor[prev_fragment_idx], U_tensor[fragment_idx]),
-            )()
-            Z = Z_tensor[fragment_idx]
-            apply_system_basis_rotation(U, wires)
-            apply_two_body_diagonal(Z, wires, first_order_time_step, control_wires, double_phase)
-            return fragment_idx
+    hamiltonian = for_loop(1)(_initial_fragment)(hamiltonian)
 
-        def one_body_fragment():
-            U_one = U_tensor[0]
-            U = merge_leaves(U_tensor[num_two_body_fragments], U_one)
+    def _remainder_of_step(endpoint_time_step):
+        """Create a loop body ending in fragment 1 at the supplied duration."""
+
+        def remainder_of_step(_, hamiltonian):
+            # ``hamiltonian`` is carried through the for-loop (rather than closed over)
+            # so the traced tensors remain valid loop-body inputs under jax capture.
+            U_tensor = hamiltonian.leaf_tensors
+            Z_tensor = hamiltonian.core_tensors
+
+            def two_body_fragment(fragment_idx, prev_fragment_idx):
+                U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[fragment_idx])
+                apply_system_basis_rotation(U, wires)
+                apply_two_body_diagonal(
+                    Z_tensor[fragment_idx],
+                    wires,
+                    first_order_time_step,
+                    control_wires,
+                    double_phase,
+                )
+                return fragment_idx
+
+            for_loop(2, num_two_body_fragments + 1)(two_body_fragment)(1)
+
+            U = merge_leaves(U_tensor[num_two_body_fragments], U_tensor[0])
             apply_system_basis_rotation(U, wires)
             apply_one_body_diagonal(
                 Z_tensor[0], wires, first_order_time_step, control_wires, double_phase
             )
 
-        prev_fragment_idx_forward = math.sign(2 * step_idx - 1)
-        for_loop(1, num_two_body_fragments + 1)(two_body_fragments)(prev_fragment_idx_forward)
+            # For one two-body fragment this loop has no iterations and returns the
+            # initial frame index 0, matching the current one-body frame.
+            prev_fragment_idx = for_loop(num_two_body_fragments, 1, -1)(two_body_fragment)(0)
 
-        one_body_fragment()
+            U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[1])
+            apply_system_basis_rotation(U, wires)
+            apply_two_body_diagonal(
+                Z_tensor[1], wires, endpoint_time_step, control_wires, double_phase
+            )
+            return hamiltonian
 
-        # Second half of the symmetric second-order Suzuki step: revisits each
-        # two-body fragment in reverse order, still at forward time (first_order_time_step).
-        prev_fragment_idx_backward = 0
-        for_loop(num_two_body_fragments, 0, -1)(two_body_fragments)(prev_fragment_idx_backward)
+        return remainder_of_step
 
-        return hamiltonian
-
-    for_loop(num_trotter_steps)(_trotter_step)(hamiltonian)
+    # Merge the two fragment-1 half blocks at each internal Trotter boundary into one
+    # full block. Keeping this as a loop preserves constant-size captured control flow.
+    hamiltonian = for_loop(num_trotter_steps - 1)(_remainder_of_step(2 * first_order_time_step))(
+        hamiltonian
+    )
+    for_loop(1)(_remainder_of_step(first_order_time_step))(hamiltonian)
 
     very_last_U = transpose_leaf(hamiltonian.leaf_tensors[1])
     apply_system_basis_rotation(very_last_U, wires)

--- a/pennylane/templates/subroutines/time_evolution/_trotter_utils.py
+++ b/pennylane/templates/subroutines/time_evolution/_trotter_utils.py
@@ -100,75 +100,61 @@ def _run_trotter_steps(
         transpose_leaf (callable): ``(U) -> U``. Inverse of a leaf, for the trailing basis
             rotation that closes the final fragment.
     """
+    U_tensor = hamiltonian.leaf_tensors
+    Z_tensor = hamiltonian.core_tensors
     if compiler.active() or capture.enabled():
         wires = math.array(wires, like="jax")
         if len(control_wires) > 0:
             control_wires = math.array(control_wires, like="jax")
+        # The diagonal layers index these tensors with traced loop indices, which a numpy
+        # array cannot do.
+        U_tensor = math.array(U_tensor, like="jax")
+        Z_tensor = math.array(Z_tensor, like="jax")
 
     second_order_time_step = evolution_time / num_trotter_steps
     first_order_time_step = second_order_time_step / 2
 
-    num_two_body_fragments = hamiltonian.leaf_tensors.shape[0] - 1
+    num_two_body_fragments = U_tensor.shape[0] - 1
 
-    def _initial_fragment(_, hamiltonian):
-        U_tensor = hamiltonian.leaf_tensors
-        Z_tensor = hamiltonian.core_tensors
-        apply_system_basis_rotation(U_tensor[1], wires)
-        apply_two_body_diagonal(
-            Z_tensor[1], wires, first_order_time_step, control_wires, double_phase
-        )
-        return hamiltonian
+    apply_system_basis_rotation(U_tensor[1], wires)
+    apply_two_body_diagonal(Z_tensor[1], wires, first_order_time_step, control_wires, double_phase)
 
-    hamiltonian = for_loop(1)(_initial_fragment)(hamiltonian)
-
-    def _remainder_of_step(endpoint_time_step):
-        """Create a loop body ending in fragment 1 at the supplied duration."""
-
-        def remainder_of_step(_, hamiltonian):
-            # ``hamiltonian`` is carried through the for-loop (rather than closed over)
-            # so the traced tensors remain valid loop-body inputs under jax capture.
-            U_tensor = hamiltonian.leaf_tensors
-            Z_tensor = hamiltonian.core_tensors
-
-            def two_body_fragment(fragment_idx, prev_fragment_idx):
-                U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[fragment_idx])
-                apply_system_basis_rotation(U, wires)
-                apply_two_body_diagonal(
-                    Z_tensor[fragment_idx],
-                    wires,
-                    first_order_time_step,
-                    control_wires,
-                    double_phase,
-                )
-                return fragment_idx
-
-            for_loop(2, num_two_body_fragments + 1)(two_body_fragment)(1)
-
-            U = merge_leaves(U_tensor[num_two_body_fragments], U_tensor[0])
-            apply_system_basis_rotation(U, wires)
-            apply_one_body_diagonal(
-                Z_tensor[0], wires, first_order_time_step, control_wires, double_phase
-            )
-
-            # For one two-body fragment this loop has no iterations and returns the
-            # initial frame index 0, matching the current one-body frame.
-            prev_fragment_idx = for_loop(num_two_body_fragments, 1, -1)(two_body_fragment)(0)
-
-            U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[1])
+    def remainder_of_step(step_idx):
+        def two_body_fragment(fragment_idx, prev_fragment_idx):
+            U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[fragment_idx])
             apply_system_basis_rotation(U, wires)
             apply_two_body_diagonal(
-                Z_tensor[1], wires, endpoint_time_step, control_wires, double_phase
+                Z_tensor[fragment_idx],
+                wires,
+                first_order_time_step,
+                control_wires,
+                double_phase,
             )
-            return hamiltonian
+            return fragment_idx
 
-        return remainder_of_step
+        for_loop(2, num_two_body_fragments + 1)(two_body_fragment)(1)
 
-    # Merge the two fragment-1 half blocks at each internal Trotter boundary into one
-    # full block. Keeping this as a loop preserves constant-size captured control flow.
-    hamiltonian = for_loop(num_trotter_steps - 1)(_remainder_of_step(2 * first_order_time_step))(
-        hamiltonian
-    )
-    for_loop(1)(_remainder_of_step(first_order_time_step))(hamiltonian)
+        U = merge_leaves(U_tensor[num_two_body_fragments], U_tensor[0])
+        apply_system_basis_rotation(U, wires)
+        apply_one_body_diagonal(
+            Z_tensor[0], wires, first_order_time_step, control_wires, double_phase
+        )
 
-    very_last_U = transpose_leaf(hamiltonian.leaf_tensors[1])
+        # Carry the index of the fragment whose inverse was most recently applied.
+        # For L=1 there is no reverse two-body loop, so the preceding frame is H0.
+        prev_fragment_idx = for_loop(num_two_body_fragments, 1, -1)(two_body_fragment)(0)
+
+        U = merge_leaves(U_tensor[prev_fragment_idx], U_tensor[1])
+        apply_system_basis_rotation(U, wires)
+        endpoint_time_step = math.where(
+            step_idx < num_trotter_steps - 1,
+            second_order_time_step,
+            first_order_time_step,
+        )
+        apply_two_body_diagonal(Z_tensor[1], wires, endpoint_time_step, control_wires, double_phase)
+
+    # End internal steps with a full fragment-1 block and the final step with a half block.
+    for_loop(num_trotter_steps)(remainder_of_step)()
+
+    very_last_U = transpose_leaf(U_tensor[1])
     apply_system_basis_rotation(very_last_U, wires)

--- a/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
@@ -441,9 +441,7 @@ def _cdf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
 
     The exact gate count can be lower at runtime because fragments whose basis rotation
     happens to be the identity are skipped when the Hamiltonian data is concrete (not
-    traced); this estimate assumes no such fragment is skipped. ``num_sysrot_calls``
-    is ``2 L r + 2`` for the merged layout; the pre-merge ``r(2L+1)+1`` over-counted
-    the eager circuit by ``r-1`` identity ``U1† U1`` skips at internal step boundaries.
+    traced); this estimate assumes no such fragment is skipped.
     """
     if num_trotter_steps <= 0:
         return {}

--- a/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
@@ -441,7 +441,9 @@ def _cdf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
 
     The exact gate count can be lower at runtime because fragments whose basis rotation
     happens to be the identity are skipped when the Hamiltonian data is concrete (not
-    traced); this estimate assumes no such fragment is skipped.
+    traced); this estimate assumes no such fragment is skipped. ``num_sysrot_calls``
+    is ``2 L r + 2`` for the merged layout; the pre-merge ``r(2L+1)+1`` over-counted
+    the eager circuit by ``r-1`` identity ``U1† U1`` skips at internal step boundaries.
     """
     if num_trotter_steps <= 0:
         return {}

--- a/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cdf.py
@@ -110,7 +110,7 @@ class TrotterCDF(Operator2):
 
     >>> specs = qp.specs(trotter_circuit)()["resources"].quantum_operations
     >>> dict(sorted(specs.items()))
-    {'GlobalPhase': 1, 'IsingZZ': 120, 'RZ': 40, 'SingleExcitation': 62}
+    {'GlobalPhase': 1, 'IsingZZ': 66, 'RZ': 40, 'SingleExcitation': 44}
 
     The :class:`~.SingleExcitation` gates are due to :class:`~.BasisRotation` decomposing
     further on ``lightning.qubit``.
@@ -185,7 +185,8 @@ class TrotterCDF(Operator2):
         which visits each two-body fragment *twice* per step (at the half-step duration
         ``first_order_time_step`` :math:`= \Delta t/2`) and the central one-body fragment *once* (at the
         full :math:`\Delta t`). The next steps derive :math:`e^{-i H_l \tau}` for a single fragment and
-        duration :math:`\tau`.
+        duration :math:`\tau`. In the circuit, adjacent :math:`H_1` half evolutions at
+        internal step boundaries are merged into one full-duration evolution.
 
         **2. Evolving a fragment**
         The fragments are optimized and derived via :doc:`compressed double factorization <demo:demos/tutorial_how_to_build_compressed_double_factorized_hamiltonians>`.
@@ -450,8 +451,8 @@ def _cdf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
     num_cas = leaf_tensors.shape[-1]
 
     resources = defaultdict(int)
-    num_sysrot_calls = num_trotter_steps * (2 * num_two_body_fragments + 1) + 1
-    num_twobody_blocks = num_trotter_steps * 2 * num_two_body_fragments
+    num_sysrot_calls = 2 * num_two_body_fragments * num_trotter_steps + 2
+    num_twobody_blocks = (2 * num_two_body_fragments - 1) * num_trotter_steps + 1
     num_onebody_blocks = num_trotter_steps
     num_twobody_rotations = num_twobody_blocks * num_cas * (2 * num_cas - 1)
     num_onebody_rotations = num_onebody_blocks * 2 * num_cas

--- a/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
@@ -471,7 +471,9 @@ def _cgf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
 
     The exact gate count can be lower at runtime because fragments whose basis rotation
     happens to be the identity are skipped when the Hamiltonian data is concrete (not
-    traced); this estimate assumes no such fragment is skipped.
+    traced); this estimate assumes no such fragment is skipped. ``num_sysrot_calls``
+    is ``2 L r + 2`` for the merged layout; the pre-merge ``r(2L+1)+1`` over-counted
+    the eager circuit by ``r-1`` identity ``U1† U1`` skips at internal step boundaries.
     """
     if num_trotter_steps <= 0:
         return {}

--- a/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
@@ -129,7 +129,7 @@ class TrotterCGF(Operator2):
 
     >>> specs = qp.specs(trotter_circuit)()["resources"].quantum_operations
     >>> dict(sorted(specs.items()))
-    {'C(IsingZZ)': 180, 'CRZ': 60, 'Hadamard': 1, 'PhaseShift': 1, 'SingleExcitation': 186}
+    {'C(IsingZZ)': 99, 'CRZ': 60, 'Hadamard': 1, 'PhaseShift': 1, 'SingleExcitation': 132}
 
     The :class:`~.SingleExcitation` gates are due to :class:`~.BasisRotation` decomposing into
     :class:`~.PhaseShift` and :class:`~.SingleExcitation` on ``lightning.qubit``.
@@ -203,7 +203,8 @@ class TrotterCGF(Operator2):
         which visits each two-body fragment *twice* per step (at the half-step duration
         ``first_order_time_step`` :math:`= \Delta t/2`) and the central one-body fragment *once* (at the
         full :math:`\Delta t`). The next steps derive :math:`e^{-i H_\nu \tau}` for a single fragment and
-        duration :math:`\tau`.
+        duration :math:`\tau`. In the circuit, adjacent :math:`H_1` half evolutions at
+        internal step boundaries are merged into one full-duration evolution.
 
         **2. Evolving a fragment**
         The fragments are obtained via Christiansen greedy fragmentation (see `arXiv:2508.11865
@@ -481,8 +482,8 @@ def _cgf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
     n_states = leaf_tensors.shape[2]
 
     resources = defaultdict(int)
-    num_sysrot_calls = num_trotter_steps * (2 * num_two_body_fragments + 1) + 1
-    num_twobody_blocks = num_trotter_steps * 2 * num_two_body_fragments
+    num_sysrot_calls = 2 * num_two_body_fragments * num_trotter_steps + 2
+    num_twobody_blocks = (2 * num_two_body_fragments - 1) * num_trotter_steps + 1
     num_onebody_blocks = num_trotter_steps
     num_pairs = num_modes * (num_modes - 1) // 2
     num_twobody_rotations = num_twobody_blocks * num_pairs * n_states**2

--- a/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
+++ b/pennylane/templates/subroutines/time_evolution/trotter_cgf.py
@@ -471,9 +471,7 @@ def _cgf_resource_counts(num_trotter_steps, hamiltonian, has_control, double_pha
 
     The exact gate count can be lower at runtime because fragments whose basis rotation
     happens to be the identity are skipped when the Hamiltonian data is concrete (not
-    traced); this estimate assumes no such fragment is skipped. ``num_sysrot_calls``
-    is ``2 L r + 2`` for the merged layout; the pre-merge ``r(2L+1)+1`` over-counted
-    the eager circuit by ``r-1`` identity ``U1† U1`` skips at internal step boundaries.
+    traced); this estimate assumes no such fragment is skipped.
     """
     if num_trotter_steps <= 0:
         return {}

--- a/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
@@ -40,6 +40,8 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.time_evolution.trotter_cdf import (
     _apply_system_basis_rotation,
     _cdf_resource_counts,
+    _controlled_trotter_cdf_decomp,
+    _energy_shift,
     _merge_leaves,
     _trotter_cdf_decomposition,
 )
@@ -54,6 +56,7 @@ from tests.templates.subroutines.time_evolution.trotter_test_helpers import (  #
     CATALYST_GATE_SET_GENUINE,
     _single_z,
     assert_merged_trotter_matches,
+    assert_resource_counts_match,
     cdf_reference_hamiltonian,
     control_branches,
     hadamard_test,
@@ -85,10 +88,6 @@ def cdf_reference_hamiltonian_leaves(ham):
     this is only reproduced by ``matrix(TrotterCDF)`` in the many-step limit (second-order Trotter
     error ``~ 1 / steps^2``).
     """
-    from pennylane.templates.subroutines.time_evolution.trotter_cdf import (  # pylint: disable=import-outside-toplevel
-        _energy_shift,
-    )
-
     Z = np.asarray(ham.core_tensors, dtype=float)
     U = np.asarray(ham.leaf_tensors, dtype=float)
     num_cas = Z.shape[-1]
@@ -145,10 +144,6 @@ def cdf_second_order_trotter_matrix(ham, evolution_time, num_steps):
         *((fragment, dt / 2) for fragment in reversed(fragments[1:])),
     ]:
         step = expm(-1j * generator * duration) @ step
-
-    from pennylane.templates.subroutines.time_evolution.trotter_cdf import (  # pylint: disable=import-outside-toplevel
-        _energy_shift,
-    )
 
     return np.exp(-1j * _energy_shift(ham) * evolution_time) * np.linalg.matrix_power(
         step, num_steps
@@ -329,32 +324,36 @@ class TestResourceRule:
     @pytest.mark.parametrize(
         ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
     )
-    def test_merged_resource_counts(self, num_steps, num_fragments, has_control, double_phase):
-        """Test analytic resource counts after merging internal H1 half blocks."""
+    @pytest.mark.capture
+    def test_merged_resource_counts_match_traced_decomposition(
+        self, num_steps, num_fragments, has_control, double_phase
+    ):
+        """Resource counts match the traced decomposition after merging H1 half blocks."""
         num_orbitals = 2
         core = np.zeros((num_fragments + 1, num_orbitals, num_orbitals))
         leaf = np.stack([np.eye(num_orbitals)] * (num_fragments + 1))
         ham = CDFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
-
         resources = _cdf_resource_counts(num_steps, ham, has_control, double_phase)
-        blocks = (2 * num_fragments - 1) * num_steps + 1
-        basis_rotations = 2 * (2 * num_fragments * num_steps + 2)
-        two_body_rotations = blocks * num_orbitals * (2 * num_orbitals - 1)
-        one_body_rotations = num_steps * 2 * num_orbitals
-        cnot_count = blocks * 2 * (2 * num_orbitals - 1) if double_phase else 0
+        num_system_wires = 2 * num_orbitals
+        trace_wires = tuple(range(num_system_wires + int(has_control)))
 
-        basis_count = sum(
-            count for op, count in resources.items() if getattr(op, "name", None) == "BasisRotation"
-        )
-        assert basis_count == basis_rotations
-        assert sum(resources.values()) == (
-            basis_rotations + two_body_rotations + one_body_rotations + cnot_count + 1
-        )
-        if not has_control:
-            assert resources[qp.IsingZZ] == two_body_rotations
-        elif double_phase:
-            assert resources[qp.IsingZZ] == two_body_rotations + one_body_rotations
-            assert resources[qp.CNOT] == cnot_count
+        def circuit(t, *wires):
+            system_wires = list(wires[:num_system_wires])
+            if not has_control:
+                _trotter_cdf_decomposition(t, num_steps, ham, system_wires, False)
+                return
+            with qp.capture.pause():
+                base = qp.TrotterCDF(t, num_steps, ham, system_wires, double_phase=double_phase)
+            _controlled_trotter_cdf_decomp(
+                base, list(wires[num_system_wires:]), [1], [], "borrowed"
+            )
+
+        args = (jax.numpy.array(0.4), *trace_wires)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", CaptureWarning)
+            jaxpr = jax.make_jaxpr(circuit)(*args)
+        operations = qp.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, *args).operations
+        assert_resource_counts_match(resources, operations)
 
 
 class TestDecomposition:
@@ -432,20 +431,6 @@ class TestDecomposition:
             has_control,
             double_phase,
         )
-
-    @pytest.mark.capture
-    def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cdf_concrete):
-        """The captured loop structure does not grow with the number of Trotter steps."""
-        ham, num_orbitals = toy_hamiltonian_cdf_concrete
-        wires = list(range(2 * num_orbitals))
-
-        def captured_jaxpr(num_steps):
-            def circuit(t):
-                _trotter_cdf_decomposition(t, num_steps, ham, wires, False)
-
-            return jax.make_jaxpr(circuit)(jax.numpy.array(0.4)).jaxpr
-
-        assert len(captured_jaxpr(2).eqns) == len(captured_jaxpr(20).eqns)
 
     @pytest.mark.slow
     def test_base_matches_expm_nonidentity_leaves(self, seed):

--- a/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
@@ -53,6 +53,7 @@ from tests.templates.subroutines.time_evolution.trotter_test_helpers import (  #
     CATALYST_GATE_SET_DOUBLE_PHASE,
     CATALYST_GATE_SET_GENUINE,
     _single_z,
+    assert_merged_trotter_matches,
     cdf_reference_hamiltonian,
     control_branches,
     hadamard_test,
@@ -404,8 +405,14 @@ class TestDecomposition:
 
     @pytest.mark.parametrize("num_fragments", [1, 2])
     @pytest.mark.parametrize("num_steps", [1, 3])
-    def test_matches_independent_second_order_trotter_product(self, seed, num_fragments, num_steps):
-        """Test that merging boundary blocks preserves the full matrix, including global phase."""
+    @pytest.mark.parametrize(
+        ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
+    )
+    def test_matches_independent_second_order_trotter_product(
+        self, seed, num_fragments, num_steps, has_control, double_phase
+    ):
+        """Merging boundary blocks preserves the full matrix, including global phase,
+        for uncontrolled, genuine-controlled, and double-phase circuits."""
         rng = np.random.default_rng(seed)
         num_orbitals = 2
         core = rng.normal(size=(num_fragments + 1, num_orbitals, num_orbitals)) * 0.4
@@ -414,12 +421,17 @@ class TestDecomposition:
         ham = CDFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.37)
         wires = list(range(2 * num_orbitals))
         evolution_time = 0.7
-
-        actual = qp.matrix(
-            qp.TrotterCDF(evolution_time, num_steps, ham, wires=wires), wire_order=wires
-        )
         expected = cdf_second_order_trotter_matrix(ham, evolution_time, num_steps)
-        assert np.allclose(actual, expected, atol=1e-10)
+        assert_merged_trotter_matches(
+            qp.TrotterCDF,
+            ham,
+            wires,
+            evolution_time,
+            num_steps,
+            expected,
+            has_control,
+            double_phase,
+        )
 
     @pytest.mark.capture
     def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cdf_concrete):

--- a/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cdf.py
@@ -39,7 +39,9 @@ from pennylane.numeric_hamiltonians import CDFHamiltonian
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.time_evolution.trotter_cdf import (
     _apply_system_basis_rotation,
+    _cdf_resource_counts,
     _merge_leaves,
+    _trotter_cdf_decomposition,
 )
 from pennylane.typing import Float, Wire
 from pennylane.wires import Wires
@@ -109,6 +111,47 @@ def cdf_reference_hamiltonian_leaves(ham):
                 Dl += (Z[frag][i // 2, j // 2] / 4) * (z_ops[i] @ z_ops[j])
         H += Bl.conj().T @ Dl @ Bl
     return H
+
+
+def cdf_second_order_trotter_matrix(ham, evolution_time, num_steps):
+    """Build the unmerged second-order Trotter product from independently assembled fragments."""
+    Z = np.asarray(ham.core_tensors, dtype=float)
+    U = np.asarray(ham.leaf_tensors, dtype=float)
+    num_orbitals = Z.shape[-1]
+    n_wires = 2 * num_orbitals
+    dim = 2**n_wires
+    z_ops = [_single_z(w, n_wires) for w in range(n_wires)]
+
+    fragments = []
+    B0 = _basis_rotation_matrix(U[0], n_wires)
+    D0 = sum((-Z[0][wire // 2, wire // 2] / 2) * z_ops[wire] for wire in range(n_wires))
+    fragments.append(B0.conj().T @ D0 @ B0)
+
+    for frag in range(1, Z.shape[0]):
+        Bl = _basis_rotation_matrix(U[frag], n_wires)
+        Dl = sum(
+            (Z[frag][i // 2, j // 2] / 4) * (z_ops[i] @ z_ops[j])
+            for i in range(n_wires)
+            for j in range(i + 1, n_wires)
+        )
+        fragments.append(Bl.conj().T @ Dl @ Bl)
+
+    dt = evolution_time / num_steps
+    step = np.eye(dim, dtype=complex)
+    for generator, duration in [
+        *((fragment, dt / 2) for fragment in fragments[1:]),
+        (fragments[0], dt),
+        *((fragment, dt / 2) for fragment in reversed(fragments[1:])),
+    ]:
+        step = expm(-1j * generator * duration) @ step
+
+    from pennylane.templates.subroutines.time_evolution.trotter_cdf import (  # pylint: disable=import-outside-toplevel
+        _energy_shift,
+    )
+
+    return np.exp(-1j * _energy_shift(ham) * evolution_time) * np.linalg.matrix_power(
+        step, num_steps
+    )
 
 
 def toy_hamiltonian_cdf_generator(seed, abstract=False):
@@ -280,6 +323,38 @@ class TestResourceRule:
         op = qp.TrotterCDF(1.0, 0, ham, wires=wires)
         assert qp.ctrl(op, control=[99]).decomposition() == []
 
+    @pytest.mark.parametrize("num_steps", [1, 4])
+    @pytest.mark.parametrize("num_fragments", [1, 3])
+    @pytest.mark.parametrize(
+        ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
+    )
+    def test_merged_resource_counts(self, num_steps, num_fragments, has_control, double_phase):
+        """Test analytic resource counts after merging internal H1 half blocks."""
+        num_orbitals = 2
+        core = np.zeros((num_fragments + 1, num_orbitals, num_orbitals))
+        leaf = np.stack([np.eye(num_orbitals)] * (num_fragments + 1))
+        ham = CDFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
+
+        resources = _cdf_resource_counts(num_steps, ham, has_control, double_phase)
+        blocks = (2 * num_fragments - 1) * num_steps + 1
+        basis_rotations = 2 * (2 * num_fragments * num_steps + 2)
+        two_body_rotations = blocks * num_orbitals * (2 * num_orbitals - 1)
+        one_body_rotations = num_steps * 2 * num_orbitals
+        cnot_count = blocks * 2 * (2 * num_orbitals - 1) if double_phase else 0
+
+        basis_count = sum(
+            count for op, count in resources.items() if getattr(op, "name", None) == "BasisRotation"
+        )
+        assert basis_count == basis_rotations
+        assert sum(resources.values()) == (
+            basis_rotations + two_body_rotations + one_body_rotations + cnot_count + 1
+        )
+        if not has_control:
+            assert resources[qp.IsingZZ] == two_body_rotations
+        elif double_phase:
+            assert resources[qp.IsingZZ] == two_body_rotations + one_body_rotations
+            assert resources[qp.CNOT] == cnot_count
+
 
 class TestDecomposition:
     """Tests of the registered base decomposition rule."""
@@ -303,6 +378,62 @@ class TestDecomposition:
         u = qp.matrix(qp.TrotterCDF(t, steps, ham, wires=sys_wires), wire_order=sys_wires)
         expected = expm(-1j * cdf_reference_hamiltonian(ham) * t)
         assert np.allclose(u, expected, atol=1e-9)
+
+    @pytest.mark.parametrize("num_fragments", [1, 3])
+    def test_endpoint_block_angles_and_counts(self, num_fragments):
+        """Only the first and last H1 blocks are half duration; internal H1 blocks are full."""
+        num_orbitals, evolution_time, num_steps = 2, 1.2, 4
+        core = np.zeros((num_fragments + 1, num_orbitals, num_orbitals))
+        core[1] = 1.0
+        core[2:] = 13.0
+        leaf = np.stack([np.eye(num_orbitals)] * (num_fragments + 1))
+        ham = CDFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
+        wires = list(range(2 * num_orbitals))
+
+        tape = qp.tape.make_qscript(_trotter_cdf_decomposition)(
+            evolution_time, num_steps, ham, wires, False
+        )
+        angles = np.array([op.data[0] for op in tape.operations if isinstance(op, qp.IsingZZ)])
+        pairs_per_block = num_orbitals * (2 * num_orbitals - 1)
+        half_angle = evolution_time / (4 * num_steps)
+        full_angle = 2 * half_angle
+
+        assert np.count_nonzero(np.isclose(angles, half_angle)) == 2 * pairs_per_block
+        assert np.count_nonzero(np.isclose(angles, full_angle)) == (num_steps - 1) * pairs_per_block
+        assert len(angles) == ((2 * num_fragments - 1) * num_steps + 1) * pairs_per_block
+
+    @pytest.mark.parametrize("num_fragments", [1, 2])
+    @pytest.mark.parametrize("num_steps", [1, 3])
+    def test_matches_independent_second_order_trotter_product(self, seed, num_fragments, num_steps):
+        """Test that merging boundary blocks preserves the full matrix, including global phase."""
+        rng = np.random.default_rng(seed)
+        num_orbitals = 2
+        core = rng.normal(size=(num_fragments + 1, num_orbitals, num_orbitals)) * 0.4
+        core = 0.5 * (core + np.transpose(core, (0, 2, 1)))
+        leaf = np.stack([random_orthogonal(num_orbitals, rng) for _ in range(num_fragments + 1)])
+        ham = CDFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.37)
+        wires = list(range(2 * num_orbitals))
+        evolution_time = 0.7
+
+        actual = qp.matrix(
+            qp.TrotterCDF(evolution_time, num_steps, ham, wires=wires), wire_order=wires
+        )
+        expected = cdf_second_order_trotter_matrix(ham, evolution_time, num_steps)
+        assert np.allclose(actual, expected, atol=1e-10)
+
+    @pytest.mark.capture
+    def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cdf_concrete):
+        """The captured loop structure does not grow with the number of Trotter steps."""
+        ham, num_orbitals = toy_hamiltonian_cdf_concrete
+        wires = list(range(2 * num_orbitals))
+
+        def captured_jaxpr(num_steps):
+            def circuit(t):
+                _trotter_cdf_decomposition(t, num_steps, ham, wires, False)
+
+            return jax.make_jaxpr(circuit)(jax.numpy.array(0.4)).jaxpr
+
+        assert len(captured_jaxpr(2).eqns) == len(captured_jaxpr(20).eqns)
 
     @pytest.mark.slow
     def test_base_matches_expm_nonidentity_leaves(self, seed):

--- a/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
@@ -50,6 +50,7 @@ from tests.templates.subroutines.time_evolution.trotter_test_helpers import (  #
     CATALYST_GATE_SET_DOUBLE_PHASE,
     CATALYST_GATE_SET_GENUINE,
     _single_z,
+    assert_merged_trotter_matches,
     cgf_reference_hamiltonian,
     control_branches,
     hadamard_test,
@@ -435,8 +436,14 @@ class TestDecomposition:
 
     @pytest.mark.parametrize("num_fragments", [1, 2])
     @pytest.mark.parametrize("num_steps", [1, 3])
-    def test_matches_independent_second_order_trotter_product(self, seed, num_fragments, num_steps):
-        """Test that merging boundary blocks preserves the full matrix, including global phase."""
+    @pytest.mark.parametrize(
+        ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
+    )
+    def test_matches_independent_second_order_trotter_product(
+        self, seed, num_fragments, num_steps, has_control, double_phase
+    ):
+        """Merging boundary blocks preserves the full matrix, including global phase,
+        for uncontrolled, genuine-controlled, and double-phase circuits."""
         rng = np.random.default_rng(seed)
         num_modes = n_states = 2
         core = rng.normal(size=(num_fragments + 1, num_modes, num_modes, n_states, n_states)) * 0.4
@@ -449,12 +456,17 @@ class TestDecomposition:
         ham = CGFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.37)
         wires = list(range(num_modes * n_states))
         evolution_time = 0.7
-
-        actual = qp.matrix(
-            qp.TrotterCGF(evolution_time, num_steps, ham, wires=wires), wire_order=wires
-        )
         expected = cgf_second_order_trotter_matrix(ham, evolution_time, num_steps)
-        assert np.allclose(actual, expected, atol=1e-10)
+        assert_merged_trotter_matches(
+            qp.TrotterCGF,
+            ham,
+            wires,
+            evolution_time,
+            num_steps,
+            expected,
+            has_control,
+            double_phase,
+        )
 
     @pytest.mark.capture
     def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cgf_concrete):

--- a/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
@@ -40,7 +40,9 @@ from pennylane.numeric_hamiltonians import CGFHamiltonian
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.time_evolution.trotter_cgf import (
     _apply_system_basis_rotation,
+    _cgf_resource_counts,
     _merge_leaves,
+    _trotter_cgf_decomposition,
 )
 from pennylane.typing import Float, Wire
 from pennylane.wires import Wires
@@ -121,6 +123,54 @@ def cgf_reference_hamiltonian_leaves(ham):
                         Dl += (Z[frag][l, m][p, q] / 4) * (z_ops[wire(l, p)] @ z_ops[wire(m, q)])
         H += Bl.conj().T @ Dl @ Bl
     return H
+
+
+def cgf_second_order_trotter_matrix(ham, evolution_time, num_steps):
+    """Build the unmerged second-order Trotter product from independently assembled fragments."""
+    Z = np.asarray(ham.core_tensors, dtype=float)
+    U = np.asarray(ham.leaf_tensors, dtype=float)
+    num_modes = Z.shape[1]
+    n_states = Z.shape[-1]
+    n_wires = num_modes * n_states
+    dim = 2**n_wires
+    z_ops = [_single_z(w, n_wires) for w in range(n_wires)]
+
+    fragments = []
+    B0 = _cgf_basis_rotation_matrix(U[0], n_states)
+    D0 = sum(
+        (-Z[0][l, l, p, p] / 2) * z_ops[l * n_states + p]
+        for l in range(num_modes)
+        for p in range(n_states)
+    )
+    fragments.append(B0.conj().T @ D0 @ B0)
+
+    for frag in range(1, Z.shape[0]):
+        Bl = _cgf_basis_rotation_matrix(np.swapaxes(U[frag], -2, -1), n_states)
+        Dl = sum(
+            (Z[frag][l, m, p, q] / 4) * (z_ops[l * n_states + p] @ z_ops[m * n_states + q])
+            for l in range(num_modes)
+            for m in range(l)
+            for p in range(n_states)
+            for q in range(n_states)
+        )
+        fragments.append(Bl.conj().T @ Dl @ Bl)
+
+    dt = evolution_time / num_steps
+    step = np.eye(dim, dtype=complex)
+    for generator, duration in [
+        *((fragment, dt / 2) for fragment in fragments[1:]),
+        (fragments[0], dt),
+        *((fragment, dt / 2) for fragment in reversed(fragments[1:])),
+    ]:
+        step = expm(-1j * generator * duration) @ step
+
+    from pennylane.templates.subroutines.time_evolution.trotter_cgf import (  # pylint: disable=import-outside-toplevel
+        _energy_shift,
+    )
+
+    return np.exp(-1j * _energy_shift(ham) * evolution_time) * np.linalg.matrix_power(
+        step, num_steps
+    )
 
 
 def toy_hamiltonian_cgf_generator(seed, abstract=False):
@@ -298,6 +348,41 @@ class TestResourceRule:
         op = qp.TrotterCGF(1.0, 0, ham, wires=wires)
         assert qp.ctrl(op, control=[99]).decomposition() == []
 
+    @pytest.mark.parametrize("num_steps", [1, 4])
+    @pytest.mark.parametrize("num_fragments", [1, 3])
+    @pytest.mark.parametrize(
+        ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
+    )
+    def test_merged_resource_counts(self, num_steps, num_fragments, has_control, double_phase):
+        """Test analytic resource counts after merging internal H1 half blocks."""
+        num_modes = n_states = 2
+        core = np.zeros((num_fragments + 1, num_modes, num_modes, n_states, n_states))
+        leaf = np.stack(
+            [np.stack([np.eye(n_states)] * num_modes) for _ in range(num_fragments + 1)]
+        )
+        ham = CGFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
+
+        resources = _cgf_resource_counts(num_steps, ham, has_control, double_phase)
+        blocks = (2 * num_fragments - 1) * num_steps + 1
+        basis_rotations = num_modes * (2 * num_fragments * num_steps + 2)
+        pairs_per_block = num_modes * (num_modes - 1) * n_states**2 // 2
+        two_body_rotations = blocks * pairs_per_block
+        one_body_rotations = num_steps * num_modes * n_states
+        cnot_count = blocks * num_modes * (num_modes - 1) * n_states if double_phase else 0
+
+        basis_count = sum(
+            count for op, count in resources.items() if getattr(op, "name", None) == "BasisRotation"
+        )
+        assert basis_count == basis_rotations
+        assert sum(resources.values()) == (
+            basis_rotations + two_body_rotations + one_body_rotations + cnot_count + 1
+        )
+        if not has_control:
+            assert resources[qp.IsingZZ] == two_body_rotations
+        elif double_phase:
+            assert resources[qp.IsingZZ] == two_body_rotations + one_body_rotations
+            assert resources[qp.CNOT] == cnot_count
+
 
 class TestDecomposition:
     """Tests of the registered base decomposition rule."""
@@ -321,6 +406,69 @@ class TestDecomposition:
         u = qp.matrix(qp.TrotterCGF(t, steps, ham, wires=sys_wires), wire_order=sys_wires)
         expected = expm(-1j * cgf_reference_hamiltonian(ham) * t)
         assert np.allclose(u, expected, atol=1e-9)
+
+    @pytest.mark.parametrize("num_fragments", [1, 3])
+    def test_endpoint_block_angles_and_counts(self, num_fragments):
+        """Only the first and last H1 blocks are half duration; internal H1 blocks are full."""
+        num_modes = n_states = 2
+        evolution_time, num_steps = 1.2, 4
+        core = np.zeros((num_fragments + 1, num_modes, num_modes, n_states, n_states))
+        core[1, 1, 0] = 1.0
+        core[2:, 1, 0] = 13.0
+        leaf = np.stack(
+            [np.stack([np.eye(n_states)] * num_modes) for _ in range(num_fragments + 1)]
+        )
+        ham = CGFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
+        wires = list(range(num_modes * n_states))
+
+        tape = qp.tape.make_qscript(_trotter_cgf_decomposition)(
+            evolution_time, num_steps, ham, wires, False
+        )
+        angles = np.array([op.data[0] for op in tape.operations if isinstance(op, qp.IsingZZ)])
+        pairs_per_block = num_modes * (num_modes - 1) * n_states**2 // 2
+        half_angle = evolution_time / (4 * num_steps)
+        full_angle = 2 * half_angle
+
+        assert np.count_nonzero(np.isclose(angles, half_angle)) == 2 * pairs_per_block
+        assert np.count_nonzero(np.isclose(angles, full_angle)) == (num_steps - 1) * pairs_per_block
+        assert len(angles) == ((2 * num_fragments - 1) * num_steps + 1) * pairs_per_block
+
+    @pytest.mark.parametrize("num_fragments", [1, 2])
+    @pytest.mark.parametrize("num_steps", [1, 3])
+    def test_matches_independent_second_order_trotter_product(self, seed, num_fragments, num_steps):
+        """Test that merging boundary blocks preserves the full matrix, including global phase."""
+        rng = np.random.default_rng(seed)
+        num_modes = n_states = 2
+        core = rng.normal(size=(num_fragments + 1, num_modes, num_modes, n_states, n_states)) * 0.4
+        leaf = np.stack(
+            [
+                np.stack([random_orthogonal(n_states, rng) for _ in range(num_modes)])
+                for _ in range(num_fragments + 1)
+            ]
+        )
+        ham = CGFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.37)
+        wires = list(range(num_modes * n_states))
+        evolution_time = 0.7
+
+        actual = qp.matrix(
+            qp.TrotterCGF(evolution_time, num_steps, ham, wires=wires), wire_order=wires
+        )
+        expected = cgf_second_order_trotter_matrix(ham, evolution_time, num_steps)
+        assert np.allclose(actual, expected, atol=1e-10)
+
+    @pytest.mark.capture
+    def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cgf_concrete):
+        """The captured loop structure does not grow with the number of Trotter steps."""
+        ham, num_modes, n_states = toy_hamiltonian_cgf_concrete
+        wires = list(range(num_modes * n_states))
+
+        def captured_jaxpr(num_steps):
+            def circuit(t):
+                _trotter_cgf_decomposition(t, num_steps, ham, wires, False)
+
+            return jax.make_jaxpr(circuit)(jax.numpy.array(0.4)).jaxpr
+
+        assert len(captured_jaxpr(2).eqns) == len(captured_jaxpr(20).eqns)
 
     @pytest.mark.slow
     def test_base_matches_expm_nonidentity_leaves(self, seed):

--- a/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
+++ b/tests/templates/subroutines/time_evolution/test_trotter_cgf.py
@@ -41,6 +41,8 @@ from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.templates.subroutines.time_evolution.trotter_cgf import (
     _apply_system_basis_rotation,
     _cgf_resource_counts,
+    _controlled_trotter_cgf_decomp,
+    _energy_shift,
     _merge_leaves,
     _trotter_cgf_decomposition,
 )
@@ -51,6 +53,7 @@ from tests.templates.subroutines.time_evolution.trotter_test_helpers import (  #
     CATALYST_GATE_SET_GENUINE,
     _single_z,
     assert_merged_trotter_matches,
+    assert_resource_counts_match,
     cgf_reference_hamiltonian,
     control_branches,
     hadamard_test,
@@ -90,10 +93,6 @@ def cgf_reference_hamiltonian_leaves(ham):
     reproduced by ``matrix(TrotterCGF)`` in the many-step limit (second-order Trotter error
     ``~ 1 / steps^2``).
     """
-    from pennylane.templates.subroutines.time_evolution.trotter_cgf import (  # pylint: disable=import-outside-toplevel
-        _energy_shift,
-    )
-
     Z = np.asarray(ham.core_tensors, dtype=float)
     U = np.asarray(ham.leaf_tensors, dtype=float)
     num_modes = Z.shape[1]
@@ -164,10 +163,6 @@ def cgf_second_order_trotter_matrix(ham, evolution_time, num_steps):
         *((fragment, dt / 2) for fragment in reversed(fragments[1:])),
     ]:
         step = expm(-1j * generator * duration) @ step
-
-    from pennylane.templates.subroutines.time_evolution.trotter_cgf import (  # pylint: disable=import-outside-toplevel
-        _energy_shift,
-    )
 
     return np.exp(-1j * _energy_shift(ham) * evolution_time) * np.linalg.matrix_power(
         step, num_steps
@@ -354,35 +349,38 @@ class TestResourceRule:
     @pytest.mark.parametrize(
         ("has_control", "double_phase"), [(False, False), (True, False), (True, True)]
     )
-    def test_merged_resource_counts(self, num_steps, num_fragments, has_control, double_phase):
-        """Test analytic resource counts after merging internal H1 half blocks."""
+    @pytest.mark.capture
+    def test_merged_resource_counts_match_traced_decomposition(
+        self, num_steps, num_fragments, has_control, double_phase
+    ):
+        """Resource counts match the traced decomposition after merging H1 half blocks."""
         num_modes = n_states = 2
         core = np.zeros((num_fragments + 1, num_modes, num_modes, n_states, n_states))
         leaf = np.stack(
             [np.stack([np.eye(n_states)] * num_modes) for _ in range(num_fragments + 1)]
         )
         ham = CGFHamiltonian(core_tensors=core, leaf_tensors=leaf, nuc_constant=0.0)
-
         resources = _cgf_resource_counts(num_steps, ham, has_control, double_phase)
-        blocks = (2 * num_fragments - 1) * num_steps + 1
-        basis_rotations = num_modes * (2 * num_fragments * num_steps + 2)
-        pairs_per_block = num_modes * (num_modes - 1) * n_states**2 // 2
-        two_body_rotations = blocks * pairs_per_block
-        one_body_rotations = num_steps * num_modes * n_states
-        cnot_count = blocks * num_modes * (num_modes - 1) * n_states if double_phase else 0
+        num_system_wires = num_modes * n_states
+        trace_wires = tuple(range(num_system_wires + int(has_control)))
 
-        basis_count = sum(
-            count for op, count in resources.items() if getattr(op, "name", None) == "BasisRotation"
-        )
-        assert basis_count == basis_rotations
-        assert sum(resources.values()) == (
-            basis_rotations + two_body_rotations + one_body_rotations + cnot_count + 1
-        )
-        if not has_control:
-            assert resources[qp.IsingZZ] == two_body_rotations
-        elif double_phase:
-            assert resources[qp.IsingZZ] == two_body_rotations + one_body_rotations
-            assert resources[qp.CNOT] == cnot_count
+        def circuit(t, *wires):
+            system_wires = list(wires[:num_system_wires])
+            if not has_control:
+                _trotter_cgf_decomposition(t, num_steps, ham, system_wires, False)
+                return
+            with qp.capture.pause():
+                base = qp.TrotterCGF(t, num_steps, ham, system_wires, double_phase=double_phase)
+            _controlled_trotter_cgf_decomp(
+                base, list(wires[num_system_wires:]), [1], [], "borrowed"
+            )
+
+        args = (jax.numpy.array(0.4), *trace_wires)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", CaptureWarning)
+            jaxpr = jax.make_jaxpr(circuit)(*args)
+        operations = qp.tape.plxpr_to_tape(jaxpr.jaxpr, jaxpr.consts, *args).operations
+        assert_resource_counts_match(resources, operations)
 
 
 class TestDecomposition:
@@ -467,20 +465,6 @@ class TestDecomposition:
             has_control,
             double_phase,
         )
-
-    @pytest.mark.capture
-    def test_capture_ir_size_independent_of_num_steps(self, toy_hamiltonian_cgf_concrete):
-        """The captured loop structure does not grow with the number of Trotter steps."""
-        ham, num_modes, n_states = toy_hamiltonian_cgf_concrete
-        wires = list(range(num_modes * n_states))
-
-        def captured_jaxpr(num_steps):
-            def circuit(t):
-                _trotter_cgf_decomposition(t, num_steps, ham, wires, False)
-
-            return jax.make_jaxpr(circuit)(jax.numpy.array(0.4)).jaxpr
-
-        assert len(captured_jaxpr(2).eqns) == len(captured_jaxpr(20).eqns)
 
     @pytest.mark.slow
     def test_base_matches_expm_nonidentity_leaves(self, seed):

--- a/tests/templates/subroutines/time_evolution/trotter_test_helpers.py
+++ b/tests/templates/subroutines/time_evolution/trotter_test_helpers.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Shared helpers for TrotterCDF and TrotterCGF tests."""
 
+from collections import Counter
+
 import numpy as np
 from scipy.linalg import expm
 
@@ -186,3 +188,16 @@ def assert_merged_trotter_matches(
     dim = expected_u.shape[0]
     assert np.allclose(block0, np.eye(dim), atol=1e-10)
     assert np.allclose(block1, expected_u, atol=1e-10)
+
+
+def assert_resource_counts_match(resources, operations):
+    """Assert that resource estimates match the operation counts of a traced decomposition."""
+
+    def resource_name(resource):
+        return resource.__name__ if isinstance(resource, type) else resource.name
+
+    expected = Counter(
+        {resource_name(resource): count for resource, count in resources.items() if count}
+    )
+    actual = Counter(op.name for op in operations)
+    assert actual == expected

--- a/tests/templates/subroutines/time_evolution/trotter_test_helpers.py
+++ b/tests/templates/subroutines/time_evolution/trotter_test_helpers.py
@@ -168,3 +168,21 @@ def control_branches(
     matrix = qp.matrix(tape, wire_order=[anc] + list(sys_wires))
     dim = 2 ** len(sys_wires)
     return matrix[:dim, :dim], matrix[dim:, dim:]
+
+
+def assert_merged_trotter_matches(
+    trotter_cls, ham, wires, t, steps, expected_u, has_control, double_phase
+):  # pylint: disable=too-many-arguments
+    """Compare the template (and both controlled variants) to an independently built Trotter product."""
+    if not has_control:
+        actual = qp.matrix(trotter_cls(t, steps, ham, wires=wires), wire_order=wires)
+        assert np.allclose(actual, expected_u, atol=1e-10)
+        return
+    block0, block1 = control_branches(trotter_cls, ham, wires, t, steps, double_phase)
+    if double_phase:
+        assert np.allclose(block0, expected_u, atol=1e-10)
+        assert np.allclose(block1, expected_u.conj().T, atol=1e-10)
+        return
+    dim = expected_u.shape[0]
+    assert np.allclose(block0, np.eye(dim), atol=1e-10)
+    assert np.allclose(block1, expected_u, atol=1e-10)


### PR DESCRIPTION
TrotterCDF and TrotterCGF now merge adjacent first-fragment half-steps at internal Trotter boundaries into a single full-duration evolution. This is exact, and it reduces two-body diagonal blocks, basis transitions, and double-phase CNOTs without changing the unitary (including genuine and double-phase controlled circuits).

Made with cursor (genAI)