### PR TITLE
Qfunc mode for resources function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -425,6 +425,11 @@
 
 <h3>Improvements 🛠</h3>
 
+* Resource functions passed to `qp.register_resources` can now be specified by abstract operators or operator
+  classes raised to powers instead of having them return a dictionary.
+  [(#10122)](https://github.com/PennyLaneAI/pennylane/pull/10122)
+
+
 * :func:`~.SumOfSlatersPrep.required_register_sizes` now works with abstract ``indices`` as input,
   for which it returns an upper bound for the register sizes, across any set of indices of the
   provided length.

--- a/pennylane/core/operator/meta.py
+++ b/pennylane/core/operator/meta.py
@@ -58,6 +58,13 @@ class OperatorMeta(ABCMeta):
         without_self = tuple(sig.parameters.values())[1:]
         return Signature(without_self)
 
+    def __pow__(cls, z):
+        if not isinstance(z, int):
+            return NotImplemented
+        if not getattr(cls, "has_fixed_sig", False):
+            return NotImplemented
+        return cls(**cls.arg_specs) ** z
+
     @_stop_autograph
     def __call__(cls, *args, **kwargs):
 

--- a/pennylane/core/operator/meta.py
+++ b/pennylane/core/operator/meta.py
@@ -62,7 +62,7 @@ class OperatorMeta(ABCMeta):
         if not isinstance(z, int):
             return NotImplemented
         if not getattr(cls, "has_fixed_sig", False):
-            return NotImplemented
+            raise TypeError("Only operator classes with fixed signatures can be raised to a power.")
         return cls(**cls.arg_specs) ** z
 
     @_stop_autograph

--- a/pennylane/decomposition/decomposition_rule.py
+++ b/pennylane/decomposition/decomposition_rule.py
@@ -42,6 +42,18 @@ from .resources import (
 from .utils import _get_decomp_args, to_name
 
 
+def _gate_counts_from_queue(q: queuing.AnnotatedQueue) -> dict:
+    gate_counts = defaultdict(int)
+    for op in q.queue:
+        if isinstance(op, qp.ops.Pow):
+            count = op.z
+            op = op.base
+        else:
+            count = 1
+        gate_counts[abstractify(op)] += count
+    return gate_counts
+
+
 @dataclass(frozen=True)
 class WorkWireSpec:
     """The number of each type of work wires that a decomposition rule requires."""
@@ -174,8 +186,8 @@ def register_resources(
     Args:
         ops (dict or Callable): a dictionary mapping unique operators within the given ``qfunc``
             to their number of occurrences therein. If a function is provided instead of a static
-            dictionary, a dictionary must be returned from the function. For more information,
-            consult the "Quantum Functions as Decomposition Rules" section below.
+            dictionary, the function must either return a dictionary or use pow-qfunc syntax.
+            For more information, consult the "Quantum Functions as Decomposition Rules" section below.
         qfunc (Callable): the quantum function that implements the decomposition. If ``None``,
             returns a decorator for acting on a function.
 
@@ -252,6 +264,17 @@ def register_resources(
         Quantum functions representing decomposition rules within the new decomposition system
         are expected to take ``(*op.parameters, op.wires, **op.hyperparameters)`` as arguments,
         where ``op`` is an instance of the operator type that the decomposition is for.
+
+        The resources can also be specified as a quantum function with abstract operators raised to powers.
+
+        .. code-block:: python
+
+            def resource_fn(x, wires):
+                # if the  class has a fixed signature, the class itself can be raised to a power
+                qp.X ** len(wires)
+
+                # otherwise, the class with abstract inputs can be raised to a power
+                qp.QubitUnitary(Float[2,2], Wire[1]) ** 2
 
     .. details::
         :title: Operators with Dynamic Resource Requirements
@@ -400,7 +423,10 @@ class DecompositionRule:
         """Computes the resources required to implement this decomposition rule."""
         if self._compute_resources is None:
             raise NotImplementedError("No resource estimation found for this decomposition rule.")
-        raw_gate_counts = self._compute_resources(*args, **kwargs)
+        with queuing.AnnotatedQueue() as q:
+            raw_gate_counts = self._compute_resources(*args, **kwargs)
+        if raw_gate_counts is None:
+            raw_gate_counts = _gate_counts_from_queue(q)
         assert isinstance(raw_gate_counts, dict), "Resource function must return a dictionary."
         gate_counter = Counter()
         for op, count in raw_gate_counts.items():

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -1057,6 +1057,7 @@ class SumOfSlatersPrep(Operator2):
         }
 
 
+# pylint: disable=expression-not-assigned, pointless-statement
 # pylint: disable-next=unused-argument
 def _sos_state_prep_resources(coefficients, wires, indices, **_):
     """Compute the resources for _sos_state_prep. It is an upper bound due to
@@ -1092,24 +1093,24 @@ def _sos_state_prep_resources(coefficients, wires, indices, **_):
 
     if not identity_encoding:
         ## Step 3 & 4 in paper (p.7). This is an upper bound
-        _ = qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
+        qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
 
     ## Step 5 in paper (p.7)
-    _ = qp.TemporaryAND ** ((num_entries - 1) * (m - 1))
-    _ = _adjoint_abstract(qp.TemporaryAND) ** ((num_entries - 1) * (m - 1))
+    qp.TemporaryAND ** ((num_entries - 1) * (m - 1))
+    _adjoint_abstract(qp.TemporaryAND) ** ((num_entries - 1) * (m - 1))
 
     # Calculate the bit counts of all integers that need to be uncomputed and sum them up.
     number_of_bits_to_unset = int(np.sum(np.bitwise_count(np.arange(1, num_entries))))
-    _ = qp.CNOT**number_of_bits_to_unset
+    qp.CNOT**number_of_bits_to_unset
 
     # We have to flip at most m control bits between any pair of the `num_entries-1` uncomputing
     # MCX groups (skipping 0 because nothing needs to be done) as well as before the first
     # and after the last group. This amounts to `num_entries` layers of bit flips
-    _ = qp.X ** (num_entries * m)
+    qp.X ** (num_entries * m)
 
     if not identity_encoding:
         ## Step 6 in paper (p.7). This is an upper bound
-        _ = qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
+        qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
 
 
 # pylint: disable=unused-argument,too-many-arguments

--- a/pennylane/templates/state_preparations/sum_of_slaters.py
+++ b/pennylane/templates/state_preparations/sum_of_slaters.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 r"""Contains the SumOfSlatersPrep template."""
 
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from itertools import combinations, product
 
 import numpy as np
@@ -1071,50 +1071,45 @@ def _sos_state_prep_resources(coefficients, wires, indices, **_):
     num_wires = n
 
     if num_entries == 1:
-        return {qp.BasisState(Bool[num_wires], Wire[num_wires]): 1}
+        qp.BasisState(Bool[num_wires], Wire[num_wires])
+        return
     d = math.ceil_log2(num_entries)
     m = min(num_bits, 2 * d - 1)
 
     identity_encoding = num_bits == m
 
-    resources = defaultdict(int)
-
     # Step 1 in paper (p.7)
-    resources[qp.MultiplexerStatePreparation(Complex[2**d], wires=Wire[d])] += 1
+    qp.MultiplexerStatePreparation(Complex[2**d], wires=Wire[d])
 
     # Step 2 in paper (p.7)
-    resources[
-        qp.QROM(
-            bitstrings=Int[num_entries, num_wires],
-            control_wires=Wire[d],
-            target_wires=Wire[num_wires],
-            work_wires=Wire[d - 1],
-            clean=True,
-        )
-    ] += 1
+    qp.QROM(
+        bitstrings=Int[num_entries, num_wires],
+        control_wires=Wire[d],
+        target_wires=Wire[num_wires],
+        work_wires=Wire[d - 1],
+        clean=True,
+    )
 
     if not identity_encoding:
         ## Step 3 & 4 in paper (p.7). This is an upper bound
-        resources[qp.CNOT] += m * num_wires  # size {u_k} * bits in u_k
+        _ = qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
 
     ## Step 5 in paper (p.7)
-    resources[qp.TemporaryAND] += (num_entries - 1) * (m - 1)
-    resources[_adjoint_abstract(qp.TemporaryAND)] += (num_entries - 1) * (m - 1)
+    _ = qp.TemporaryAND ** ((num_entries - 1) * (m - 1))
+    _ = _adjoint_abstract(qp.TemporaryAND) ** ((num_entries - 1) * (m - 1))
 
     # Calculate the bit counts of all integers that need to be uncomputed and sum them up.
     number_of_bits_to_unset = int(np.sum(np.bitwise_count(np.arange(1, num_entries))))
-    resources[qp.CNOT] += number_of_bits_to_unset
+    _ = qp.CNOT**number_of_bits_to_unset
 
     # We have to flip at most m control bits between any pair of the `num_entries-1` uncomputing
     # MCX groups (skipping 0 because nothing needs to be done) as well as before the first
     # and after the last group. This amounts to `num_entries` layers of bit flips
-    resources[qp.X] += num_entries * m
+    _ = qp.X ** (num_entries * m)
 
     if not identity_encoding:
         ## Step 6 in paper (p.7). This is an upper bound
-        resources[qp.CNOT] += m * num_wires  # size {u_k} * bits in u_k
-
-    return resources
+        _ = qp.CNOT ** (m * num_wires)  # size {u_k} * bits in u_k
 
 
 # pylint: disable=unused-argument,too-many-arguments

--- a/tests/core/operator/test_operator2_metaclass.py
+++ b/tests/core/operator/test_operator2_metaclass.py
@@ -48,23 +48,30 @@ class FixedSigOp(Operator2):
     arg_specs = {"x": Float, "wires": Wire[2]}
 
     def __init__(self, x, wires):
-        super.__init__(x, wires)
+        super().__init__(x, wires)
 
 
 class TestTypeToPow:
+    """Tests for raising Operator2 to powers."""
 
     def test_fixed_fix_pow(self):
         """Test that a class with a fixed sig can be raised to a power."""
         op = FixedSigOp**3
-        assert isinstance(op, qp.ops.Pow2)
+        assert isinstance(op, qp.ops.op_math.pow2.Pow2)
         assert op.z == 3
-        assert qp.assert_equal(op.base, FixedSigOp(Float, Wire[2]))
+        qp.assert_equal(op.base, FixedSigOp(Float, Wire[2]))
 
     @pytest.mark.parametrize("z", (2.0, 2.5, "a"))
     def test_non_integer_pow(self, z):
         """Test non-integer powers are not supported."""
         with pytest.raises(TypeError):
-            FixedSigOp**z
+            _ = FixedSigOp**z
+
+    def test_error_if_no_fixed_sig(self):
+        """Test that a TypeError is raised if the class doesn't have a fixed sig."""
+
+        with pytest.raises(TypeError, match="Only operator classes with fixed signatures "):
+            _ = DynCanonOp**2
 
 
 @pytest.mark.capture

--- a/tests/core/operator/test_operator2_metaclass.py
+++ b/tests/core/operator/test_operator2_metaclass.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from operator2_utils import CompilableOp, DynOp, StaticOp
 
+import pennylane as qp
 from pennylane.core.operator import Operator2
 from pennylane.core.operator.operator2 import operator_p
 from pennylane.typing import AbstractArray, Complex, Float, Int, Wire
@@ -39,6 +40,31 @@ def test_child_constructor_runs_when_concrete():
     # __init__ is hit so phi is doubled
     assert op.phi == 4.0
     assert op.wires == Wires(0)
+
+
+class FixedSigOp(Operator2):
+
+    dynamic_argnames = "x"
+    arg_specs = {"x": Float, "wires": Wire[2]}
+
+    def __init__(self, x, wires):
+        super.__init__(x, wires)
+
+
+class TestTypeToPow:
+
+    def test_fixed_fix_pow(self):
+        """Test that a class with a fixed sig can be raised to a power."""
+        op = FixedSigOp**3
+        assert isinstance(op, qp.ops.Pow2)
+        assert op.z == 3
+        assert qp.assert_equal(op.base, FixedSigOp(Float, Wire[2]))
+
+    @pytest.mark.parametrize("z", (2.0, 2.5, "a"))
+    def test_non_integer_pow(self, z):
+        """Test non-integer powers are not supported."""
+        with pytest.raises(TypeError):
+            FixedSigOp**z
 
 
 @pytest.mark.capture

--- a/tests/core/operator/test_operator2_metaclass.py
+++ b/tests/core/operator/test_operator2_metaclass.py
@@ -42,11 +42,12 @@ def test_child_constructor_runs_when_concrete():
     assert op.wires == Wires(0)
 
 
-class FixedSigOp(Operator2):
+class FixedSigOp(Operator2):  # pylint: disable=too-few-public-methods
 
     dynamic_argnames = "x"
     arg_specs = {"x": Float, "wires": Wire[2]}
 
+    # pylint: disable=useless-parent-delegation
     def __init__(self, x, wires):
         super().__init__(x, wires)
 

--- a/tests/decomposition/test_decomposition_rule.py
+++ b/tests/decomposition/test_decomposition_rule.py
@@ -706,6 +706,77 @@ class TestDecompDictionary:
             assert list(qp.list_decomps(op)) == []
 
 
+# pylint: disable=unused-argument
+class TestDecompQfunc:
+    """Tests for specifying resources as a qfunc with abstract operators."""
+
+    def test_single_abstract_operator(self):
+        """Test a single abstract operator is considered that operator once."""
+
+        def r(wires):
+            qp.X(Wire[1])
+
+        @qp.register_resources(r)
+        def f(wires):
+            qp.X(wires)
+
+        assert f.compute_resources((0,)).gate_counts == {qp.X(Wire[1]): 1}
+
+    def test_operator_to_pow(self):
+        """test an abstract operator being raised to a power."""
+
+        def r(wires):
+            _ = qp.X(Wire[1]) ** 100
+
+        @qp.register_resources(r)
+        def f(wires):
+            qp.X(wires)
+
+        assert f.compute_resources(Wire[1]).gate_counts == {qp.X(Wire[1]): 100}
+
+    def test_same_abstract_operator_multiple_times(self):
+        """Test that the same operator can be queued multiple times."""
+
+        def r(wires):
+            _ = qp.X(Wire[1]) ** 3
+            _ = qp.X(Wire[1]) ** 5
+
+        @qp.register_resources(r)
+        def f(wires):
+            qp.X(wires)
+
+        assert f.compute_resources(Wire[1]).gate_counts == {qp.X(Wire[1]): 8}
+
+    def test_class_fixed_sig_to_power(self):
+        """Test that a class can be raised to a power if it has a fixed signature."""
+
+        def r(wires):
+            _ = qp.X**3
+            _ = qp.Rot**10
+
+        @qp.register_resources(r)
+        def f(wires):
+            qp.X(wires)
+
+        assert f.compute_resources(Wire[1]).gate_counts == {
+            qp.X(Wire[1]): 3,
+            qp.Rot(Float, Float, Float, Wire[1]): 10,
+        }
+
+    def test_abstractify_operators(self):
+        """Test real operators can be in the qfunc but get abstractified."""
+
+        def r(wires):
+            _ = qp.X(0)
+            _ = qp.RX(0.5, Wire[1]) ** 2
+
+        @qp.register_resources(r)
+        def f(wires):
+            pass
+
+        assert f.compute_resources(0).gate_counts == {qp.X(Wire[1]): 1, qp.RX(Float, Wire[1]): 2}
+
+
 class TestDecompCollection:
     """Tests the DecompCollection class."""
 


### PR DESCRIPTION
**Context:**

Just an easy idea for a nice UI for specifying resources. Might be easier to read than a dictionary.

**Description of the Change:**

Allows resources functions to be specified by a qfunc with abstract operators raised to powers.

```
def my_resources(wires):
   qp.QFT(Wire[4]) ** 10 # 10 4-qubit QFT's

   qp.X ** 100 # 100 X's

```

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
