### PR TITLE
Use `Prod2` if operands are all `Operator2` subclasses

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1281,6 +1281,7 @@
     [(#10027)](https://github.com/PennyLaneAI/pennylane/pull/10027)
     [(#10047)](https://github.com/PennyLaneAI/pennylane/pull/10047)
     [(#9999)](https://github.com/PennyLaneAI/pennylane/pull/9999)
+    [(#10124)](https://github.com/PennyLaneAI/pennylane/pull/10124)
   - Integration with :mod:`pennylane.capture`.
     [(#9556)](https://github.com/PennyLaneAI/pennylane/pull/9556)
     [(#9729)](https://github.com/PennyLaneAI/pennylane/pull/9729)

--- a/pennylane/estimator/resource_mapping.py
+++ b/pennylane/estimator/resource_mapping.py
@@ -618,6 +618,16 @@ def _(op: qops.ChangeOpBasis):
 
 
 @_map_to_resource_op.register
+def _(op: qops.ChangeOpBasis2):
+    return re_ops.ChangeOpBasis(
+        _map_to_resource_op(op.compute_op),
+        _map_to_resource_op(op.target_op),
+        _map_to_resource_op(op.uncompute_op),
+        wires=op.wires,
+    )
+
+
+@_map_to_resource_op.register
 def _(op: Prod):
     return re_ops.Prod(
         res_ops=[_map_to_resource_op(factor) for factor in op.operands],

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -33,7 +33,6 @@ from pennylane.core.operator import Operator2, abstractify
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
-    resource_rep,
 )
 from pennylane.exceptions import PennyLaneDeprecationWarning
 from pennylane.ops.identity import I
@@ -430,15 +429,9 @@ def _ry_to_rx_cliff(phi, wires: WiresLike):
 def _ry_to_rz_cliff_resources(*_, **__):
     resources = {
         _change_op_basis_abstract(
-            resource_rep(
-                qp.ops.op_math.Prod,
-                resources={_adjoint_abstract(qp.S): 1, abstractify(qp.Hadamard): 1},
-            ),
+            qp.ops.op_math.Prod2((abstractify(qp.Hadamard), qp.adjoint(qp.S(Wire[1])))),
             qp.RZ,
-            resource_rep(
-                qp.ops.op_math.Prod,
-                resources={abstractify(qp.S): 1, abstractify(qp.Hadamard): 1},
-            ),
+            qp.ops.op_math.Prod2((abstractify(qp.S), abstractify(qp.Hadamard))),
         ): 1
     }
     return resources
@@ -447,9 +440,9 @@ def _ry_to_rz_cliff_resources(*_, **__):
 @register_resources(_ry_to_rz_cliff_resources)
 def _ry_to_rz_cliff(phi, wires: WiresLike):
     qp.change_op_basis(
-        qp.Hadamard(wires) @ qp.adjoint(qp.S(wires)),
+        qp.ops.op_math.Prod2((qp.Hadamard(wires), qp.adjoint(qp.S(wires)))),
         qp.RZ(phi, wires),
-        qp.S(wires) @ qp.Hadamard(wires),
+        qp.ops.op_math.Prod2((qp.S(wires), qp.Hadamard(wires))),
     )
 
 

--- a/pennylane/ops/qubit/parametric_ops_single_qubit.py
+++ b/pennylane/ops/qubit/parametric_ops_single_qubit.py
@@ -706,15 +706,9 @@ def _rz_to_rx_cliff(phi, wires: WiresLike):
 def _rz_to_ry_cliff_resources(phi, wires):
     resources = {
         _change_op_basis_abstract(
-            resource_rep(
-                qp.ops.op_math.Prod,
-                resources={abstractify(qp.S): 1, abstractify(qp.Hadamard): 1},
-            ),
+            qp.ops.op_math.Prod2((abstractify(qp.S), abstractify(qp.Hadamard))),
             qp.RY,
-            resource_rep(
-                qp.ops.op_math.Prod,
-                resources={_adjoint_abstract(qp.S): 1, abstractify(qp.Hadamard): 1},
-            ),
+            qp.ops.op_math.Prod2((abstractify(qp.Hadamard), _adjoint_abstract(qp.S))),
         ): 1
     }
     return resources
@@ -723,9 +717,9 @@ def _rz_to_ry_cliff_resources(phi, wires):
 @register_resources(_rz_to_ry_cliff_resources)
 def _rz_to_ry_cliff(phi, wires: WiresLike):
     qp.change_op_basis(
-        qp.S(wires) @ qp.Hadamard(wires),
+        qp.ops.op_math.Prod2((qp.S(wires), qp.Hadamard(wires))),
         qp.RY(phi, wires),
-        qp.Hadamard(wires) @ qp.adjoint(qp.S(wires)),
+        qp.ops.op_math.Prod2((qp.Hadamard(wires), qp.adjoint(qp.S(wires)))),
     )
 
 

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -24,7 +24,7 @@ from pennylane.decomposition import (
     register_resources,
     resource_rep,
 )
-from pennylane.ops import SWAP, Prod, adjoint, change_op_basis, prod
+from pennylane.ops import SWAP, Prod2, adjoint, change_op_basis
 from pennylane.ops.op_math.adjoint2 import _adjoint_abstract
 from pennylane.ops.op_math.change_op_basis2 import _change_op_basis_abstract
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
@@ -240,8 +240,8 @@ class Multiplier(Operation):
             ControlledSequence(PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires),
         )
 
-        target_op = prod(
-            *reversed([SWAP(wires) for wires in zip(x_wires, wires_aux_swap, strict=True)])
+        target_op = Prod2(
+            list(reversed([SWAP(wires) for wires in zip(x_wires, wires_aux_swap, strict=True)]))
         )
 
         inv_k = pow(k, -1, mod)
@@ -267,10 +267,7 @@ def _multiplier_decomposition_resources(
         "base_rep": resource_rep(PhaseAdder, num_x_wires=num_wires_aux, mod=mod),
         "num_control_wires": num_x_wires,
     }
-    if num_x_wires > 1:
-        target_op_rep = resource_rep(Prod, resources={abstractify(SWAP): num_x_wires})
-    else:
-        target_op_rep = SWAP
+    target_op_rep = Prod2([SWAP(Wire[2]) for _ in range(num_x_wires)])
     _compute_op = QFT(Wire[num_wires_aux])
     resources = {
         _change_op_basis_abstract(
@@ -304,12 +301,14 @@ def _multiplier_decomposition(k, x_wires: WiresLike, mod, work_wires: WiresLike,
         QFT(wires=wires_aux),
         ControlledSequence(PhaseAdder(k, wires_aux, mod, work_wire_aux), control=x_wires),
     )
-    prod(
-        *reversed(
-            [
-                SWAP(wires=[x_wire, aux_wire])
-                for x_wire, aux_wire in zip(x_wires, wires_aux_swap, strict=True)
-            ]
+    Prod2(
+        list(
+            reversed(
+                [
+                    SWAP(wires=[x_wire, aux_wire])
+                    for x_wire, aux_wire in zip(x_wires, wires_aux_swap, strict=True)
+                ]
+            )
         )
     )
     change_op_basis(

--- a/pennylane/templates/subroutines/arithmetic/multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/multiplier.py
@@ -17,7 +17,7 @@ Contains the Multiplier template.
 
 import numpy as np
 
-from pennylane.core.operator import Operation, abstractify
+from pennylane.core.operator import Operation
 from pennylane.decomposition import (
     add_decomps,
     adjoint_resource_rep,

--- a/pennylane/templates/subroutines/arithmetic/out_multiplier.py
+++ b/pennylane/templates/subroutines/arithmetic/out_multiplier.py
@@ -25,7 +25,7 @@ from pennylane.decomposition import (
     register_resources,
 )
 from pennylane.decomposition.resources import resource_rep
-from pennylane.ops import BasisState, H, Prod, X, adjoint, change_op_basis, ctrl, prod
+from pennylane.ops import BasisState, H, Prod2, X, adjoint, change_op_basis, ctrl
 from pennylane.ops.op_math.change_op_basis2 import _change_op_basis_abstract
 from pennylane.templates.subroutines.controlled_sequence import ControlledSequence
 from pennylane.templates.subroutines.qft import QFT
@@ -283,7 +283,7 @@ def _out_multiplier_with_qft_resources(
     num_qft_wires = num_output_wires + 1 if mod != 2**num_output_wires else num_output_wires
 
     if output_wires_zeroed:
-        compute_rep = resource_rep(Prod, resources={abstractify(H): num_qft_wires})
+        compute_rep = Prod2([abstractify(H) for _ in range(num_qft_wires)])
     else:
         compute_rep = QFT(Wire[num_qft_wires])
 
@@ -336,7 +336,7 @@ def _out_multiplier_with_qft(
         work_wire = output_wires[:0]
 
     if output_wires_zeroed:
-        compute_op = prod(*(H(w) for w in qft_output_wires))
+        compute_op = Prod2([H(w) for w in qft_output_wires])
     else:
         compute_op = QFT(qft_output_wires)
     uncompute_op = adjoint(QFT(qft_output_wires))

--- a/pennylane/templates/subroutines/arithmetic/phase_adder.py
+++ b/pennylane/templates/subroutines/arithmetic/phase_adder.py
@@ -25,7 +25,6 @@ from pennylane.core.operator import Operation, abstractify
 from pennylane.decomposition import (
     add_decomps,
     register_resources,
-    resource_rep,
 )
 from pennylane.ops.op_math.change_op_basis2 import _change_op_basis_abstract
 from pennylane.templates.subroutines.qft import QFT
@@ -257,13 +256,17 @@ class PhaseAdder(Operation):
 
             op_list.append(
                 ops.change_op_basis(
-                    ops.prod(
-                        ops.X(aux_k),
-                        ops.adjoint(QFT)(wires=x_wires),
-                        *[ops.adjoint(op) for op in _add_k_fourier(k, x_wires)],
+                    ops.op_math.Prod2(
+                        (
+                            ops.X(aux_k),
+                            ops.adjoint(QFT)(wires=x_wires),
+                            *[ops.adjoint(op) for op in _add_k_fourier(k, x_wires)],
+                        )
                     ),
                     ops.CNOT(wires=[aux_k, work_wire[0]]),
-                    ops.prod(*_add_k_fourier(k, x_wires)[::-1], QFT(wires=x_wires), ops.X(aux_k)),
+                    ops.op_math.Prod2(
+                        (*_add_k_fourier(k, x_wires)[::-1], QFT(wires=x_wires), ops.X(aux_k))
+                    ),
                 )
             )
 
@@ -303,9 +306,13 @@ def _phase_adder_decomposition_resources(num_x_wires, mod) -> dict:
         ): 1,
         ops.ControlledPhaseShift: num_x_wires,
         _change_op_basis_abstract(
-            resource_rep(ops.Prod, resources=dict(basis_op_resources1)),
+            ops.op_math.Prod2(
+                tuple(op for op, count in basis_op_resources1.items() for _ in range(count))
+            ),
             ops.CNOT,
-            resource_rep(ops.Prod, resources=dict(basis_op_resources2)),
+            ops.op_math.Prod2(
+                tuple(op for op, count in basis_op_resources2.items() for _ in range(count))
+            ),
         ): 1,
     }
     return resources
@@ -336,13 +343,15 @@ def _phase_adder_decomposition(k, x_wires: WiresLike, mod, work_wire, **__):
     )
     ops.ctrl(_add_k_fourier_loop, control=work_wire)(mod)
     ops.change_op_basis(
-        ops.prod(
-            ops.X(aux_k),
-            ops.adjoint(QFT)(wires=x_wires),
-            *reversed(ops.adjoint(_add_k_fourier_loop)(k)),
+        ops.op_math.Prod2(
+            (
+                ops.X(aux_k),
+                ops.adjoint(QFT)(wires=x_wires),
+                *reversed(ops.adjoint(_add_k_fourier_loop)(k)),
+            )
         ),
         ops.CNOT(wires=[aux_k, work_wire[0]]),
-        ops.prod(ops.prod(_add_k_fourier_loop)(k), QFT(wires=x_wires), ops.X(aux_k), lazy=False),
+        ops.op_math.Prod2((*_add_k_fourier(k, x_wires), QFT(wires=x_wires), ops.X(aux_k))),
     )
 
 

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -361,7 +361,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(4), control_values=AbstractArray((3,), bool)): 2, PauliX: 3}
     Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(4), control_values=AbstractArray((3,), bool)): 2}
     Wire Allocations: {'zero': 1}
-    Full Expansion Gates: {CNOT: 34, GlobalPhase: 68, MidMeasure: 2, RX: 12, RY: 18, RZ: 58}
+    Full Expansion Gates: {CNOT: 36, GlobalPhase: 66, MidMeasure: 2, RX: 12, RY: 14, RZ: 60}
     Weighted Cost: 124.0
     <BLANKLINE>
     Decomposition 1 (name: controlled(_multi_rz_decomposition))
@@ -372,7 +372,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
     5: ─╰●─╰●────────╰●─┤
     Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2, PauliX: 3}
     Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-    Full Expansion Gates: {CNOT: 72, GlobalPhase: 90, MidMeasure: 4, RX: 30, RY: 24, RZ: 80}
+    Full Expansion Gates: {CNOT: 76, GlobalPhase: 86, MidMeasure: 4, RX: 30, RY: 16, RZ: 84}
     Weighted Cost: 210.0
 
     For applicable decompositions, the "First-Level Expansion" label refers to the operators immediately produced by the decomposition rule,
@@ -515,7 +515,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, PauliX: 4, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
         Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
-        Full Expansion Gates: {CNOT: 58, GlobalPhase: 66, RX: 27, RY: 12, RZ: 55}
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 62, RX: 27, RY: 14, RZ: 53}
         Weighted Cost: 152.0
         <BLANKLINE>
         Decomposition 1 (name: one_borrowed_worker)
@@ -619,7 +619,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
          [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
         Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, PauliX: 4, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
         Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, Controlled(GlobalPhase, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 4, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
-        Full Expansion Gates: {CNOT: 58, GlobalPhase: 66, RX: 27, RY: 12, RZ: 55}
+        Full Expansion Gates: {CNOT: 58, GlobalPhase: 62, RX: 27, RY: 14, RZ: 53}
         Weighted Cost: 152.0
         <BLANKLINE>
         Decomposition 1 (name: one_borrowed_worker)

--- a/pennylane/transforms/decomp_inspector.py
+++ b/pennylane/transforms/decomp_inspector.py
@@ -485,7 +485,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2, PauliX: 4}
         Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {CNOT: 58, GlobalPhase: 117, MidMeasure: 2, RX: 25, RY: 26, RZ: 94}
+        Full Expansion Gates: {CNOT: 60, GlobalPhase: 115, MidMeasure: 2, RX: 25, RY: 22, RZ: 96}
         Weighted Cost: 205.0
         <BLANKLINE>
         Decomposition 1 (name: controlled(_multi_rz_decomposition))
@@ -497,7 +497,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         6: ─╰●─╰●────────╰●─┤
         Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, MultiControlledX(wires=AbstractWires(6), control_values=AbstractArray((5,), bool)): 2, PauliX: 4}
         Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(4), control_values=AbstractArray((4,), bool)): 1, MultiControlledX(wires=AbstractWires(6), control_values=AbstractArray((5,), bool)): 2}
-        Full Expansion Gates: {CNOT: 96, GlobalPhase: 218, MidMeasure: 6, RX: 50, RY: 54, RZ: 170}
+        Full Expansion Gates: {CNOT: 102, GlobalPhase: 212, MidMeasure: 6, RX: 50, RY: 42, RZ: 176}
         Weighted Cost: 376.0
 
         Similarly, for the ``MultiControlledX`` in the circuit:
@@ -541,7 +541,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         Estimated First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 6, TemporaryAND: 1, Toffoli: 3}
         Actual First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 2, TemporaryAND: 1, Toffoli: 3}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {CNOT: 22, GlobalPhase: 47, MidMeasure: 1, RX: 10, RY: 11, RZ: 37}
+        Full Expansion Gates: {CNOT: 23, GlobalPhase: 46, MidMeasure: 1, RX: 10, RY: 9, RZ: 38}
         Weighted Cost: 81.0
         <BLANKLINE>
         Decomposition 3 (name: two_borrowed_workers)
@@ -569,7 +569,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         Estimated First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 6, TemporaryAND: 1, Toffoli: 3}
         Actual First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 2, TemporaryAND: 1, Toffoli: 3}
         Wire Allocations: {'zero': 2}
-        Full Expansion Gates: {CNOT: 22, GlobalPhase: 47, MidMeasure: 1, RX: 10, RY: 11, RZ: 37}
+        Full Expansion Gates: {CNOT: 23, GlobalPhase: 46, MidMeasure: 1, RX: 10, RY: 9, RZ: 38}
         Weighted Cost: 81.0
         <BLANKLINE>
         Decomposition 5 (name: many_borrowed_workers)
@@ -595,7 +595,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
              |0>├─╰⊕─╰●─────●╯──⊕╯──┤
         First-Level Expansion Gates: {Adjoint(TemporaryAND): 2, TemporaryAND: 2, Toffoli: 1}
         Wire Allocations: {'zero': 2}
-        Full Expansion Gates: {CNOT: 14, GlobalPhase: 37, MidMeasure: 2, RX: 8, RY: 12, RZ: 29}
+        Full Expansion Gates: {CNOT: 16, GlobalPhase: 35, MidMeasure: 2, RX: 8, RY: 8, RZ: 31}
         Weighted Cost: 65.0
 
         We can see that the chosen decomposition rule for the ``MultiControlledX`` uses two work
@@ -645,7 +645,7 @@ def decomp_inspector(  # pylint: disable=too-many-arguments
         Estimated First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 6, TemporaryAND: 1, Toffoli: 3}
         Actual First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 2, TemporaryAND: 1, Toffoli: 3}
         Wire Allocations: {'zero': 1}
-        Full Expansion Gates: {CNOT: 22, GlobalPhase: 47, MidMeasure: 1, RX: 10, RY: 11, RZ: 37}
+        Full Expansion Gates: {CNOT: 23, GlobalPhase: 46, MidMeasure: 1, RX: 10, RY: 9, RZ: 38}
         Weighted Cost: 81.0
         <BLANKLINE>
         Decomposition 3 (name: two_borrowed_workers)

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -1408,10 +1408,11 @@ class TestToBloqEstimator:
                     work_wires=[5, 6, 7, 8, 9],
                 ),
                 {
-                    (qp.Hadamard(0), True): 9708,
-                    (qp.CNOT([0, 1]), True): 7374,
-                    (qp.T(0), True): 312576,
-                    (qp.Toffoli([0, 1, 2]), True): 8829,
+                    (qp.Hadamard(0), True): 2316,
+                    (qp.CNOT([0, 1]), True): 5232,
+                    (qp.T(0), True): 268224,
+                    (qp.Toffoli([0, 1, 2]), True): 2865,
+                    (qp.X(0), True): 42,
                 },
             ),
             (

--- a/tests/io/test_qualtran_io.py
+++ b/tests/io/test_qualtran_io.py
@@ -1408,11 +1408,10 @@ class TestToBloqEstimator:
                     work_wires=[5, 6, 7, 8, 9],
                 ),
                 {
-                    (qp.Hadamard(0), True): 6012,
-                    (qp.CNOT([0, 1]), True): 6156,
-                    (qp.T(0), True): 283008,
-                    (qp.Toffoli([0, 1, 2]), True): 5469,
-                    (qp.X(0), True): 42,
+                    (qp.Hadamard(0), True): 9708,
+                    (qp.CNOT([0, 1]), True): 7374,
+                    (qp.T(0), True): 312576,
+                    (qp.Toffoli([0, 1, 2]), True): 8829,
                 },
             ),
             (

--- a/tests/ops/op_math/test_change_op_basis2.py
+++ b/tests/ops/op_math/test_change_op_basis2.py
@@ -462,7 +462,7 @@ class TestWrapperFunc:  # pylint: disable=too-few-public-methods
 
         factors = (qp.PauliX(wires=1), qp.RX(1.23, wires=0), qp.CNOT(wires=[0, 1]))
 
-        change_op_basis_func_op = ChangeOpBasis2(*factors)
+        change_op_basis_func_op = change_op_basis(*factors)
         change_op_basis_class_op = ChangeOpBasis2(*factors)
         qp.assert_equal(change_op_basis_func_op, change_op_basis_class_op)
 

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -119,7 +119,7 @@ class TestInspectDecompGraph:
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-            Full Expansion Gates: {CNOT: 160, GlobalPhase: 140, RX: 64, RY: 24, RZ: 136}
+            Full Expansion Gates: {CNOT: 160, GlobalPhase: 140, RX: 56, RY: 24, RZ: 144}
             Weighted Cost: 384.0
             """).strip()
 
@@ -151,9 +151,9 @@ class TestInspectDecompGraph:
             | :--- | :--- |
             | CNOT | 160 |
             | GlobalPhase | 140 |
-            | RX | 64 |
+            | RX | 56 |
             | RY | 24 |
-            | RZ | 136 |
+            | RZ | 144 |
             | **Weighted Cost** | 384.0 |
             </details>
             """).strip()
@@ -274,7 +274,7 @@ class TestInspectDecompGraph:
              [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
             Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 2, PauliX: 3, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
             Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 2, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 37, RX: 18, RY: 8, RZ: 31}
+            Full Expansion Gates: {CNOT: 24, GlobalPhase: 37, RX: 14, RY: 8, RZ: 35}
             Weighted Cost: 81.0
 
             Decomposition 1 (name: one_borrowed_worker)

--- a/tests/transforms/test_decomp_inspector.py
+++ b/tests/transforms/test_decomp_inspector.py
@@ -119,7 +119,7 @@ class TestInspectDecompGraph:
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-            Full Expansion Gates: {CNOT: 160, GlobalPhase: 140, RX: 56, RY: 24, RZ: 144}
+            Full Expansion Gates: {CNOT: 160, GlobalPhase: 140, RX: 64, RY: 24, RZ: 136}
             Weighted Cost: 384.0
             """).strip()
 
@@ -151,9 +151,9 @@ class TestInspectDecompGraph:
             | :--- | :--- |
             | CNOT | 160 |
             | GlobalPhase | 140 |
-            | RX | 56 |
+            | RX | 64 |
             | RY | 24 |
-            | RZ | 144 |
+            | RZ | 136 |
             | **Weighted Cost** | 384.0 |
             </details>
             """).strip()
@@ -182,7 +182,7 @@ class TestInspectDecompGraph:
             Estimated First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(4), control_values=AbstractArray((3,), bool)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(MultiRZ(AbstractArray((), float64, weak_type=True), wires=AbstractWires(2)), control_wires=AbstractWires(1), control_values=AbstractArray((1,), bool)): 1, MultiControlledX(wires=AbstractWires(4), control_values=AbstractArray((3,), bool)): 2}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {CNOT: 34, GlobalPhase: 68, MidMeasure: 2, RX: 12, RY: 18, RZ: 58}
+            Full Expansion Gates: {CNOT: 36, GlobalPhase: 66, MidMeasure: 2, RX: 12, RY: 14, RZ: 60}
             Weighted Cost: 124.0
 
             Decomposition 1 (name: controlled(_multi_rz_decomposition))
@@ -193,7 +193,7 @@ class TestInspectDecompGraph:
             5: ─╰●─╰●────────╰●─┤  
             Estimated First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2, PauliX: 3}
             Actual First-Level Expansion Gates: {Controlled(RZ, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, MultiControlledX(wires=AbstractWires(5), control_values=AbstractArray((4,), bool)): 2}
-            Full Expansion Gates: {CNOT: 72, GlobalPhase: 90, MidMeasure: 4, RX: 30, RY: 24, RZ: 80}
+            Full Expansion Gates: {CNOT: 76, GlobalPhase: 86, MidMeasure: 4, RX: 30, RY: 16, RZ: 84}
             Weighted Cost: 210.0
             """).strip()
 
@@ -222,12 +222,12 @@ class TestInspectDecompGraph:
 
             | Full Expansion | Count |
             | :--- | :--- |
-            | CNOT | 34 |
-            | GlobalPhase | 68 |
+            | CNOT | 36 |
+            | GlobalPhase | 66 |
             | MidMeasure | 2 |
             | RX | 12 |
-            | RY | 18 |
-            | RZ | 58 |
+            | RY | 14 |
+            | RZ | 60 |
             | **Weighted Cost** | 124.0 |
             </details>
 
@@ -252,12 +252,12 @@ class TestInspectDecompGraph:
 
             | Full Expansion | Count |
             | :--- | :--- |
-            | CNOT | 72 |
-            | GlobalPhase | 90 |
+            | CNOT | 76 |
+            | GlobalPhase | 86 |
             | MidMeasure | 4 |
             | RX | 30 |
-            | RY | 24 |
-            | RZ | 80 |
+            | RY | 16 |
+            | RZ | 84 |
             | **Weighted Cost** | 210.0 |
             </details>
             """).strip()
@@ -274,7 +274,7 @@ class TestInspectDecompGraph:
              [ 5.34910791e-34+0.j          9.23879533e-01-0.38268343j]]
             Estimated First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 2, PauliX: 3, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
             Actual First-Level Expansion Gates: {Adjoint(QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1))): 2, CNOT: 2, Controlled(GlobalPhase, control_wires=AbstractWires(3), control_values=AbstractArray((3,), bool)): 1, Hadamard: 2, MultiControlledX(wires=AbstractWires(3), control_values=AbstractArray((2,), bool)): 2, QubitUnitary(U=AbstractArray((2, 2), complex128, weak_type=True), wires=AbstractWires(1)): 2}
-            Full Expansion Gates: {CNOT: 24, GlobalPhase: 37, RX: 14, RY: 8, RZ: 35}
+            Full Expansion Gates: {CNOT: 24, GlobalPhase: 37, RX: 18, RY: 8, RZ: 31}
             Weighted Cost: 81.0
 
             Decomposition 1 (name: one_borrowed_worker)
@@ -298,7 +298,7 @@ class TestInspectDecompGraph:
             Estimated First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, PauliX: 3, TemporaryAND: 1, Toffoli: 1}
             Actual First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, TemporaryAND: 1, Toffoli: 1}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {CNOT: 10, GlobalPhase: 26, MidMeasure: 1, RX: 7, RY: 7, RZ: 19}
+            Full Expansion Gates: {CNOT: 11, GlobalPhase: 25, MidMeasure: 1, RX: 7, RY: 5, RZ: 20}
             Weighted Cost: 44.0
 
             Decomposition 3 (name: two_borrowed_workers)
@@ -326,7 +326,7 @@ class TestInspectDecompGraph:
                  |0>├─╰⊕─╰●──⊕╯──┤    
             First-Level Expansion Gates: {Adjoint(TemporaryAND): 1, TemporaryAND: 1, Toffoli: 1}
             Wire Allocations: {'zero': 1}
-            Full Expansion Gates: {CNOT: 10, GlobalPhase: 23, MidMeasure: 1, RX: 4, RY: 7, RZ: 19}
+            Full Expansion Gates: {CNOT: 11, GlobalPhase: 22, MidMeasure: 1, RX: 4, RY: 5, RZ: 20}
             Weighted Cost: 41.0
             """).strip()
 


### PR DESCRIPTION
**Context:** To unblock critical work, we need to make use of `Prod2` where possible until `qp.prod` properly dispatches to `Prod2`.

**Description of the Change:** Uses `Prod2` where needed.

**Benefits:** We unblock critical workflows.

**Possible Drawbacks:** A temporary fix until we can use `qp.prod`.

**Related GitHub Issues:** [sc-128922] [sc-129805]
