### PR TITLE
Add bootstrap to tcdq mmd loss

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1590,6 +1590,11 @@
   using Pauli-type observables.
   [(#10123)](https://github.com/PennyLaneAI/pennylane/pull/10123)
 
+* Config option added to qubit MMD loss that bootstraps target data by default to ensure
+  unbiasedness of the estimator
+  [(#10128)](https://github.com/PennyLaneAI/pennylane/pull/10128)
+
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1579,6 +1579,10 @@
 * Various decomposition rules are updated so that they accept positionally passed arguments.
   [(#10088)](https://github.com/PennyLaneAI/pennylane/pull/10088)
 
+* ``mmd_loss`` replaced with ``mmd_loss_pauli`` and now supports any expectation value function
+  using Pauli-type observables.
+  [(#10123)](https://github.com/PennyLaneAI/pennylane/pull/10123)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/labs/tcdq/__init__.py
+++ b/pennylane/labs/tcdq/__init__.py
@@ -35,9 +35,9 @@ Core classes and functions
     ~MMDConfig
     ~QuditMMDConfig
     ~build_expval_func
+    ~build_mmd_loss_pauli
     ~build_qudit_expval_func
     ~build_qudit_mmd_loss
-    ~mmd_loss_pauli
     ~median_heuristic
     ~train
     ~training_iterator
@@ -143,18 +143,25 @@ dataset of bitstrings, use the built-in Maximum Mean Discrepancy (MMD)
 loss. The MMD is a kernel-based distance between probability distributions.
 Smaller values mean the circuit output is closer to the target data.
 
+:func:`~build_mmd_loss_pauli` takes any Pauli expectation value callable,
+the number of qubits, and the MMD hyperparameters, and returns a reusable
+loss function with signature ``loss_fn(params, target_data, key=None)``.
+Because it takes a callable rather than a circuit configuration, the same
+loss works for any model that can estimate Pauli-``Z`` expectation values,
+not only IQP circuits.
+
 The ``bandwidth`` parameter controls how sensitive the loss is to
 fine-grained versus broad differences between distributions. A good
 default is the median pairwise distance of the dataset, computed with
 :func:`~median_heuristic`.
 
 For more detail on how the loss is constructed, see
-`Section IV B, Loss functions via graph-Fourier kernels. <https://arxiv.org/pdf/2607.06675>`_
+`Section 3.3 of IQPopt: Fast optimization of instantaneous quantum polynomial circuits in JAX <https://arxiv.org/pdf/2501.04776>`_.
 
 .. code-block:: python
 
    import numpy as np
-   from pennylane.labs.tcdq import MMDConfig, mmd_loss_pauli, median_heuristic
+   from pennylane.labs.tcdq import MMDConfig, build_mmd_loss_pauli, median_heuristic
 
    np.random.seed(42)
    target_data = np.random.binomial(1, 0.5, size=(500, n_qubits))
@@ -162,23 +169,23 @@ For more detail on how the loss is constructed, see
    bandwidth = median_heuristic(target_data)
    mmd_config = MMDConfig(bandwidth=bandwidth, n_ops=100)
 
-   loss_kwargs = {
-       "params": params,
-       "circuit_config": config,
-       "mmd_config": mmd_config,
-       "target_data": target_data,
-   }
+   # Build the loss once, then reuse it for every optimization step
+   loss_fn = build_mmd_loss_pauli(expval_fn, n_qubits, mmd_config)
 
    mmd_result = train(
        optimizer="Adam",
-       loss=mmd_loss_pauli,
+       loss=loss_fn,
        stepsize=0.01,
        n_iters=100,
-       loss_kwargs=loss_kwargs,
+       loss_kwargs={"params": params, "target_data": target_data},
        options=TrainingOptions(unroll_steps=10),
    )
 
    print("Final MMD loss:", float(mmd_result.losses[-1]))
+
+Any extra keyword arguments needed by the expectation value callable are
+forwarded through the loss, for example
+``loss_fn(params, target_data, key, n_samples=8000)``.
 
 
 Qudit circuits
@@ -217,7 +224,7 @@ qudit.
    m_vecs = jnp.zeros_like(l_vecs)
 
    config = QuditCircuitConfig(
-       d=d,
+       dims=d,
        n_qudits=n_qudits,
        gates=gates,
        observables=(l_vecs, m_vecs),
@@ -267,7 +274,7 @@ kernel: ``"cycle"`` respects the ordering of neighbouring levels, while
    }
 
    circuit_config = QuditCircuitConfig(
-       d=d,
+       dims=d,
        n_qudits=n_qudits,
        gates=gates,
        n_samples=2000,
@@ -303,7 +310,7 @@ from .qudit_expval_functions import (
     QuditCircuitConfig,
     build_qudit_expval_func,
 )
-from .mmd_loss_pauli import MMDConfig, median_heuristic, mmd_loss_pauli
+from .mmd_loss_pauli import MMDConfig, build_mmd_loss_pauli, median_heuristic
 from .qudit_mmd_loss import QuditMMDConfig, build_qudit_mmd_loss
 from .training import BatchResult, TrainingOptions, TrainingResult, train, training_iterator
 from .utils import (
@@ -319,8 +326,8 @@ __all__ = [
     "MMDConfig",
     "QuditMMDConfig",
     "build_expval_func",
+    "build_mmd_loss_pauli",
     "build_qudit_expval_func",
-    "mmd_loss_pauli",
     "build_qudit_mmd_loss",
     "median_heuristic",
     "BatchResult",

--- a/pennylane/labs/tcdq/__init__.py
+++ b/pennylane/labs/tcdq/__init__.py
@@ -37,7 +37,7 @@ Core classes and functions
     ~build_expval_func
     ~build_qudit_expval_func
     ~build_qudit_mmd_loss
-    ~mmd_loss
+    ~mmd_loss_pauli
     ~median_heuristic
     ~train
     ~training_iterator
@@ -154,7 +154,7 @@ For more detail on how the loss is constructed, see
 .. code-block:: python
 
    import numpy as np
-   from pennylane.labs.tcdq import MMDConfig, mmd_loss, median_heuristic
+   from pennylane.labs.tcdq import MMDConfig, mmd_loss_pauli, median_heuristic
 
    np.random.seed(42)
    target_data = np.random.binomial(1, 0.5, size=(500, n_qubits))
@@ -171,7 +171,7 @@ For more detail on how the loss is constructed, see
 
    mmd_result = train(
        optimizer="Adam",
-       loss=mmd_loss,
+       loss=mmd_loss_pauli,
        stepsize=0.01,
        n_iters=100,
        loss_kwargs=loss_kwargs,
@@ -303,7 +303,7 @@ from .qudit_expval_functions import (
     QuditCircuitConfig,
     build_qudit_expval_func,
 )
-from .mmd_loss import MMDConfig, median_heuristic, mmd_loss
+from .mmd_loss_pauli import MMDConfig, median_heuristic, mmd_loss_pauli
 from .qudit_mmd_loss import QuditMMDConfig, build_qudit_mmd_loss
 from .training import BatchResult, TrainingOptions, TrainingResult, train, training_iterator
 from .utils import (

--- a/pennylane/labs/tcdq/__init__.py
+++ b/pennylane/labs/tcdq/__init__.py
@@ -320,7 +320,7 @@ __all__ = [
     "QuditMMDConfig",
     "build_expval_func",
     "build_qudit_expval_func",
-    "mmd_loss",
+    "mmd_loss_pauli",
     "build_qudit_mmd_loss",
     "median_heuristic",
     "BatchResult",

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -26,7 +26,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.typing import ArrayLike, PyTree
+from jax.typing import ArrayLike
 
 
 @dataclass(frozen=True)
@@ -323,7 +323,7 @@ def build_mmd_loss_pauli(
         raise ValueError("bandwidth must not be empty")
 
     def loss_fn(
-        params: PyTree,
+        params: ArrayLike,
         target_data: ArrayLike,
         key: ArrayLike | None = None,
         **expval_kwargs,

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -140,19 +140,6 @@ def _compute_single_mmd(
     return jnp.sqrt(jnp.abs(reduced)) if sqrt_loss else reduced
 
 
-def _partition_by_hashability(items: tuple) -> tuple[tuple, tuple]:
-    """Split ``(name, value)`` pairs into hashable (static) and unhashable (traced) groups."""
-    static, dynamic = [], []
-    for name, value in items:
-        try:
-            hash(value)
-        except TypeError:
-            dynamic.append((name, value))
-        else:
-            static.append((name, value))
-    return tuple(static), tuple(dynamic)
-
-
 # pylint: disable=too-many-arguments,too-many-locals
 @partial(
     jax.jit,
@@ -162,7 +149,6 @@ def _partition_by_hashability(items: tuple) -> tuple[tuple, tuple]:
         "wire_tuple",
         "sqrt_loss",
         "expval_fn",
-        "static_kwargs",
     ],
 )
 def _compute_loss_for_bandwidth(
@@ -171,13 +157,12 @@ def _compute_loss_for_bandwidth(
     eval_key: jnp.ndarray,
     params: jnp.ndarray,
     target_data: jnp.ndarray,
-    traced_kwargs: dict,
+    expval_kwargs: dict,
     n_ops: int,
     n_qubits: int,
     wire_tuple: tuple[int, ...],
     sqrt_loss: bool,
     expval_fn: Callable,
-    static_kwargs: tuple,
 ):
     """JIT-compiled step that fuses observable generation and expectation value math."""
     wire_list = list(wire_tuple)
@@ -193,12 +178,10 @@ def _compute_loss_for_bandwidth(
 
     pauli_obs = _binary_ops_to_pauli_int(all_ops)
 
-    call_kwargs = dict(static_kwargs)
-    call_kwargs.update(traced_kwargs)
-    call_kwargs["observables"] = pauli_obs
-    call_kwargs["key"] = eval_key
+    expval_kwargs["observables"] = pauli_obs
+    expval_kwargs["key"] = eval_key
 
-    model_output = expval_fn(params, **call_kwargs)
+    model_output = expval_fn(params, **expval_kwargs)
 
     model_expvals, model_expvals_variances = (
         model_output if isinstance(model_output, tuple) else (model_output, None)
@@ -373,9 +356,6 @@ def build_mmd_loss_pauli(
                 "and passes them to expval_fn itself"
             )
 
-        static_kwargs, dynamic_kwargs = _partition_by_hashability(tuple(expval_kwargs.items()))
-        traced_kwargs = dict(dynamic_kwargs)
-
         active_key = jax.random.PRNGKey(0) if key is None else key
 
         target_data = jnp.asarray(target_data)
@@ -403,13 +383,12 @@ def build_mmd_loss_pauli(
                 eval_key=eval_key,
                 params=jnp.asarray(params),
                 target_data=target_data,
-                traced_kwargs=traced_kwargs,
                 n_ops=mmd_config.n_ops,
                 n_qubits=n_qubits,
                 wire_tuple=wire_tuple,
                 sqrt_loss=mmd_config.sqrt_loss,
                 expval_fn=expval_fn,
-                static_kwargs=static_kwargs,
+                expval_kwargs=expval_kwargs,
             )
             losses.append(loss_val)
 

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -19,7 +19,7 @@ estimates their expectation values with a user-supplied callable, and combines t
 MMD loss.
 """
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import partial
 
@@ -204,7 +204,7 @@ def _compute_loss_for_bandwidth(
     try:
         model_output = expval_fn(params, **call_kwargs)
     except TypeError as exc:
-        for name in ("observables", "key"):
+        for name in ("observables", "key") if inject_key else ("observables",):
             if f"unexpected keyword argument '{name}'" in str(exc):
                 raise TypeError(
                     f"expval_fn does not accept a '{name}' keyword argument. The loss calls "
@@ -240,33 +240,33 @@ def _compute_loss_for_bandwidth(
     )
 
 
-def mmd_loss_pauli(
-    params: ArrayLike,
+
+
+def build_mmd_loss_pauli(
     expval_fn: Callable,
     n_qubits: int,
     mmd_config: MMDConfig,
-    target_data: ArrayLike,
-    key: ArrayLike | None = None,
-    expval_kwargs: Mapping | None = None,
-) -> jnp.ndarray | list[jnp.ndarray]:
-    r"""Compute the MMD loss between a Pauli expectation value function and a target dataset.
+    inject_key: bool = True,
+) -> Callable:
+    r"""Build a reusable loss function that computes the qubit Pauli-kernel MMD.
 
-    This function estimates how far the model's output distribution is from the
-    empirical distribution defined by ``target_data``. The model is called as
+    The returned callable measures the distance between a model's output
+    distribution and an empirical target dataset of bitstrings using the
+    Maximum Mean Discrepancy (MMD) with an RBF kernel expanded in Pauli-Z
+    strings. The model is called as
 
     .. code-block:: python
 
         expval_fn(params, observables=..., key=..., **expval_kwargs)
 
-    where ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
+    where the ``key`` argument is omitted when ``inject_key=False``, and
+    ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
     Pauli codes (``0=I``, ``1=X``, ``2=Y``, ``3=Z``), of which only ``I`` and
     ``Z`` are generated. It must return ``expvals`` of shape ``(n_ops,)``, or
     ``(expvals, variances)`` where ``variances[i]`` is the variance of the
     estimator ``expvals[i]``; returning ``expvals`` alone declares the model exact.
 
     Args:
-        params (ArrayLike): Trainable model parameters, passed to ``expval_fn``
-            as its first argument.
         expval_fn (Callable): Pauli expectation value function, as above. Must be
             hashable and JAX-traceable.
         n_qubits (int): Number of qubits the model acts on, i.e. the width of the
@@ -274,37 +274,34 @@ def mmd_loss_pauli(
         mmd_config (MMDConfig): Hyperparameters for the MMD computation,
             including the RBF bandwidth and number of observables. See
             :class:`MMDConfig`.
-        target_data (ArrayLike): Binary dataset of shape ``(m, n_qubits)``, or
-            ``(m, len(mmd_config.wires))`` when a wire subset is selected, where
-            each row is a bitstring sample from the target distribution.
-        key (ArrayLike | None): Optional JAX PRNG key. If ``None``, uses
-            ``jax.random.PRNGKey(0)``.
-        expval_kwargs (Mapping | None): Extra keyword arguments forwarded to
-            ``expval_fn``, for example ``{"n_samples": 4000}``. Hashable values
-            are forwarded as compile-time constants; unhashable ones, notably
-            arrays, are traced.
+        inject_key (bool): If ``True`` (default), pass a freshly split ``key``
+            to ``expval_fn`` on every bandwidth. If ``False``, do not pass
+            ``key`` at all, leaving the model to source its own randomness, for
+            example via ``functools.partial(expval_fn, key=my_key)`` or a key
+            stored on the model. Note that ``inject_key=False`` reuses the same
+            model randomness for every bandwidth and every call, which gives
+            repeatable estimates but correlates them.
 
     Returns:
-        jnp.ndarray | list[jnp.ndarray]: A scalar MMD² estimate averaged over
-        all bandwidths by default, or a list of per-bandwidth estimates when
-        ``mmd_config.return_per_bandwidth=True``.
+        Callable: A function with signature
+        ``loss_fn(params, target_data, key=None, **expval_kwargs)`` that returns
+        either a scalar MMD² estimate (averaged across bandwidths) or a list of
+        per-bandwidth values when ``mmd_config.return_per_bandwidth=True``.
 
     Raises:
         ValueError: If ``mmd_config`` leaves ``bandwidth`` or ``n_ops`` unset, if
-            ``mmd_config.wires`` exceeds ``n_qubits``, if ``target_data`` has
-            fewer than two rows or an unexpected number of columns, if
-            ``expval_kwargs`` contains ``"observables"``, or if ``expval_fn``
-            returns arrays of the wrong shape.
-        TypeError: If ``expval_fn`` does not accept the ``observables`` or ``key``
-            keyword arguments.
+            ``mmd_config.bandwidth`` is empty, if ``mmd_config.n_ops < 1``, or if
+            ``mmd_config.wires`` contains duplicates or indices outside
+            ``[0, n_qubits)``.
 
     **Example**
 
     >>> import jax
+    >>> import jax.numpy as jnp
     >>> import numpy as np
     >>> from pennylane.labs.tcdq import (
-    ...     CircuitConfig, MMDConfig, build_expval_func, create_local_gates,
-    ...     median_heuristic, mmd_loss_pauli,
+    ...     CircuitConfig, MMDConfig, build_expval_func, build_mmd_loss_pauli,
+    ...     create_local_gates, median_heuristic,
     ... )
     >>> n_qubits = 4
     >>> gates = create_local_gates(n_qubits, max_weight=2)
@@ -312,14 +309,11 @@ def mmd_loss_pauli(
     ...     gates=gates, n_samples=1000, key=jax.random.PRNGKey(0), n_qubits=n_qubits
     ... )
     >>> target = np.random.binomial(1, 0.5, size=(100, n_qubits))
-    >>> bw = median_heuristic(target)
-    >>> mmd_cfg = MMDConfig(bandwidth=bw, n_ops=50)
-    >>> import jax.numpy as jnp
+    >>> mmd_config = MMDConfig(bandwidth=median_heuristic(target), n_ops=50)
+    >>> loss_fn = build_mmd_loss_pauli(build_expval_func(config), n_qubits, mmd_config)
     >>> params = jnp.zeros(len(gates))
-    >>> loss_val = mmd_loss_pauli(
-    ...     params, build_expval_func(config), n_qubits, mmd_cfg, target, key=config.key
-    ... )
-    >>> loss_val.shape
+    >>> loss = loss_fn(params, target, key=jax.random.PRNGKey(123))
+    >>> loss.shape
     ()
 
     .. seealso::
@@ -330,37 +324,17 @@ def mmd_loss_pauli(
     if mmd_config.bandwidth is None or mmd_config.n_ops is None:
         raise ValueError("mmd_config must specify both bandwidth and n_ops")
 
-    expval_kwargs = dict(expval_kwargs or {})
-    if "observables" in expval_kwargs:
-        raise ValueError(
-            "expval_kwargs must not contain 'observables': the loss samples the observables "
-            "and passes them to expval_fn itself"
-        )
-    inject_key = "key" not in expval_kwargs
-
-    static_kwargs, dynamic_kwargs = _partition_by_hashability(tuple(expval_kwargs.items()))
-    traced_kwargs = dict(dynamic_kwargs)
-
-    active_key = jax.random.PRNGKey(0) if key is None else key
+    if mmd_config.n_ops < 1:
+        raise ValueError("n_ops must be at least 1")
 
     wire_tuple = tuple(range(n_qubits)) if mmd_config.wires is None else tuple(mmd_config.wires)
-    if max(wire_tuple, default=-1) >= n_qubits:
-        raise ValueError(f"wires {wire_tuple} are out of range for n_qubits={n_qubits}")
 
-    target_data = jnp.asarray(target_data)
-    if target_data.ndim != 2:
-        raise ValueError(f"target_data must be 2-dimensional, got shape {target_data.shape}")
-    if target_data.shape[0] <= 1:
-        raise ValueError("target_data must contain more than one sample")
-    if target_data.shape[1] == n_qubits:
-        target_data = target_data[:, list(wire_tuple)]
-    elif target_data.shape[1] != len(wire_tuple):
-        expected = (
-            f"{n_qubits} (one per qubit)"
-            if len(wire_tuple) == n_qubits
-            else f"{len(wire_tuple)} (one per selected wire) or {n_qubits} (one per qubit)"
-        )
-        raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
+    for w in wire_tuple:
+        if w < 0 or w >= n_qubits:
+            raise ValueError(f"Wire index {w} out of range for {n_qubits} qubits")
+
+    if len(set(wire_tuple)) != len(wire_tuple):
+        raise ValueError("wires must not contain duplicates")
 
     bandwidth_list = (
         [mmd_config.bandwidth]
@@ -368,27 +342,106 @@ def mmd_loss_pauli(
         else list(mmd_config.bandwidth)
     )
 
-    losses = []
-    for bandwidth in bandwidth_list:
-        active_key, subkey, eval_key = jax.random.split(active_key, 3)
+    if len(bandwidth_list) == 0:
+        raise ValueError("bandwidth must not be empty")
 
-        loss_val = _compute_loss_for_bandwidth(
-            bandwidth=bandwidth,
-            subkey=subkey,
-            eval_key=eval_key,
-            params=params,
-            target_data=target_data,
-            traced_kwargs=traced_kwargs,
-            n_ops=mmd_config.n_ops,
-            n_qubits=n_qubits,
-            wire_tuple=wire_tuple,
-            sqrt_loss=mmd_config.sqrt_loss,
-            expval_fn=expval_fn,
-            static_kwargs=static_kwargs,
-            inject_key=inject_key,
-        )
-        losses.append(loss_val)
+    def loss_fn(
+        params: ArrayLike,
+        target_data: ArrayLike,
+        key: ArrayLike | None = None,
+        **expval_kwargs,
+    ) -> jnp.ndarray | list[jnp.ndarray]:
+        """Estimate the empirical qubit MMD loss for one parameter setting.
 
-    if mmd_config.return_per_bandwidth:
-        return losses
-    return jnp.mean(jnp.stack(losses))
+        The input ``target_data`` is interpreted as samples from the empirical
+        data distribution on the visible wires. For each requested bandwidth,
+        this function samples a fresh batch of Pauli-Z observables, estimates
+        their expectation values with ``expval_fn``, computes the matching
+        empirical moments from ``target_data``, and returns the resulting
+        unbiased MMD estimate.
+
+        If multiple bandwidths are configured, each bandwidth gets its own
+        independent observable batch and model-evaluation randomness.
+
+        Args:
+            params: Trainable model parameters, passed to ``expval_fn`` as its
+                first argument.
+            target_data: Binary array of shape ``(m, n_qubits)``, or
+                ``(m, len(mmd_config.wires))`` when a wire subset is selected,
+                whose rows are bitstring samples from the target distribution.
+            key: Optional JAX PRNG key seeding this call. It is split once per
+                bandwidth into one key for observable sampling and one that is
+                forwarded to ``expval_fn``. If ``None``, uses
+                ``jax.random.PRNGKey(0)``.
+            **expval_kwargs: Extra keyword arguments forwarded to ``expval_fn``,
+                for example ``n_samples=4000``. Hashable values are forwarded as
+                compile-time constants; unhashable ones, notably arrays, are
+                traced. ``observables`` is reserved, and ``key`` is controlled by
+                ``inject_key`` rather than passed here.
+
+        Returns:
+            Either a scalar mean across bandwidths or a list of per-bandwidth
+            loss values when ``return_per_bandwidth`` is enabled.
+
+        Raises:
+            ValueError: If ``target_data`` is not 2-dimensional, has fewer than
+                two rows or an unexpected number of columns, if
+                ``expval_kwargs`` contains ``"observables"``, or if ``expval_fn``
+                returns arrays of the wrong shape.
+            TypeError: If ``expval_fn`` does not accept the ``observables`` or
+                ``key`` keyword arguments.
+        """
+        if "observables" in expval_kwargs:
+            raise ValueError(
+                "expval_kwargs must not contain 'observables': the loss samples the observables "
+                "and passes them to expval_fn itself"
+            )
+
+        static_kwargs, dynamic_kwargs = _partition_by_hashability(tuple(expval_kwargs.items()))
+        traced_kwargs = dict(dynamic_kwargs)
+
+        active_key = jax.random.PRNGKey(0) if key is None else key
+
+        target_data = jnp.asarray(target_data)
+        if target_data.ndim != 2:
+            raise ValueError(f"target_data must be 2-dimensional, got shape {target_data.shape}")
+        if target_data.shape[0] <= 1:
+            raise ValueError("target_data must contain more than one sample")
+        if target_data.shape[1] == n_qubits:
+            target_data = target_data[:, list(wire_tuple)]
+        elif target_data.shape[1] != len(wire_tuple):
+            expected = (
+                f"{n_qubits} (one per qubit)"
+                if len(wire_tuple) == n_qubits
+                else f"{len(wire_tuple)} (one per selected wire) or {n_qubits} (one per qubit)"
+            )
+            raise ValueError(
+                f"target_data has {target_data.shape[1]} columns, expected {expected}"
+            )
+
+        losses = []
+        for bandwidth in bandwidth_list:
+            active_key, subkey, eval_key = jax.random.split(active_key, 3)
+
+            loss_val = _compute_loss_for_bandwidth(
+                bandwidth=bandwidth,
+                subkey=subkey,
+                eval_key=eval_key,
+                params=jnp.asarray(params),
+                target_data=target_data,
+                traced_kwargs=traced_kwargs,
+                n_ops=mmd_config.n_ops,
+                n_qubits=n_qubits,
+                wire_tuple=wire_tuple,
+                sqrt_loss=mmd_config.sqrt_loss,
+                expval_fn=expval_fn,
+                static_kwargs=static_kwargs,
+                inject_key=inject_key,
+            )
+            losses.append(loss_val)
+
+        if mmd_config.return_per_bandwidth:
+            return losses
+        return jnp.mean(jnp.stack(losses))
+
+    return loss_fn

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -26,7 +26,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.typing import ArrayLike
+from jax.typing import ArrayLike, PyTree
 
 
 @dataclass(frozen=True)
@@ -323,7 +323,7 @@ def build_mmd_loss_pauli(
         raise ValueError("bandwidth must not be empty")
 
     def loss_fn(
-        params: ArrayLike,
+        params: PyTree,
         target_data: ArrayLike,
         key: ArrayLike | None = None,
         **expval_kwargs,

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -49,6 +49,10 @@ class MMDConfig:
         return_per_bandwidth (bool): If ``True``, return a list of
             per-bandwidth loss values instead of their scalar average.
             Defaults to ``False``.
+        bootstrap_target_data (bool): If ``True``, resample ``target_data`` with
+            replacement before computing the loss. This makes the target-target
+            U-statistic unbiased with respect to the empirical target
+            distribution. Defaults to ``True``.
 
     **Example**
 
@@ -69,6 +73,8 @@ class MMDConfig:
     sqrt_loss: bool = False
     #: If ``True``, return per-bandwidth losses instead of their average.
     return_per_bandwidth: bool = False
+    #: If ``True``, bootstrap the target data before computing the loss.
+    bootstrap_target_data: bool = True
 
 
 def median_heuristic(samples: ArrayLike) -> float:
@@ -330,6 +336,7 @@ def build_mmd_loss_pauli(
                 ``(m, len(mmd_config.wires))`` when a wire subset is selected,
                 whose rows are bitstring samples from the target distribution.
             key: Optional JAX PRNG key seeding this call. It is split once per
+                call to resample the target data when requested, then once per
                 bandwidth into one key for observable sampling and one that is
                 forwarded to ``expval_fn``. If ``None``, uses
                 ``jax.random.PRNGKey(0)``.
@@ -372,6 +379,13 @@ def build_mmd_loss_pauli(
                 else f"{len(wire_tuple)} (one per selected wire) or {n_qubits} (one per qubit)"
             )
             raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
+
+        if mmd_config.bootstrap_target_data:
+            active_key, target_key = jax.random.split(active_key)
+            target_indices = jax.random.choice(
+                target_key, target_data.shape[0], shape=(target_data.shape[0],), replace=True
+            )
+            target_data = target_data[target_indices]
 
         losses = []
         for bandwidth in bandwidth_list:

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -232,7 +232,6 @@ def build_mmd_loss_pauli(
     expval_fn: Callable,
     n_qubits: int,
     mmd_config: MMDConfig,
-    inject_key: bool = True,
 ) -> Callable:
     r"""Build a reusable loss function that computes the qubit Pauli-kernel MMD.
 
@@ -243,10 +242,9 @@ def build_mmd_loss_pauli(
 
     .. code-block:: python
 
-        expval_fn(params, observables=..., key=..., **expval_kwargs)
+        expval_fn(params, observables=..., **expval_kwargs)
 
-    where the ``key`` argument is omitted when ``inject_key=False``, and
-    ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
+    where ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
     Pauli codes (``0=I``, ``1=X``, ``2=Y``, ``3=Z``), of which only ``I`` and
     ``Z`` are generated. It must return ``expvals`` of shape ``(n_ops,)``, or
     ``(expvals, variances)`` where ``variances[i]`` is the variance of the
@@ -260,13 +258,6 @@ def build_mmd_loss_pauli(
         mmd_config (MMDConfig): Hyperparameters for the MMD computation,
             including the RBF bandwidth and number of observables. See
             :class:`MMDConfig`.
-        inject_key (bool): If ``True`` (default), pass a freshly split ``key``
-            to ``expval_fn`` on every bandwidth. If ``False``, do not pass
-            ``key`` at all, leaving the model to source its own randomness, for
-            example via ``functools.partial(expval_fn, key=my_key)`` or a key
-            stored on the model. Note that ``inject_key=False`` reuses the same
-            model randomness for every bandwidth and every call, which gives
-            repeatable estimates but correlates them.
 
     Returns:
         Callable: A function with signature
@@ -362,8 +353,7 @@ def build_mmd_loss_pauli(
             **expval_kwargs: Extra keyword arguments forwarded to ``expval_fn``,
                 for example ``n_samples=4000``. Hashable values are forwarded as
                 compile-time constants; unhashable ones, notably arrays, are
-                traced. ``observables`` is reserved, and ``key`` is controlled by
-                ``inject_key`` rather than passed here.
+                traced. ``observables`` is reserved.
 
         Returns:
             Either a scalar mean across bandwidths or a list of per-bandwidth
@@ -420,7 +410,6 @@ def build_mmd_loss_pauli(
                 sqrt_loss=mmd_config.sqrt_loss,
                 expval_fn=expval_fn,
                 static_kwargs=static_kwargs,
-                inject_key=inject_key,
             )
             losses.append(loss_val)
 

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -225,7 +225,7 @@ def build_mmd_loss_pauli(
 
     .. code-block:: python
 
-        expval_fn(params, observables=..., **expval_kwargs)
+        expval_fn(params, observables=..., key=..., **expval_kwargs)
 
     where ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
     Pauli codes (``0=I``, ``1=X``, ``2=Y``, ``3=Z``), of which only ``I`` and

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -49,6 +49,10 @@ class MMDConfig:
         return_per_bandwidth (bool): If ``True``, return a list of
             per-bandwidth loss values instead of their scalar average.
             Defaults to ``False``.
+        bootstrap_target_data (bool): If ``True``, resample ``target_data`` with
+            replacement before computing the loss. This makes the target-target
+            U-statistic unbiased with respect to the empirical training
+            distribution. Defaults to ``True``.
 
     **Example**
 
@@ -69,6 +73,8 @@ class MMDConfig:
     sqrt_loss: bool = False
     #: If ``True``, return per-bandwidth losses instead of their average.
     return_per_bandwidth: bool = False
+    #: If ``True``, bootstrap the target data before computing the loss.
+    bootstrap_target_data: bool = True
 
 
 def median_heuristic(samples: ArrayLike) -> float:
@@ -330,6 +336,7 @@ def build_mmd_loss_pauli(
                 ``(m, len(mmd_config.wires))`` when a wire subset is selected,
                 whose rows are bitstring samples from the target distribution.
             key: Optional JAX PRNG key seeding this call. It is split once per
+                call to resample the target data when requested, then once per
                 bandwidth into one key for observable sampling and one that is
                 forwarded to ``expval_fn``. If ``None``, uses
                 ``jax.random.PRNGKey(0)``.
@@ -373,6 +380,13 @@ def build_mmd_loss_pauli(
             )
             raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
 
+        if mmd_config.bootstrap_target_data:
+            active_key, target_key = jax.random.split(active_key)
+            target_indices = jax.random.choice(
+                target_key, target_data.shape[0], shape=(target_data.shape[0],), replace=True
+            )
+            target_data = target_data[target_indices]
+
         losses = []
         for bandwidth in bandwidth_list:
             active_key, subkey, eval_key = jax.random.split(active_key, 3)
@@ -381,7 +395,7 @@ def build_mmd_loss_pauli(
                 bandwidth=bandwidth,
                 subkey=subkey,
                 eval_key=eval_key,
-                params=jnp.asarray(params),
+                params=params,
                 target_data=target_data,
                 n_ops=mmd_config.n_ops,
                 n_qubits=n_qubits,

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Maximum Mean Discrepancy (MMD) loss for qubit IQP circuits.
+"""Maximum Mean Discrepancy (MMD) loss for Pauli expectation value functions.
 
-This module compares the output of a qubit IQP circuit to a dataset of
+This module compares the output distribution of a model to a dataset of
 bitstrings. It samples Pauli-Z observables from an RBF (Radial Basis Function) kernel distribution,
-estimates their expectation values, and combines the results into an MMD loss.
+estimates their expectation values with a user-supplied callable, and combines the results into an
+MMD loss.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
 
@@ -27,15 +28,13 @@ import jax.numpy as jnp
 import numpy as np
 from jax.typing import ArrayLike
 
-from .expval_functions import CircuitConfig, build_expval_func
-
 
 @dataclass(frozen=True)
 class MMDConfig:
     r"""Hyperparameters for the qubit Maximum Mean Discrepancy (MMD) loss.
 
-    The MMD measures how well the circuit's output distribution matches a
-    target dataset.
+    The MMD measures how well the model's output distribution matches a target
+    dataset.
 
     Args:
         bandwidth (float | Sequence[float]): The bandwidth :math:`\sigma^2` of the kernel. If a sequence is provided,
@@ -120,32 +119,51 @@ def _binary_ops_to_pauli_int(binary_ops: ArrayLike) -> jnp.ndarray:
 @partial(jax.jit, static_argnames=["sqrt_loss"])
 def _compute_single_mmd(
     model_expvals: jnp.ndarray,
-    model_expvals_variances: jnp.ndarray,
+    model_expvals_variances: jnp.ndarray | None,
     target_data: jnp.ndarray,
     visible_ops: jnp.ndarray,
     sqrt_loss: bool,
 ) -> jnp.ndarray:
-    """Core, heavily JIT-compiled math for MMD calculation."""
+    """Core, heavily JIT-compiled math for MMD calculation.
+
+    ``model_expvals_variances`` may be ``None`` for an exact model.
+    """
     tr_train = jnp.mean(1 - 2 * ((target_data @ visible_ops.T) % 2), axis=0)
     m = target_data.shape[0]
 
-    result = model_expvals**2 - model_expvals_variances
+    result = model_expvals**2
+    if model_expvals_variances is not None:
+        result = result - model_expvals_variances
     result = result - 2 * model_expvals * tr_train + (tr_train * tr_train * m - 1) / (m - 1)
 
     reduced = jnp.mean(result)
     return jnp.sqrt(jnp.abs(reduced)) if sqrt_loss else reduced
 
 
-# pylint: disable=too-many-arguments
+def _partition_by_hashability(items: tuple) -> tuple[tuple, tuple]:
+    """Split ``(name, value)`` pairs into hashable (static) and unhashable (traced) groups."""
+    static, dynamic = [], []
+    for name, value in items:
+        try:
+            hash(value)
+        except TypeError:
+            dynamic.append((name, value))
+        else:
+            static.append((name, value))
+    return tuple(static), tuple(dynamic)
+
+
+# pylint: disable=too-many-arguments,too-many-locals
 @partial(
     jax.jit,
     static_argnames=[
         "n_ops",
         "n_qubits",
         "wire_tuple",
-        "effective_samples",
         "sqrt_loss",
-        "expval_func",
+        "expval_fn",
+        "static_kwargs",
+        "inject_key",
     ],
 )
 def _compute_loss_for_bandwidth(
@@ -154,14 +172,14 @@ def _compute_loss_for_bandwidth(
     eval_key: jnp.ndarray,
     params: jnp.ndarray,
     target_data: jnp.ndarray,
-    effective_init_state_elems: jnp.ndarray | None,
-    effective_init_state_amps: jnp.ndarray | None,
+    traced_kwargs: dict,
     n_ops: int,
     n_qubits: int,
     wire_tuple: tuple[int, ...],
-    effective_samples: int,
     sqrt_loss: bool,
-    expval_func: Callable,
+    expval_fn: Callable,
+    static_kwargs: tuple,
+    inject_key: bool,
 ):
     """JIT-compiled step that fuses observable generation and expectation value math."""
     wire_list = list(wire_tuple)
@@ -177,14 +195,41 @@ def _compute_loss_for_bandwidth(
 
     pauli_obs = _binary_ops_to_pauli_int(all_ops)
 
-    model_expvals, model_expvals_variances = expval_func(
-        gates_params=params,
-        observables=pauli_obs,
-        key=eval_key,
-        n_samples=effective_samples,
-        init_state_elems=effective_init_state_elems,
-        init_state_amps=effective_init_state_amps,
+    call_kwargs = dict(static_kwargs)
+    call_kwargs.update(traced_kwargs)
+    call_kwargs["observables"] = pauli_obs
+    if inject_key:
+        call_kwargs["key"] = eval_key
+
+    try:
+        model_output = expval_fn(params, **call_kwargs)
+    except TypeError as exc:
+        for name in ("observables", "key"):
+            if f"unexpected keyword argument '{name}'" in str(exc):
+                raise TypeError(
+                    f"expval_fn does not accept a '{name}' keyword argument. The loss calls "
+                    "expval_fn(params, observables=..., key=..., **expval_kwargs)"
+                ) from exc
+        raise
+
+    model_expvals, model_expvals_variances = (
+        model_output if isinstance(model_output, tuple) else (model_output, None)
     )
+
+    model_expvals = jnp.asarray(model_expvals)
+    if model_expvals_variances is not None:
+        model_expvals_variances = jnp.asarray(model_expvals_variances)
+
+    if model_expvals.shape != (n_ops,):
+        raise ValueError(
+            f"expval_fn returned expectation values of shape {model_expvals.shape}, "
+            f"expected ({n_ops},)"
+        )
+    if model_expvals_variances is not None and model_expvals_variances.shape != (n_ops,):
+        raise ValueError(
+            f"expval_fn returned variances of shape {model_expvals_variances.shape}, "
+            f"expected ({n_ops},)"
+        )
 
     return _compute_single_mmd(
         model_expvals,
@@ -195,30 +240,49 @@ def _compute_loss_for_bandwidth(
     )
 
 
-def mmd_loss(
+def mmd_loss_pauli(
     params: ArrayLike,
-    circuit_config: CircuitConfig,
+    expval_fn: Callable,
+    n_qubits: int,
     mmd_config: MMDConfig,
     target_data: ArrayLike,
     key: ArrayLike | None = None,
+    expval_kwargs: Mapping | None = None,
 ) -> jnp.ndarray | list[jnp.ndarray]:
-    """Compute the MMD loss between a qubit IQP circuit and a target dataset.
+    r"""Compute the MMD loss between a Pauli expectation value function and a target dataset.
 
-    This function estimates how far the circuit's output distribution is from
-    the empirical distribution defined by ``target_data``.
+    This function estimates how far the model's output distribution is from the
+    empirical distribution defined by ``target_data``. The model is called as
+
+    .. code-block:: python
+
+        expval_fn(params, observables=..., key=..., **expval_kwargs)
+
+    where ``observables`` is an integer array of shape ``(n_ops, n_qubits)`` of
+    Pauli codes (``0=I``, ``1=X``, ``2=Y``, ``3=Z``), of which only ``I`` and
+    ``Z`` are generated. It must return ``expvals`` of shape ``(n_ops,)``, or
+    ``(expvals, variances)`` where ``variances[i]`` is the variance of the
+    estimator ``expvals[i]``; returning ``expvals`` alone declares the model exact.
 
     Args:
-        params (ArrayLike): Trainable circuit parameters, shape ``(n_params,)``.
-        circuit_config (CircuitConfig): Circuit description specifying the gate
-            structure, number of qubits, and sample count. See
-            :class:`~pennylane.labs.tcdq.CircuitConfig` for how to construct one.
+        params (ArrayLike): Trainable model parameters, passed to ``expval_fn``
+            as its first argument.
+        expval_fn (Callable): Pauli expectation value function, as above. Must be
+            hashable and JAX-traceable.
+        n_qubits (int): Number of qubits the model acts on, i.e. the width of the
+            observable array passed to ``expval_fn``.
         mmd_config (MMDConfig): Hyperparameters for the MMD computation,
             including the RBF bandwidth and number of observables. See
             :class:`MMDConfig`.
-        target_data (ArrayLike): Binary dataset of shape ``(m, n_qubits)``
-            where each row is a bitstring sample from the target distribution.
-        key (ArrayLike | None): Optional JAX PRNG key. If ``None``, uses the
-            key stored in ``circuit_config``.
+        target_data (ArrayLike): Binary dataset of shape ``(m, n_qubits)``, or
+            ``(m, len(mmd_config.wires))`` when a wire subset is selected, where
+            each row is a bitstring sample from the target distribution.
+        key (ArrayLike | None): Optional JAX PRNG key. If ``None``, uses
+            ``jax.random.PRNGKey(0)``.
+        expval_kwargs (Mapping | None): Extra keyword arguments forwarded to
+            ``expval_fn``, for example ``{"n_samples": 4000}``. Hashable values
+            are forwarded as compile-time constants; unhashable ones, notably
+            arrays, are traced.
 
     Returns:
         jnp.ndarray | list[jnp.ndarray]: A scalar MMD² estimate averaged over
@@ -226,14 +290,21 @@ def mmd_loss(
         ``mmd_config.return_per_bandwidth=True``.
 
     Raises:
-        ValueError: If ``circuit_config.n_samples <= 1``.
+        ValueError: If ``mmd_config`` leaves ``bandwidth`` or ``n_ops`` unset, if
+            ``mmd_config.wires`` exceeds ``n_qubits``, if ``target_data`` has
+            fewer than two rows or an unexpected number of columns, if
+            ``expval_kwargs`` contains ``"observables"``, or if ``expval_fn``
+            returns arrays of the wrong shape.
+        TypeError: If ``expval_fn`` does not accept the ``observables`` or ``key``
+            keyword arguments.
 
     **Example**
 
     >>> import jax
     >>> import numpy as np
     >>> from pennylane.labs.tcdq import (
-    ...     CircuitConfig, MMDConfig, mmd_loss, create_local_gates, median_heuristic
+    ...     CircuitConfig, MMDConfig, build_expval_func, create_local_gates,
+    ...     median_heuristic, mmd_loss_pauli,
     ... )
     >>> n_qubits = 4
     >>> gates = create_local_gates(n_qubits, max_weight=2)
@@ -245,7 +316,9 @@ def mmd_loss(
     >>> mmd_cfg = MMDConfig(bandwidth=bw, n_ops=50)
     >>> import jax.numpy as jnp
     >>> params = jnp.zeros(len(gates))
-    >>> loss_val = mmd_loss(params, config, mmd_cfg, target)
+    >>> loss_val = mmd_loss_pauli(
+    ...     params, build_expval_func(config), n_qubits, mmd_cfg, target, key=config.key
+    ... )
     >>> loss_val.shape
     ()
 
@@ -254,25 +327,48 @@ def mmd_loss(
         :func:`~pennylane.labs.tcdq.build_expval_func`,
         `Section 3.3 of IQPopt: Fast optimization of instantaneous quantum polynomial circuits in JAX <https://arxiv.org/pdf/2501.04776>`_
     """
-    effective_samples = circuit_config.n_samples
-    if effective_samples <= 1:
-        raise ValueError("n_samples must be greater than 1")
+    if mmd_config.bandwidth is None or mmd_config.n_ops is None:
+        raise ValueError("mmd_config must specify both bandwidth and n_ops")
 
-    active_key = circuit_config.key if key is None else key
-    n_qubits = circuit_config.n_qubits
+    expval_kwargs = dict(expval_kwargs or {})
+    if "observables" in expval_kwargs:
+        raise ValueError(
+            "expval_kwargs must not contain 'observables': the loss samples the observables "
+            "and passes them to expval_fn itself"
+        )
+    inject_key = "key" not in expval_kwargs
+
+    static_kwargs, dynamic_kwargs = _partition_by_hashability(tuple(expval_kwargs.items()))
+    traced_kwargs = dict(dynamic_kwargs)
+
+    active_key = jax.random.PRNGKey(0) if key is None else key
 
     wire_tuple = tuple(range(n_qubits)) if mmd_config.wires is None else tuple(mmd_config.wires)
+    if max(wire_tuple, default=-1) >= n_qubits:
+        raise ValueError(f"wires {wire_tuple} are out of range for n_qubits={n_qubits}")
+
+    target_data = jnp.asarray(target_data)
+    if target_data.ndim != 2:
+        raise ValueError(f"target_data must be 2-dimensional, got shape {target_data.shape}")
+    if target_data.shape[0] <= 1:
+        raise ValueError("target_data must contain more than one sample")
+    if target_data.shape[1] == n_qubits:
+        target_data = target_data[:, list(wire_tuple)]
+    elif target_data.shape[1] != len(wire_tuple):
+        expected = (
+            f"{n_qubits} (one per qubit)"
+            if len(wire_tuple) == n_qubits
+            else f"{len(wire_tuple)} (one per selected wire) or {n_qubits} (one per qubit)"
+        )
+        raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
 
     bandwidth_list = (
         [mmd_config.bandwidth]
         if isinstance(mmd_config.bandwidth, (int, float))
         else list(mmd_config.bandwidth)
     )
-    target_data = jnp.asarray(target_data)
 
-    expval_func = build_expval_func(circuit_config)
     losses = []
-
     for bandwidth in bandwidth_list:
         active_key, subkey, eval_key = jax.random.split(active_key, 3)
 
@@ -282,14 +378,14 @@ def mmd_loss(
             eval_key=eval_key,
             params=params,
             target_data=target_data,
-            effective_init_state_elems=circuit_config.init_state_elems,
-            effective_init_state_amps=circuit_config.init_state_amps,
+            traced_kwargs=traced_kwargs,
             n_ops=mmd_config.n_ops,
             n_qubits=n_qubits,
             wire_tuple=wire_tuple,
-            effective_samples=effective_samples,
             sqrt_loss=mmd_config.sqrt_loss,
-            expval_func=expval_func,
+            expval_fn=expval_fn,
+            static_kwargs=static_kwargs,
+            inject_key=inject_key,
         )
         losses.append(loss_val)
 

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -49,10 +49,6 @@ class MMDConfig:
         return_per_bandwidth (bool): If ``True``, return a list of
             per-bandwidth loss values instead of their scalar average.
             Defaults to ``False``.
-        bootstrap_target_data (bool): If ``True``, resample ``target_data`` with
-            replacement before computing the loss. This makes the target-target
-            U-statistic unbiased with respect to the empirical training
-            distribution. Defaults to ``True``.
 
     **Example**
 
@@ -73,8 +69,6 @@ class MMDConfig:
     sqrt_loss: bool = False
     #: If ``True``, return per-bandwidth losses instead of their average.
     return_per_bandwidth: bool = False
-    #: If ``True``, bootstrap the target data before computing the loss.
-    bootstrap_target_data: bool = True
 
 
 def median_heuristic(samples: ArrayLike) -> float:
@@ -336,7 +330,6 @@ def build_mmd_loss_pauli(
                 ``(m, len(mmd_config.wires))`` when a wire subset is selected,
                 whose rows are bitstring samples from the target distribution.
             key: Optional JAX PRNG key seeding this call. It is split once per
-                call to resample the target data when requested, then once per
                 bandwidth into one key for observable sampling and one that is
                 forwarded to ``expval_fn``. If ``None``, uses
                 ``jax.random.PRNGKey(0)``.
@@ -380,13 +373,6 @@ def build_mmd_loss_pauli(
             )
             raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
 
-        if mmd_config.bootstrap_target_data:
-            active_key, target_key = jax.random.split(active_key)
-            target_indices = jax.random.choice(
-                target_key, target_data.shape[0], shape=(target_data.shape[0],), replace=True
-            )
-            target_data = target_data[target_indices]
-
         losses = []
         for bandwidth in bandwidth_list:
             active_key, subkey, eval_key = jax.random.split(active_key, 3)
@@ -395,7 +381,7 @@ def build_mmd_loss_pauli(
                 bandwidth=bandwidth,
                 subkey=subkey,
                 eval_key=eval_key,
-                params=params,
+                params=jnp.asarray(params),
                 target_data=target_data,
                 n_ops=mmd_config.n_ops,
                 n_qubits=n_qubits,

--- a/pennylane/labs/tcdq/mmd_loss_pauli.py
+++ b/pennylane/labs/tcdq/mmd_loss_pauli.py
@@ -163,7 +163,6 @@ def _partition_by_hashability(items: tuple) -> tuple[tuple, tuple]:
         "sqrt_loss",
         "expval_fn",
         "static_kwargs",
-        "inject_key",
     ],
 )
 def _compute_loss_for_bandwidth(
@@ -179,7 +178,6 @@ def _compute_loss_for_bandwidth(
     sqrt_loss: bool,
     expval_fn: Callable,
     static_kwargs: tuple,
-    inject_key: bool,
 ):
     """JIT-compiled step that fuses observable generation and expectation value math."""
     wire_list = list(wire_tuple)
@@ -198,19 +196,9 @@ def _compute_loss_for_bandwidth(
     call_kwargs = dict(static_kwargs)
     call_kwargs.update(traced_kwargs)
     call_kwargs["observables"] = pauli_obs
-    if inject_key:
-        call_kwargs["key"] = eval_key
+    call_kwargs["key"] = eval_key
 
-    try:
-        model_output = expval_fn(params, **call_kwargs)
-    except TypeError as exc:
-        for name in ("observables", "key") if inject_key else ("observables",):
-            if f"unexpected keyword argument '{name}'" in str(exc):
-                raise TypeError(
-                    f"expval_fn does not accept a '{name}' keyword argument. The loss calls "
-                    "expval_fn(params, observables=..., key=..., **expval_kwargs)"
-                ) from exc
-        raise
+    model_output = expval_fn(params, **call_kwargs)
 
     model_expvals, model_expvals_variances = (
         model_output if isinstance(model_output, tuple) else (model_output, None)
@@ -238,8 +226,6 @@ def _compute_loss_for_bandwidth(
         visible_ops,
         sqrt_loss,
     )
-
-
 
 
 def build_mmd_loss_pauli(
@@ -415,9 +401,7 @@ def build_mmd_loss_pauli(
                 if len(wire_tuple) == n_qubits
                 else f"{len(wire_tuple)} (one per selected wire) or {n_qubits} (one per qubit)"
             )
-            raise ValueError(
-                f"target_data has {target_data.shape[1]} columns, expected {expected}"
-            )
+            raise ValueError(f"target_data has {target_data.shape[1]} columns, expected {expected}")
 
         losses = []
         for bandwidth in bandwidth_list:

--- a/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
+++ b/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
@@ -19,13 +19,13 @@ import numpy as np
 import pytest
 
 import pennylane as qp
-from pennylane.labs.tcdq.expval_functions import CircuitConfig
-from pennylane.labs.tcdq.mmd_loss import (
+from pennylane.labs.tcdq.expval_functions import CircuitConfig, build_expval_func
+from pennylane.labs.tcdq.mmd_loss_pauli import (
     MMDConfig,
     _binary_ops_to_pauli_int,
     _compute_single_mmd,
     median_heuristic,
-    mmd_loss,
+    mmd_loss_pauli,
 )
 
 jax = pytest.importorskip("jax")
@@ -281,25 +281,7 @@ class TestExactMMDConsistency:
 
 
 class TestMMDLossAPI:
-    """Tests for :func:`mmd_loss`."""
-
-    def test_raises_n_samples_le_one(self):
-        """``n_samples <= 1`` should raise ``ValueError``."""
-        config = CircuitConfig(
-            gates={0: [[0]]},
-            n_samples=1,
-            key=jax.random.PRNGKey(0),
-            n_qubits=1,
-        )
-        mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=5)
-
-        with pytest.raises(ValueError, match="n_samples must be greater than 1"):
-            mmd_loss(
-                jnp.array([0.1]),
-                config,
-                mmd_cfg,
-                jnp.array([[0]]),
-            )
+    """Tests for :func:`mmd_loss_pauli`."""
 
     def test_return_per_bandwidth_type_and_length(self):
         """``return_per_bandwidth=True`` returns a list of length ``len(bandwidth)``."""
@@ -309,12 +291,14 @@ class TestMMDLossAPI:
             key=jax.random.PRNGKey(0),
             n_qubits=2,
         )
+        expval_fn = build_expval_func(config)
         mmd_cfg = MMDConfig(bandwidth=[0.5, 1.0], n_ops=30, return_per_bandwidth=True)
         data = jnp.array([[0, 1], [1, 0], [0, 0]])
 
-        res = mmd_loss(
+        res = mmd_loss_pauli(
             jnp.array([0.1, 0.2]),
-            config,
+            expval_fn,
+            2,
             mmd_cfg,
             data,
         )
@@ -335,12 +319,13 @@ class TestMMDLossAPI:
         )
         data = jnp.array([[0, 1], [1, 0], [0, 0], [1, 1]])
         bandwidths = [0.5, 1.0, 2.0]
+        expval_fn = build_expval_func(config)
 
         cfg_per = MMDConfig(bandwidth=bandwidths, n_ops=100, return_per_bandwidth=True)
         cfg_avg = MMDConfig(bandwidth=bandwidths, n_ops=100, return_per_bandwidth=False)
 
-        per = mmd_loss(jnp.array([0.1, 0.2]), config, cfg_per, data)
-        avg = mmd_loss(jnp.array([0.1, 0.2]), config, cfg_avg, data)
+        per = mmd_loss_pauli(jnp.array([0.1, 0.2]), expval_fn, 2, cfg_per, data)
+        avg = mmd_loss_pauli(jnp.array([0.1, 0.2]), expval_fn, 2, cfg_avg, data)
 
         expected = np.mean([float(v) for v in per])
         assert np.isclose(float(avg), expected, atol=1e-6)
@@ -355,8 +340,9 @@ class TestMMDLossAPI:
         )
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=20)
         data = jnp.array([[0], [1]])
+        expval_fn = build_expval_func(config)
 
-        res = mmd_loss(jnp.array([0.5]), config, mmd_cfg, data)
+        res = mmd_loss_pauli(jnp.array([0.5]), expval_fn, 1, mmd_cfg, data)
         assert res.shape == ()
 
     def test_deterministic_same_key(self):
@@ -367,13 +353,15 @@ class TestMMDLossAPI:
             key=jax.random.PRNGKey(99),
             n_qubits=2,
         )
+        expval_fn = build_expval_func(config)
         kwargs = {
             "params": jnp.array([0.3, 0.5, 0.1]),
-            "circuit_config": config,
+            "expval_fn": expval_fn,
+            "n_qubits": 2,
             "mmd_config": MMDConfig(bandwidth=1.0, n_ops=100),
             "target_data": jnp.array([[0, 1], [1, 0], [0, 0], [1, 1]]),
         }
-        assert float(mmd_loss(**kwargs)) == float(mmd_loss(**kwargs))
+        assert float(mmd_loss_pauli(**kwargs)) == float(mmd_loss_pauli(**kwargs))
 
     def test_different_keys_give_different_results(self):
         """Different PRNG keys should (almost surely) give different losses."""
@@ -382,32 +370,40 @@ class TestMMDLossAPI:
         params = jnp.array([0.3, 0.7])
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=100)
 
-        r1 = mmd_loss(
+        r1 = mmd_loss_pauli(
             params,
-            CircuitConfig(
-                gates=gates,
-                n_samples=200,
-                key=jax.random.PRNGKey(0),
-                n_qubits=2,
+            build_expval_func(
+                CircuitConfig(
+                    gates=gates,
+                    n_samples=200,
+                    key=jax.random.PRNGKey(0),
+                    n_qubits=2,
+                )
             ),
+            2,
             mmd_cfg,
             data,
+            key=jax.random.PRNGKey(0),
         )
-        r2 = mmd_loss(
+        r2 = mmd_loss_pauli(
             params,
-            CircuitConfig(
-                gates=gates,
-                n_samples=200,
-                key=jax.random.PRNGKey(999),
-                n_qubits=2,
+            build_expval_func(
+                CircuitConfig(
+                    gates=gates,
+                    n_samples=200,
+                    key=jax.random.PRNGKey(999),
+                    n_qubits=2,
+                )
             ),
+            2,
             mmd_cfg,
             data,
+            key=jax.random.PRNGKey(999),
         )
         assert float(r1) != float(r2)
 
     def test_mmd_loss_with_custom_init_state(self):
-        """Ensure mmd_loss properly passes down separated init_state_elems and init_state_amps."""
+        """Ensure mmd_loss_pauli properly passes down separated init_state_elems and init_state_amps."""
         jax_state_elems = jnp.array([[0, 0], [1, 1]])
         jax_state_amps = jnp.array([1 / jnp.sqrt(2), 1 / jnp.sqrt(2)])
 
@@ -422,9 +418,10 @@ class TestMMDLossAPI:
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=10)
         data = jnp.array([[0, 0], [1, 1]])
         params = jnp.array([0.5])
+        expval_fn = build_expval_func(config)
 
         # This should execute and return a finite scalar without any JAX tracer/shape errors
-        res = mmd_loss(params, config, mmd_cfg, data)
+        res = mmd_loss_pauli(params, expval_fn, 2, mmd_cfg, data)
         assert res.shape == () and np.isfinite(float(res))
 
 
@@ -502,11 +499,13 @@ class TestMMDLossStatistical:
             loss_key, sample_key = jax.random.split(key)
 
             idx = jax.random.choice(sample_key, n_data, shape=(batch,), replace=False)
+            expval_fn = build_expval_func(config)
 
-            return mmd_loss(
+            return mmd_loss_pauli(
                 params=params_jnp,
-                circuit_config=config,
+                expval_fn=expval_fn,
                 mmd_config=mmd_cfg,
+                n_qubits=n_qubits,
                 target_data=X_jnp[idx],
                 key=loss_key,
             )
@@ -528,7 +527,7 @@ class TestMMDLossStatistical:
         ), f"Z-test FAILED: z={z:.2f}, exact={exact:.6f}, mean={mean_est:.6f}, se={se:.6f}"
 
     def test_wires_subset_executes(self):
-        """``mmd_loss`` with a ``wires`` subset should run without error."""
+        """``mmd_loss_pauli`` with a ``wires`` subset should run without error."""
         config = CircuitConfig(
             gates={0: [[0]], 1: [[1]], 2: [[2]], 3: [[0, 1]]},
             n_samples=500,
@@ -538,10 +537,12 @@ class TestMMDLossStatistical:
         rng = np.random.default_rng(0)
         data = jnp.array(rng.binomial(1, 0.5, (30, 2)))
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=50, wires=[0, 2])
+        expval_fn = build_expval_func(config)
 
-        res = mmd_loss(
+        res = mmd_loss_pauli(
             jnp.array([0.1, 0.2, 0.3, 0.15]),
-            config,
+            expval_fn,
+            3,
             mmd_cfg,
             data,
         )
@@ -558,10 +559,12 @@ class TestMMDLossStatistical:
         rng = np.random.default_rng(0)
         data = jnp.array(rng.binomial(1, 0.3, (50, 2)))
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=200, sqrt_loss=True)
+        expval_fn = build_expval_func(config)
 
-        res = mmd_loss(
+        res = mmd_loss_pauli(
             jnp.array([0.5, 0.3]),
-            config,
+            expval_fn,
+            2,
             mmd_cfg,
             data,
         )
@@ -569,7 +572,7 @@ class TestMMDLossStatistical:
         assert float(res) >= 0.0
 
     def test_key_override_provides_new_randomness(self):
-        """Passing ``key`` to ``mmd_loss`` should override ``config.key``."""
+        """Passing ``key`` to ``mmd_loss_pauli`` should override ``config.key``."""
         config = CircuitConfig(
             gates={0: [[0]], 1: [[1]]},
             n_samples=500,
@@ -579,11 +582,13 @@ class TestMMDLossStatistical:
         data = jnp.array([[0, 1], [1, 0], [0, 0], [1, 1]])
         params = jnp.array([0.3, 0.7])
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=100)
+        expval_fn = build_expval_func(config)
 
-        r_default = mmd_loss(params, config, mmd_cfg, data)
-        r_override = mmd_loss(
+        r_default = mmd_loss_pauli(params, expval_fn, 2, mmd_cfg, data)
+        r_override = mmd_loss_pauli(
             params,
-            config,
+            expval_fn,
+            2,
             mmd_cfg,
             data,
             key=jax.random.PRNGKey(12345),

--- a/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
+++ b/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
@@ -25,7 +25,7 @@ from pennylane.labs.tcdq.mmd_loss_pauli import (
     _binary_ops_to_pauli_int,
     _compute_single_mmd,
     median_heuristic,
-    mmd_loss_pauli,
+    build_mmd_loss_pauli,
 )
 
 jax = pytest.importorskip("jax")
@@ -295,11 +295,10 @@ class TestMMDLossAPI:
         mmd_cfg = MMDConfig(bandwidth=[0.5, 1.0], n_ops=30, return_per_bandwidth=True)
         data = jnp.array([[0, 1], [1, 0], [0, 0]])
 
-        res = mmd_loss_pauli(
+        loss_fn = build_mmd_loss_pauli(expval_fn, 2, mmd_cfg)
+
+        res = loss_fn(
             jnp.array([0.1, 0.2]),
-            expval_fn,
-            2,
-            mmd_cfg,
             data,
         )
         assert isinstance(res, list)
@@ -324,8 +323,11 @@ class TestMMDLossAPI:
         cfg_per = MMDConfig(bandwidth=bandwidths, n_ops=100, return_per_bandwidth=True)
         cfg_avg = MMDConfig(bandwidth=bandwidths, n_ops=100, return_per_bandwidth=False)
 
-        per = mmd_loss_pauli(jnp.array([0.1, 0.2]), expval_fn, 2, cfg_per, data)
-        avg = mmd_loss_pauli(jnp.array([0.1, 0.2]), expval_fn, 2, cfg_avg, data)
+        loss_fn_per = build_mmd_loss_pauli(expval_fn, 2, cfg_per)
+        loss_fn_avg = build_mmd_loss_pauli(expval_fn, 2, cfg_avg)
+
+        per = loss_fn_per(jnp.array([0.1, 0.2]), data)
+        avg = loss_fn_avg(jnp.array([0.1, 0.2]), data)
 
         expected = np.mean([float(v) for v in per])
         assert np.isclose(float(avg), expected, atol=1e-6)
@@ -341,8 +343,9 @@ class TestMMDLossAPI:
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=20)
         data = jnp.array([[0], [1]])
         expval_fn = build_expval_func(config)
+        loss_fn = build_mmd_loss_pauli(expval_fn, 1, mmd_cfg)
 
-        res = mmd_loss_pauli(jnp.array([0.5]), expval_fn, 1, mmd_cfg, data)
+        res = loss_fn(jnp.array([0.5]), data)
         assert res.shape == ()
 
     def test_deterministic_same_key(self):
@@ -355,13 +358,18 @@ class TestMMDLossAPI:
         )
         expval_fn = build_expval_func(config)
         kwargs = {
-            "params": jnp.array([0.3, 0.5, 0.1]),
             "expval_fn": expval_fn,
             "n_qubits": 2,
             "mmd_config": MMDConfig(bandwidth=1.0, n_ops=100),
-            "target_data": jnp.array([[0, 1], [1, 0], [0, 0], [1, 1]]),
         }
-        assert float(mmd_loss_pauli(**kwargs)) == float(mmd_loss_pauli(**kwargs))
+
+        params = jnp.array([0.3, 0.5, 0.1])
+        target_data = jnp.array([[0, 1], [1, 0], [0, 0], [1, 1]])
+
+        loss_fn_1 = build_mmd_loss_pauli(**kwargs)
+        loss_fn_2 = build_mmd_loss_pauli(**kwargs)
+
+        assert float(loss_fn_1(params, target_data)) == float(loss_fn_2(params, target_data))
 
     def test_different_keys_give_different_results(self):
         """Different PRNG keys should (almost surely) give different losses."""
@@ -370,8 +378,7 @@ class TestMMDLossAPI:
         params = jnp.array([0.3, 0.7])
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=100)
 
-        r1 = mmd_loss_pauli(
-            params,
+        loss_fn_1 = build_mmd_loss_pauli(
             build_expval_func(
                 CircuitConfig(
                     gates=gates,
@@ -382,11 +389,9 @@ class TestMMDLossAPI:
             ),
             2,
             mmd_cfg,
-            data,
-            key=jax.random.PRNGKey(0),
         )
-        r2 = mmd_loss_pauli(
-            params,
+
+        loss_fn_2 = build_mmd_loss_pauli(
             build_expval_func(
                 CircuitConfig(
                     gates=gates,
@@ -397,9 +402,11 @@ class TestMMDLossAPI:
             ),
             2,
             mmd_cfg,
-            data,
-            key=jax.random.PRNGKey(999),
         )
+
+        r1 = loss_fn_1(params, data, key=jax.random.PRNGKey(0))
+        r2 = loss_fn_2(params, data, key=jax.random.PRNGKey(999))
+
         assert float(r1) != float(r2)
 
     def test_mmd_loss_with_custom_init_state(self):
@@ -419,9 +426,10 @@ class TestMMDLossAPI:
         data = jnp.array([[0, 0], [1, 1]])
         params = jnp.array([0.5])
         expval_fn = build_expval_func(config)
+        loss_fn = build_mmd_loss_pauli(expval_fn, 2, mmd_cfg)
 
         # This should execute and return a finite scalar without any JAX tracer/shape errors
-        res = mmd_loss_pauli(params, expval_fn, 2, mmd_cfg, data)
+        res = loss_fn(params, data)
         assert res.shape == () and np.isfinite(float(res))
 
 
@@ -500,15 +508,9 @@ class TestMMDLossStatistical:
 
             idx = jax.random.choice(sample_key, n_data, shape=(batch,), replace=False)
             expval_fn = build_expval_func(config)
+            loss_fn = build_mmd_loss_pauli(expval_fn, n_qubits, mmd_cfg, inject_key=True)
 
-            return mmd_loss_pauli(
-                params=params_jnp,
-                expval_fn=expval_fn,
-                mmd_config=mmd_cfg,
-                n_qubits=n_qubits,
-                target_data=X_jnp[idx],
-                key=loss_key,
-            )
+            return loss_fn(params_jnp, X_jnp[idx], key=loss_key)
 
         vmapped_eval = jax.vmap(evaluate_single_trial)
 
@@ -527,7 +529,7 @@ class TestMMDLossStatistical:
         ), f"Z-test FAILED: z={z:.2f}, exact={exact:.6f}, mean={mean_est:.6f}, se={se:.6f}"
 
     def test_wires_subset_executes(self):
-        """``mmd_loss_pauli`` with a ``wires`` subset should run without error."""
+        """Loss function with a ``wires`` subset should run without error."""
         config = CircuitConfig(
             gates={0: [[0]], 1: [[1]], 2: [[2]], 3: [[0, 1]]},
             n_samples=500,
@@ -538,14 +540,9 @@ class TestMMDLossStatistical:
         data = jnp.array(rng.binomial(1, 0.5, (30, 2)))
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=50, wires=[0, 2])
         expval_fn = build_expval_func(config)
+        loss_fn = build_mmd_loss_pauli(expval_fn, 3, mmd_cfg)
 
-        res = mmd_loss_pauli(
-            jnp.array([0.1, 0.2, 0.3, 0.15]),
-            expval_fn,
-            3,
-            mmd_cfg,
-            data,
-        )
+        res = loss_fn(jnp.array([0.1, 0.2, 0.3, 0.15]), data)
         assert res.shape == () and np.isfinite(float(res))
 
     def test_sqrt_loss_positive(self):
@@ -560,19 +557,15 @@ class TestMMDLossStatistical:
         data = jnp.array(rng.binomial(1, 0.3, (50, 2)))
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=200, sqrt_loss=True)
         expval_fn = build_expval_func(config)
+        loss_fn = build_mmd_loss_pauli(expval_fn, 2, mmd_cfg)
 
-        res = mmd_loss_pauli(
-            jnp.array([0.5, 0.3]),
-            expval_fn,
-            2,
-            mmd_cfg,
-            data,
-        )
+        res = loss_fn(jnp.array([0.5, 0.3]), data)
+
         assert res.shape == ()
         assert float(res) >= 0.0
 
     def test_key_override_provides_new_randomness(self):
-        """Passing ``key`` to ``mmd_loss_pauli`` should override ``config.key``."""
+        """Passing ``key`` to loss function should override key."""
         config = CircuitConfig(
             gates={0: [[0]], 1: [[1]]},
             n_samples=500,
@@ -583,14 +576,8 @@ class TestMMDLossStatistical:
         params = jnp.array([0.3, 0.7])
         mmd_cfg = MMDConfig(bandwidth=1.0, n_ops=100)
         expval_fn = build_expval_func(config)
+        loss_fn = build_mmd_loss_pauli(expval_fn, 2, mmd_cfg)
 
-        r_default = mmd_loss_pauli(params, expval_fn, 2, mmd_cfg, data)
-        r_override = mmd_loss_pauli(
-            params,
-            expval_fn,
-            2,
-            mmd_cfg,
-            data,
-            key=jax.random.PRNGKey(12345),
-        )
+        r_default = loss_fn(params, data)
+        r_override = loss_fn(params, data, key=jax.random.PRNGKey(12345))
         assert float(r_default) != float(r_override)

--- a/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
+++ b/pennylane/labs/tests/tcdq/test_mmd_loss_pauli.py
@@ -24,8 +24,8 @@ from pennylane.labs.tcdq.mmd_loss_pauli import (
     MMDConfig,
     _binary_ops_to_pauli_int,
     _compute_single_mmd,
-    median_heuristic,
     build_mmd_loss_pauli,
+    median_heuristic,
 )
 
 jax = pytest.importorskip("jax")
@@ -508,7 +508,7 @@ class TestMMDLossStatistical:
 
             idx = jax.random.choice(sample_key, n_data, shape=(batch,), replace=False)
             expval_fn = build_expval_func(config)
-            loss_fn = build_mmd_loss_pauli(expval_fn, n_qubits, mmd_cfg, inject_key=True)
+            loss_fn = build_mmd_loss_pauli(expval_fn, n_qubits, mmd_cfg)
 
             return loss_fn(params_jnp, X_jnp[idx], key=loss_key)
 


### PR DESCRIPTION
**Description of the Change:**
In order to be a properly unbiased estimator, the target data should be resampled with replacement at every call to the MMD loss. Previously this wasn't the case, so the user would have to code this themselves to ensure unbiasedness. There is now a config variable that allows this, which is True by default. 
