### PR TITLE
Add double-phase RZ phase-gradient decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,14 @@
 
 <h3>New features since last release</h3>
 
+* Added :func:`~.transforms.decompositions.make_rz_to_phase_gradient_decomp_double_phase`, an alternative
+  phase-gradient decomposition of :class:`~.RZ` that loads the angle with Clifford ``X`` gates and
+  cancels the unwanted phase on :math:`|0\rangle` by flipping the phase-gradient register. That trades
+  a sparse, angle-dependent CNOT count for a fixed ``2p`` CNOTs, which is cheaper when the binary
+  angle is dense. It takes the same ``adaptive_precision`` keyword as
+  :func:`~.transforms.decompositions.make_rz_to_phase_gradient_decomp`.
+  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+
 * Two new numeric Hamiltonians called :class:`pennylane.CDFHamiltonian` (based on `arXiv:2506.15784, Sec. III A <https://arxiv.org/abs/2506.15784>`) and :class:`pennylane.CGFHamiltonian` have been added (based on `arXiv:2508.11865, Sec. III C <https://arxiv.org/abs/2508.11865>`), which define compressed double-factorized (CDF) and Christiansen greedy-fragmentation Hamiltonians, respectively. These Hamiltonians can be defined
   with both concrete numeric data or abstract data (using ``qp.typing.Float[...]``).
   [(#10048)](https://github.com/PennyLaneAI/pennylane/pull/10048)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,7 +8,7 @@
   a sparse, angle-dependent CNOT count for a fixed ``2p`` CNOTs, which is cheaper when the binary
   angle is dense. It takes the same ``adaptive_precision`` keyword as
   :func:`~.transforms.decompositions.make_rz_to_phase_gradient_decomp`.
-  [(#XXXX)](https://github.com/PennyLaneAI/pennylane/pull/XXXX)
+  [(#10135)](https://github.com/PennyLaneAI/pennylane/pull/10135)
 
 * Two new numeric Hamiltonians called :class:`pennylane.CDFHamiltonian` (based on `arXiv:2506.15784, Sec. III A <https://arxiv.org/abs/2506.15784>`) and :class:`pennylane.CGFHamiltonian` have been added (based on `arXiv:2508.11865, Sec. III C <https://arxiv.org/abs/2508.11865>`), which define compressed double-factorized (CDF) and Christiansen greedy-fragmentation Hamiltonians, respectively. These Hamiltonians can be defined
   with both concrete numeric data or abstract data (using ``qp.typing.Float[...]``).

--- a/pennylane/transforms/decompositions/__init__.py
+++ b/pennylane/transforms/decompositions/__init__.py
@@ -15,6 +15,10 @@ r"""This module contains decompositions for quantum circuits."""
 
 from .clifford_t_transform import clifford_t_decomposition
 from .gridsynth import gridsynth
-from .rz_phase_gradient import make_rz_to_phase_gradient_decomp, validate_phase_gradient_wires
+from .rz_phase_gradient import (
+    make_rz_to_phase_gradient_decomp,
+    make_rz_to_phase_gradient_decomp_double_phase,
+    validate_phase_gradient_wires,
+)
 from .select_pauli_rot_phase_gradient import make_selectpaulirot_to_phase_gradient_decomp
 from .crz_phase_gradient import make_crz_to_phase_gradient_decomp

--- a/pennylane/transforms/decompositions/rz_phase_gradient.py
+++ b/pennylane/transforms/decompositions/rz_phase_gradient.py
@@ -15,8 +15,11 @@ r"""
 Decomposition rule for RZ in terms of `phase gradient states <https://pennylane.ai/compilation/phase-gradient/b-rotations>`__
 """
 
+import numpy as np
+
 import pennylane as qp
 from pennylane.ops.op_math.change_op_basis2 import ChangeOpBasis2
+from pennylane.ops.op_math.prod2 import Prod2
 from pennylane.transforms.rz_phase_gradient import _rz_phase_gradient
 from pennylane.typing import Bool, Wire
 from pennylane.wires import WireError, Wires
@@ -71,7 +74,7 @@ def make_rz_to_phase_gradient_decomp(
     Returns:
         qp.decomposition.DecompositionRule: decomposition rule to be used within :func:`~.pennylane.decompose`.
 
-    .. seealso:: :func:`~.make_selectpaulirot_to_phase_gradient_decomp`
+    .. seealso:: :func:`~.make_rz_to_phase_gradient_decomp_double_phase`, :func:`~.make_selectpaulirot_to_phase_gradient_decomp`
 
     **Example**
 
@@ -149,5 +152,143 @@ def make_rz_to_phase_gradient_decomp(
         _rz_phase_gradient(
             phi, wires, angle_wires, phase_grad_wires, work_wires, adaptive_precision
         )
+
+    return _decomp_fn
+
+
+def make_rz_to_phase_gradient_decomp_double_phase(
+    angle_wires, phase_grad_wires, work_wires, adaptive_precision=True
+):
+    r"""
+    Create a custom decomposition rule for :class:`~.RZ` gates using the double-phase trick.
+
+    Same wiring as :func:`~.make_rz_to_phase_gradient_decomp`, but the angle bits are loaded
+    unconditionally (Clifford ``X`` gates) and the unwanted phase on :math:`|0\rangle` is
+    cancelled by flipping the phase-gradient register when the target is :math:`|0\rangle`.
+    That is the same trick used in :func:`~.make_crz_to_phase_gradient_decomp`.
+
+    Compared to :func:`~.make_rz_to_phase_gradient_decomp`, this spends a fixed ``2p`` CNOTs
+    (independent of the angle) plus ``2 \times n_{\mathrm{set}}`` Clifford ``X`` gates, instead
+    of ``2 \times n_{\mathrm{set}}`` CNOTs. It is cheaper when the binary angle is dense
+    (``n_{\mathrm{set}}`` close to ``p``) and more expensive for sparse angles.
+
+    The angle is encoded in units of :math:`4\pi` (same as :func:`~.make_crz_to_phase_gradient_decomp`),
+    so that :math:`+\theta` on :math:`|1\rangle` and :math:`-\theta` on :math:`|0\rangle` realize
+    :class:`~.RZ` rather than :class:`~.PhaseShift`.
+
+    Parameters:
+        angle_wires (Wires): wires that encode the binary representation of the rotation angle
+        phase_grad_wires (Wires): wires that carry a phase gradient state
+        work_wires (Wires): additional work wires for :class:`~.SemiAdder` decomposition
+        adaptive_precision (bool): If ``True`` (default), narrow the ``SemiAdder`` and the
+            phase-gradient flip for each concrete angle to the bits up to its least-significant
+            set bit (dropping trailing zero bits) and skip angles that round to zero. If
+            ``False``, always construct the full ``len(angle_wires)``-bit circuit.
+
+    Returns:
+        qp.decomposition.DecompositionRule: decomposition rule to be used within :func:`~.pennylane.decompose`.
+
+    .. seealso:: :func:`~.make_rz_to_phase_gradient_decomp`, :func:`~.make_crz_to_phase_gradient_decomp`
+
+    **Example**
+
+    In this example we decompose a circuit containing only a single :class:`~.RZ` gate using the
+    double-phase factory. The angle ``111`` loads three unconditional ``X`` gates, and the
+    phase-gradient register is flipped with ``p`` CNOTs controlled on :math:`|0\rangle`.
+
+    .. code-block:: python
+
+        import pennylane as qp
+        from pennylane.transforms.decompositions import make_rz_to_phase_gradient_decomp_double_phase
+        import numpy as np
+
+        qp.decomposition.enable_graph()
+
+        prec = 3
+        phi = (1/2 + 1/4 + 1/8) * 4 * np.pi # binary rep is (111)
+
+        angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
+        phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
+        work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
+
+        custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+            angle_wires, phase_grad_wires, work_wires
+        )
+
+        gate_set = {"CNOT", "SemiAdder", "PauliX"}
+
+        @qp.transforms.decompose(gate_set=gate_set, fixed_decomps={qp.RZ: custom_decomp})
+        @qp.qnode(qp.device("null.qubit"))
+        def circuit():
+            qp.RZ(phi, 0)
+            return qp.state()
+
+        specs = qp.specs(circuit)()["resources"].quantum_operations
+
+    >>> specs
+    {'PauliX': 10, 'CNOT': 6, 'SemiAdder': 1}
+    >>> wire_order = [0] + angle_wires + phase_grad_wires + work_wires
+    >>> print(qp.draw(circuit, wire_order=wire_order)())
+         0: ──X─╭●─╭●─╭●──X──────────X─╭●─╭●─╭●──X─┤ ╭State
+     aux_0: ──X─│──│──│──╭SemiAdder──X─│──│──│─────┤ ├State
+     aux_1: ──X─│──│──│──├SemiAdder──X─│──│──│─────┤ ├State
+     aux_2: ──X─│──│──│──├SemiAdder──X─│──│──│─────┤ ├State
+     qft_0: ────╰X─│──│──├SemiAdder────╰X─│──│─────┤ ├State
+     qft_1: ───────╰X─│──├SemiAdder───────╰X─│─────┤ ├State
+     qft_2: ──────────╰X─├SemiAdder──────────╰X────┤ ├State
+    work_0: ─────────────├SemiAdder────────────────┤ ├State
+    work_1: ─────────────╰SemiAdder────────────────┤ ╰State
+
+    """
+    angle_wires, phase_grad_wires, work_wires = validate_phase_gradient_wires(
+        angle_wires, phase_grad_wires, work_wires
+    )
+
+    def _resource_fn(phi, wires):  # pylint: disable=unused-argument
+        # Full-precision cost from the wires in the outer scope. The unconditional angle-load
+        # MultiX emits one X per *set* bit, and adaptive_precision may narrow the adder and the
+        # phase-gradient flip, so this is an upper bound (exact=False below).
+        precision = len(angle_wires)
+        target_op = qp.SemiAdder(
+            Wire[precision],
+            Wire[precision],
+            Wire[len(work_wires)],
+        )
+        angle_load = qp.MultiX(Bool[precision], Wire[precision])
+        phg_flip = qp.ctrl(qp.MultiX(Bool[precision], Wire[precision]), control=Wire[1])
+        # Prod is right-to-left: apply angle_load, then phg_flip.
+        compute_op = uncompute_op = Prod2((phg_flip, angle_load))
+        change_basis_rep = ChangeOpBasis2(compute_op, target_op, uncompute_op)
+        return {change_basis_rep: 1}
+
+    @qp.register_resources(_resource_fn, exact=False)
+    def _decomp_fn(phi, wires):
+        precision = len(angle_wires)
+        # Double-phase applies +θ on |1⟩ and -θ on |0⟩, i.e. RZ(2θ). Encode φ in units of 4π
+        # so that θ = φ/2 (same convention as :func:`~.make_crz_to_phase_gradient_decomp`).
+        binary_int = qp.math.binary_decimals(phi, precision, unit=4 * np.pi)
+        ang_wires = angle_wires
+        phg_wires = phase_grad_wires
+
+        if adaptive_precision and not qp.math.is_abstract(phi):
+            width = qp.math.where(binary_int)[0].max(initial=-1) + 1
+            if width == 0:
+                return
+            binary_int = binary_int[:width]
+            ang_wires = angle_wires[:width]
+            phg_wires = phase_grad_wires[:width]
+
+        wire = Wires(wires)[0]
+
+        def _compute_fn():
+            qp.MultiX(binary_int, ang_wires)
+            qp.ctrl(
+                qp.MultiX([1] * len(phg_wires), phg_wires),
+                control=wire,
+                control_values=[0],
+            )
+
+        target_op = qp.SemiAdder(ang_wires, phg_wires, work_wires=work_wires)
+        qp.change_op_basis(_compute_fn, target_op, _compute_fn)
 
     return _decomp_fn

--- a/tests/transforms/decompositions/test_rz_phase_gradient.py
+++ b/tests/transforms/decompositions/test_rz_phase_gradient.py
@@ -14,7 +14,7 @@
 
 """Tests for ``qp.transforms.decompositions.make_rz_to_phase_gradient_decomp``"""
 
-# pylint: disable=no-value-for-parameter,disable=too-many-arguments
+# pylint: disable=no-value-for-parameter,disable=too-many-arguments,disable=no-name-in-module
 
 import numpy as np
 import pytest
@@ -23,6 +23,7 @@ import pennylane as qp
 from pennylane.ops.functions.assert_valid import _test_decomposition_rule
 from pennylane.transforms.decompositions import (
     make_rz_to_phase_gradient_decomp,
+    make_rz_to_phase_gradient_decomp_double_phase,
     validate_phase_gradient_wires,
 )
 from pennylane.wires import WireError
@@ -256,6 +257,215 @@ def test_adaptive_truncation(frac):
     all_wires = angle_wires + phase_grad_wires + work_wires + sys
 
     custom_decomp = make_rz_to_phase_gradient_decomp(angle_wires, phase_grad_wires, work_wires)
+    phase_grad_state = np.exp(-1j * 2 * np.pi * np.arange(2**prec) / 2**prec) / np.sqrt(2**prec)
+
+    @qp.transforms.decompose(
+        gate_set={
+            "StatePrep",
+            "Adjoint(StatePrep)",
+            "SemiAdder",
+            "CNOT",
+            "PauliX",
+            "GlobalPhase",
+        },
+        fixed_decomps={qp.RZ: custom_decomp},
+    )
+    @qp.qnode(qp.device("default.qubit", wires=all_wires))
+    def circuit(in_state):
+        qp.StatePrep(in_state, wires=sys)
+        qp.StatePrep(phase_grad_state, wires=phase_grad_wires)
+        qp.RZ(phi, sys)
+        qp.adjoint(qp.StatePrep(phase_grad_state, wires=phase_grad_wires))
+        return qp.state()
+
+    rng = np.random.default_rng(0)
+    in_state = rng.random(2)
+    in_state /= np.linalg.norm(in_state)
+
+    out_state = circuit(in_state)
+    zeros = np.eye(2 ** (len(all_wires) - 1), 1)[:, 0]
+    out_state_expected = np.kron(zeros, qp.matrix(qp.RZ(phi, sys)) @ in_state)
+    assert np.allclose(out_state, out_state_expected)
+
+
+def _msb_anchored_width_double_phase(phi, p):
+    """MSB-anchored significant width of ``phi`` at ``p`` bits in units of ``4*pi``."""
+    bits = [int(b) for b in qp.math.binary_decimals(phi, p, unit=4 * np.pi)]
+    set_positions = [i for i, b in enumerate(bits) if b]
+    return (max(set_positions) + 1) if set_positions else 0
+
+
+def _num_set_bits_double_phase(phi, p):
+    """Number of set bits in the ``p``-bit binary representation of ``phi`` (in units of 4*pi)."""
+    bits = [int(b) for b in qp.math.binary_decimals(phi, p, unit=4 * np.pi)]
+    return sum(bits)
+
+
+def _expected_rz_double_phase_specs(phi, p, adaptive_precision):
+    """Expected specs for a single ``RZ`` via the double-phase factory.
+
+    The compute/uncompute loads the angle bits with an *unconditional* ``MultiX`` (one ``X`` per
+    set bit, so ``2 * num_set_bits`` ``PauliX``) and flips the phase-gradient wires with a
+    ``MultiX`` controlled on |0> (``width`` ``CNOT``\\ s plus one ``PauliX`` flip of the target
+    wire, per pass). With ``adaptive_precision=True``, ``width`` is the MSB-anchored significant
+    width; with ``False`` it is the full ``p``. A zero angle emits an empty circuit."""
+    n = _num_set_bits_double_phase(phi, p)
+    width = _msb_anchored_width_double_phase(phi, p)
+    if adaptive_precision and width == 0:
+        return {}
+    cnot_width = width if adaptive_precision else p
+    return {"SemiAdder": 1, "CNOT": 2 * cnot_width, "PauliX": 4 + 2 * n}
+
+
+@pytest.mark.usefixtures("enable_and_disable_capture")
+@pytest.mark.parametrize("adaptive_precision", [True, False])
+@pytest.mark.parametrize("p", [2, 3, 4])
+def test_valid_decomp_double_phase(p, adaptive_precision):
+    """Test that ``make_rz_to_phase_gradient_decomp_double_phase`` yields a valid decomposition,
+    with capture both disabled (concrete angle) and enabled (abstract angle).
+
+    ``_test_decomposition_rule`` checks the emitted circuit against the rule's full-precision
+    resource estimate. We use an all-ones angle so the concrete decomposition saturates that
+    estimate (every bit is set)."""
+
+    phi = (1 - 2.0**-p) * 4 * np.pi  # binary all-ones at p bits (double-phase uses units of 4*pi)
+    first_free = 1
+    angle_wires = list(range(first_free, first_free + p))
+    phase_grad_wires = list(range(first_free + p, first_free + 2 * p))
+    work_wires = list(range(first_free + 2 * p, first_free + 3 * p - 1))
+
+    custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+        angle_wires, phase_grad_wires, work_wires, adaptive_precision=adaptive_precision
+    )
+    _test_decomposition_rule(qp.RZ(phi, 0), custom_decomp, skip_decomp_matrix_check=True)
+
+
+@pytest.mark.usefixtures("enable_graph_decomposition")
+@pytest.mark.parametrize("adaptive_precision", [True, False])
+@pytest.mark.parametrize("phi", [0.5, 0.3, 1 / 2 + 1 / 4 + 1 / 8, 1.0])
+@pytest.mark.parametrize("p", [2, 3, 4])
+def test_as_fixed_decomps_double_phase(phi, p, adaptive_precision):
+    """Test that ``make_rz_to_phase_gradient_decomp_double_phase`` works as a fixed decomposition
+    and yields the correct resources."""
+    angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(p)])
+    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(p)])
+    work_wires = qp.wires.Wires([f"work_{i}" for i in range(p - 1)])
+
+    custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+        angle_wires, phase_grad_wires, work_wires, adaptive_precision=adaptive_precision
+    )
+    gate_set = {"SemiAdder", "CNOT", "PauliX"}
+
+    @qp.transforms.decompose(gate_set=gate_set, fixed_decomps={qp.RZ: custom_decomp})
+    @qp.qnode(qp.device("null.qubit"))
+    def circuit():
+        qp.RZ(phi, 0)
+        return qp.state()
+
+    expected = _expected_rz_double_phase_specs(phi, p, adaptive_precision)
+    specs = qp.specs(circuit)()["resources"].quantum_operations
+    assert specs == expected
+
+
+@pytest.mark.usefixtures("enable_graph_decomposition")
+@pytest.mark.parametrize("adaptive_precision", [True, False])
+@pytest.mark.parametrize("phi", [0.5, 0.3, 1 / 2 + 1 / 4 + 1 / 8, 1.0])
+@pytest.mark.parametrize("p", [2, 3, 4])
+def test_as_alt_decomps_double_phase(phi, p, adaptive_precision):
+    """Test that ``make_rz_to_phase_gradient_decomp_double_phase`` works as an alternative
+    decomposition and yields the correct resources."""
+    angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(p)])
+    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(p)])
+    work_wires = qp.wires.Wires([f"work_{i}" for i in range(p - 1)])
+
+    custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+        angle_wires, phase_grad_wires, work_wires, adaptive_precision=adaptive_precision
+    )
+    gate_set = {"SemiAdder", "CNOT", "PauliX"}
+
+    @qp.transforms.decompose(gate_set=gate_set, alt_decomps={qp.RZ: [custom_decomp]})
+    @qp.qnode(qp.device("null.qubit"))
+    def circuit():
+        qp.RZ(phi, 0)
+        return qp.state()
+
+    expected = _expected_rz_double_phase_specs(phi, p, adaptive_precision)
+    specs = qp.specs(circuit)()["resources"].quantum_operations
+    assert specs == expected
+
+
+@pytest.mark.usefixtures("enable_graph_decomposition")
+def test_integration_multi_wire_double_phase(seed):
+    """Tests that the double-phase factory realizes ``RZ`` against a phase-gradient state."""
+
+    prec = 3
+
+    phi = (1 / 2 + 0 / 4 + 1 / 8) * 4 * np.pi
+    wires = [0]
+
+    angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
+    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
+    work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
+
+    phase_grad_state = np.exp(-1j * 2 * np.pi * np.arange(2**3) / 2**3) / np.sqrt(2**3)
+
+    all_wires = angle_wires + phase_grad_wires + work_wires + wires
+
+    custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+        angle_wires, phase_grad_wires, work_wires
+    )
+
+    @qp.transforms.decompose(
+        gate_set={
+            "StatePrep",
+            "Adjoint(StatePrep)",
+            "SemiAdder",
+            "CNOT",
+            "PauliX",
+            "GlobalPhase",
+        },
+        fixed_decomps={qp.RZ: custom_decomp},
+    )
+    @qp.qnode(qp.device("default.qubit", wires=all_wires))
+    def circuit(phi, in_state):
+        qp.StatePrep(in_state, wires=wires)  # input state
+        qp.StatePrep(phase_grad_state, wires=phase_grad_wires)  # phase gradient state
+        qp.RZ(phi, wires)
+        qp.adjoint(
+            qp.StatePrep(phase_grad_state, wires=phase_grad_wires)
+        )  # uncompute phase gradient state
+        return qp.state()
+
+    rng = np.random.default_rng(seed=seed)
+    in_state = rng.random(2 ** len(wires))
+    in_state /= np.linalg.norm(in_state)
+
+    out_state = circuit(phi, in_state)
+
+    zeros = np.eye(2 ** (prec * 3 - 1), 1)[:, 0]  # |000> on all the aux wires
+    out_state_expected = qp.matrix(qp.RZ(phi, wires)) @ in_state
+    out_state_expected = np.kron(zeros, out_state_expected)
+
+    assert np.allclose(out_state, out_state_expected)
+
+
+@pytest.mark.usefixtures("enable_graph_decomposition")
+@pytest.mark.parametrize("frac", [0.0, 0.5, 0.25, 0.75, 0.125, 0.875])
+def test_adaptive_truncation_double_phase(frac):
+    """Double-phase truncation stays exact for representable angles, including trailing zeros
+    and the zero angle (empty circuit)."""
+    prec = 4
+    phi = frac * 4 * np.pi
+
+    angle_wires = qp.wires.Wires([f"aux_{i}" for i in range(prec)])
+    phase_grad_wires = qp.wires.Wires([f"qft_{i}" for i in range(prec)])
+    work_wires = qp.wires.Wires([f"work_{i}" for i in range(prec - 1)])
+    sys = qp.wires.Wires([0])
+    all_wires = angle_wires + phase_grad_wires + work_wires + sys
+
+    custom_decomp = make_rz_to_phase_gradient_decomp_double_phase(
+        angle_wires, phase_grad_wires, work_wires
+    )
     phase_grad_state = np.exp(-1j * 2 * np.pi * np.arange(2**prec) / 2**prec) / np.sqrt(2**prec)
 
     @qp.transforms.decompose(


### PR DESCRIPTION
Stacked on #10109.

Alternative RZ factory: unconditional X load + |0>-controlled phase-gradient flip (same trick as CRZ). Cheaper when `n_set` is close to `p`. Angle is encoded in units of 4π, so there is no GlobalPhase.

`adaptive_precision` also truncates that flip, not just the adder. Merge #10109 first.

Authored with AI assistant.


Made with [Cursor](https://cursor.com)