### PR TITLE
Update release workflows with miscellaneous improvements

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,9 +15,6 @@ on:
         required: true
         type: string
 
-env:
-  UV_SYSTEM_PYTHON: 1
-
 jobs:
   bump_rc_branch:
     name: Update catalyst and lightning in RC branch
@@ -34,16 +31,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: 0.9.17
-          enable-cache: true  
-
-      - name: Install dependencies
-        run: |
-          uv pip install setuptools wheel twine
-
       - name: Change Catalyst, Lightning, and/or Pennylane versions
         run: |
           git config --global user.name "ringo-but-quantum"
@@ -59,14 +46,14 @@ jobs:
           lightning_major_minor=$(echo "${lightning_version}" | grep -oE '^[0-9]+\.[0-9]+')
 
           sed -i -E "s/pennylane-lightning>=[0-9.]*/pennylane-lightning>=${lightning_major_minor}/" "pyproject.toml" # Update pyproject.toml
-          sed -i -E "s/PL_CATALYST_MIN_VERSION = Version\(\"[0-9.]*\"\)/PL_CATALYST_MIN_VERSION = Version(\"${catalyst_version}\")/" "pennylane/compiler/compiler.py" 
+          sed -i -E "s/PL_CATALYST_MIN_VERSION = Version\(\"[0-9.]*\"\)/PL_CATALYST_MIN_VERSION = Version(\"${catalyst_version}\")/" "pennylane/compiler/compiler.py"
           sed -i -E "s/[0-9]+\.[0-9]+\.[0-9]+[-A-Za-z0-9]+/${{ inputs.release_version }}/" pennylane/_version.py
 
           echo "Pushing changes..."
           git add pyproject.toml pennylane/compiler/compiler.py pennylane/_version.py
           git commit --allow-empty -m "Bump minimum Lightning, Catalyst, and Pennylane versions to ${lightning_version}, ${catalyst_version}, and ${{ inputs.release_version }}"
-        
-          git push 
+
+          git push
 
   create_release:
     name: Create the release
@@ -80,17 +67,37 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_branch }}
-     
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: 0.9.17
+          enable-cache: true
+
+      - name: Build PennyLane wheel
+        run: |
+          uv build --wheel --out-dir dist
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: pennylane-wheel
+          path: dist/*.whl
+
       - name: Create release tag
         run: |
           git config user.name "GitHub Actions Bot"
-          git config user.email "<>"        
+          git config user.email "<>"
           git tag -a "v${{ inputs.release_version }}" -m "Release version v${{ inputs.release_version }}"
           git push origin "v${{ inputs.release_version }}"
 
       - name: Create Release
         run: |
-          gh release create "v${{ inputs.release_version }}" --repo PennyLaneAI/pennylane --title "Release ${{ inputs.release_version }}" --notes "$RELEASE_NOTES" --draft
+          gh release create "v${{ inputs.release_version }}" dist/*.whl --repo PennyLaneAI/pennylane --title "Release ${{ inputs.release_version }}" --notes "$RELEASE_NOTES" --draft
 
   merge-rc-pr:
     name: Create PR to merge RC branch into main

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           uv build --wheel --out-dir dist
 
+      - uses: actions/upload-artifact@v6
+        with:
+          name: pennylane-wheel
+          path: dist/*.whl
+
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,7 +3,7 @@ permissions:
   contents: read
 on:
   release:
-    types: [published]
+    types: [released]
 
 env:
   UV_SYSTEM_PYTHON: 1
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           version: 0.9.17
-          enable-cache: true  
+          enable-cache: true
 
       - name: Build PennyLane wheel
         run: |


### PR DESCRIPTION
**Context:**
During the Backline prerelease, some areas for improvement were found in the release workflows that this PR adds.

**Description of the Change:**
* Change the release trigger for `upload.yml` from `published` to `released`. This basically omits prereleases from the trigger events.
  * [Source from GH docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)
* Update `create_release.yml` to build the wheel and upload it as an asset to the draft release. Not needed _generally_. However, we did need to manually build and upload the wheel as an asset for the Backline prerelease.
  * This was because the release was not uploaded to PyPI and we needed to be able to install it using:
    ```
    pip install pennylane \
      --find-links https://github.com/PennyLaneAI/pennylane/releases/expanded_assets/<release_tag>
    ```
* Update `create_release.yml` and `upload.yml` to save the built wheel as an artifact. Not needed, but nice to have.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-130341][sc-130380]