### PR TITLE
Fix Pow/Pow2 eigvals branch cut on Python 3.14

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1596,6 +1596,12 @@
 * Various decomposition rules are updated so that they accept positionally passed arguments.
   [(#10088)](https://github.com/PennyLaneAI/pennylane/pull/10088)
 
+* Fixed :class:`~pennylane.ops.op_math.Pow` and ``Pow2`` returning the complex conjugate of the
+  correct eigenvalues for fractional powers of operators with negative eigenvalues on Python 3.14.
+  Python 3.14 implements C99 mixed-mode arithmetic, so multiplying a negative real by ``1 + 0j`` now
+  yields a negative zero imaginary part, which selects the wrong branch of the power function.
+  [(#10139)](https://github.com/PennyLaneAI/pennylane/pull/10139)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1427,6 +1427,7 @@
 
 * Fix `qp.eigvals` returns `NaN` for a legal fractional power operator.
   [(#9802)](https://github.com/PennyLaneAI/pennylane/pull/9802)
+  [(#10139)](https://github.com/PennyLaneAI/pennylane/pull/10139)
 
 * Fixed the decomposition rule of :class:`~.QROM` so that it can be captured and compiled with
   Catalyst. Tracing the ``clean`` branch previously raised a ``TracerIntegerConversionError``
@@ -1595,12 +1596,6 @@
 
 * Various decomposition rules are updated so that they accept positionally passed arguments.
   [(#10088)](https://github.com/PennyLaneAI/pennylane/pull/10088)
-
-* Fixed :class:`~pennylane.ops.op_math.Pow` and ``Pow2`` returning the complex conjugate of the
-  correct eigenvalues for fractional powers of operators with negative eigenvalues on Python 3.14.
-  Python 3.14 implements C99 mixed-mode arithmetic, so multiplying a negative real by ``1 + 0j`` now
-  yields a negative zero imaginary part, which selects the wrong branch of the power function.
-  [(#10139)](https://github.com/PennyLaneAI/pennylane/pull/10139)
 
 <h3>Contributors ✍️</h3>
 

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -18,7 +18,6 @@ This submodule defines the symbolic operation that stands for the power of an op
 import copy
 from typing import Union
 
-import numpy as np
 from scipy.linalg import fractional_matrix_power
 
 import pennylane as qp
@@ -338,7 +337,9 @@ class Pow(ScalarSymbolicOp):
 
     def eigvals(self):
         base_eigvals = self.base.eigvals()
-        return np.array(base_eigvals, dtype=complex) ** self.z
+        is_single_precision = math.get_dtype_name(base_eigvals) in ("float32", "complex64")
+        complex_dtype = "complex64" if is_single_precision else "complex128"
+        return math.cast(base_eigvals, complex_dtype) ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -18,6 +18,7 @@ This submodule defines the symbolic operation that stands for the power of an op
 import copy
 from typing import Union
 
+import numpy as np
 from scipy.linalg import fractional_matrix_power
 
 import pennylane as qp
@@ -336,11 +337,8 @@ class Pow(ScalarSymbolicOp):
         return self.base.diagonalizing_gates()
 
     def eigvals(self):
-        # Cast rather than multiply by ``1 + 0j``: since Python 3.14 implements C99 mixed-mode
-        # arithmetic, ``(1 + 0j) * -1.0`` is ``-1 - 0j``, and the negative zero imaginary part
-        # puts negative eigenvalues on the wrong side of the branch cut of ``**``.
         base_eigvals = self.base.eigvals()
-        return math.cast(base_eigvals, "complex128") ** self.z
+        return np.array(base_eigvals, dtype=complex) ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/pow.py
+++ b/pennylane/ops/op_math/pow.py
@@ -336,8 +336,11 @@ class Pow(ScalarSymbolicOp):
         return self.base.diagonalizing_gates()
 
     def eigvals(self):
+        # Cast rather than multiply by ``1 + 0j``: since Python 3.14 implements C99 mixed-mode
+        # arithmetic, ``(1 + 0j) * -1.0`` is ``-1 - 0j``, and the negative zero imaginary part
+        # puts negative eigenvalues on the wrong side of the branch cut of ``**``.
         base_eigvals = self.base.eigvals()
-        return [((1 + 0j) * value) ** self.z for value in base_eigvals]
+        return math.cast(base_eigvals, "complex128") ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/pow2.py
+++ b/pennylane/ops/op_math/pow2.py
@@ -17,7 +17,6 @@
 from functools import reduce
 from typing import Union, override
 
-import numpy as np
 from scipy.linalg import fractional_matrix_power
 
 import pennylane as qp
@@ -243,7 +242,9 @@ class Pow2(SymbolicOp2):
     @override
     def eigvals(self):
         base_eigvals = self.base.eigvals()
-        return np.array(base_eigvals, dtype=complex) ** self.z
+        is_single_precision = math.get_dtype_name(base_eigvals) in ("float32", "complex64")
+        complex_dtype = "complex64" if is_single_precision else "complex128"
+        return math.cast(base_eigvals, complex_dtype) ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/pow2.py
+++ b/pennylane/ops/op_math/pow2.py
@@ -17,6 +17,7 @@
 from functools import reduce
 from typing import Union, override
 
+import numpy as np
 from scipy.linalg import fractional_matrix_power
 
 import pennylane as qp
@@ -241,11 +242,8 @@ class Pow2(SymbolicOp2):
 
     @override
     def eigvals(self):
-        # Cast rather than multiply by ``1 + 0j``: since Python 3.14 implements C99 mixed-mode
-        # arithmetic, ``(1 + 0j) * -1.0`` is ``-1 - 0j``, and the negative zero imaginary part
-        # puts negative eigenvalues on the wrong side of the branch cut of ``**``.
         base_eigvals = self.base.eigvals()
-        return math.cast(base_eigvals, "complex128") ** self.z
+        return np.array(base_eigvals, dtype=complex) ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/pennylane/ops/op_math/pow2.py
+++ b/pennylane/ops/op_math/pow2.py
@@ -241,8 +241,11 @@ class Pow2(SymbolicOp2):
 
     @override
     def eigvals(self):
+        # Cast rather than multiply by ``1 + 0j``: since Python 3.14 implements C99 mixed-mode
+        # arithmetic, ``(1 + 0j) * -1.0`` is ``-1 - 0j``, and the negative zero imaginary part
+        # puts negative eigenvalues on the wrong side of the branch cut of ``**``.
         base_eigvals = self.base.eigvals()
-        return [((1 + 0j) * value) ** self.z for value in base_eigvals]
+        return math.cast(base_eigvals, "complex128") ** self.z
 
     # pylint: disable=arguments-renamed, invalid-overridden-method
     @property

--- a/tests/ops/op_math/test_pow2.py
+++ b/tests/ops/op_math/test_pow2.py
@@ -356,6 +356,8 @@ def test_eigvals_fractional_power_negative_eigenvalue_2(z, power_method):
     expected_eigvals = np.array([1.0**z, (-1.0 + 0j) ** z])
 
     assert np.allclose(eigvals, expected_eigvals)
+    # the eigenvalues must sit on the same branch of ``**`` as the matrix
+    assert np.allclose(eigvals, np.diag(qp.matrix(op)))
 
 
 # pylint: disable-next=too-few-public-methods

--- a/tests/ops/op_math/test_pow_op.py
+++ b/tests/ops/op_math/test_pow_op.py
@@ -446,6 +446,8 @@ class TestProperties:
         expected_eigvals = np.array([1.0**z, (-1.0 + 0j) ** z])
 
         assert np.allclose(eigvals, expected_eigvals)
+        # the eigenvalues must sit on the same branch of ``**`` as the matrix
+        assert np.allclose(eigvals, np.diag(qp.matrix(op)))
 
 
 class TestSimplify:


### PR DESCRIPTION
> [!NOTE]
> Drafted with AI assistance (GitHub Copilot CLI), reviewed before opening.

**Context:**

`Pow.eigvals()` / `Pow2.eigvals()` return the complex conjugate of the correct eigenvalues for non-integer `z`, on Python 3.14 only. Regression from #9802, which changed the cast idiom to `((1 + 0j) * value) ** self.z`.

Python 3.14 implements C99 mixed-mode real/complex arithmetic ([python/cpython#69639](https://github.com/python/cpython/issues/69639)), so `complex * float` is now componentwise instead of promoting the float to `complex(x, +0.0)`:

| | `(1+0j) * -1.0` | `** 0.5` |
|---|---|---|
| 3.13 | `(-1+0j)` | `+1j` |
| 3.14 | `(-1-0j)` | `-1j` |

That `-0.0` puts `-1` on the wrong side of the branch cut of `**`. It is specific to multiplication — `-1.0 + 0j` and `complex(-1.0)` are unaffected.

All six `core-tests (*, 3.14)` shards fail on `main` (9 failures, scattered by `pytest-split`): https://github.com/PennyLaneAI/pennylane/actions/runs/34502136095

**Description of the Change:**

Restore the cast-based form in `pow.py` and `pow2.py`:

```python
return math.cast(self.base.eigvals(), "complex128") ** self.z
```

Both tests now also assert `eigvals() == np.diag(qml.matrix(op))`, so branch-cut flips are caught on any Python version rather than only against a hardcoded literal.

**Benefits:**

`qml.eigvals` was silently returning wrong values for fractional powers of operators with negative eigenvalues, affecting anything that pairs eigvals with diagonalizing gates. The NaN fix from #9802 (#9632) still holds.

**Possible Drawbacks:**

`eigvals()` now returns a tensor rather than a `list`. This matches the documented `Returns: tensor_like` contract, and nothing depends on the list form.

**Related GitHub Issues:**

Regression from #9802.

---

Verified on 3.14 and 3.13: 182 passed across `test_pow_op.py` + `test_pow2.py` (9 failed on 3.14 before). Wider `tests/ops/op_math/` + `test_eigvals.py` run on 3.14 shows no new failures.

Follow-up: eight other live uses of the `(1 + 0j) *` promotion idiom (`channel.py`, `qchem_ops.py`, `parametric_ops_single_qubit.py`, `controlled_ops.py`) are benign today, but 3.14 changes signed-zero behaviour there too.

[sc-130383]
