### PR TITLE
Fix ceil_log2 precision for large integers

### DIFF
--- a/pennylane/math/utils.py
+++ b/pennylane/math/utils.py
@@ -550,6 +550,45 @@ def in_backprop(tensor, interface=None):
     raise ValueError(f"Cannot determine if {tensor} is in backpropagation.")
 
 
+def _is_integer_scalar(n) -> bool:
+    """Return whether ``n`` is a concrete scalar with an integer dtype."""
+    if isinstance(n, (int, _np.integer)):
+        return True
+
+    if getattr(n, "shape", None) != ():
+        return False
+
+    try:
+        dtype_name = math.get_dtype_name(n)
+    except (TypeError, ValueError):
+        return False
+
+    return dtype_name.startswith(("int", "uint"))
+
+
+def _is_integer_dtype(dtype) -> bool:
+    """Return whether ``dtype`` is an integer dtype recognized by NumPy."""
+    if dtype is None:
+        return False
+
+    try:
+        return _np.issubdtype(dtype, _np.integer)
+    except TypeError:
+        return False
+
+
+def _ceil_log2_integer_array(n):
+    """Compute ``ceil(log2(n))`` exactly for integer arrays."""
+    n_minus_one = n - 1
+    out = np.zeros_like(n_minus_one)
+    max_exponent = _np.iinfo(getattr(n, "dtype")).max.bit_length()
+
+    for exponent in range(max_exponent):
+        out = out + (n_minus_one >= (1 << exponent)).astype(int)
+
+    return out.astype(int)
+
+
 def ceil_log2(n: int) -> int:
     """Compute the ceiling of the base-2 logarithm of an integer, with integer as output data type.
 
@@ -582,5 +621,16 @@ def ceil_log2(n: int) -> int:
     4
     """
     if is_abstract(n):
-        return np.ceil(np.log2(n)).astype(int)
+        log2 = np.ceil(np.log2(n)).astype(int)
+
+        if _is_integer_dtype(getattr(n, "dtype", None)):
+            return np.where(n > 0, _ceil_log2_integer_array(n), log2)
+
+        return log2
+
+    if _is_integer_scalar(n):
+        n_int = int(n)
+        if n_int > 0:
+            return (n_int - 1).bit_length()
+
     return int(np.ceil(np.log2(n)))

--- a/tests/math/test_basic_math.py
+++ b/tests/math/test_basic_math.py
@@ -27,7 +27,8 @@ jnp = pytest.importorskip("jax.numpy")
 
 
 @pytest.mark.parametrize(
-    "n, exp", [(1, 0), (2, 1), (4, 2), (1024, 10), (3, 2), (17, 5), (1023, 10)]
+    "n, exp",
+    [(1, 0), (2, 1), (4, 2), (1024, 10), (3, 2), (17, 5), (1023, 10), (2**53 + 1, 54)],
 )
 class TestCeilLog2:
     """Tests for ``qp.math.ceil_log2``."""
@@ -47,6 +48,18 @@ class TestCeilLog2:
         assert out.dtype == jnp.int64
         assert out == exp
         assert fn.ceil_log2(2**out) == out
+
+
+def test_ceil_log2_numpy_scalar():
+    """Test that ``ceil_log2`` is exact for large NumPy integer scalars."""
+    out = fn.ceil_log2(onp.array(2**53 + 1))
+    assert isinstance(out, int)
+    assert out == 54
+
+
+def test_ceil_log2_arbitrary_precision_integer():
+    """Test that ``ceil_log2`` is exact for integers beyond fixed-width dtypes."""
+    assert fn.ceil_log2(2**100 + 1) == 101
 
 
 class TestFrobeniusInnerProduct:


### PR DESCRIPTION
## Summary
- compute ceil_log2 exactly for concrete integer scalars before falling back to floating log2
- preserve traced integer-array support with an integer-safe abstract path
- add regressions for 2**53 + 1, NumPy integer scalars, and arbitrary-precision Python integers

Fixes #10100

## Tests
- MPLCONFIGDIR=/private/tmp/mpl-cache .venv/bin/python -m pytest tests/math/test_basic_math.py::TestCeilLog2 tests/math/test_basic_math.py::test_ceil_log2_numpy_scalar tests/math/test_basic_math.py::test_ceil_log2_arbitrary_precision_integer -q
- MPLCONFIGDIR=/private/tmp/mpl-cache .venv/bin/python -m pytest tests/math/test_basic_math.py -q
- .venv/bin/python -m py_compile pennylane/math/utils.py tests/math/test_basic_math.py
- git diff --check